### PR TITLE
INTDEV-341 use same command format in export command

### DIFF
--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -11,7 +11,7 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Command, Option } from 'commander';
+import { Argument, Command } from 'commander';
 import {
   CardsOptions,
   Cmd,
@@ -288,11 +288,8 @@ program
 program
   .command('export')
   .description('Export a project or a card')
-  .argument('[cardkey]', 'Path to card')
-  .option('-o, --output [path]', 'Output path')
-  .option('-p, --project-path [path]', `${pathGuideline}`)
-  .addOption(
-    new Option('-f, --format <format>', 'Export format').choices([
+  .addArgument(
+    new Argument('<format>', 'Export format').choices([
       'adoc',
       'csv',
       'html',
@@ -300,10 +297,24 @@ program
       'site',
     ]),
   )
-  .action(async (cardkey: string, options: CardsOptions) => {
-    const result = await commandHandler.command(Cmd.export, [cardkey], options);
-    handleResponse(result);
-  });
+  .argument('<output>', 'Output path')
+  .argument('[cardkey]', 'Path to card')
+  .option('-p, --project-path [path]', `${pathGuideline}`)
+  .action(
+    async (
+      format: string,
+      output: string,
+      cardkey: string,
+      options: CardsOptions,
+    ) => {
+      const result = await commandHandler.command(
+        Cmd.export,
+        [format, output, cardkey],
+        options,
+      );
+      handleResponse(result);
+    },
+  );
 
 const importCmd = program.command('import');
 

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -276,13 +276,8 @@ export class Commands {
         return this.edit(cardkey, options);
       }
       if (command === Cmd.export) {
-        const [cardkey] = args;
-        return this.export(
-          options.output,
-          this.projectPath,
-          cardkey,
-          options.format,
-        );
+        const [format, output, cardkey] = args;
+        return this.export(output, this.projectPath, cardkey, format);
       }
       if (command === Cmd.import) {
         const target = args.splice(0, 1)[0];

--- a/tools/data-handler/src/export.ts
+++ b/tools/data-handler/src/export.ts
@@ -42,6 +42,7 @@ export class Export {
 
   // Finds card based on name.
   private findCard(path: string, cards: card[] | undefined) {
+    console.log('path', path, basename(path));
     return cards?.find((card) => card.key === basename(path));
   }
 

--- a/tools/data-handler/test/export.test.ts
+++ b/tools/data-handler/test/export.test.ts
@@ -51,16 +51,20 @@ describe('export command', () => {
     });
   });
   it('export to HTML (success)', async () => {
-    optionsMini.format = 'html';
-    optionsMini.output = join(testDirForExport, 'output');
-    const result = await commandHandler.command(Cmd.export, [], optionsMini);
+    const result = await commandHandler.command(
+      Cmd.export,
+      ['html', join(testDirForExport, 'output')],
+      optionsMini,
+    );
     expect(result.statusCode).to.equal(200);
   });
   it('export partial tree to HTML (success)', async () => {
     const card = 'decision_5';
-    options.format = 'html';
-    options.output = join(testDirForExport, 'output');
-    const result = await commandHandler.command(Cmd.export, [card], options);
+    const result = await commandHandler.command(
+      Cmd.export,
+      ['html', join(testDirForExport, 'output'), card],
+      options,
+    );
     expect(result.message).to.be.equal(undefined);
     expect(result.statusCode).to.equal(200);
   });


### PR DESCRIPTION
Before, the export command was using flags.  e.g. `cyberismo export -f site …`
After the change, parameters are given as arguments. e.g. `cyberismo export site output`