### PR TITLE
INTDEV-365 Ensure that card array is returned when creating cards

### DIFF
--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -411,8 +411,8 @@ export class Commands {
             parentCardKey = '';
         }
         try {
-            await this.createCmd.createCard(path, templateName, parentCardKey);
-            return { statusCode: 200 };
+            const createdCards = await this.createCmd.createCard(path, templateName, parentCardKey);
+            return { statusCode: 200, message: `Created cards ${JSON.stringify(createdCards)}` };
         } catch (e) {
             return {statusCode: 400, message: errorFunction(e)};
         }

--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -46,7 +46,7 @@ export class Template extends CardContainer {
     //           Then rename the folder based on mapped names.
     //           Make 'card' item changed to write them to json file.
     //           Finally copy from temp to real place.
-    private async doCreateCards(cards: card[], parentCard?: card): Promise<string[]> {
+    private async doCreateCards(cards: card[], parentCard?: card): Promise<card[]> {
         const templateIDMap: mappingValue[] = [];
         const tempDestination = join(this.project.cardrootFolder, 'temp');
 
@@ -148,8 +148,7 @@ export class Template extends CardContainer {
                 throw new Error(error.message);
             }
         }
-        const createdCards = templateIDMap.map(item => item.to);
-        return createdCards;
+        return cards;
     }
 
     // fetches path to module.
@@ -328,7 +327,7 @@ export class Template extends CardContainer {
      * @param parentCard parent card
      * @returns array of created card keys
      */
-    public async createCards(parentCard?: card): Promise<string[]> {
+    public async createCards(parentCard?: card): Promise<card[]> {
         const cards = await this.cards('', { content: true, contentType: 'adoc', metadata: true, attachments: true });
         if (cards.length === 0) {
             throw new Error(`No cards in template '${this.containerName}'. Please add template cards with 'add' command first.`);

--- a/tools/data-handler/src/create.ts
+++ b/tools/data-handler/src/create.ts
@@ -163,8 +163,9 @@ export class Create extends EventEmitter {
      * @param {string} projectPath project path
      * @param {string} templateName name of a template to use
      * @param {string} parentCardKey (Optional) card-key of a parent card. If missing, cards are added to the cardroot.
+     * @returns array of card keys that were created.
      */
-    public async createCard(projectPath: string, templateName: string, parentCardKey: string) {
+    public async createCard(projectPath: string, templateName: string, parentCardKey: string): Promise<string[]> {
         // todo: should validator validate the whole schema before creating a new card to it?
         //       this might keep the integrity and consistency of the project more easily valid.
 
@@ -200,6 +201,7 @@ export class Create extends EventEmitter {
         if (createdCards.length > 0) {
             this.emit('created', createdCards);
         }
+        return createdCards.map(item => item.key);
     }
 
     /**


### PR DESCRIPTION
The return type of card creation was changed from `card[]` to `string[]` when `requestStatus` was dropped. 
This causes issues with emitting the changed cards for calculations. 

Switching the return value back to `card[]`.