### PR TITLE
Code scanning alert fix: Use global flag when listing type names

### DIFF
--- a/tools/data-handler/src/create.ts
+++ b/tools/data-handler/src/create.ts
@@ -465,12 +465,8 @@ export class Create extends EventEmitter {
             : join(baseDir, '../../schema');
 
         const schemaContent = readJsonFileSync(join(baseFolder, 'field-type-schema.json'));
-        // ugly way to split the pattern into array of strings
         return schemaContent.properties.dataType.pattern
-            .split('$|^')
-            .join(',')
-            .replace('^', '')
-            .replace('$', '')
-            .split(',');
+            .replace(/\$|\^/g, '')
+            .split('|');
     }
 }


### PR DESCRIPTION
Code scanner raised an issue about non-complete replacing; i.e. using `replace` without global flag. 

The implementation actually split a long pattern string to parts first, so there were always one `$` and one `^` in each part (at most). But the implementation was ugly (and was noted so in a comment). Replace the implementation with one that uses global flag first, then splits the patterns into strings.