### PR TITLE
Rank for cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2391,6 +2391,11 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "dev": true
     },
+    "node_modules/@juggle/resize-observer": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
+    },
     "node_modules/@lezer/common": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.1.tgz",
@@ -3110,6 +3115,21 @@
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
+    },
+    "node_modules/@react-dnd/asap": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-4.0.1.tgz",
+      "integrity": "sha512-kLy0PJDDwvwwTXxqTFNAAllPHD73AycE9ypWeln/IguoGBEbvFcPDbCV03G52bEcC5E+YgupBE0VzHGdC8SIXg=="
+    },
+    "node_modules/@react-dnd/invariant": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-2.0.0.tgz",
+      "integrity": "sha512-xL4RCQBCBDJ+GRwKTFhGUW8GXa4yoDfJrPbLblc3U09ciS+9ZJXJ3Qrcs/x2IODOdIE5kQxvMmE2UKyqUictUw=="
+    },
+    "node_modules/@react-dnd/shallowequal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-2.0.0.tgz",
+      "integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg=="
     },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.2.5",
@@ -4116,7 +4136,7 @@
       "version": "20.12.12",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
       "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -6593,6 +6613,24 @@
       },
       "engines": {
         "node": ">=10.0"
+      }
+    },
+    "node_modules/dnd-core": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-14.0.1.tgz",
+      "integrity": "sha512-+PVS2VPTgKFPYWo3vAFEA8WPbTf7/xo43TifH9G8S1KqnrQu0o77A3unrF5yOugy4mIz7K5wAVFHUcha7wsz6A==",
+      "dependencies": {
+        "@react-dnd/asap": "^4.0.0",
+        "@react-dnd/invariant": "^2.0.0",
+        "redux": "^4.1.1"
+      }
+    },
+    "node_modules/dnd-core/node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/doctrine": {
@@ -12121,6 +12159,11 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -14059,6 +14102,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-arborist": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/react-arborist/-/react-arborist-3.4.0.tgz",
+      "integrity": "sha512-QI46oRGXJr0oaQfqqVobIiIoqPp5Y5gM69D2A2P7uHVif+X75XWnScR5drC7YDKgJ4CXVaDeFwnYKOWRRfncMg==",
+      "dependencies": {
+        "react-dnd": "^14.0.3",
+        "react-dnd-html5-backend": "^14.0.3",
+        "react-window": "^1.8.10",
+        "redux": "^5.0.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14",
+        "react-dom": ">= 16.14"
+      }
+    },
     "node_modules/react-copy-to-clipboard": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.1.0.tgz",
@@ -14083,6 +14142,43 @@
       },
       "peerDependencies": {
         "react": "^15.3.0 || 16 || 17 || 18"
+      }
+    },
+    "node_modules/react-dnd": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-14.0.5.tgz",
+      "integrity": "sha512-9i1jSgbyVw0ELlEVt/NkCUkxy1hmhJOkePoCH713u75vzHGyXhPDm28oLfc2NMSBjZRM1Y+wRjHXJT3sPrTy+A==",
+      "dependencies": {
+        "@react-dnd/invariant": "^2.0.0",
+        "@react-dnd/shallowequal": "^2.0.0",
+        "dnd-core": "14.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "@types/hoist-non-react-statics": ">= 3.3.1",
+        "@types/node": ">= 12",
+        "@types/react": ">= 16",
+        "react": ">= 16.14"
+      },
+      "peerDependenciesMeta": {
+        "@types/hoist-non-react-statics": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-dnd-html5-backend": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-14.1.0.tgz",
+      "integrity": "sha512-6ONeqEC3XKVf4eVmMTe0oPds+c5B9Foyj8p/ZKLb7kL2qh9COYxiBHv3szd6gztqi/efkmriywLUVlPotqoJyw==",
+      "dependencies": {
+        "dnd-core": "14.0.1"
       }
     },
     "node_modules/react-dom": {
@@ -14221,6 +14317,22 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.10",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.10.tgz",
+      "integrity": "sha512-Y0Cx+dnU6NLa5/EvoHukUD0BklJ8qITCtVEPY1C/nL8wwoZ0b5aEw8Ff1dOVHw7fCzMt55XfJDd8S8W8LCaUCg==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/readable-stream": {
@@ -16358,7 +16470,7 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/unique-stream": {
       "version": "2.3.1",
@@ -16438,6 +16550,18 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-resize-observer": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-9.1.0.tgz",
+      "integrity": "sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==",
+      "dependencies": {
+        "@juggle/resize-observer": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": "16.8.0 - 18",
+        "react-dom": "16.8.0 - 18"
       }
     },
     "node_modules/use-sync-external-store": {
@@ -17298,12 +17422,14 @@
         "next": "14.1.1",
         "node-html-parser": "^6.1.13",
         "react": "^18",
+        "react-arborist": "^3.4.0",
         "react-dom": "^18",
         "react-hook-form": "^7.51.5",
         "react-i18next": "^14.1.2",
         "react-redux": "^9.1.2",
         "redux-persist": "^6.0.0",
-        "swr": "^2.2.5"
+        "swr": "^2.2.5",
+        "use-resize-observer": "^9.1.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.2",

--- a/tools/app/__tests__/components.test.tsx
+++ b/tools/app/__tests__/components.test.tsx
@@ -6,6 +6,12 @@ import StateSelector from '@/app/components/StateSelector';
 import { workflowCategory } from '../../data-handler/src/interfaces/project-interfaces';
 import { useTranslation } from 'react-i18next';
 
+// mock resize observer
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
 // Mock useRouter:
 jest.mock('next/navigation', () => ({
   useRouter() {
@@ -43,9 +49,9 @@ describe('TreeMenu', () => {
         selectedCardKey={'USDL-46'}
       />,
     );
-    const node = screen.getByText('Demand phase').parentNode;
+    const node = screen.getByText('Demand phase').parentNode?.parentNode;
     expect(node).toBeVisible();
-    expect(node).toHaveClass('Mui-selected');
+    expect(node).toHaveAttribute('aria-selected', 'true');
   });
 });
 

--- a/tools/app/app/api/cards/[key]/route.tsx
+++ b/tools/app/app/api/cards/[key]/route.tsx
@@ -180,12 +180,20 @@ export async function PUT(request: NextRequest) {
       if (error instanceof Error) errors.push(error.message);
     }
   }
+  if (res.index != null) {
+    const moveCommand = new Move();
+    try {
+      await moveCommand.rankByIndex(projectPath, key, res.index);
+      successes++;
+    } catch (error) {
+      if (error instanceof Error) errors.push(error.message);
+    }
+  }
 
   // TODO add other update options here
 
   // contentType defaults to adoc if not set
   const contentType = request.nextUrl.searchParams.get('contentType') ?? 'adoc';
-
   if (errors.length > 0 && successes == 0) {
     // All updates failed
     return new NextResponse(errors.join('\n'), { status: 400 });

--- a/tools/app/app/cards/[key]/edit/page.tsx
+++ b/tools/app/app/cards/[key]/edit/page.tsx
@@ -117,19 +117,6 @@ function AttachmentPreviewCard({
     </Card>
   );
 }
-/**
- * 
- * @param param0 
-          <Button
-            disabled={isUpdating}
-            onClick={async () => {
-              await removeAttachment(name);
-            }}
-          >
-            Hi
-          </Button>
- * @returns 
- */
 
 export default function Page({ params }: { params: { key: string } }) {
   const { t } = useTranslation();

--- a/tools/app/app/components/DnDFile.tsx
+++ b/tools/app/app/components/DnDFile.tsx
@@ -1,3 +1,14 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
 import { DragEventHandler, ReactNode, useState } from 'react';
 
 function DnDFile({

--- a/tools/app/app/components/TreeMenu.tsx
+++ b/tools/app/app/components/TreeMenu.tsx
@@ -108,7 +108,7 @@ export const TreeMenu: React.FC<TreeMenuProps> = ({
           idAccessor={(node) => node.key}
           selection={selectedCardKey || undefined}
           indent={30}
-          width={width}
+          width={(width || 0) - 1}
           onMove={(n) => {
             if (onMove && n.dragIds.length === 1) {
               onMove(n.dragIds[0], n.parentId ?? 'root', n.index);

--- a/tools/app/app/components/TreeMenu.tsx
+++ b/tools/app/app/components/TreeMenu.tsx
@@ -53,8 +53,7 @@ const renderTree = ({ node, style, dragHandle }: NodeRendererProps<Card>) => (
         }}
       />
     )}
-    <Typography level="body-md" noWrap>
-      {' '}
+    <Typography level="title-sm" noWrap alignSelf="center">
       {node.data.metadata?.summary ?? node.data.key}
     </Typography>
   </Box>
@@ -89,12 +88,16 @@ export const TreeMenu: React.FC<TreeMenuProps> = ({
     });
   };
   return (
-    <Stack padding={2} bgcolor="#f0f0f0" height="100%" width="100%">
+    <Stack
+      paddingTop={2}
+      paddingLeft={2}
+      bgcolor="#f0f0f0"
+      height="100%"
+      width="100%"
+    >
       <Typography level="h4">{title}</Typography>
       <Box
         sx={{
-          overflowY: 'scroll',
-          scrollbarWidth: 'thin',
           flexGrow: 1,
         }}
         ref={ref}
@@ -107,8 +110,9 @@ export const TreeMenu: React.FC<TreeMenuProps> = ({
           }
           idAccessor={(node) => node.key}
           selection={selectedCardKey || undefined}
-          indent={30}
+          indent={24}
           width={(width || 0) - 1}
+          height={height}
           onMove={(n) => {
             if (onMove && n.dragIds.length === 1) {
               onMove(n.dragIds[0], n.parentId ?? 'root', n.index);

--- a/tools/app/app/components/TreeMenu.tsx
+++ b/tools/app/app/components/TreeMenu.tsx
@@ -11,21 +11,22 @@
 */
 
 'use client';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Card } from '../lib/definitions';
-import { TreeView } from '@mui/x-tree-view/TreeView';
-import { TreeItem } from '@mui/x-tree-view/TreeItem';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
-import { findPathTo } from '../lib/utils';
-import { Stack, Typography } from '@mui/joy';
+import { findCard, findParentCard } from '../lib/utils';
+import { Box, Stack, Typography } from '@mui/joy';
 import { sortItems } from '@cyberismocom/data-handler/utils/lexorank';
+import { Tree, NodeRendererProps } from 'react-arborist';
+import useResizeObserver from 'use-resize-observer';
+import { updateCard } from '../lib/api';
 
 type TreeMenuProps = {
   title: string;
   cards: Card[];
   selectedCardKey: string | null;
   onCardSelect?: (cardKey: string) => void;
+  onMove?: (card: string, newParent: string, index: number) => void;
 };
 
 // since we aren't using buckets, 1 means that missing ranks will be last
@@ -33,19 +34,30 @@ function rankGetter(card: Card) {
   return card.metadata?.rank || '1|z';
 }
 
-const renderTree = (nodes: Card, handleClick: (cardKey: string) => void) => (
-  <TreeItem
-    key={nodes.key}
-    nodeId={nodes.key}
-    onClick={() => handleClick(nodes.key)}
-    label={nodes.metadata?.summary ?? nodes.key}
+const renderTree = ({ node, style, dragHandle }: NodeRendererProps<Card>) => (
+  <Box
+    style={style}
+    ref={dragHandle}
+    onClick={() => {
+      node.toggle();
+    }}
+    alignContent="center"
+    display="flex"
+    bgcolor={node.isSelected ? 'primary.softActiveBg' : 'transparent'}
   >
-    {Array.isArray(nodes.children)
-      ? sortItems(nodes.children, rankGetter).map((node) =>
-          renderTree(node, handleClick),
-        )
-      : null}
-  </TreeItem>
+    {node.data.children && node.data.children.length > 0 && (
+      <ExpandMoreIcon
+        sx={{
+          // direction is down if open, right if closed
+          transform: node.isOpen ? 'rotate(0deg)' : 'rotate(-90deg)',
+        }}
+      />
+    )}
+    <Typography level="body-md" noWrap>
+      {' '}
+      {node.data.metadata?.summary ?? node.data.key}
+    </Typography>
+  </Box>
 );
 
 export const TreeMenu: React.FC<TreeMenuProps> = ({
@@ -54,47 +66,58 @@ export const TreeMenu: React.FC<TreeMenuProps> = ({
   title,
   onCardSelect,
 }) => {
-  const [expanded, setExpanded] = React.useState<string[]>([]);
+  const { ref, width, height } = useResizeObserver();
 
-  // Expand the tree until selected node is visible OR expand the first level of the tree if no selection
-  useEffect(() => {
-    const defaultExpanded = selectedCardKey
-      ? findPathTo(selectedCardKey, cards)?.map((card) => card.key) ?? []
-      : cards.map((card) => card.key);
-    setExpanded(defaultExpanded);
-  }, [selectedCardKey, cards]);
+  // sort card at all levels
+  const sortCards = (cards: Card[]): Card[] => {
+    return sortItems(cards, rankGetter).map((card) => {
+      if (card.children) {
+        card.children = sortCards(card.children);
+      }
+      return card;
+    });
+  };
+  cards = sortCards(cards);
 
+  const onMove = async (cardKey: string, newParent: string, index: number) => {
+    const card = findCard(cards, cardKey);
+    if (!card) return;
+    const parent = findParentCard(cards, cardKey);
+    await updateCard(cardKey, {
+      parent: newParent === parent?.key ? undefined : newParent,
+      index,
+    });
+  };
   return (
     <Stack padding={2} bgcolor="#f0f0f0" height="100%" width="100%">
       <Typography level="h4">{title}</Typography>
-      <TreeView
-        defaultCollapseIcon={<ExpandMoreIcon />}
-        defaultExpandIcon={<ChevronRightIcon />}
-        expanded={expanded}
-        selected={selectedCardKey}
-        onNodeToggle={(_, nodes) => {
-          setExpanded(nodes);
-        }}
+      <Box
         sx={{
-          '& .MuiTreeItem-root': {
-            mt: '6px', // Adds margin at the bottom of each TreeItem
-            '& .MuiTreeItem-iconContainer': {
-              marginRight: '2px',
-            },
-          },
-          '& .MuiTreeItem-label': {
-            fontSize: '1.0em',
-            lineHeight: '1.3em',
-          },
           overflowY: 'scroll',
           scrollbarWidth: 'thin',
           flexGrow: 1,
         }}
+        ref={ref}
       >
-        {sortItems(cards, rankGetter).map((treeItem) =>
-          renderTree(treeItem, onCardSelect || (() => {})),
-        )}
-      </TreeView>
+        <Tree
+          data={cards}
+          openByDefault={false}
+          onSelect={(nodes) =>
+            nodes.length > 0 && onCardSelect && onCardSelect(nodes[0].data.key)
+          }
+          idAccessor={(node) => node.key}
+          selection={selectedCardKey || undefined}
+          indent={30}
+          width={width}
+          onMove={(n) => {
+            if (onMove && n.dragIds.length === 1) {
+              onMove(n.dragIds[0], n.parentId ?? 'root', n.index);
+            }
+          }}
+        >
+          {renderTree}
+        </Tree>
+      </Box>
     </Stack>
   );
 };

--- a/tools/app/app/components/TreeMenu.tsx
+++ b/tools/app/app/components/TreeMenu.tsx
@@ -19,6 +19,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { findPathTo } from '../lib/utils';
 import { Stack, Typography } from '@mui/joy';
+import { sortItems } from '@cyberismocom/data-handler/utils/lexorank';
 
 type TreeMenuProps = {
   title: string;
@@ -26,6 +27,11 @@ type TreeMenuProps = {
   selectedCardKey: string | null;
   onCardSelect?: (cardKey: string) => void;
 };
+
+// since we aren't using buckets, 1 means that missing ranks will be last
+function rankGetter(card: Card) {
+  return card.metadata?.rank || '1|z';
+}
 
 const renderTree = (nodes: Card, handleClick: (cardKey: string) => void) => (
   <TreeItem
@@ -35,7 +41,9 @@ const renderTree = (nodes: Card, handleClick: (cardKey: string) => void) => (
     label={nodes.metadata?.summary ?? nodes.key}
   >
     {Array.isArray(nodes.children)
-      ? nodes.children.map((node) => renderTree(node, handleClick))
+      ? sortItems(nodes.children, rankGetter).map((node) =>
+          renderTree(node, handleClick),
+        )
       : null}
   </TreeItem>
 );
@@ -83,7 +91,7 @@ export const TreeMenu: React.FC<TreeMenuProps> = ({
           flexGrow: 1,
         }}
       >
-        {cards.map((treeItem) =>
+        {sortItems(cards, rankGetter).map((treeItem) =>
           renderTree(treeItem, onCardSelect || (() => {})),
         )}
       </TreeView>

--- a/tools/app/app/lib/api/card.ts
+++ b/tools/app/app/lib/api/card.ts
@@ -62,22 +62,7 @@ export async function updateCard(key: string, cardUpdate: CardUpdate) {
   // revalidation not needed since api returns the updated card
   mutate(swrKey, result, false);
 
-  mutate(
-    apiPaths.project(),
-    (project: Project | undefined) => {
-      if (!project) return project;
-      let cards = editCardDetails(deepCopy(project.cards), result);
-
-      if (cardUpdate.parent) {
-        cards = moveCard(cards, key, cardUpdate.parent);
-      }
-      return {
-        ...project,
-        cards,
-      };
-    },
-    false,
-  );
+  mutate(apiPaths.project());
 }
 
 export async function deleteCard(key: string) {

--- a/tools/app/app/lib/api/types.ts
+++ b/tools/app/app/lib/api/types.ts
@@ -47,6 +47,7 @@ export type FullCardUpdate = {
   metadata: Record<string, any>;
   state: { name: string };
   parent: string;
+  index: number;
 };
 
 export type CardUpdate = Partial<FullCardUpdate>;

--- a/tools/app/app/lib/definitions.ts
+++ b/tools/app/app/lib/definitions.ts
@@ -52,6 +52,7 @@ export type CardMetadata = {
   summary: string;
   workflowState: string;
   cardtype: string;
+  rank: string;
 } & Record<string, MetadataValue>;
 
 export type MetadataValue = string | number | boolean | Date | string[] | null;

--- a/tools/app/app/lib/utils.ts
+++ b/tools/app/app/lib/utils.ts
@@ -318,17 +318,18 @@ export function moveCard(
   const parent = findParentCard(cards, cardKey);
 
   const newParent = findCard(cards, newParentKey);
-  if (!newParent) {
-    return cards;
-  }
   if (parent) {
     parent.children =
       parent.children?.filter((child) => child.key !== cardKey) || [];
   } else {
     cards = cards.filter((c) => c.key !== cardKey);
   }
-  newParent.children = newParent.children || [];
-  newParent.children.push(card);
+  if (newParent) {
+    newParent.children = newParent.children || [];
+    newParent.children.push(card);
+  } else {
+    cards.push(card);
+  }
   return cards;
 }
 

--- a/tools/app/package.json
+++ b/tools/app/package.json
@@ -28,12 +28,14 @@
     "next": "14.1.1",
     "node-html-parser": "^6.1.13",
     "react": "^18",
+    "react-arborist": "^3.4.0",
     "react-dom": "^18",
     "react-hook-form": "^7.51.5",
     "react-i18next": "^14.1.2",
     "react-redux": "^9.1.2",
     "redux-persist": "^6.0.0",
-    "swr": "^2.2.5"
+    "swr": "^2.2.5",
+    "use-resize-observer": "^9.1.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.2",

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -378,6 +378,47 @@ program
     },
   );
 
+const rank = program.command('rank');
+
+rank
+  .command('card')
+  .description('Set the rank of a card to be after another card')
+  .argument('<cardKey>', 'Cardkey of the card to be moved')
+  .argument(
+    '<afterCardKey>',
+    'Cardkey of the card that the card should be after',
+  )
+  .option('-p, --project-path [path]', `${pathGuideline}`)
+  .action(
+    async (cardKey: string, afterCardKey: string, options: CardsOptions) => {
+      const result = await commandHandler.command(
+        Cmd.rank,
+        ['card', cardKey, afterCardKey],
+        options,
+      );
+      handleResponse(result);
+    },
+  );
+
+rank
+  .command('rebalance')
+  .description(
+    'Rebalance the rank of all cards in the project. Can be also used, if ranks do not exist',
+  )
+  .argument(
+    '[parentCardKey]',
+    'if null, rebalance the whole project, otherwise rebalance only the direct children of the cardkey',
+  )
+  .option('-p, --project-path [path]', `${pathGuideline}`)
+  .action(async (cardKey: string, options: CardsOptions) => {
+    const result = await commandHandler.command(
+      Cmd.rank,
+      ['rebalance', cardKey],
+      options,
+    );
+    handleResponse(result);
+  });
+
 // Remove command
 program
   .command('remove')

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -57,6 +57,7 @@ export enum Cmd {
   start = 'start',
   transition = 'transition',
   validate = 'validate',
+  rank = 'rank',
 }
 
 /**
@@ -297,6 +298,31 @@ export class Commands {
           return { statusCode: 200 };
         } catch (error) {
           return { statusCode: 400, message: errorFunction(error) };
+        }
+      }
+      if (command === Cmd.rank) {
+        const target = args.splice(0, 1)[0];
+        if (target === 'card') {
+          const [card, before] = args;
+          try {
+            await this.moveCmd.rankCard(this.projectPath, card, before);
+            return { statusCode: 200 };
+          } catch (e) {
+            return { statusCode: 400, message: errorFunction(e) };
+          }
+        }
+        if (target === 'rebalance') {
+          const [cardKey] = args;
+          try {
+            if (cardKey) {
+              this.moveCmd.rebalanceChildren(this.projectPath, cardKey);
+            } else {
+              await this.moveCmd.rebalanceProject(this.projectPath);
+            }
+            return { statusCode: 200 };
+          } catch (e) {
+            return { statusCode: 400, message: errorFunction(e) };
+          }
         }
       }
       if (command === Cmd.remove) {

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -305,7 +305,11 @@ export class Commands {
         if (target === 'card') {
           const [card, before] = args;
           try {
-            await this.moveCmd.rankCard(this.projectPath, card, before);
+            if (before === 'first') {
+              await this.moveCmd.rankFirst(this.projectPath, card);
+            } else {
+              await this.moveCmd.rankCard(this.projectPath, card, before);
+            }
             return { statusCode: 200 };
           } catch (e) {
             return { statusCode: 400, message: errorFunction(e) };

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -914,7 +914,9 @@ export class Project extends CardContainer {
       throw new Error(`Card '${cardKey}' does not exist in the project`);
     }
 
-    const validCard = await this.validateCard(card);
+    const validCard = Project.isTemplateCard(card)
+      ? ''
+      : await this.validateCard(card);
     if (validCard.length !== 0) {
       throw new Error(`Card '${cardKey}' is not valid! ${validCard}`);
     }

--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -31,7 +31,12 @@ import { Project } from './project.js';
 
 // Base class
 import { CardContainer } from './card-container.js';
-import { EMPTY_RANK, getRankAfter, sortItems } from '../utils/lexorank.js';
+import {
+  EMPTY_RANK,
+  FIRST_RANK,
+  getRankAfter,
+  sortItems,
+} from '../utils/lexorank.js';
 
 // Simple mapping table for card instantiation
 interface mappingValue {
@@ -87,15 +92,19 @@ export class Template extends CardContainer {
 
     // find parent cards
     // here we want to insert the cards after the last card, but not after a card that has no rank
+    // for clarity: These are the "root" template cards
     const parentCards = sortItems(
       cards.filter((c) => c.parent === this.containerName),
       (c) => c?.metadata?.rank || '',
     );
 
     // If parent card is not defined, then we are creating top-level cards.
-    const futureSiblings = parentCard
-      ? parentCard.children || []
-      : await this.project.showProjectCards();
+    // also filter out cards that have no rank
+    const futureSiblings = (
+      parentCard
+        ? parentCard.children || []
+        : await this.project.showProjectCards()
+    ).filter((c) => c.metadata?.rank !== undefined);
 
     let latestRank = sortItems(
       futureSiblings,
@@ -103,7 +112,7 @@ export class Template extends CardContainer {
     ).pop()?.metadata?.rank;
 
     if (!latestRank) {
-      latestRank = EMPTY_RANK;
+      latestRank = FIRST_RANK;
     }
 
     parentCards.forEach((card) => {

--- a/tools/data-handler/src/create.ts
+++ b/tools/data-handler/src/create.ts
@@ -286,7 +286,10 @@ export class Create extends EventEmitter {
     }
 
     const specificCard = parentCardKey
-      ? await projectObject.findSpecificCard(parentCardKey)
+      ? await projectObject.findSpecificCard(parentCardKey, {
+          metadata: true,
+          children: true,
+        })
       : undefined;
     if (parentCardKey && !specificCard) {
       throw new Error(`Card '${parentCardKey}' not found from project`);

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -83,6 +83,7 @@ export interface cardMetadata {
   summary: string;
   cardtype: string;
   workflowState: string;
+  rank: string;
   lastTransitioned?: string;
   lastUpdated?: string;
   [key: string]: metadataContent;

--- a/tools/data-handler/src/move.ts
+++ b/tools/data-handler/src/move.ts
@@ -17,6 +17,14 @@ import { join, sep } from 'node:path';
 import { copyDir, deleteDir } from './utils/file-utils.js';
 import { card } from './interfaces/project-interfaces.js';
 import { Project } from './containers/project.js';
+import {
+  EMPTY_RANK,
+  FIRST_RANK,
+  getRankAfter,
+  getRankBetween,
+  rebalanceRanks,
+  sortItems,
+} from './utils/lexorank.js';
 
 export class Move {
   static project: Project;
@@ -77,7 +85,222 @@ export class Move {
         ? join(Move.project.cardrootFolder, sourceCard.key)
         : join(destinationCard.path, 'c', sourceCard.key);
 
+    // rerank the card in the new location
+    // it will be the last one in the new location
+    let children;
+    if (destination !== 'root') {
+      const parent = await Move.project.findSpecificCard(destination, {
+        children: true,
+        metadata: true,
+      });
+      if (!parent) {
+        throw new Error(`Parent card ${destination} not found from project`);
+      }
+      children = parent.children;
+    } else {
+      children = await Move.project.showProjectCards();
+    }
+
+    if (!children) {
+      throw new Error(`Children not found from card ${destination}`);
+    }
+
+    children = sortItems(children, (item) => item?.metadata?.rank || 'z');
+    const lastChild = children[children.length - 1];
+
+    const rank =
+      lastChild && lastChild.metadata
+        ? getRankAfter(lastChild.metadata.rank)
+        : FIRST_RANK;
+    await Move.project.updateCardMetadata(sourceCard.key, 'rank', rank);
     await copyDir(sourceCard.path, destinationPath);
     await deleteDir(sourceCard.path);
+  }
+
+  /**
+   * Sets the rank of a card to be after another card.
+   * @param path Project path
+   * @param cardKey Card to rank
+   * @param beforeCardKey Card key after which the card will be ranked
+   */
+  public async rankCard(path: string, cardKey: string, beforeCardKey: string) {
+    Move.project = new Project(path);
+
+    const card = await Move.project.findSpecificCard(cardKey, {
+      metadata: true,
+      parent: true,
+    });
+    if (!card) {
+      throw new Error(`Card ${cardKey} not found from project`);
+    }
+
+    const beforeCard = await Move.project.findSpecificCard(beforeCardKey, {
+      metadata: true,
+      parent: true,
+    });
+
+    if (!beforeCard) {
+      throw new Error(`Card ${beforeCardKey} not found from project`);
+    }
+
+    if (beforeCard.parent !== card.parent) {
+      throw new Error(`Cards must be in the same parent`);
+    }
+
+    const isRoot = beforeCard.parent === 'root' && card.parent === 'root';
+
+    let children;
+    if (isRoot) {
+      const res = await Move.project.showProjectCards();
+      children = res;
+    } else {
+      if (!beforeCard.parent) {
+        throw new Error(
+          `Before card ${beforeCardKey} does not have a parent in project`,
+        );
+      }
+      const parentCard = await Move.project.findSpecificCard(
+        beforeCard.parent,
+        {
+          children: true,
+          metadata: true,
+        },
+      );
+
+      if (!parentCard) {
+        throw new Error(
+          `Parent card ${beforeCard.parent} not found from project`,
+        );
+      }
+      // rank is a lexographic comparison of string
+      children = parentCard.children;
+    }
+
+    if (!children) {
+      throw new Error(`Children not found from card ${beforeCard.parent}`);
+    }
+
+    children = sortItems(children, (item) => item.metadata?.rank || EMPTY_RANK);
+
+    const beforeCardIndex = children.findIndex(
+      (child) => child.key === beforeCard.key,
+    );
+
+    if (beforeCardIndex === -1) {
+      throw new Error(
+        `Card ${beforeCardKey} is not a child of ${isRoot ? 'root' : beforeCard.parent}`,
+      );
+    }
+
+    if (
+      children[beforeCardIndex].key === cardKey ||
+      children[beforeCardIndex + 1]?.key === cardKey
+    ) {
+      throw new Error(`Card ${cardKey} is already in the correct position`);
+    }
+
+    if (beforeCardIndex === children.length - 1) {
+      await Move.project.updateCardMetadata(
+        cardKey,
+        'rank',
+        getRankAfter(beforeCard.metadata?.rank as string),
+      );
+    } else {
+      await Move.project.updateCardMetadata(
+        cardKey,
+        'rank',
+        getRankBetween(
+          beforeCard.metadata?.rank as string,
+          children[beforeCardIndex + 1].metadata?.rank as string,
+        ),
+      );
+    }
+  }
+
+  /**
+   * Rebalances the ranks of the cards in the whole project, including templates
+   * Can be used even if the ranks do not exist
+   * @param path
+   */
+  public async rebalanceProject(path: string) {
+    Move.project = new Project(path);
+
+    const cards = await Move.project.showProjectCards();
+
+    await this.rebalanceProjectRecursively(cards);
+
+    // rebalance templates
+    const templates = await Move.project.templates(true);
+    for (const template of templates) {
+      const templateObject = await Move.project.createTemplateObject(template);
+
+      if (!templateObject) {
+        throw new Error(`Template '${template}' not found`);
+      }
+
+      const templateCards = await templateObject.cards('', {
+        parent: true,
+        metadata: true,
+      });
+
+      const cardGroups = templateCards.reduce(
+        (acc, card) => {
+          if (!card.parent) {
+            return acc;
+          }
+          if (!acc[card.parent]) {
+            acc[card.parent] = [];
+          }
+          acc[card.parent].push(card);
+          return acc;
+        },
+        {} as Record<string, card[]>,
+      );
+
+      for (const [, cards] of Object.entries(cardGroups)) {
+        await this.rebalanceCards(cards);
+      }
+    }
+  }
+
+  /**
+   * Rebalances the ranks of the children of a card
+   */
+  public async rebalanceChildren(path: string, parentCardKey: string) {
+    Move.project = new Project(path);
+
+    const parentCard = await Move.project.findSpecificCard(parentCardKey, {
+      children: true,
+      metadata: true,
+    });
+    if (!parentCard || !parentCard.children) {
+      throw new Error(`Card ${parentCardKey} not found from project`);
+    }
+    await this.rebalanceCards(parentCard.children);
+  }
+
+  private async rebalanceCards(cards: card[]) {
+    const ranks = rebalanceRanks(cards.length);
+
+    cards = sortItems(cards, (item) => item.metadata?.rank || 'z');
+
+    for (let i = 0; i < cards.length; i++) {
+      const card = cards[i];
+      await Move.project.updateCardMetadata(card.key, 'rank', ranks[i]);
+    }
+  }
+
+  private async rebalanceProjectRecursively(cards: card[]) {
+    const ranks = rebalanceRanks(cards.length);
+
+    cards = sortItems(cards, (item) => item.metadata?.rank || 'z');
+
+    for (let i = 0; i < cards.length; i++) {
+      const card = cards[i];
+      await Move.project.updateCardMetadata(card.key, 'rank', ranks[i]);
+      if (card.children && card.children.length > 0) {
+        await this.rebalanceProjectRecursively(card.children);
+      }
+    }
   }
 }

--- a/tools/data-handler/src/utils/lexorank.ts
+++ b/tools/data-handler/src/utils/lexorank.ts
@@ -1,3 +1,14 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
 const ALPHABET = 'abcdefghijklmnopqrstuvwxyz';
 const ALPHABET_SIZE = ALPHABET.length;
 

--- a/tools/data-handler/src/utils/lexorank.ts
+++ b/tools/data-handler/src/utils/lexorank.ts
@@ -58,6 +58,21 @@ export function getRankAfter(rank: Rank): Rank {
   }
   return PREFIX + newRank;
 }
+/**
+ * Returns the previous available rank before the given rank
+ * if the rank is already the first rank, it throws an error
+ * @param rank rank to get the previous rank before
+ * @returns the previous available rank before the given rank
+ */
+export function getRankBefore(rank: Rank): Rank {
+  rank = rank.replace(PREFIX, '');
+  let num = debase(rank);
+  num--;
+  if (num < 0) {
+    throw new Error('Rank cannot be negative');
+  }
+  return PREFIX + enbase(num);
+}
 
 /**
  * Get the rank between two ranks

--- a/tools/data-handler/src/utils/lexorank.ts
+++ b/tools/data-handler/src/utils/lexorank.ts
@@ -1,0 +1,154 @@
+const ALPHABET = 'abcdefghijklmnopqrstuvwxyz';
+const ALPHABET_SIZE = ALPHABET.length;
+
+const PREFIX = '0|'; // prefix to allow easy addition of buckets later if required
+
+export const FIRST_RANK = PREFIX + ALPHABET[0];
+export const LAST_RANK = PREFIX + ALPHABET[ALPHABET_SIZE - 1];
+
+export const EMPTY_RANK = `1|${ALPHABET[0]}`; // rank to be used when no rank is available
+
+type Rank = string; // Rank is a string that represents a number in base 26
+
+/**
+ * Convert a number to base 26
+ * @param num number to convert to base 26
+ * @returns the string representation of the number in base 26
+ */
+export function enbase(num: number): string {
+  if (num === 0) return ALPHABET[0];
+
+  let result = '';
+  while (num > 0) {
+    result =
+      String.fromCharCode(ALPHABET.charCodeAt(0) + (num % ALPHABET_SIZE)) +
+      result;
+    num = Math.floor(num / ALPHABET_SIZE);
+  }
+  return result;
+}
+
+/**
+ * Convert a rank to a number
+ * @param str rank to convert to a number
+ * @returns the number representation of the rank
+ */
+export function debase(str: string): number {
+  let result = 0;
+  for (let i = 0; i < str.length; i++) {
+    result +=
+      (str.charCodeAt(i) - ALPHABET.charCodeAt(0)) *
+      Math.pow(ALPHABET_SIZE, str.length - i - 1);
+  }
+  return result;
+}
+
+/**
+ * Returns the next available rank after the given rank
+ * @param rank rank to get the next rank after
+ * @returns the next available rank after the given rank
+ */
+export function getRankAfter(rank: Rank): Rank {
+  rank = rank.replace(PREFIX, '');
+  let num = debase(rank);
+  num++;
+  const newRank = enbase(num);
+  if (newRank.length > rank.length) {
+    return PREFIX + rank + ALPHABET[ALPHABET_SIZE / 2];
+  }
+  return PREFIX + newRank;
+}
+
+/**
+ * Get the rank between two ranks
+ * Rank is a string that represents a number in base 26
+ * Rank must be a string of lowercase letters
+ * @param rank1 first rank
+ * @param rank2 second rank
+ * @returns the rank between the two ranks
+ */
+export function getRankBetween(rank1: string, rank2: string): string {
+  // must be padded for the comparison
+
+  rank1 = rank1.replace(PREFIX, '');
+  rank2 = rank2.replace(PREFIX, '');
+
+  const length = Math.max(rank1.length, rank2.length);
+
+  // padding with 'a' to make the ranks equal length
+  // since comparison is done lexicographically
+  // it does not effect the comparison
+
+  const paddedRank1 = rank1.padEnd(length, ALPHABET[0]);
+
+  const paddedRank2 = rank2.padEnd(length, ALPHABET[0]);
+
+  const num1 = debase(paddedRank1);
+  const num2 = debase(paddedRank2);
+
+  if (num1 >= num2) {
+    throw new Error('Rank1 must be smaller than rank2');
+  }
+
+  const res = enbase(Math.floor((num1 + num2) / 2)).padStart(
+    length,
+    ALPHABET[0],
+  );
+  if (res !== paddedRank1 && res !== paddedRank2) {
+    return PREFIX + res;
+  }
+  return PREFIX + res + ALPHABET[ALPHABET_SIZE / 2];
+}
+
+/**
+ * Rebalance the ranks so that the distance between each rank is equal
+ * @param rankAmount number of ranks to rebalance
+ * @returns rebalanced ranks
+ */
+export function rebalanceRanks(rankAmount: number): string[] {
+  if (rankAmount === 0) return [];
+  if (rankAmount === 1) return [FIRST_RANK];
+  const requiredLevels = Math.ceil(
+    Math.log(rankAmount) / Math.log(ALPHABET_SIZE),
+  );
+  // set minumum rank consisting of all 'a's and maximum rank consisting of all 'z's
+  const minRank = ALPHABET[0].repeat(requiredLevels);
+  const maxRank = ALPHABET[ALPHABET_SIZE - 1].repeat(requiredLevels);
+
+  // step size determines the distance between each rank
+  const stepSize = Math.floor(debase(maxRank) / (rankAmount - 1));
+
+  const ranks = [];
+  for (let i = 0; i < rankAmount; i++) {
+    if (i === 0) {
+      ranks.push(PREFIX + minRank);
+    } else if (i === rankAmount - 1) {
+      ranks.push(PREFIX + maxRank);
+    } else {
+      const rank = debase(minRank) + stepSize * i;
+      ranks.push(PREFIX + enbase(rank));
+    }
+  }
+  return ranks;
+}
+
+/**
+ * Sort items based on lexorank
+ * @param items items to sort
+ * @param rankGetter should return the lexorank of the item
+ * @returns sorted items
+ */
+export function sortItems<T>(items: T[], rankGetter: (item: T) => string): T[] {
+  if (items.length === 0) return items;
+  return items.sort((a, b) => compare(rankGetter(a), rankGetter(b)));
+}
+
+/**
+ * default compare function
+ * @param a first string
+ * @param b second string
+ * @returns -1 if a < b, 0 if a === b, 1 if a > b
+ */
+export function compare(a: string, b: string): number {
+  return a.localeCompare(b);
+}

--- a/tools/data-handler/test/command-handler.test.ts
+++ b/tools/data-handler/test/command-handler.test.ts
@@ -1859,6 +1859,24 @@ describe('rank command', () => {
       );
       expect(details.metadata?.rank).to.equal('0|bn');
     });
+    // Note: this tests depends on the previous test
+    it('rank card first(success)', async () => {
+      const key = 'decision_5';
+      const result = await commandHandler.command(
+        Cmd.rank,
+        ['card', key, 'first'],
+        optionsReuse,
+      );
+      expect(result.statusCode).to.equal(200);
+
+      const details = await new Show().showCardDetails(
+        optionsReuse.projectPath,
+        { metadata: true, content: true },
+        key,
+      );
+
+      expect(details.metadata?.rank).to.equal('0|a');
+    });
     it('try rank card - project missing', async () => {
       const rankBefore = 'decision_6';
       const invalidProject = { projectPath: 'idontexist' };

--- a/tools/data-handler/test/edit.test.ts
+++ b/tools/data-handler/test/edit.test.ts
@@ -27,8 +27,6 @@ describe('edit card', () => {
     const cards = await project.cards();
     const firstCard = cards.at(0);
 
-    expect(firstCard?.metadata?.lastUpdated).to.be.undefined;
-
     // Modify content
     if (firstCard) {
       await EditCmd.editCardContent(project.basePath, firstCard.key, 'whoopie');
@@ -40,7 +38,9 @@ describe('edit card', () => {
       });
       if (changedCard) {
         expect(changedCard.content).to.equal('whoopie');
-        expect(changedCard.metadata?.lastUpdated).to.not.be.undefined;
+        expect(changedCard.metadata?.lastUpdated).to.not.equal(
+          firstCard.metadata?.lastUpdated,
+        );
       } else {
         expect(false);
       }

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/templates/decision/c/decision_1/index.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/templates/decision/c/decision_1/index.json
@@ -2,5 +2,7 @@
     "cardtype": "decision-cardtype",
     "summary": "Untitled",
     "workflowState": "Draft",
-    "obsoletedBy": null
+    "obsoletedBy": null,
+    "rank": "0|a",
+    "lastUpdated": "2024-07-12T11:07:35.266Z"
 }

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/templates/simplepage/c/decision_2/index.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/templates/simplepage/c/decision_2/index.json
@@ -1,5 +1,7 @@
 {
     "cardtype": "simplepage-cardtype",
     "summary": "Untitled",
-    "workflowState": "Created"
+    "workflowState": "Created",
+    "rank": "0|a",
+    "lastUpdated": "2024-07-12T11:07:35.280Z"
 }

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/templates/simplepage/c/decision_3/c/decision_4/index.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/templates/simplepage/c/decision_3/c/decision_4/index.json
@@ -1,5 +1,7 @@
 {
     "cardtype": "simplepage-cardtype",
     "summary": "Untitled",
-    "workflowState": "Created"
+    "workflowState": "Created",
+    "rank": "0|a",
+    "lastUpdated": "2024-07-12T11:07:35.288Z"
 }

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/templates/simplepage/c/decision_3/index.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/templates/simplepage/c/decision_3/index.json
@@ -1,5 +1,7 @@
 {
     "cardtype": "simplepage-cardtype",
     "summary": "Untitled",
-    "workflowState": "Created"
+    "workflowState": "Created",
+    "rank": "0|z",
+    "lastUpdated": "2024-07-12T11:07:35.284Z"
 }

--- a/tools/data-handler/test/test-data/valid/decision-records/cardroot/decision_5/c/decision_6/index.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/cardroot/decision_5/c/decision_6/index.json
@@ -10,5 +10,7 @@
     "last-changed-timestamp": null,
     "number-of-commits": null,
     "percentage-ready": null,
-    "responsible": null
+    "responsible": null,
+    "rank": "0|a",
+    "lastUpdated": "2024-07-12T11:07:35.257Z"
 }

--- a/tools/data-handler/test/test-data/valid/decision-records/cardroot/decision_5/index.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/cardroot/decision_5/index.json
@@ -1,5 +1,7 @@
 {
     "cardtype": "simplepage-cardtype",
     "summary": "Decision Records",
-    "workflowState": "Created"
+    "workflowState": "Created",
+    "rank": "0|a",
+    "lastUpdated": "2024-07-12T11:07:35.247Z"
 }

--- a/tools/data-handler/test/utils/lexorank.test.ts
+++ b/tools/data-handler/test/utils/lexorank.test.ts
@@ -3,6 +3,7 @@ import {
   getRankBetween,
   getRankAfter,
   rebalanceRanks,
+  getRankBefore,
 } from '../../src/utils/lexorank.js';
 import { expect } from 'chai';
 
@@ -36,6 +37,13 @@ const getRankeAfterTests = [
   ['0|ba', '0|bb'],
 ];
 
+const getRankBeforeTests = [
+  ['0|b', '0|a'],
+  ['0|c', '0|b'],
+  ['0|zn', '0|zm'],
+  ['0|bb', '0|ba'],
+];
+
 describe('lexorank', () => {
   getRankBetweenTests.forEach(([a, b, expected]) => {
     it(`getRankBetween(${a}, ${b})`, () => {
@@ -66,6 +74,17 @@ describe('lexorank', () => {
       expect(getRankAfter(rank)).to.equal(expected);
     });
   });
+
+  getRankBeforeTests.forEach(([rank, expected]) => {
+    it(`getRankBefore(${rank})`, () => {
+      expect(getRankBefore(rank)).to.equal(expected);
+    });
+  });
+
+  it('getRankBefore(a) throws error', () => {
+    expect(() => getRankBefore('0|a')).to.throw('Rank cannot be negative');
+  });
+
   it(`rebalanceRanks(1 level)`, () => {
     const ranks = 3;
     const expected = ['0|a', '0|m', '0|z'];

--- a/tools/data-handler/test/utils/lexorank.test.ts
+++ b/tools/data-handler/test/utils/lexorank.test.ts
@@ -1,0 +1,91 @@
+import {
+  enbase,
+  getRankBetween,
+  getRankAfter,
+  rebalanceRanks,
+} from '../../src/utils/lexorank.js';
+import { expect } from 'chai';
+
+// list different test cases
+// getRankBetween returns the rank between two ranks(e.g. 'a' and 'b' returns 'an')
+
+const getRankBetweenTests = [
+  ['0|a', '0|b', '0|an'],
+  ['0|a', '0|c', '0|b'],
+  ['0|b', '0|c', '0|bn'],
+  ['0|a', '0|z', '0|m'],
+  ['0|a', '0|ba', '0|an'],
+  ['0|a', '0|bb', '0|an'],
+  ['0|a', '0|bc', '0|ao'],
+];
+
+const enbaseTests = [
+  [0, 'a'],
+  [13, 'n'],
+  [25, 'z'],
+  [26, 'ba'],
+  [52, 'ca'],
+  [53, 'cb'],
+  [26 * 3 + 25, 'dz'],
+];
+
+const getRankeAfterTests = [
+  ['0|a', '0|b'],
+  ['0|b', '0|c'],
+  ['0|z', '0|zn'],
+  ['0|ba', '0|bb'],
+];
+
+describe('lexorank', () => {
+  getRankBetweenTests.forEach(([a, b, expected]) => {
+    it(`getRankBetween(${a}, ${b})`, () => {
+      expect(getRankBetween(a, b)).to.equal(expected);
+    });
+  });
+
+  it('getRankBetween throws error if rank1 is greater than rank2', () => {
+    expect(() => getRankBetween('b', 'a')).to.throw(
+      'Rank1 must be smaller than rank2',
+    );
+  });
+
+  it('getRankBetween throws error if rank1 is equal to rank2', () => {
+    expect(() => getRankBetween('a', 'a')).to.throw(
+      'Rank1 must be smaller than rank2',
+    );
+  });
+
+  enbaseTests.forEach(([n, expected]) => {
+    it(`enbase(${n})`, () => {
+      expect(enbase(n as number)).to.equal(expected);
+    });
+  });
+
+  getRankeAfterTests.forEach(([rank, expected]) => {
+    it(`getRankAfter(${rank})`, () => {
+      expect(getRankAfter(rank)).to.equal(expected);
+    });
+  });
+  it(`rebalanceRanks(1 level)`, () => {
+    const ranks = 3;
+    const expected = ['0|a', '0|m', '0|z'];
+
+    expect(rebalanceRanks(ranks)).to.deep.equal(expected);
+  });
+  it(`rebalanceRanks(2 levels)`, () => {
+    const ranks = 26 * 6;
+
+    const rebalanced = rebalanceRanks(ranks);
+
+    expect(rebalanced.length).to.equal(ranks);
+    expect(rebalanced[0]).to.equal('0|aa');
+    expect(rebalanced[rebalanced.length - 1]).to.equal('0|zz');
+  });
+  it('rebalanceRanks with 0 items', () => {
+    expect(rebalanceRanks(0)).to.deep.equal([]);
+  });
+
+  it('rebalanceRanks with 1 item', () => {
+    expect(rebalanceRanks(1)).to.deep.equal(['0|a']);
+  });
+});

--- a/tools/schema/card-base-schema.json
+++ b/tools/schema/card-base-schema.json
@@ -20,6 +20,10 @@
       "type": "string",
       "description": "the name of the card's current state in the workflow"
     },
+    "rank": {
+      "type": "string",
+      "description": "The rank of the card in relative to its siblings"
+    },
     "lastTransitioned": {
       "type": "string",
       "format": "date-time",
@@ -72,5 +76,5 @@
       }
     }
   },
-  "required": ["summary", "cardtype", "workflowState"]
+  "required": ["summary", "cardtype", "workflowState", "rank"]
 }


### PR DESCRIPTION
This PR includes ranking for cards:
# Features
## CLI
`cyberismo rank rebalance card` - rebalance children of a specific card. NOTE: this is not recursive
`cyberismo rank rebalance` - rebalance the whole project recursively(also templates)
`cyberismo rank card some_card other_card` - ranks some_card after other_card. It can also be 'first' if you want to rank card as the first card

It should be also mentioned that rebalance-commands work even if the project is missing some or all ranks. Old projects, which do not have ranks, can be updated by running the `cyberismo rank rebalance`-command. Not having project in the card's metadata is not supported
## App
User can drag and drop cards using the tree view. It is possible to move/rank at the same time. When creating a new card, it is added to as the last element.

# Technical
I used a partially implemented lexorank. If you look at the ranks, they look like this:
- `0|a`
- `0|an`
- `0|z`
The first 2 characters are not used, but I left them in case we want to fully implement lexorank based system where the first number references its bucket. The ranks can be simply sorted by comparing the strings.

When you rebalance, the ranks are calculated so that they are evenly separated. If there is no space between two ranks(e.g. a and b), the letter `n` is append two the first one. This means that strings, which represent the ranks, might grow in size, but we will pretty much never run out of ranks. Since strings are compared letter to letter, appending an n doesn't require a rebalance. 

However, this must be taken into account when adding another item between them, because if we tried to insert an item between b and bn, we'd get unwanted results because b's numeric value(base 26, where a is lowest and z is highest) is 1 and bn is 39(1*26+13). Average of those would be 20, which would result in the letter `u`. This would be wrong, because u would come after both b and bn. This is fixed by adding the letter `a` to the shorter string until they are the same length. In the previous example, we would calculate the average between ba(26*1+0=26) and bn(stil 39), which would result in a letter that is between both b and bn.

There another issue: What if we tried to insert element before an element, which has the rank `a`(or any amount of a's).?Unfortunately, we cannot get around that and we must update both the existing first element and the item being moved to the first place. The existing first place's new place will be calculated to be rank between itself and the next element. The item that is being moved to the first place will just be updated to `a`, which means it will be the first element.

I also added a new tree component, which handles drag and drop out of box.

## Templates
Templates are just so the same commands work for them. Currently there is no way to rebalance a single template. When creating new cards from templates, they automatically come after the existing cards. They keep the same order they were in as a template.
