### PR TITLE
Use root level .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,21 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
-/node_modules
-/.pnp
+**/node_modules
+**/.pnp
 .pnp.js
 .yarn/install-state.gz
 
 # testing
-/coverage
+**/coverage
 
 # next.js
-/.next/
-/out/
+**/.next/
+**/out/
 
 # production
-/build
+**/build
+**/dist
 
 # misc
 .DS_Store


### PR DESCRIPTION
There is currently only one `.gitignore` on tools/app.

Git ignore file should be on root level so that it affects the whole repository.

FYI: @samilempinen @henryhaverinen 