### PR TITLE
INTDEV-305 Fetch attachment details when renaming project

### DIFF
--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -650,7 +650,7 @@ export class Commands {
 
     /**
      * Changes project prefix, and renames all project cards.
-     * @param to New project prefix
+     * @param {string} to New project prefix
      * @param {string} path Optional. Path to the project. If omitted, project is set from current path.
      *       statusCode 200 when operation succeeded
      *  <br> statusCode 400 when input validation failed

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -279,10 +279,14 @@ export class Project extends CardContainer {
 
     /**
      * Returns an array of all the cards in the project. Cards have content and metadata
-     * @returns all cards in the project.
+     * @param {string} path Optional path from which to fetch the cards. Generally it is best to fetch from Project root, e.g. Project.cardRootFolder
+     * @param {string} details Which details to include in the cards; by default only "content" and "metadata" are included.
+     * @returns all cards from the given path in the project.
      */
-    public async cards(): Promise<card[]> {
-        return super.cards(this.cardrootFolder, { content: true, metadata: true });
+    public async cards(
+        path: string = this.cardrootFolder,
+        details: fetchCardDetails = { content: true, metadata: true }): Promise<card[]> {
+        return super.cards(path, details);
     }
 
     /**

--- a/tools/data-handler/src/rename.ts
+++ b/tools/data-handler/src/rename.ts
@@ -79,7 +79,7 @@ export class Rename extends EventEmitter {
         }
 
         // Then rename all project cards. Sort cards so that cards that deeper in file hierarchy are renamed first.
-        const projectCards = (await Rename.project.cards())
+        const projectCards = (await Rename.project.cards(Rename.project.cardrootFolder, { metadata: true, attachments: true }))
             .sort((a, b) => {
                 return this.sortCards(a, b);
             });
@@ -94,7 +94,7 @@ export class Rename extends EventEmitter {
         const templates = await Rename.project.templates(true);
         for (const template of templates) {
             const templateObject = new Template(projectPath, template, Rename.project);
-            const templateCards = (await templateObject.cards())
+            const templateCards = (await templateObject.cards("", { metadata: true, attachments: true }))
                 .sort((a, b) => {
                     return this.sortCards(a, b);
                 });


### PR DESCRIPTION
When project prefix is changed, all of the card keys and references to them are needed to be updated.
This includes attachments and links to them from the cards. 

Unfortunately, the earlier implementation didn't fetch card details for attachments (`{attachments: true}, ...}`) when it fetched the cards for renaming. This meant that it looked like that the cards didn't have any attachments at all.

Fixed by adding `attachments: true` to the card details when they are fetched.