### PR TITLE
INTDEV-361 Make 'createProject()' use its own sanity checks

### DIFF
--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -189,21 +189,22 @@ export class Commands {
     public async command(command: Cmd, args: string[], options: CardsOptions): Promise<requestStatus> {
         // Set project path and validate it.
         const creatingNewProject = command === Cmd.create && args[0] === 'project';
+        // createProject() method makes its own checks; others have common sanity check:
         if (!creatingNewProject) {
             this.projectPath = await this.setProjectPath(options.projectPath);
             this.projectPath = resolveTilde(this.projectPath);
-        }
-        if (!this.validateFolder(this.projectPath)) {
-            return {
-                statusCode: 400,
-                message: `Input validation error: folder name is invalid '${options.projectPath}'`
-            };
-        }
-        if (!pathExists(this.projectPath)) {
-            return {
-                statusCode: 400,
-                message: `Input validation error: cannot find project '${options.projectPath}'`
-            };
+            if (!this.validateFolder(this.projectPath)) {
+                return {
+                    statusCode: 400,
+                    message: `Input validation error: folder name is invalid '${options.projectPath}'`
+                };
+            }
+            if (!pathExists(this.projectPath)) {
+                return {
+                    statusCode: 400,
+                    message: `Input validation error: cannot find project '${options.projectPath}'`
+                };
+            }
         }
 
         if (command === Cmd.add) {

--- a/tools/data-handler/test/command-handler.test.ts
+++ b/tools/data-handler/test/command-handler.test.ts
@@ -10,7 +10,7 @@ import { dirname, join } from 'node:path';
 
 // ismo
 import { CardsOptions, Cmd, Commands } from '../src/command-handler.js';
-import { copyDir, resolveTilde } from '../src/utils/file-utils.js'
+import { copyDir, deleteDir, resolveTilde } from '../src/utils/file-utils.js'
 import { Create } from '../src/create.js';
 import { attachmentPayload, requestStatus } from '../src/interfaces/request-status-interfaces.js';
 import { moduleSettings } from '../src/interfaces/project-interfaces.js';
@@ -592,9 +592,9 @@ describe('create command', () => {
 
     // project
     it('project (success)', async () => {
-        const projectDir = join(testDir, 'project-name');
         const prefix = 'proj';
         const name = 'test-project';
+        const projectDir = join(testDir, name);
         const testOptions: CardsOptions = { projectPath: projectDir };
         const result = await commandHandler.command(Cmd.create, ['project', prefix, name ], testOptions);
         try {
@@ -618,6 +618,14 @@ describe('create command', () => {
             assert(false, 'project folder could not be created');
         }
         expect(result.statusCode).to.equal(200);
+    });
+    it('project creation without options (success)', async () => {
+        const prefix = 'demo';
+        const name = 'demo';
+        const testOptions = { projectPath: name };
+        const result = await commandHandler.command(Cmd.create, ['project', name, prefix], testOptions);
+        expect(result.statusCode).to.equal(200);
+        await deleteDir(name);
     });
     it('project missing target', async () => {
         const testOptions = { projectPath: '' };


### PR DESCRIPTION
Currently, it is impossible to create a new project. This is due to that the shared validations for input parameters check that they can find a project folder. 

Creating project should have its own checks. This is different from other commands, which have always 'project' folder to find.

Added also unit test to cover the case.