### PR TITLE
INTDEV-321 Remove 'hidden' workflow category

### DIFF
--- a/examples/decision-records/.cards/local/workflows/decision-workflow.json
+++ b/examples/decision-records/.cards/local/workflows/decision-workflow.json
@@ -4,7 +4,7 @@
         { "name": "Draft", "category": "initial" },
         { "name":"Approved", "category": "closed" },
         { "name":"Rejected", "category": "closed" },
-        { "name":"Deprecated", "category": "hidden" }
+        { "name":"Deprecated", "category": "closed" }
     ],
     "transitions": [
         {

--- a/tools/app/__tests__/components.test.tsx
+++ b/tools/app/__tests__/components.test.tsx
@@ -196,7 +196,7 @@ const testProject: Project = {
         },
         {
           name: 'Archived',
-          category: workflowCategory.hidden,
+          category: workflowCategory.closed,
         },
       ],
       transitions: [

--- a/tools/app/app/components/StateSelector.tsx
+++ b/tools/app/app/components/StateSelector.tsx
@@ -38,7 +38,6 @@ const StateSelector: React.FC<StateSelectorProps> = ({
 
   if (
     currentState == null ||
-    currentState.category == workflowCategory.hidden ||
     workflow == null ||
     !workflow.states.find((state) => state.name == currentState.name)
   )

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -126,8 +126,7 @@ export interface workflowMetadata {
 export enum workflowCategory {
     initial = "initial",
     active = "active",
-    closed = "closed",
-    hidden = "hidden"
+    closed = "closed"
 }
 
 // Workflow state.

--- a/tools/data-handler/test/test-data/invalid/invalid-card-has-wrong-state/.cards/local/workflows/decision-workflow.json
+++ b/tools/data-handler/test/test-data/invalid/invalid-card-has-wrong-state/.cards/local/workflows/decision-workflow.json
@@ -5,7 +5,7 @@
         { "name": "Approved", "category": "closed" },
         { "name": "Rejected", "category": "closed" },
         { "name": "Rerejected", "category": "closed" },
-        { "name": "Deprecated", "category": "hidden" }
+        { "name": "Deprecated", "category": "closed" }
     ],
     "transitions": [
         {

--- a/tools/data-handler/test/test-data/invalid/invalid-card-has-wrong-state/.cards/local/workflows/simple-workflow.json
+++ b/tools/data-handler/test/test-data/invalid/invalid-card-has-wrong-state/.cards/local/workflows/simple-workflow.json
@@ -3,7 +3,7 @@
     "states": [
         { "name": "Created", "category": "initial" },
         { "name": "Approved", "category": "closed" },
-        { "name": "Deprecated", "category": "hidden" } ],
+        { "name": "Deprecated", "category": "closed" } ],
     "transitions": [
         {
             "name": "Create",

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/workflows/decision-workflow.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/workflows/decision-workflow.json
@@ -5,7 +5,7 @@
         { "name": "Approved", "category": "closed" },
         { "name": "Rejected", "category": "closed" },
         { "name": "Rerejected", "category": "closed" },
-        { "name": "Deprecated", "category": "hidden" }
+        { "name": "Deprecated", "category": "closed" }
     ],
     "transitions": [
         {

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/workflows/simple-workflow.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/workflows/simple-workflow.json
@@ -3,7 +3,7 @@
     "states": [
         { "name": "Created", "category": "initial" },
         { "name": "Approved", "category": "closed" },
-        { "name": "Deprecated", "category": "hidden" } ],
+        { "name": "Deprecated", "category": "closed" } ],
     "transitions": [
         {
             "name": "Create",

--- a/tools/schema/workflow-schema.json
+++ b/tools/schema/workflow-schema.json
@@ -26,7 +26,7 @@
                     },
                     "category": {
                         "description": "The category of a workflow state",
-                        "enum": ["initial", "active", "closed", "hidden"]
+                        "enum": ["initial", "active", "closed"]
                     }
                 },
                 "required": ["name", "category"]


### PR DESCRIPTION
We don't have a good concept for using the "hidden" category for now.

Let's remove it until there is a clear picture how to use it.