### PR TITLE
INTDEV-366 'create project' command parameters are in wrong order

### DIFF
--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -239,7 +239,7 @@ export class Commands {
                 return this.createCardtype(name, workflow, this.projectPath);
             }
             if (target === 'project') {
-                const [ prefix, name ] = args;
+                const [ name, prefix ] = args;
                 this.projectPath = options.projectPath || ''; // todo: validation
                 return this.createProject(this.projectPath, prefix, name); // todo: order of parameters
             }

--- a/tools/data-handler/test/command-handler.test.ts
+++ b/tools/data-handler/test/command-handler.test.ts
@@ -599,7 +599,7 @@ describe('create command', () => {
         const name = 'test-project';
         const projectDir = join(testDir, name);
         const testOptions: CardsOptions = { projectPath: projectDir };
-        const result = await commandHandler.command(Cmd.create, ['project', prefix, name ], testOptions);
+        const result = await commandHandler.command(Cmd.create, ['project', name, prefix ], testOptions);
         try {
             await access(projectDir, fsConstants.R_OK);
         } catch (error) {
@@ -613,7 +613,7 @@ describe('create command', () => {
         const name = 'test-project';
         const testOptions: CardsOptions = { projectPath: path };
 
-        const result = await commandHandler.command(Cmd.create, ['project', prefix, name ], testOptions);
+        const result = await commandHandler.command(Cmd.create, ['project', name, prefix ], testOptions);
         try {
             // nodeJS does not automatically expand paths with tilde
             await access(resolveTilde(path), fsConstants.F_OK);


### PR DESCRIPTION
There was regression when `CommandHandler` interface was modified: `create project` parameters were flipped in the receiving end. 