### PR TITLE
Fixed: edit view shows "2 attachments" when there are no attachments

### DIFF
--- a/tools/app/app/cards/[key]/edit/page.tsx
+++ b/tools/app/app/cards/[key]/edit/page.tsx
@@ -317,7 +317,7 @@ export default function Page({ params }: { params: { key: string } }) {
                       borderRadius={40}
                       paddingX={1}
                     >
-                      2
+                      {card?.attachments?.length || 0}
                     </Typography>
                     <Typography level="body-xs" marginLeft={2}>
                       {t('attachments')}


### PR DESCRIPTION
A fixed number was used, now the number of attachments is used