### PR TITLE
INTDEV-364 Template is created to wrong path

### DIFF
--- a/tools/data-handler/test/0_validate.test.ts
+++ b/tools/data-handler/test/0_validate.test.ts
@@ -213,12 +213,10 @@ describe('validate cmd tests', () => {
         }
     });
     it('try to validateWorkflowState - workflow not found from card', async () => {
-        console.log('here1')
         const project = new Project('test/test-data/invalid/invalid-card-has-wrong-state/');
         const card = await project.findSpecificCard('decision_8', {metadata: true});
         if (card) {
             const valid = await validateCmd.validateWorkflowState(project, card);
-            console.log(valid)
             expect(valid.length).to.be.greaterThan(0);
         }
     });

--- a/tools/data-handler/test/command-handler.test.ts
+++ b/tools/data-handler/test/command-handler.test.ts
@@ -886,6 +886,8 @@ describe('modifying imported module content is forbidden', () => {
         const cardType = 'decision-cardtype';
         const cardKey = '';
         const result = await commandHandler.command(Cmd.add, [templateName, cardType, cardKey ], options);
+        // todo: the reason why this fails is due to a bug where templates with names without module
+        //       name are the same (one local, one imported)
         expect(result.statusCode).to.equal(400);
     });
     it('try to add child card to a module card', async () => {
@@ -894,6 +896,8 @@ describe('modifying imported module content is forbidden', () => {
         const cardKey = 'decision_2';
         // try to add new card to decision_2 when 'decision-records' has been imported to 'minimal'
         const result = await commandHandler.command(Cmd.add, [templateName, cardType, cardKey], optionsMini);
+        // todo: the reason why this fails is due to a bug where templates with names without module
+        //       name are the same (one local, one imported)
         expect(result.statusCode).to.equal(400);
     });
 


### PR DESCRIPTION
Template creation used wrong path if there were modules imported.
There was a clear programming error, as it was looking for "modules" path to exist, when it should have tried to find "modules/templates/<templateName>"