### PR TITLE
Show fieldTypes in module details

### DIFF
--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -571,6 +571,7 @@ export class Project extends CardContainer {
                 // resources:
                 calculations: [...(await this.collectResourcesFromModules('calculations')).map(item => item.name)],
                 cardtypes: [...(await this.collectResourcesFromModules('cardtypes')).map(item => item.name)],
+                fieldtypes: [...(await this.collectResourcesFromModules('fieldtypes')).map(item => item.name)],
                 templates: [...(await this.collectResourcesFromModules('templates')).map(item => item.name)],
                 workflows: [...(await this.collectResourcesFromModules('workflows')).map(item => item.name)],
             }

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -19,11 +19,12 @@ export interface projectSettings {
     nextAvailableCardNumber: number
 }
 
-//
+// Module content
 export interface moduleSettings extends projectSettings {
     path: string
     cardtypes: string[]
     calculations: string[]
+    fieldtypes: string[]
     templates: string[]
     workflows: string[]
 }


### PR DESCRIPTION
Currently `show module` shows cards, card-types, calculations, templates, workflows and basic info on module.
Field-types are not shown.  Add these to the command output.