### PR TITLE
Add feature: attachments

### DIFF
--- a/tools/app/app/api/cards/[key]/a/[attachment]/route.tsx
+++ b/tools/app/app/api/cards/[key]/a/[attachment]/route.tsx
@@ -47,7 +47,7 @@ export async function GET(request: NextRequest) {
   }
 
   const urlComponents = request.nextUrl.pathname.split('/');
-  const filename = urlComponents?.pop();
+  const filename = decodeURI(urlComponents?.pop() || ''); // filename should unescaped
   urlComponents?.pop();
   const cardKey = urlComponents?.pop();
 
@@ -73,7 +73,10 @@ export async function GET(request: NextRequest) {
     const payload: attachmentPayload = attachmentResponse as attachmentPayload;
 
     return new NextResponse(payload.fileBuffer, {
-      headers: { 'content-type': payload.mimeType },
+      headers: {
+        'Content-Type': payload.mimeType,
+        'Content-Disposition': `attachment; filename="${filename}"`,
+      },
     });
   } catch (error) {
     return new NextResponse(

--- a/tools/app/app/api/cards/[key]/a/route.tsx
+++ b/tools/app/app/api/cards/[key]/a/route.tsx
@@ -1,0 +1,105 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { NextResponse } from 'next/server';
+import { Create } from '@cyberismocom/data-handler/create';
+import { Calculate } from '@cyberismocom/data-handler/calculate';
+import { Remove } from '@cyberismocom/data-handler/remove';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * @swagger
+ * /api/cards/{key}/a:
+ *   post:
+ *     summary: Used to upload an attachment to a card.
+ *     responses:
+ *       204:
+ *         description: Attachments uploaded successfully.
+ *       400:
+ *         description: Failed to upload attachment.
+ *       500:
+ *         description: project_path not set or other internal error
+ */
+export async function POST(
+  request: Request,
+  {
+    params,
+  }: {
+    params: {
+      key: string;
+    };
+  },
+) {
+  const projectPath = process.env.npm_config_project_path;
+  if (!projectPath) {
+    return new NextResponse('project_path environment variable not set.', {
+      status: 500,
+    });
+  }
+
+  const formData = await request.formData();
+  // get all the files from the form data
+  const files = await Promise.all(
+    formData
+      .getAll('file')
+      .filter((file) => file instanceof File)
+      .reduce<File[]>((files, file) => {
+        if (files.find((f) => f.name === file.name)) {
+          return files;
+        }
+        files.push(file);
+        return files;
+      }, [])
+      .map(async (file) => ({
+        name: file.name,
+        buffer: Buffer.from(await file.arrayBuffer()),
+      })),
+  );
+
+  const calc = new Calculate();
+  const createCommand = new Create(calc);
+  const removeCommand = new Remove(calc);
+
+  const succeeded = [];
+  let error: Error | null = null;
+  for (const file of files) {
+    try {
+      await createCommand.createAttachment(
+        params.key,
+        projectPath,
+        file.name,
+        file.buffer,
+      );
+      succeeded.push(file.name);
+    } catch (err) {
+      error =
+        err instanceof Error ? err : new Error('Failed to upload attachment.');
+      break;
+    }
+  }
+
+  if (error) {
+    for (const file of succeeded) {
+      try {
+        await removeCommand.remove(projectPath, 'attachment', params.key, file);
+      } catch (error) {
+        return new NextResponse('Failed to delete attachment.', {
+          status: 500,
+        });
+      }
+    }
+    return new NextResponse(error.message, { status: 400 });
+  }
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/tools/app/app/components/CardContextMenu.tsx
+++ b/tools/app/app/components/CardContextMenu.tsx
@@ -32,7 +32,12 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useModals } from '../lib/utils';
 import { useCard } from '../lib/api';
-import { MoveCardModal, DeleteModal, MetadataModal } from './modals';
+import {
+  MoveCardModal,
+  DeleteModal,
+  MetadataModal,
+  AddAttachmentModal,
+} from './modals';
 
 interface CardContextMenuProps {
   cardKey: string;
@@ -43,6 +48,7 @@ const CardContextMenu: React.FC<CardContextMenuProps> = ({ cardKey }) => {
     delete: false,
     move: false,
     metadata: false,
+    addAttachment: false,
   });
 
   const { t } = useTranslation();
@@ -62,6 +68,9 @@ const CardContextMenu: React.FC<CardContextMenuProps> = ({ cardKey }) => {
           <MenuItem onClick={openModal('move')}>
             <Typography>{t('move')}</Typography>
           </MenuItem>
+          <MenuItem onClick={openModal('addAttachment')}>
+            <Typography>{t('addAttachment')}</Typography>
+          </MenuItem>
         </Menu>
       </Dropdown>
 
@@ -78,6 +87,11 @@ const CardContextMenu: React.FC<CardContextMenuProps> = ({ cardKey }) => {
       <MetadataModal
         open={modalOpen.metadata}
         onClose={closeModal('metadata')}
+        cardKey={cardKey}
+      />
+      <AddAttachmentModal
+        open={modalOpen.addAttachment}
+        onClose={closeModal('addAttachment')}
         cardKey={cardKey}
       />
     </>

--- a/tools/app/app/components/ContentArea.tsx
+++ b/tools/app/app/components/ContentArea.tsx
@@ -46,12 +46,11 @@ export const ContentArea: React.FC<ContentAreaProps> = ({
   let htmlContent = Processor()
     .convert(asciidocContent, {
       safe: 'safe',
+      attributes: {
+        imagesdir: `/api/cards/${card.key}/a`,
+      },
     })
     .toString();
-
-  if (card.attachments) {
-    htmlContent = updateAttachmentLinks(htmlContent, card.attachments);
-  }
 
   // On scroll, check which document headers are visible and update the table of contents scrolling state
   const handleScroll = () => {
@@ -159,19 +158,4 @@ function renderTableOfContents(
       </div>
     </aside>
   );
-}
-
-function updateAttachmentLinks(
-  htmlContent: string,
-  attachments: CardAttachment[],
-): string {
-  attachments.forEach((attachment) => {
-    htmlContent = htmlContent
-      .replaceAll(`a/${attachment.fileName}`, attachment.fileName) // Remove imagesdir from links
-      .replaceAll(
-        attachment.fileName,
-        `/api/cards/${attachment.card}/a/${attachment.fileName}`,
-      ); // Add API path to attachment links
-  });
-  return htmlContent;
 }

--- a/tools/app/app/components/ContentToolbar.tsx
+++ b/tools/app/app/components/ContentToolbar.tsx
@@ -11,7 +11,7 @@
 */
 
 'use client';
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { Box, Button } from '@mui/joy';
 import EditIcon from '@mui/icons-material/Edit';
 import { ProjectBreadcrumbs } from './ProjectBreadcrumbs';
@@ -40,7 +40,7 @@ const ContentToolbar: React.FC<ContentToolbarProps> = ({
   const { t } = useTranslation();
 
   const { project } = useProject();
-  const { card, updateWorkFlowState } = useCard(cardKey);
+  const { card, updateWorkFlowState, isUpdating } = useCard(cardKey);
 
   const dispatch = useAppDispatch();
 
@@ -113,6 +113,7 @@ const ContentToolbar: React.FC<ContentToolbarProps> = ({
           aria-label="update"
           style={{ marginLeft: 16, minWidth: 80 }}
           onClick={onUpdate}
+          disabled={isUpdating}
         >
           {t('update')}
         </Button>

--- a/tools/app/app/components/DnDFile.tsx
+++ b/tools/app/app/components/DnDFile.tsx
@@ -1,0 +1,51 @@
+import { DragEventHandler, ReactNode, useState } from 'react';
+
+function DnDFile({
+  children,
+  onDrop,
+}: {
+  children: ({ isHovering }: { isHovering: boolean }) => ReactNode;
+  onDrop?: (files: FileList) => void;
+}) {
+  const [isHovering, setIsHovering] = useState<boolean>(false);
+
+  const handleDragLeave: DragEventHandler = (e) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = e.clientX;
+    const y = e.clientY;
+
+    if (
+      x <= rect.left ||
+      x >= rect.right ||
+      y <= rect.top ||
+      y >= rect.bottom
+    ) {
+      setIsHovering(false);
+    }
+  };
+
+  const handleDragEnter: DragEventHandler = (e) => {
+    setIsHovering(true);
+  };
+
+  const handleDrop: DragEventHandler = (e) => {
+    e.preventDefault();
+    setIsHovering(false);
+    if (onDrop && e.dataTransfer.files.length > 0) onDrop(e.dataTransfer.files);
+  };
+
+  return (
+    <div
+      onDragLeave={handleDragLeave}
+      onDragEnter={handleDragEnter}
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={handleDrop}
+    >
+      {children({
+        isHovering,
+      })}
+    </div>
+  );
+}
+
+export default DnDFile;

--- a/tools/app/app/components/modals/AddAttachmentModal.tsx
+++ b/tools/app/app/components/modals/AddAttachmentModal.tsx
@@ -46,7 +46,7 @@ export function AddAttachmentModal({
 
   const [files, setFiles] = React.useState<File[]>([]);
 
-  const { addAttachments } = useAttachments(cardKey);
+  const { addAttachments, isUpdating } = useAttachments(cardKey);
 
   const dispatch = useAppDispatch();
 
@@ -103,14 +103,31 @@ export function AddAttachmentModal({
               </Stack>
             )}
           </DnDFile>
-          {files.map((file) => (
-            <Box key={file.name} paddingY={2} paddingX={3}>
-              <Typography level="title-sm">{file.name}</Typography>
-            </Box>
-          ))}
+          <Typography level="body-sm">
+            {t('addAttachmentModal.acceptedFormats')}
+          </Typography>
+          <Box
+            sx={{
+              // make the box scrollable
+              overflowY: 'scroll',
+              scrollbarWidth: 'thin',
+            }}
+          >
+            {files.map((file) => (
+              <Box
+                key={file.name}
+                paddingY={2}
+                marginY={1}
+                paddingX={3}
+                bgcolor="white"
+              >
+                <Typography level="title-sm">{file.name}</Typography>
+              </Box>
+            ))}
+          </Box>
           <DialogActions>
             <Button
-              disabled={files.length === 0}
+              disabled={files.length === 0 || isUpdating}
               color="primary"
               onClick={async () => {
                 try {
@@ -121,6 +138,7 @@ export function AddAttachmentModal({
                       type: 'success',
                     }),
                   );
+                  onClose();
                   router.push(`/cards/${cardKey}/edit`);
                 } catch (error) {
                   dispatch(

--- a/tools/app/app/components/modals/AddAttachmentModal.tsx
+++ b/tools/app/app/components/modals/AddAttachmentModal.tsx
@@ -1,0 +1,152 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import React, { useEffect } from 'react';
+import {
+  Modal,
+  ModalDialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  ModalClose,
+  Stack,
+  Typography,
+  Box,
+} from '@mui/joy';
+import { useTranslation } from 'react-i18next';
+import DnDFile from '../DnDFile';
+import { useAttachments } from '@/app/lib/api/attachments';
+import { useAppDispatch } from '@/app/lib/hooks';
+import { addNotification } from '@/app/lib/slices/notifications';
+import { ApiCallError } from '@/app/lib/swr';
+import { useRouter } from 'next/navigation';
+
+interface AddAttachmentModalProps {
+  open: boolean;
+  onClose: () => void;
+  cardKey: string | null;
+}
+
+export function AddAttachmentModal({
+  open,
+  onClose,
+  cardKey,
+}: AddAttachmentModalProps) {
+  const { t } = useTranslation();
+
+  const [files, setFiles] = React.useState<File[]>([]);
+
+  const { addAttachments } = useAttachments(cardKey);
+
+  const dispatch = useAppDispatch();
+
+  const router = useRouter();
+
+  const addFiles = (newFiles: FileList) => {
+    // find files that are not already in the list
+    const newFilesArray = Array.from(newFiles);
+    const filteredFiles = newFilesArray.filter(
+      (newFile) => !files.find((file) => file.name === newFile.name),
+    );
+    setFiles([...files, ...filteredFiles]);
+  };
+
+  useEffect(() => {
+    setFiles([]);
+  }, [open]);
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <ModalDialog>
+        <ModalClose />
+        <DialogTitle>{t('addAttachmentModal.title')}</DialogTitle>
+        <DialogContent>
+          <DnDFile onDrop={(files) => addFiles(files)}>
+            {({ isHovering }) => (
+              <Stack
+                padding={10}
+                spacing={2}
+                borderRadius={20}
+                border={1}
+                alignItems="center"
+                borderColor="primary.outlinedBorder"
+                sx={{
+                  borderStyle: 'dashed',
+                  backgroundColor: isHovering
+                    ? 'primary.outlinedHoverBg'
+                    : 'transparent',
+                }}
+              >
+                <Typography>{t('addAttachmentModal.dragNdrop')}</Typography>
+                <Typography>{t('or')}</Typography>
+                <Button variant="outlined" component="label">
+                  {t('addAttachmentModal.browseFiles')}
+                  <input
+                    type="file"
+                    onChange={(e) => {
+                      if (e.target.files) addFiles(e.target.files);
+                    }}
+                    multiple
+                    hidden
+                  />
+                </Button>
+              </Stack>
+            )}
+          </DnDFile>
+          {files.map((file) => (
+            <Box key={file.name} paddingY={2} paddingX={3}>
+              <Typography level="title-sm">{file.name}</Typography>
+            </Box>
+          ))}
+          <DialogActions>
+            <Button
+              disabled={files.length === 0}
+              color="primary"
+              onClick={async () => {
+                try {
+                  await addAttachments(files);
+                  dispatch(
+                    addNotification({
+                      message: t('addAttachmentModal.success'),
+                      type: 'success',
+                    }),
+                  );
+                  router.push(`/cards/${cardKey}/edit`);
+                } catch (error) {
+                  dispatch(
+                    addNotification({
+                      message: t('addAttachmentModal.error', {
+                        error:
+                          error instanceof ApiCallError
+                            ? error.reason
+                            : t('addAttachmentModal.errorDefault'),
+                      }),
+                      type: 'error',
+                    }),
+                  );
+                }
+              }}
+            >
+              {t('add')}
+            </Button>
+            <Button onClick={onClose} variant="plain" color="neutral">
+              {t('cancel')}
+            </Button>
+          </DialogActions>
+        </DialogContent>
+      </ModalDialog>
+    </Modal>
+  );
+}
+
+export default AddAttachmentModal;

--- a/tools/app/app/components/modals/index.ts
+++ b/tools/app/app/components/modals/index.ts
@@ -14,3 +14,4 @@ export * from './DeleteModal';
 export * from './MoveCardModal';
 export * from './NewCardModal';
 export * from './MetadataModal';
+export * from './AddAttachmentModal';

--- a/tools/app/app/lib/api/actions/index.ts
+++ b/tools/app/app/lib/api/actions/index.ts
@@ -9,24 +9,4 @@
     You should have received a copy of the GNU Affero General Public
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-
-import useSWR, { SWRConfiguration } from 'swr';
-
-import { Resources, ResourceName, SwrResult } from './types';
-import { useUpdating } from '../hooks';
-
-export function useSWRHook<T extends ResourceName>(
-  swrKey: string | null,
-  name: T,
-  options?: SWRConfiguration,
-) {
-  const { data, ...rest } = useSWR<Resources[T]>(swrKey, options);
-  const { isUpdating, call } = useUpdating(swrKey);
-
-  return {
-    ...rest,
-    [name]: data || null,
-    isUpdating,
-    callUpdate: call,
-  } as SwrResult<T>;
-}
+export * from './attachments';

--- a/tools/app/app/lib/api/attachments.ts
+++ b/tools/app/app/lib/api/attachments.ts
@@ -1,0 +1,56 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { apiPaths } from '../swr';
+
+import useSWR, { SWRConfiguration } from 'swr';
+import { useCard } from './card';
+import { Attachment } from '../definitions';
+
+export const useAttachments = (
+  key: string | null,
+  options?: SWRConfiguration,
+) => {
+  const { card } = useCard(key, options);
+
+  options = {
+    ...options,
+    fetcher: (args: string[]) => {
+      return Promise.all(
+        args.map((url) => {
+          return fetch(url)
+            .then((res) => res.blob())
+            .then((data) => handleAttachment(url.split('/').pop() || '', data));
+        }),
+      );
+    },
+  };
+
+  const swrData = useSWR<Attachment[]>(
+    key != null && card
+      ? card?.attachments?.map((a) => apiPaths.attachment(key, a.fileName))
+      : null,
+    options,
+  );
+  return {
+    ...swrData,
+    attachments: swrData.data?.filter((a) => a != null) || [],
+  };
+};
+
+function handleAttachment(fileName: string, data: Blob) {
+  if (data.type.startsWith('image')) {
+    const image = URL.createObjectURL(data);
+    return { type: 'image', fileName, data, image };
+  }
+  return { type: 'file', fileName, data };
+}

--- a/tools/app/app/lib/api/attachments.ts
+++ b/tools/app/app/lib/api/attachments.ts
@@ -10,9 +10,9 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { apiPaths } from '../swr';
+import { apiPaths, callApi } from '../swr';
 
-import useSWR, { SWRConfiguration } from 'swr';
+import useSWR, { mutate, SWRConfiguration } from 'swr';
 import { useCard } from './card';
 import { Attachment } from '../definitions';
 
@@ -44,8 +44,16 @@ export const useAttachments = (
   return {
     ...swrData,
     attachments: swrData.data?.filter((a) => a != null) || [],
+    addAttachments: (files: File[]) => key && addAttachments(key, files),
   };
 };
+
+async function addAttachments(key: string, files: File[]) {
+  const formData = new FormData();
+  files.forEach((file) => formData.append('file', file));
+  await callApi(apiPaths.attachments(key), 'POST', formData);
+  mutate(apiPaths.card(key));
+}
 
 function handleAttachment(fileName: string, data: Blob) {
   if (data.type.startsWith('image')) {

--- a/tools/app/app/lib/api/card.ts
+++ b/tools/app/app/lib/api/card.ts
@@ -27,24 +27,30 @@ import { cardDeleted } from '../actions';
 
 export const useCard = (key: string | null, options?: SWRConfiguration) => {
   const dispatch = useAppDispatch();
+  const { callUpdate, ...rest } = useSWRHook(
+    key ? apiPaths.card(key) : null,
+    'card',
+    options,
+  );
+
   return {
-    ...useSWRHook(key ? apiPaths.card(key) : null, 'card', options),
+    ...rest,
     updateCard: async (update: CardUpdate) =>
-      (key && updateCard(key, update)) || null,
+      (key && (await callUpdate(() => updateCard(key, update)))) || null,
     deleteCard: async () => {
       if (!key) return;
-      await deleteCard(key);
+      await callUpdate(() => deleteCard(key));
       dispatch(cardDeleted(key));
     },
     createCard: async (template: string) =>
-      (key && createCard(key, template)) || null,
+      (key && (await callUpdate(() => createCard(key, template)))) || null,
     updateWorkFlowState: async (state: string) =>
       (key &&
-        updateCard(key, {
-          state: {
-            name: state,
-          },
-        })) ||
+        (await callUpdate(() =>
+          updateCard(key, {
+            state: { name: state },
+          }),
+        ))) ||
       null,
   };
 };

--- a/tools/app/app/lib/api/types.ts
+++ b/tools/app/app/lib/api/types.ts
@@ -28,9 +28,19 @@ export type Resources = {
 
 export type ResourceName = keyof Resources;
 
+export type AdditionalState = {
+  isUpdating: boolean;
+};
+
+export type AdditionalProperties = {
+  callUpdate: <T>(fn: () => Promise<T>) => Promise<T>;
+};
+
 export type SwrResult<T extends ResourceName> = {
   [key in T]: Resources[T] | null;
-} & Omit<SWRResponse<Resources[T]>, 'data'>;
+} & Omit<SWRResponse<Resources[T]>, 'data'> &
+  AdditionalProperties &
+  AdditionalState;
 
 export type FullCardUpdate = {
   content: string;

--- a/tools/app/app/lib/codemirror/index.ts
+++ b/tools/app/app/lib/codemirror/index.ts
@@ -1,3 +1,15 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import { EditorView } from '@uiw/react-codemirror';
 import { Attachment, CardAttachment } from '../definitions';
 import { apiPaths } from '../swr';
@@ -122,7 +134,7 @@ export function addAttachment(
     editor.dispatch({
       changes: {
         from: target,
-        insert: `${'\n'.repeat(2 - newLinesBefore)}image::${apiPaths.attachment(cardKey, attachment.fileName)}[]${hasNewLineAfter ? '' : '\n'}`,
+        insert: `${'\n'.repeat(2 - newLinesBefore)}image::${attachment.fileName}[]${hasNewLineAfter ? '' : '\n'}`,
       },
     });
   } else {

--- a/tools/app/app/lib/codemirror/index.ts
+++ b/tools/app/app/lib/codemirror/index.ts
@@ -1,0 +1,137 @@
+import { EditorView } from '@uiw/react-codemirror';
+import { Attachment, CardAttachment } from '../definitions';
+import { apiPaths } from '../swr';
+
+/**
+ * Counts the number of empty lines in the codemirror editor in the given direction
+ * @param editorView CodeMirror editor, can be obtained from the `useCodeMirror` hook or useRef
+ * @param direction The direction to count the empty lines, either 'up' or 'down'
+ * @param pos The position to start counting from
+ * @param countSelf Whether to count the current line if it is empty.
+ * @param maxCount The maximum number of empty lines to count
+ * @returns The number of empty lines in the given direction
+ */
+export function countEmptyLines(
+  editorView: EditorView,
+  direction: 'up' | 'down',
+  pos: number,
+  countSelf: boolean = false,
+  maxCount: number = 1,
+) {
+  const currentLine = editorView.state.doc.lineAt(pos);
+
+  const lineNumber = currentLine.number;
+
+  const current = currentLine.length === 0 && countSelf ? 1 : 0;
+
+  if (lineNumber === 1 && direction === 'up') {
+    return current;
+  }
+
+  if (lineNumber === editorView.state.doc.lines && direction === 'down') {
+    return current;
+  }
+
+  // if the current line is not empty and we are moving up, or if the current line is not empty and we are moving down
+  // then we should return 0
+  if (
+    (currentLine.length !== 0 &&
+      direction === 'up' &&
+      !isFirstChar(editorView, pos)) ||
+    (currentLine.length !== 0 &&
+      direction === 'down' &&
+      !isLastChar(editorView, pos))
+  ) {
+    return 0;
+  }
+
+  let count = 0;
+
+  let line = editorView.state.doc.line(
+    currentLine.number + (direction === 'up' ? -1 : 1),
+  );
+  while (line.length === 0 && count < maxCount) {
+    count++;
+
+    if (
+      (direction === 'up' && line.number === 1) ||
+      (direction === 'down' && line.number === editorView.state.doc.lines)
+    ) {
+      break;
+    }
+    line = editorView.state.doc.line(
+      line.number + (direction === 'up' ? -1 : 1),
+    );
+  }
+  return countSelf && count !== maxCount ? count + current : count;
+}
+
+/**
+ * Checks if the character at the given position is the given character
+ * @param view CodeMirror editor, can be obtained from the `useCodeMirror` hook or useRef
+ * @param char The character to check for
+ * @param position The position to check
+ * @returns True if the character at the given position is the given character and false otherwise
+ */
+export function hasCharAt(view: EditorView, char: string, position: number) {
+  const line = view.state.doc.lineAt(position);
+  return line.text[position - line.from] === char;
+}
+
+/**
+ * Returns true if the given position is the first character in the line
+ * @param view CodeMirror editor, can be obtained from the `useCodeMirror` hook or useRef
+ * @param position The position to check
+ * @returns True if the given position is the first character in the line and false otherwise
+ */
+export function isFirstChar(view: EditorView, position: number) {
+  const line = view.state.doc.lineAt(position);
+  return position === line.from;
+}
+
+/**
+ * Returns true if the given position is the last character in the line
+ * @param view CodeMirror editor, can be obtained from the `useCodeMirror` hook or useRef
+ * @param position The position to check
+ * @returns True if the given position is the last character in the line and false otherwise
+ */
+export function isLastChar(view: EditorView, position: number) {
+  const line = view.state.doc.lineAt(position);
+  return position === line.to;
+}
+
+/**
+ * Adds an attachment to the codemirror editor at the given position.
+ * Images are added as images and other types of files are added as links.
+ * @param editor The codemirror editor view
+ * @param attachment The attachment to add
+ * @param cardKey The key of the card that the attachment belongs to
+ */
+export function addAttachment(
+  editor: EditorView,
+  attachment: Attachment,
+  cardKey: string,
+) {
+  const target = editor.state.selection.main.to;
+
+  if (attachment.type === 'image') {
+    const newLinesBefore = countEmptyLines(editor, 'up', target, true, 2);
+
+    const hasNewLineAfter = countEmptyLines(editor, 'down', target, true, 1);
+    // image requires empty lines before and after
+    editor.dispatch({
+      changes: {
+        from: target,
+        insert: `${'\n'.repeat(2 - newLinesBefore)}image::${apiPaths.attachment(cardKey, attachment.fileName)}[]${hasNewLineAfter ? '' : '\n'}`,
+      },
+    });
+  } else {
+    // adds a space before and after the link if there is a character before or after the cursor
+    editor.dispatch({
+      changes: {
+        from: target,
+        insert: `${isFirstChar(editor, target) || hasCharAt(editor, ' ', target - 1) ? '' : ' '}link:${encodeURI(apiPaths.attachment(cardKey, attachment.fileName))}[${attachment.fileName}]${isLastChar(editor, target) || hasCharAt(editor, ' ', target) ? '' : ' '}`,
+      },
+    });
+  }
+}

--- a/tools/app/app/lib/codemirror/index.ts
+++ b/tools/app/app/lib/codemirror/index.ts
@@ -11,8 +11,8 @@
 */
 
 import { EditorView } from '@uiw/react-codemirror';
-import { Attachment, CardAttachment } from '../definitions';
 import { apiPaths } from '../swr';
+import { attachmentDetails } from '@cyberismocom/data-handler/interfaces/project-interfaces';
 
 /**
  * Counts the number of empty lines in the codemirror editor in the given direction
@@ -121,12 +121,12 @@ export function isLastChar(view: EditorView, position: number) {
  */
 export function addAttachment(
   editor: EditorView,
-  attachment: Attachment,
+  { fileName, mimeType }: attachmentDetails,
   cardKey: string,
 ) {
   const target = editor.state.selection.main.to;
 
-  if (attachment.type === 'image') {
+  if (mimeType?.startsWith('image')) {
     const newLinesBefore = countEmptyLines(editor, 'up', target, true, 2);
 
     const hasNewLineAfter = countEmptyLines(editor, 'down', target, true, 1);
@@ -134,7 +134,7 @@ export function addAttachment(
     editor.dispatch({
       changes: {
         from: target,
-        insert: `${'\n'.repeat(2 - newLinesBefore)}image::${attachment.fileName}[]${hasNewLineAfter ? '' : '\n'}`,
+        insert: `${'\n'.repeat(2 - newLinesBefore)}image::${fileName}[]${hasNewLineAfter ? '' : '\n'}`,
       },
     });
   } else {
@@ -142,7 +142,7 @@ export function addAttachment(
     editor.dispatch({
       changes: {
         from: target,
-        insert: `${isFirstChar(editor, target) || hasCharAt(editor, ' ', target - 1) ? '' : ' '}link:${encodeURI(apiPaths.attachment(cardKey, attachment.fileName))}[${attachment.fileName}]${isLastChar(editor, target) || hasCharAt(editor, ' ', target) ? '' : ' '}`,
+        insert: `${isFirstChar(editor, target) || hasCharAt(editor, ' ', target - 1) ? '' : '\n'}link:${encodeURI(apiPaths.attachment(cardKey, fileName))}[${fileName}]${isLastChar(editor, target) || hasCharAt(editor, ' ', target) ? '' : '\n'}`,
       },
     });
   }

--- a/tools/app/app/lib/definitions.ts
+++ b/tools/app/app/lib/definitions.ts
@@ -121,3 +121,10 @@ export interface FieldTypeDefinition {
   dataType: DataType;
   enumValues?: Array<EnumDefinition>;
 }
+
+export interface Attachment {
+  type: 'image' | 'file';
+  fileName: string;
+  data: Blob;
+  image?: string;
+}

--- a/tools/app/app/lib/definitions.ts
+++ b/tools/app/app/lib/definitions.ts
@@ -60,6 +60,7 @@ export interface CardAttachment {
   card: string;
   fileName: string;
   path: string;
+  mimeType: string;
 }
 
 export enum CardMode {
@@ -120,11 +121,4 @@ export interface FieldTypeDefinition {
   fieldDescription?: string;
   dataType: DataType;
   enumValues?: Array<EnumDefinition>;
-}
-
-export interface Attachment {
-  type: 'image' | 'file';
-  fileName: string;
-  data: Blob;
-  image?: string;
 }

--- a/tools/app/app/lib/hooks/redux.ts
+++ b/tools/app/app/lib/hooks/redux.ts
@@ -12,7 +12,33 @@
 
 import { useDispatch, useSelector, useStore } from 'react-redux';
 import type { RootState, AppDispatch, AppStore } from '../store';
+import { setIsUpdating } from '../slices/swr';
 
 export const useAppDispatch = useDispatch.withTypes<AppDispatch>();
 export const useAppSelector = useSelector.withTypes<RootState>();
 export const useAppStore = useStore.withTypes<AppStore>();
+
+/**
+ * A hook that calls isUpdating function automatically
+ * @param key - key that identifies the function
+ */
+export function useUpdating(key: string | null) {
+  const dispatch = useAppDispatch();
+
+  return {
+    isUpdating: useAppSelector(
+      (state) => (key && state.swr.additionalProps[key]?.isUpdating) || false,
+    ),
+    call: async <T>(fn: () => Promise<T>) => {
+      if (!key) {
+        return;
+      }
+      dispatch(setIsUpdating({ key, isUpdating: true }));
+      try {
+        return await fn();
+      } finally {
+        dispatch(setIsUpdating({ key, isUpdating: false }));
+      }
+    },
+  };
+}

--- a/tools/app/app/lib/slices/index.ts
+++ b/tools/app/app/lib/slices/index.ts
@@ -13,10 +13,12 @@
 import { combineReducers } from '@reduxjs/toolkit';
 import recentlyViewed from './recentlyViewed';
 import notifications from './notifications';
+import swr from './swr';
 
 const rootReducer = combineReducers({
   recentlyViewed,
   notifications,
+  swr,
 });
 
 export default rootReducer;

--- a/tools/app/app/lib/slices/swr.ts
+++ b/tools/app/app/lib/slices/swr.ts
@@ -1,0 +1,49 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { AdditionalState } from '../api/types';
+
+export interface SwrState {
+  additionalProps: Record<string, AdditionalState>; // stores additional state for swr hooks
+}
+
+export const initialState: SwrState = {
+  additionalProps: {},
+};
+
+export const swrSlice = createSlice({
+  name: 'swr',
+  initialState,
+  reducers: {
+    setIsUpdating(
+      state,
+      action: PayloadAction<{ key: string; isUpdating: boolean }>,
+    ) {
+      state.additionalProps[action.payload.key] = {
+        isUpdating: action.payload.isUpdating,
+      };
+    },
+  },
+  selectors: {
+    selectIsUpdating: (state, key: string | null): boolean => {
+      if (!key) return false;
+      return state.additionalProps[key]?.isUpdating || false;
+    },
+  },
+});
+
+export const { setIsUpdating } = swrSlice.actions;
+
+export const { selectIsUpdating } = swrSlice.selectors;
+
+export default swrSlice.reducer;

--- a/tools/app/app/lib/store.ts
+++ b/tools/app/app/lib/store.ts
@@ -27,7 +27,7 @@ import storage from 'redux-persist/lib/storage';
 const persistConfig = {
   key: 'root',
   storage,
-  blacklist: ['notifications'],
+  blacklist: ['notifications', 'swr'],
 };
 
 const persistedReducer = persistReducer(persistConfig, rootReducer);

--- a/tools/app/app/lib/swr.ts
+++ b/tools/app/app/lib/swr.ts
@@ -87,5 +87,4 @@ export const apiPaths = {
   templates: () => '/api/templates',
   attachment: (cardKey: string, attachment: string) =>
     `/api/cards/${cardKey}/a/${attachment}`,
-  attachments: (cardKey: string) => `/api/cards/${cardKey}/a`,
 };

--- a/tools/app/app/lib/swr.ts
+++ b/tools/app/app/lib/swr.ts
@@ -63,7 +63,7 @@ export async function callApi<T>(
 }
 
 // default fetcher for swr
-const fetcher = async function (...args: Parameters<typeof fetch>) {
+export const fetcher = async function (...args: Parameters<typeof fetch>) {
   return handleResponse(await fetch(...args));
 };
 
@@ -80,4 +80,6 @@ export const apiPaths = {
   fieldTypes: () => '/api/fieldtypes',
   cardType: (key: string) => `/api/cardtypes/${key}`,
   templates: () => '/api/templates',
+  attachment: (cardKey: string, attachment: string) =>
+    `/api/cards/${cardKey}/a/${attachment}`,
 };

--- a/tools/app/app/lib/utils.ts
+++ b/tools/app/app/lib/utils.ts
@@ -430,3 +430,20 @@ export function filterCards(
     return false;
   });
 }
+
+/**
+ * Calls a function with setIsUpdating set to true before and false after the function call
+ * @param setIsUpdating: function to call with true before and false after the function call
+ * @param func: function to call
+ */
+export async function withUpdating<T>(
+  setIsUpdating: (updating: boolean) => void,
+  func: () => Promise<T>,
+): Promise<T> {
+  try {
+    setIsUpdating(true);
+    return await func();
+  } finally {
+    setIsUpdating(false);
+  }
+}

--- a/tools/app/app/locales/en/translation.json
+++ b/tools/app/app/locales/en/translation.json
@@ -17,6 +17,13 @@
     "content_other": "Are you sure you want to delete the card <bold>\"{{card}}\"</bold> and the tree under it? This cannot be undone.",
     "content_one": "Are you sure you want to delete the card <bold>\"{{card}}\"</bold>? This cannot be undone."
   },
+  "addAttachmentModal": {
+    "title": "Add Attachment",
+    "dragNdrop": "Drag and drop your files here",
+    "browseFiles": "Browse files",
+    "error": "Error uploading file: {{error}}",
+    "success": "Attachment(s) added successfully"
+  },
   "createCardModal": {
     "success": "Card created successfully"
   },
@@ -53,6 +60,7 @@
   "create": "Create",
   "no": "No",
   "yes": "Yes",
+  "or": "or",
   "createUnder": "Create under \"{{parent}}\"",
   "viewedAgo": "Viewed {{time}} ago",
   "lastTransitioned": "Last Transitioned",
@@ -64,5 +72,7 @@
     "status": "Status: {{state}}"
   },
   "none": "None",
-  "attachments": "Attachments"
+  "attachments": "Attachments",
+  "addAttachment": "Add Attachment",
+  "add": "Add"
 }

--- a/tools/app/app/locales/en/translation.json
+++ b/tools/app/app/locales/en/translation.json
@@ -63,5 +63,6 @@
   "stateSelector": {
     "status": "Status: {{state}}"
   },
-  "none": "None"
+  "none": "None",
+  "attachments": "Attachments"
 }

--- a/tools/app/app/locales/en/translation.json
+++ b/tools/app/app/locales/en/translation.json
@@ -22,7 +22,8 @@
     "dragNdrop": "Drag and drop your files here",
     "browseFiles": "Browse files",
     "error": "Error uploading file: {{error}}",
-    "success": "Attachment(s) added successfully"
+    "success": "Attachment(s) added successfully",
+    "acceptedFormats": "Accepted file types: ..."
   },
   "createCardModal": {
     "success": "Card created successfully"

--- a/tools/data-handler/src/containers/card-container.ts
+++ b/tools/data-handler/src/containers/card-container.ts
@@ -29,6 +29,8 @@ import {
 // asciidoctor
 import asciidoctor from '@asciidoctor/core';
 
+import mime from 'mime-types';
+
 /**
  * Card container base class. Used for both Project and Template.
  * Contains common card-related functionality.
@@ -201,6 +203,7 @@ export class CardContainer {
               card: cardItem,
               fileName: attachment.name,
               path: attachment.path,
+              mimeType: mime.lookup(attachment.name) || null,
             }),
           );
           if (pathExists(childrenFolder)) {

--- a/tools/data-handler/src/create.ts
+++ b/tools/data-handler/src/create.ts
@@ -204,12 +204,14 @@ export class Create extends EventEmitter {
    * Adds an attachment to a card.
    * @param {string} cardKey card ID
    * @param {string} projectPath path to a project
-   * @param {string} attachment path to an attachment
+   * @param {string} attachment path to an attachment file or attachment name if buffer is defined
+   * @param {Buffer} buffer (Optional) attachment buffer
    */
   public async createAttachment(
     cardKey: string,
     projectPath: string,
     attachment: string,
+    buffer?: Buffer,
   ) {
     const project = new Project(projectPath);
     const attachmentFolder = await project.cardAttachmentFolder(cardKey);
@@ -224,10 +226,17 @@ export class Create extends EventEmitter {
 
     try {
       await mkdir(attachmentFolder, { recursive: true }).then(async () => {
-        return await copyFile(
-          attachment,
+        if (!buffer) {
+          return await copyFile(
+            attachment,
+            join(attachmentFolder, basename(attachment)),
+            fsConstants.COPYFILE_EXCL,
+          );
+        }
+        return await writeFile(
           join(attachmentFolder, basename(attachment)),
-          fsConstants.COPYFILE_EXCL,
+          buffer,
+          { flag: 'wx' },
         );
       });
     } catch (error) {

--- a/tools/data-handler/src/export.ts
+++ b/tools/data-handler/src/export.ts
@@ -33,6 +33,8 @@ import { readADocFileSync, readJsonFileSync } from './utils/json.js';
 // asciidoctor
 import Processor from '@asciidoctor/core';
 
+import mime from 'mime-types';
+
 const attachmentFolder: string = 'a';
 
 export class Export {
@@ -117,6 +119,7 @@ export class Export {
               card: found.key,
               fileName: entry.name,
               path: entry.path,
+              mimeType: mime.lookup(entry.name) || null,
             });
           } else {
             console.error(

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -183,6 +183,7 @@ export interface attachmentDetails {
   card: string;
   path: string;
   fileName: string;
+  mimeType: string | null;
 }
 
 // Name for a card (consists of prefix and running number; e.g. 'test_1')


### PR DESCRIPTION
Attachments can be added, inserted to adoc and deleted.
Attachments are assumed to be either files or images. Images are shown while files can be downloaded.

I also tried server functions in this commit. I think we should continue to use them, if there is no reason not to(=Do we need an external api, I think)