### PR TITLE
INTDEV-376 handle errors when using cli

### DIFF
--- a/tools/cli/bin/run
+++ b/tools/cli/bin/run
@@ -2,4 +2,7 @@
 
 import program from '@cyberismocom/cli';
 
-program.parse(process.argv);
+program.parseAsync(process.argv).catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -133,7 +133,9 @@ export class Commands {
     if (!path) {
       path = await Project.findProjectRoot(process.cwd());
       if (path === '') {
-        throw new Error('Unknown path');
+        throw new Error(
+          "If project path is not given, the command must be run inside a project's folder.",
+        );
         /*
                 // when sinon is used for testing, use this instead. Otherwise, cannot have unit tests that cause process exit.
                 console.error('No path defined - exiting');


### PR DESCRIPTION
CLI will now give a human readable message if it is run from a folder which is not the project root or inside of it