### PR TITLE
INTDEV-308 Validate 'customFields' in cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6284,6 +6284,14 @@
       "integrity": "sha512-JUfU61e8tr+i5Y1FKXcKs+Xe+rJ+CEqm4cgv1kMihPE2EvYHmYyVr3Im/+1+Z5B29Be2EEGCZCwAc6Tazdl1Yg==",
       "dev": true
     },
+    "node_modules/email-validator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
+      "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ==",
+      "engines": {
+        "node": ">4.0"
+      }
+    },
     "node_modules/emittery": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
@@ -16858,6 +16866,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "directory-schema-validator": "^1.0.17",
+        "email-validator": "^2.0.4",
         "isomorphic-git": "^1.25.2",
         "js-yaml": "^4.1.0",
         "json-schema": "^0.4.0",

--- a/tools/data-handler/package.json
+++ b/tools/data-handler/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "directory-schema-validator": "^1.0.17",
+    "email-validator": "^2.0.4",
     "isomorphic-git": "^1.25.2",
     "js-yaml": "^4.1.0",
     "json-schema": "^0.4.0",

--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -107,9 +107,10 @@ export class Template extends CardContainer {
                     card.metadata.cardtype = cardtype.name;
                     if (cardtype.customFields !== undefined) {
                         for (const customField of cardtype.customFields) {
+                            const defaultValue = null;
                             card.metadata = {
                                 ...card.metadata,
-                                [customField.name]: card.metadata[customField.name]
+                                [customField.name]: card.metadata[customField.name] || defaultValue
                             };
                         }
                     }

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -77,7 +77,7 @@ export interface fieldtype {
     displayName?: string,
     fieldDescription?: string,
     dataType: string,
-    enumValues?: object[]
+    enumValues?: enumValue[]
 }
 
 // Project metadata details.
@@ -146,8 +146,8 @@ export interface workflowTransition {
 
 // Custom field enum value
 export interface enumValue {
-    value: string,
-    displayValue: string,
+    enumValue: string,
+    enumDisplayValue: string,
     enumDescription: string,
 }
 
@@ -179,4 +179,4 @@ export interface fetchCardDetails {
     parent?: boolean,
 }
 
-export type metadataContent = number | boolean | string | string[];
+export type metadataContent = number | boolean | string | string[] | null;

--- a/tools/data-handler/test/0_validate.test.ts
+++ b/tools/data-handler/test/0_validate.test.ts
@@ -219,5 +219,32 @@ describe('validate cmd tests', () => {
             expect(valid.statusCode).to.equal(500);
         }
     });
+
+    it('validate card custom fields data (success)', async () => {
+        const project = new Project('test/test-data/valid/decision-records/');
+        // card _6 has all of the types as custom fields (with null values)
+        const card = await project.findSpecificCard('decision_6', {metadata: true});
+        if (card) {
+            const valid = await validateCmd.validateCustomFields(project, card);
+            expect(valid.statusCode).to.equal(200);
+        }
+    });
+    it('try to validate card custom fields - cardtype not found', async () => {
+        const project = new Project('test/test-data/invalid/invalid-card-has-wrong-state/');
+        const card = await project.findSpecificCard('decision_5', {metadata: true});
+        if (card) {
+            const valid = await validateCmd.validateCustomFields(project, card);
+            expect(valid.statusCode).to.equal(500);
+        }
+    });
+    it('try to validate card custom fields - no metadata for the card', async () => {
+        const project = new Project('test/test-data/valid/decision-records/');
+        const card = await project.findSpecificCard('decision_5', {metadata: false});
+        if (card) {
+            const valid = await validateCmd.validateCustomFields(project, card);
+            expect(valid.statusCode).to.equal(500);
+        }
+    });
+    // @todo add more tests that test various values types can have (correct and incorrect)
 })
 

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/cardtypes/decision-cardtype.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/cardtypes/decision-cardtype.json
@@ -5,8 +5,32 @@
         {
             "name": "obsoletedBy",
             "isEditable": true
+        },
+        {
+            "name": "admins"
+        },
+        {
+            "name": "commit-description"
+        },
+        {
+            "name": "responsible"
+        },
+        {
+            "name": "number-of-commits"
+        },
+        {
+            "name": "percentage-ready"
+        },
+        {
+            "name": "last-changed-date"
+        },
+        {
+            "name": "last-changed-timestamp"
+        },
+        {
+            "name": "finished"
         }
     ],
-    "alwaysVisibleFields": [ "obsoletedBy" ],
+    "alwaysVisibleFields": [ "obsoletedBy", "admins", "commit-description" ],
     "optionallyVisibleFields": []
 }

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldtypes/admins.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldtypes/admins.json
@@ -1,0 +1,6 @@
+{
+    "name": "admins",
+    "displayName": "Administrators",
+    "fieldDescription": "List of admin persons",
+    "dataType": "list"
+}

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldtypes/commit-description.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldtypes/commit-description.json
@@ -1,0 +1,6 @@
+{
+    "name": "commit-desciption",
+    "displayName": "Commit Description",
+    "fieldDescription": "In long format describe how source code was changed",
+    "dataType": "longtext"
+}

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldtypes/finished.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldtypes/finished.json
@@ -1,0 +1,6 @@
+{
+    "name": "finished",
+    "displayName": "Finished",
+    "fieldDescription": "True, if the task is ready; false otherwise",
+    "dataType": "boolean"
+}

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldtypes/last-changed-date.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldtypes/last-changed-date.json
@@ -1,0 +1,6 @@
+{
+    "name": "last-changed-date",
+    "displayName": "Last changed date",
+    "fieldDescription": "Date when the task was last updated",
+    "dataType": "date"
+}

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldtypes/last-changed-timestamp.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldtypes/last-changed-timestamp.json
@@ -1,0 +1,6 @@
+{
+    "name": "last-changed-timestamp",
+    "displayName": "Last changed timestamp",
+    "fieldDescription": "Date and time when the task was last time updated",
+    "dataType": "datetime"
+}

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldtypes/number-of-commits.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldtypes/number-of-commits.json
@@ -1,0 +1,6 @@
+{
+    "name": "number-of-commits",
+    "displayName": "Number of commits",
+    "fieldDescription": "How many commits have been done related to this task",
+    "dataType": "integer"
+}

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldtypes/percentage-ready.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldtypes/percentage-ready.json
@@ -1,0 +1,6 @@
+{
+    "name": "percentage-ready",
+    "displayName": "Percentage ready",
+    "fieldDescription": "How complete (in %) the task is",
+    "dataType": "number"
+}

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldtypes/responsible.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldtypes/responsible.json
@@ -1,0 +1,6 @@
+{
+    "name": "responsible",
+    "displayName": "Responsible",
+    "fieldDescription": "Who is responsible for the task",
+    "dataType": "person"
+}

--- a/tools/data-handler/test/test-data/valid/decision-records/cardroot/decision_5/c/decision_6/index.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/cardroot/decision_5/c/decision_6/index.json
@@ -2,5 +2,13 @@
     "cardtype": "decision-cardtype",
     "summary": "Document Decisions with Decision Records",
     "workflowState": "Approved",
-    "obsoletedBy": null
+    "obsoletedBy": null,
+    "admins": null,
+    "commit-description": null,
+    "finished": null,
+    "last-changed-date": null,
+    "last-changed-timestamp": null,
+    "number-of-commits": null,
+    "percentage-ready": null,
+    "responsible": null
 }


### PR DESCRIPTION
Continuation of card data validation. 

Card's custom fields are validated against types defined by "field types".

**Note** that `null` is acceptable value for all; `person` also allows for empty string. 

Additionally, fixed an issue with card creation where custom fields without values from template cards were not properly initialised. Now, they are set to `null` unless a template card has a value for them. This needs to be improved later with potential default values (from JSON schema `default`), or from custom field's default values (INTDEV-167). Potentially, also basic types might have default values apart from `null`. But `null` will suffice for now.

When "isms" project is validated with these changes the following validation errors are notified:
<img width="1094" alt="Screenshot 2024-06-05 at 21 39 32" src="https://github.com/CyberismoCom/cyberismo/assets/3634615/0e1fe5ca-f6b3-49c9-b2ce-1eda19ede52c">
When this PR is merged to "main" that project needs to be fixed.