### PR TITLE
Macros

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6764,20 +6764,6 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.3.tgz",
       "integrity": "sha512-qlD8YNDqyTKTyuITrDOffsl6Tdhv+UC4hcdAVuQsK4IMQ99nSgd1MIA/Q+jQYoh9r3hVUXhYh7urSRmXPkW04g=="
     },
-    "node_modules/internal-slot": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
-      "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
-      "dev": true,
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "hasown": "^2.0.0",
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/interpret": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
@@ -12616,106 +12602,6 @@
         "typescript": "^5"
       }
     },
-    "tools/cards": {
-      "name": "@cyberismocom/cli",
-      "version": "1.0.0",
-      "extraneous": true,
-      "license": "AGPL-3.0",
-      "dependencies": {
-        "commander": "^12.0.0"
-      },
-      "bin": {
-        "cards": "bin/run"
-      },
-      "devDependencies": {
-        "@types/node": "^20.11.25",
-        "typescript": "^5.4.2"
-      }
-    },
-    "tools/cli": {
-      "name": "@cyberismocom/cli",
-      "version": "1.0.0",
-      "license": "AGPL-3.0",
-      "dependencies": {
-        "commander": "^12.0.0"
-      },
-      "bin": {
-        "cyberismo": "bin/run"
-      },
-      "devDependencies": {
-        "@types/node": "^20.11.25",
-        "eslint-config-prettier": "^9.1.0",
-        "typescript": "^5.4.2"
-      }
-    },
-    "tools/cli/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "tools/data-handler": {
-      "name": "@cyberismocom/data-handler",
-      "version": "1.0.0",
-      "license": "AGPL-3.0",
-      "dependencies": {
-        "csv-parse": "^5.5.6",
-        "directory-schema-validator": "^1.0.17",
-        "email-validator": "^2.0.4",
-        "handlebars": "^4.7.8",
-        "isomorphic-git": "^1.25.2",
-        "js-yaml": "^4.1.0",
-        "json-schema": "^0.4.0",
-        "jsonschema": "^1.4.1",
-        "mime-types": "^2.1.35",
-        "tslib": "^2.6.2"
-      },
-      "devDependencies": {
-        "@types/chai": "^4.3.14",
-        "@types/chai-as-promised": "^7.1.8",
-        "@types/js-yaml": "^4.0.9",
-        "@types/json-schema": "^7.0.15",
-        "@types/mime-types": "^2.1.4",
-        "@types/mocha": "^10.0.6",
-        "@types/node": "^20.10.3",
-        "@typescript-eslint/eslint-plugin": "^7.0.2",
-        "@typescript-eslint/parser": "^7.0.1",
-        "chai": "^5.1.1",
-        "chai-as-promised": "^8.0.0",
-        "eslint": "8.56.0",
-        "eslint-config-prettier": "^9.1.0",
-        "mocha": "^10.2.0",
-        "ts-node": "^10.9.1",
-        "typescript": "^5.4.5",
-        "typescript-eslint": "^7.10.0"
-      }
-    },
-    "tools/data-handler/node_modules/@eslint/js": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
-      "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^9.6.0",
-        "globals": "^13.19.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "tools/app/node_modules/@eslint/js": {
       "version": "8.57.0",
       "dev": true,
@@ -13149,6 +13035,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "tools/cards": {
+      "name": "@cyberismocom/cli",
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "commander": "^12.0.0"
+      },
+      "bin": {
+        "cards": "bin/run"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.25",
+        "typescript": "^5.4.2"
+      }
+    },
     "tools/cli": {
       "name": "@cyberismocom/cli",
       "version": "1.0.0",
@@ -13188,6 +13090,7 @@
         "csv-parse": "^5.5.6",
         "directory-schema-validator": "^1.0.17",
         "email-validator": "^2.0.4",
+        "handlebars": "^4.7.8",
         "isomorphic-git": "^1.25.2",
         "js-yaml": "^4.1.0",
         "json-schema": "^0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6491,6 +6491,15 @@
         "node": ">=14"
       }
     },
+    "node_modules/html-dom-parser": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.9.tgz",
+      "integrity": "sha512-QGeoFYwgQ582EDvrBx0+ejIz76/LuQcwwkmSR4ueKncjl2yWbciA45Kfz/LrHvWR3CgtKnxKFkr4Mpq2Sh1QNg==",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "htmlparser2": "9.1.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -6515,6 +6524,44 @@
       "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
       "dependencies": {
         "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/html-react-parser": {
+      "version": "5.1.12",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.1.12.tgz",
+      "integrity": "sha512-OPv8fsIvxxv/+pLj9mYvyNu8PE5dPMowTRdd5VHpcoZpXlstp8eYCxQ5rzqAE5Tb75rhdiWUXnPltfb62zCVjg==",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "html-dom-parser": "5.0.9",
+        "react-property": "2.0.2",
+        "style-to-js": "1.1.12"
+      },
+      "peerDependencies": {
+        "@types/react": "0.14 || 15 || 16 || 17 || 18",
+        "react": "0.14 || 15 || 16 || 17 || 18"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -6711,6 +6758,25 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.3.tgz",
+      "integrity": "sha512-qlD8YNDqyTKTyuITrDOffsl6Tdhv+UC4hcdAVuQsK4IMQ99nSgd1MIA/Q+jQYoh9r3hVUXhYh7urSRmXPkW04g=="
+    },
+    "node_modules/internal-slot": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
+      "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.0",
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/interpret": {
       "version": "1.4.0",
@@ -10151,6 +10217,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
+    "node_modules/react-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+      "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug=="
+    },
     "node_modules/react-redux": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.2.tgz",
@@ -11184,6 +11255,22 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
       "integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw=="
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.12.tgz",
+      "integrity": "sha512-tv+/FkgNYHI2fvCoBMsqPHh5xovwiw+C3X0Gfnss/Syau0Nr3IqGOJ9XiOYXoPnToHVbllKFf5qCNFJGwFg5mg==",
+      "dependencies": {
+        "style-to-object": "1.0.6"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.6.tgz",
+      "integrity": "sha512-khxq+Qm3xEyZfKd/y9L3oIWQimxuc4STrQKtQn8aSDRHb8mFgpukgX1hdzfrMEW6JCjyJ8p89x+IUMVnCBI1PA==",
+      "dependencies": {
+        "inline-style-parser": "0.2.3"
+      }
     },
     "node_modules/styled-jsx": {
       "version": "5.1.1",
@@ -12495,6 +12582,7 @@
         "@reduxjs/toolkit": "^2.2.5",
         "@uiw/react-codemirror": "^4.22.2",
         "codemirror-asciidoc": "^2.0.1",
+        "html-react-parser": "^5.1.12",
         "i18next": "^23.11.5",
         "moment": "^2.30.1",
         "next": "14.1.1",
@@ -12528,8 +12616,86 @@
         "typescript": "^5"
       }
     },
-    "tools/app/node_modules/@eslint/eslintrc": {
-      "version": "2.1.4",
+    "tools/cards": {
+      "name": "@cyberismocom/cli",
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "commander": "^12.0.0"
+      },
+      "bin": {
+        "cards": "bin/run"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.25",
+        "typescript": "^5.4.2"
+      }
+    },
+    "tools/cli": {
+      "name": "@cyberismocom/cli",
+      "version": "1.0.0",
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "commander": "^12.0.0"
+      },
+      "bin": {
+        "cyberismo": "bin/run"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.25",
+        "eslint-config-prettier": "^9.1.0",
+        "typescript": "^5.4.2"
+      }
+    },
+    "tools/cli/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "tools/data-handler": {
+      "name": "@cyberismocom/data-handler",
+      "version": "1.0.0",
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "csv-parse": "^5.5.6",
+        "directory-schema-validator": "^1.0.17",
+        "email-validator": "^2.0.4",
+        "handlebars": "^4.7.8",
+        "isomorphic-git": "^1.25.2",
+        "js-yaml": "^4.1.0",
+        "json-schema": "^0.4.0",
+        "jsonschema": "^1.4.1",
+        "mime-types": "^2.1.35",
+        "tslib": "^2.6.2"
+      },
+      "devDependencies": {
+        "@types/chai": "^4.3.14",
+        "@types/chai-as-promised": "^7.1.8",
+        "@types/js-yaml": "^4.0.9",
+        "@types/json-schema": "^7.0.15",
+        "@types/mime-types": "^2.1.4",
+        "@types/mocha": "^10.0.6",
+        "@types/node": "^20.10.3",
+        "@typescript-eslint/eslint-plugin": "^7.0.2",
+        "@typescript-eslint/parser": "^7.0.1",
+        "chai": "^5.1.1",
+        "chai-as-promised": "^8.0.0",
+        "eslint": "8.56.0",
+        "eslint-config-prettier": "^9.1.0",
+        "mocha": "^10.2.0",
+        "ts-node": "^10.9.1",
+        "typescript": "^5.4.5",
+        "typescript-eslint": "^7.10.0"
+      }
+    },
+    "tools/data-handler/node_modules/@eslint/js": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
+      "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "test-data-handler": "cd tools/data-handler && npm run test && cd ../..",
     "watch": "npm-watch",
     "prettier-check": "prettier --check .",
-    "prettier-fix": "prettier --write ."
+    "prettier-fix": "prettier --write .",
+    "script:schemas": "node scripts/generateSchemaImports && prettier --write tools/data-handler/src/utils/schemas.ts"
   },
   "watch": {
     "build": {

--- a/scripts/generateSchemaImports.js
+++ b/scripts/generateSchemaImports.js
@@ -1,0 +1,75 @@
+const fs = require('fs');
+const path = require('path');
+
+const schemaDir = './tools/schema';
+const outputFilePath = './tools/data-handler/src/utils/schemas.ts';
+const parentSchemaFile = 'cardtree-directory-schema';
+
+const schemas = [];
+
+function nameToCamelCase(name) {
+  return name.replace(/-(\w)/g, (_, letter) => letter.toUpperCase());
+}
+
+function getImportPath(filePath) {
+  return path
+    .relative(path.dirname(outputFilePath), filePath)
+    .replace(/\\/g, '/');
+}
+
+const parentSchemaTs = nameToCamelCase(parentSchemaFile);
+
+function readSchemas(dir) {
+  const files = fs.readdirSync(dir);
+
+  files.forEach((file) => {
+    const filePath = path.join(dir, file);
+    const stat = fs.statSync(filePath);
+    const name = path.basename(file, '.json');
+
+    if (stat.isDirectory()) {
+      readSchemas(filePath);
+    } else if (path.extname(file) === '.json') {
+      // do not include parent schema file
+      if (name === parentSchemaFile) {
+        return;
+      }
+      // convert file path to relative path from output file
+      schemas.push({
+        path: getImportPath(filePath),
+        name: nameToCamelCase(name),
+      });
+    }
+  });
+}
+
+readSchemas(schemaDir);
+
+// create output
+// formatting doesn't matter, prettier will take care of it
+let outputContent = schemas
+  .map(({ path, name }) => {
+    return `import ${name} from '${path.replace(/\\/g, '/')}';`;
+  })
+  .join('\n');
+
+// also import parent schema file
+outputContent += `\nimport ${parentSchemaTs} from '${getImportPath(path.join(schemaDir, parentSchemaFile + '.json'))}';\n`;
+
+/*
+outputContent +=
+  '\n\nconst schemas = [' +
+  schemas.map(({ name }) => name).join(', ') +
+  '];\nexport default schemas;\n';*/
+
+// create schemas array
+outputContent += '\n\nexport const schemas = [\n';
+outputContent += schemas.map(({ name }) => name).join(',');
+outputContent += '];\n';
+
+// export parent schema file
+outputContent += `\nexport const parentSchema = ${parentSchemaTs};`;
+
+fs.writeFileSync(outputFilePath, outputContent);
+
+console.log('Schemas imported successfully!');

--- a/scripts/generateSchemaImports.js
+++ b/scripts/generateSchemaImports.js
@@ -5,6 +5,21 @@ const schemaDir = './tools/schema';
 const outputFilePath = './tools/data-handler/src/utils/schemas.ts';
 const parentSchemaFile = 'cardtree-directory-schema';
 
+const license = `
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+`;
+
 const schemas = [];
 
 function nameToCamelCase(name) {
@@ -47,11 +62,13 @@ readSchemas(schemaDir);
 
 // create output
 // formatting doesn't matter, prettier will take care of it
-let outputContent = schemas
-  .map(({ path, name }) => {
-    return `import ${name} from '${path.replace(/\\/g, '/')}';`;
-  })
-  .join('\n');
+let outputContent =
+  license +
+  schemas
+    .map(({ path, name }) => {
+      return `import ${name} from '${path.replace(/\\/g, '/')}';`;
+    })
+    .join('\n');
 
 // also import parent schema file
 outputContent += `\nimport ${parentSchemaTs} from '${getImportPath(path.join(schemaDir, parentSchemaFile + '.json'))}';\n`;

--- a/scripts/generateSchemaImports.js
+++ b/scripts/generateSchemaImports.js
@@ -66,18 +66,12 @@ let outputContent =
   license +
   schemas
     .map(({ path, name }) => {
-      return `import ${name} from '${path.replace(/\\/g, '/')}';`;
+      return `import ${name} from '${path.replace(/\\/g, '/')}' with {type: 'json'};`;
     })
     .join('\n');
 
 // also import parent schema file
-outputContent += `\nimport ${parentSchemaTs} from '${getImportPath(path.join(schemaDir, parentSchemaFile + '.json'))}';\n`;
-
-/*
-outputContent +=
-  '\n\nconst schemas = [' +
-  schemas.map(({ name }) => name).join(', ') +
-  '];\nexport default schemas;\n';*/
+outputContent += `\nimport ${parentSchemaTs} from '${getImportPath(path.join(schemaDir, parentSchemaFile + `.json' with {type: 'json'};`))}\n`;
 
 // create schemas array
 outputContent += '\n\nexport const schemas = [\n';

--- a/tools/app/.env
+++ b/tools/app/.env
@@ -1,1 +1,3 @@
 NEXT_TELEMETRY_DISABLED=1
+npm_config_project_path=../../../cyberismo-isms
+#npm_config_project_path=../../examples/decision-records

--- a/tools/app/.env
+++ b/tools/app/.env
@@ -1,3 +1,1 @@
 NEXT_TELEMETRY_DISABLED=1
-npm_config_project_path=../../../cyberismo-isms
-#npm_config_project_path=../../examples/decision-records

--- a/tools/app/app/cards/[key]/edit/page.tsx
+++ b/tools/app/app/cards/[key]/edit/page.tsx
@@ -51,6 +51,7 @@ import { addAttachment } from '@/app/lib/codemirror';
 import { apiPaths } from '@/app/lib/swr';
 import { useAttachments } from '@/app/lib/api/attachments';
 import { isEdited } from '@/app/lib/slices/pageState';
+import LoadingGate from '@/app/components/LoadingGate';
 
 const extensions = [StreamLanguage.define(asciidoc), EditorView.lineWrapping];
 
@@ -374,7 +375,7 @@ export default function Page({ params }: { params: { key: string } }) {
                           name={attachment.fileName}
                           cardKey={params.key}
                         >
-                          {attachment.mimeType.startsWith('image') ? (
+                          {attachment.mimeType?.startsWith('image') ? (
                             <Image
                               src={apiPaths.attachment(
                                 card.key,
@@ -400,13 +401,14 @@ export default function Page({ params }: { params: { key: string } }) {
               }}
             >
               <Box height="100%">
-                <ContentArea
-                  card={previewCard}
-                  error={null}
-                  linkTypes={linkTypes}
-                  project={project}
-                  preview={true}
-                />
+                <LoadingGate values={[linkTypes]}>
+                  <ContentArea
+                    card={previewCard}
+                    linkTypes={linkTypes!}
+                    project={project}
+                    preview={true}
+                  />
+                </LoadingGate>
               </Box>
             </TabPanel>
           </Tabs>

--- a/tools/app/app/cards/[key]/page.tsx
+++ b/tools/app/app/cards/[key]/page.tsx
@@ -13,6 +13,7 @@
 'use client';
 import { ContentArea } from '@/app/components/ContentArea';
 import ContentToolbar from '@/app/components/ContentToolbar';
+import LoadingGate from '@/app/components/LoadingGate';
 import { cardViewed } from '@/app/lib/actions';
 import { useCard, useLinkTypes, useProject } from '@/app/lib/api';
 import { CardMode } from '@/app/lib/definitions';
@@ -59,53 +60,53 @@ export default function Page({ params }: { params: { key: string } }) {
         onInsertLink={() => setLinksVisible(true)}
       />
       <Box flexGrow={1} minHeight={0}>
-        <ContentArea
-          card={card}
-          error={error?.message}
-          onMetadataClick={() =>
-            router.push(`/cards/${params.key}/edit?expand=true`)
-          }
-          linkTypes={linkTypes}
-          project={project}
-          onLinkFormSubmit={async (data) => {
-            try {
-              await createLink(
-                data.cardKey,
-                data.linkType,
-                data.linkDescription,
-                data.direction,
-              );
-              return true;
-            } catch (error) {
-              dispatch(
-                addNotification({
-                  message: `Failed to create link: ${error instanceof Error ? error.message : 'Unknown error'}`,
-                  type: 'error',
-                }),
-              );
-              return false;
+        <LoadingGate values={[card, linkTypes]}>
+          <ContentArea
+            card={card!}
+            onMetadataClick={() =>
+              router.push(`/cards/${params.key}/edit?expand=true`)
             }
-          }}
-          linksVisible={linksVisible}
-          onLinkToggle={() => setLinksVisible(!linksVisible)}
-          onDeleteLink={async (data) => {
-            try {
-              await deleteLink(
-                data.fromCard,
-                data.cardKey,
-                data.linkType,
-                data.linkDescription,
-              );
-            } catch (error) {
-              dispatch(
-                addNotification({
-                  message: `Failed to delete link: ${error instanceof Error ? error.message : 'Unknown error'}`,
-                  type: 'error',
-                }),
-              );
-            }
-          }}
-        />
+            linkTypes={linkTypes!}
+            project={project}
+            onLinkFormSubmit={async (data) => {
+              try {
+                await createLink(
+                  data.cardKey,
+                  data.linkType,
+                  data.linkDescription,
+                );
+                return true;
+              } catch (error) {
+                dispatch(
+                  addNotification({
+                    message: `Failed to create link: ${error instanceof Error ? error.message : 'Unknown error'}`,
+                    type: 'error',
+                  }),
+                );
+                return false;
+              }
+            }}
+            linksVisible={linksVisible}
+            onLinkToggle={() => setLinksVisible(!linksVisible)}
+            onDeleteLink={async (data) => {
+              try {
+                await deleteLink(
+                  data.fromCard,
+                  data.cardKey,
+                  data.linkType,
+                  data.linkDescription,
+                );
+              } catch (error) {
+                dispatch(
+                  addNotification({
+                    message: `Failed to delete link: ${error instanceof Error ? error.message : 'Unknown error'}`,
+                    type: 'error',
+                  }),
+                );
+              }
+            }}
+          />
+        </LoadingGate>
       </Box>
     </Stack>
   );

--- a/tools/app/app/components/ContentArea.tsx
+++ b/tools/app/app/components/ContentArea.tsx
@@ -281,6 +281,7 @@ export const ContentArea: React.FC<ContentAreaProps> = ({
       safe: 'safe',
       attributes: {
         imagesdir: `/api/cards/${card.key}/a`,
+        icons: 'font',
       },
     })
     .toString();

--- a/tools/app/app/components/ContentArea.tsx
+++ b/tools/app/app/components/ContentArea.tsx
@@ -287,7 +287,7 @@ export const ContentArea: React.FC<ContentAreaProps> = ({
     .toString();
 
   const combinedMacros = Object.entries(macros).reduce<
-    (Macro<any> & { component: (props: any) => ReactElement })[]
+    (Macro & { component: (props: any) => ReactElement })[]
   >((acc, [key, value]) => {
     acc.push({
       ...value,

--- a/tools/app/app/components/ContentArea.tsx
+++ b/tools/app/app/components/ContentArea.tsx
@@ -305,6 +305,7 @@ export const ContentArea: React.FC<ContentAreaProps> = ({
           return macro.component({
             ...node.attribs,
             key: card.key,
+            preview,
           });
         }
       }

--- a/tools/app/app/components/LoadingGate.tsx
+++ b/tools/app/app/components/LoadingGate.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface LoadingGateProps {
+  values?: any[];
+  isLoading?: boolean;
+  loadingIndicator?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+const LoadingGate: React.FC<LoadingGateProps> = ({
+  isLoading,
+  values,
+  loadingIndicator,
+  children,
+}) => {
+  if (isLoading || values?.some((value) => value === null)) {
+    return loadingIndicator ? loadingIndicator : <div>Loading...</div>;
+  }
+
+  return <>{children}</>;
+};
+
+export default LoadingGate;

--- a/tools/app/app/components/LoadingGate.tsx
+++ b/tools/app/app/components/LoadingGate.tsx
@@ -1,3 +1,15 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import React from 'react';
 
 interface LoadingGateProps {

--- a/tools/app/app/components/macros/CreateCards.tsx
+++ b/tools/app/app/components/macros/CreateCards.tsx
@@ -14,7 +14,7 @@ import { useCard } from '@/app/lib/api';
 import { Button } from '@mui/joy';
 import { useTranslation } from 'react-i18next';
 import { MacroContext } from '.';
-import { useAppDispatch } from '@/app/lib/hooks';
+import { useAppDispatch, useAppRouter } from '@/app/lib/hooks';
 import { addNotification } from '@/app/lib/slices/notifications';
 import { useState } from 'react';
 
@@ -35,6 +35,7 @@ export default function CreateCards({
   const { createCard, isUpdating } = useCard(cardkey || key);
   const dispatch = useAppDispatch();
   const [loading, setLoading] = useState(false);
+  const router = useAppRouter();
 
   return (
     <Button
@@ -52,13 +53,17 @@ export default function CreateCards({
             return;
           }
           setLoading(true);
-          await createCard(template);
+          const cards = await createCard(template);
           dispatch(
             addNotification({
               message: t('createCard.success'),
               type: 'success',
             }),
           );
+
+          if (cards && cards.length > 0) {
+            router.push(`/cards/${cards[0]}/edit`);
+          }
         } catch (e) {
           dispatch(
             addNotification({

--- a/tools/app/app/components/macros/CreateCards.tsx
+++ b/tools/app/app/components/macros/CreateCards.tsx
@@ -29,6 +29,7 @@ export default function CreateCards({
   template,
   cardkey,
   key,
+  preview,
 }: CreateCardsProps) {
   const { t } = useTranslation();
   const { createCard, isUpdating } = useCard(cardkey || key);
@@ -41,6 +42,15 @@ export default function CreateCards({
       disabled={isUpdating}
       onClick={async () => {
         try {
+          if (preview) {
+            dispatch(
+              addNotification({
+                message: t('createCard.macro.preview'),
+                type: 'success',
+              }),
+            );
+            return;
+          }
           setLoading(true);
           await createCard(template);
           dispatch(

--- a/tools/app/app/components/macros/CreateCards.tsx
+++ b/tools/app/app/components/macros/CreateCards.tsx
@@ -45,14 +45,14 @@ export default function CreateCards({
           await createCard(template);
           dispatch(
             addNotification({
-              message: t('macros.cardsCreated'),
+              message: t('createCard.success'),
               type: 'success',
             }),
           );
         } catch (e) {
           dispatch(
             addNotification({
-              message: e instanceof Error ? e.message : t('macros.error'),
+              message: e instanceof Error ? e.message : t('unknownError'),
               type: 'error',
             }),
           );

--- a/tools/app/app/components/macros/CreateCards.tsx
+++ b/tools/app/app/components/macros/CreateCards.tsx
@@ -1,0 +1,55 @@
+import { useCard } from '@/app/lib/api';
+import { Button } from '@mui/joy';
+import { useTranslation } from 'react-i18next';
+import { MacroContext } from '.';
+import { useAppDispatch } from '@/app/lib/hooks';
+import { addNotification } from '@/app/lib/slices/notifications';
+import { useState } from 'react';
+
+export type CreateCardsProps = {
+  buttonlabel: string;
+  template: string;
+  cardkey?: string;
+} & MacroContext;
+
+export default function CreateCards({
+  buttonlabel,
+  template,
+  cardkey,
+  key,
+}: CreateCardsProps) {
+  const { t } = useTranslation();
+  const { createCard, isUpdating } = useCard(cardkey || key);
+  const dispatch = useAppDispatch();
+  const [loading, setLoading] = useState(false);
+
+  return (
+    <Button
+      loading={loading}
+      disabled={isUpdating}
+      onClick={async () => {
+        try {
+          setLoading(true);
+          await createCard(template);
+          dispatch(
+            addNotification({
+              message: t('macros.cardsCreated'),
+              type: 'success',
+            }),
+          );
+        } catch (e) {
+          dispatch(
+            addNotification({
+              message: e instanceof Error ? e.message : t('macros.error'),
+              type: 'error',
+            }),
+          );
+        } finally {
+          setLoading(false);
+        }
+      }}
+    >
+      {buttonlabel}
+    </Button>
+  );
+}

--- a/tools/app/app/components/macros/CreateCards.tsx
+++ b/tools/app/app/components/macros/CreateCards.tsx
@@ -1,3 +1,15 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import { useCard } from '@/app/lib/api';
 import { Button } from '@mui/joy';
 import { useTranslation } from 'react-i18next';

--- a/tools/app/app/components/macros/index.ts
+++ b/tools/app/app/components/macros/index.ts
@@ -1,0 +1,11 @@
+import { MacroName } from '@cyberismocom/data-handler/utils/macros';
+import CreateCards from './CreateCards';
+import { ReactNode } from 'react';
+
+export interface MacroContext {
+  key: string; // The key of the current card
+}
+
+export const macros: Record<MacroName, (props: any) => React.ReactElement> = {
+  createCards: CreateCards,
+};

--- a/tools/app/app/components/macros/index.ts
+++ b/tools/app/app/components/macros/index.ts
@@ -1,6 +1,17 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import { MacroName } from '@cyberismocom/data-handler/utils/macros';
 import CreateCards from './CreateCards';
-import { ReactNode } from 'react';
 
 export interface MacroContext {
   key: string; // The key of the current card

--- a/tools/app/app/components/macros/index.ts
+++ b/tools/app/app/components/macros/index.ts
@@ -14,7 +14,14 @@ import { MacroName } from '@cyberismocom/data-handler/utils/macros';
 import CreateCards from './CreateCards';
 
 export interface MacroContext {
-  key: string; // The key of the current card
+  /**
+   * The key inside of which the macro is rendered.
+   */
+  key: string;
+  /**
+   * True if the macro is rendered in preview mode.
+   */
+  preview: boolean;
 }
 
 export const macros: Record<MacroName, (props: any) => React.ReactElement> = {

--- a/tools/app/app/lib/definitions.ts
+++ b/tools/app/app/lib/definitions.ts
@@ -74,7 +74,7 @@ export interface CardAttachment {
   card: string;
   fileName: string;
   path: string;
-  mimeType: string;
+  mimeType: string | null;
 }
 
 export enum CardMode {

--- a/tools/app/app/locales/en/translation.json
+++ b/tools/app/app/locales/en/translation.json
@@ -35,7 +35,10 @@
     "success": "Card saved successfully"
   },
   "createCard": {
-    "success": "Card created successfully"
+    "success": "Card created successfully",
+    "macro": {
+      "preview": "Creating cards with this macro is not supported in the preview mode"
+    }
   },
   "deleteCard": "Delete Card",
   "delete": "Delete",

--- a/tools/app/app/locales/en/translation.json
+++ b/tools/app/app/locales/en/translation.json
@@ -86,5 +86,6 @@
   },
   "deleteLink": "Delete Link",
   "deleteLinkConfirm": "Are you sure you want to delete this link?",
-  "failedToLoad": "Failed to load"
+  "failedToLoad": "Failed to load",
+  "unknownError": "An unknown error occurred"
 }

--- a/tools/app/next.config.mjs
+++ b/tools/app/next.config.mjs
@@ -1,4 +1,13 @@
+import path from 'path';
+
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  webpack: (config) => {
+    config.resolve.alias.handlebars = path.resolve(
+      '../../node_modules/handlebars/dist/handlebars.js',
+    );
+    return config;
+  },
+};
 
 export default nextConfig;

--- a/tools/app/package.json
+++ b/tools/app/package.json
@@ -23,6 +23,7 @@
     "@reduxjs/toolkit": "^2.2.5",
     "@uiw/react-codemirror": "^4.22.2",
     "codemirror-asciidoc": "^2.0.1",
+    "html-react-parser": "^5.1.12",
     "i18next": "^23.11.5",
     "moment": "^2.30.1",
     "next": "14.1.1",

--- a/tools/data-handler/package.json
+++ b/tools/data-handler/package.json
@@ -44,6 +44,7 @@
     "csv-parse": "^5.5.6",
     "directory-schema-validator": "^1.0.17",
     "email-validator": "^2.0.4",
+    "handlebars": "^4.7.8",
     "isomorphic-git": "^1.25.2",
     "js-yaml": "^4.1.0",
     "json-schema": "^0.4.0",

--- a/tools/data-handler/src/exceptions/index.ts
+++ b/tools/data-handler/src/exceptions/index.ts
@@ -1,3 +1,15 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import { ValidationError } from 'json-schema';
 
 export class DHValidationError extends Error {

--- a/tools/data-handler/src/exceptions/index.ts
+++ b/tools/data-handler/src/exceptions/index.ts
@@ -1,0 +1,17 @@
+import { ValidationError } from 'json-schema';
+
+export class DHValidationError extends Error {
+  public errors?: ValidationError[];
+  constructor(message: string, errors?: ValidationError[]) {
+    super(message);
+    this.name = 'DHValidationError';
+    this.errors = errors;
+  }
+}
+
+export class SchemaNotFound extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SchemaNotFound';
+  }
+}

--- a/tools/data-handler/src/interfaces/adoc.ts
+++ b/tools/data-handler/src/interfaces/adoc.ts
@@ -1,0 +1,6 @@
+export type AdmonitionType =
+  | 'NOTE'
+  | 'TIP'
+  | 'IMPORTANT'
+  | 'CAUTION'
+  | 'WARNING';

--- a/tools/data-handler/src/utils/macros/createCards.ts
+++ b/tools/data-handler/src/utils/macros/createCards.ts
@@ -1,0 +1,38 @@
+import { validateJson } from '../validate.js';
+import {
+  createHtmlPlaceholder,
+  handleMacroError,
+  Macro,
+  validateMacroContent,
+} from './index.js';
+
+export interface CreateCardsOptions {
+  buttonLabel: string;
+  template: string;
+  cardKey?: string;
+  [key: string]: string | undefined;
+}
+
+const macro: Macro<CreateCardsOptions> = {
+  name: 'createCards',
+  tagName: 'create-cards',
+  schema: 'create-cards-macro-schema',
+  handleStatic: (data: string) => {
+    // Buttons aren't supported in static mode
+    return '';
+  },
+  handleInject: (data: string) => {
+    try {
+      if (!data) {
+        throw new Error('data is required');
+      }
+      const options = validateMacroContent(macro, data);
+
+      return createHtmlPlaceholder(macro, options);
+    } catch (e) {
+      return handleMacroError(e, macro);
+    }
+  },
+};
+
+export default macro;

--- a/tools/data-handler/src/utils/macros/createCards.ts
+++ b/tools/data-handler/src/utils/macros/createCards.ts
@@ -1,4 +1,15 @@
-import { validateJson } from '../validate.js';
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import {
   createHtmlPlaceholder,
   handleMacroError,

--- a/tools/data-handler/src/utils/macros/createCards.ts
+++ b/tools/data-handler/src/utils/macros/createCards.ts
@@ -34,8 +34,8 @@ const macro: Macro<CreateCardsOptions> = {
   },
   handleInject: (data: string) => {
     try {
-      if (!data) {
-        throw new Error('data is required');
+      if (!data || typeof data !== 'string') {
+        throw new Error('createCards macro requires a JSON object as data');
       }
       const options = validateMacroContent(macro, data);
 

--- a/tools/data-handler/src/utils/macros/createCards.ts
+++ b/tools/data-handler/src/utils/macros/createCards.ts
@@ -24,11 +24,11 @@ export interface CreateCardsOptions {
   [key: string]: string | undefined;
 }
 
-const macro: Macro<CreateCardsOptions> = {
+const macro: Macro = {
   name: 'createCards',
   tagName: 'create-cards',
   schema: 'create-cards-macro-schema',
-  handleStatic: (data: string) => {
+  handleStatic: () => {
     // Buttons aren't supported in static mode
     return '';
   },
@@ -37,7 +37,7 @@ const macro: Macro<CreateCardsOptions> = {
       if (!data || typeof data !== 'string') {
         throw new Error('createCards macro requires a JSON object as data');
       }
-      const options = validateMacroContent(macro, data);
+      const options = validateMacroContent<CreateCardsOptions>(macro, data);
 
       return createHtmlPlaceholder(macro, options);
     } catch (e) {

--- a/tools/data-handler/src/utils/macros/index.ts
+++ b/tools/data-handler/src/utils/macros/index.ts
@@ -1,0 +1,112 @@
+import Handlebars from 'handlebars';
+import createCards from './createCards.js';
+import { validateJson } from '../validate.js';
+import { DHValidationError } from '../../exceptions/index.js';
+
+type Mode = 'static' | 'inject';
+
+export interface Macro<T> {
+  /**
+   * The name of the macro. This is the name that will be used in the content
+   */
+  name: string;
+  /**
+   * The tag name of the macro. This is the name that will be used in the HTML. This is separated for clarity since tags cannot have uppercase letters
+   */
+  tagName: string;
+
+  /**
+   * The schema of the macro. This is used to validate the data passed to the macro
+   */
+  schema: string;
+  /**
+   * The function to handle the macro in static mode(when adoc is being generated)
+   */
+  handleStatic: (data: string) => string;
+  /**
+   * Inject mode handler - Used to generate an injectable pass-through element
+   */
+  handleInject: (data: string) => string;
+}
+
+export function validateMacroContent<T>(macro: Macro<T>, data: string): T {
+  return validateJson<T>(JSON.parse(data), macro.schema);
+}
+
+export const macros = {
+  createCards,
+};
+
+export type MacroName = keyof typeof macros;
+
+/**
+ * Registers the macros with Handlebars
+ * @param {Mode} mode - The mode to register the macros in
+ */
+export function registerMacros(instance: typeof Handlebars, mode: Mode) {
+  for (const macro of Object.keys(macros) as MacroName[]) {
+    instance.registerHelper(macro, function (data: string) {
+      return macros[macro][mode === 'static' ? 'handleStatic' : 'handleInject'](
+        data,
+      );
+    });
+  }
+}
+
+/**
+ * Handle the macros in the content
+ */
+export function handleMacros(content: string, mode: Mode) {
+  const handlebars = Handlebars.create();
+  registerMacros(handlebars, mode);
+  return handlebars.compile(content, {
+    strict: true,
+  })({});
+}
+
+/**
+ * Validates macros and returns the cause of the error
+ * @param content - The content to validate
+ * @returns The error message or null if template is valid
+ */
+export function validateMacros(content: string): string | null {
+  const handlebars = Handlebars.create();
+
+  registerMacros(handlebars, 'static');
+
+  const template = handlebars.compile(content, {
+    strict: true,
+  });
+
+  try {
+    template({});
+    return null;
+  } catch (error) {
+    return error instanceof Error ? error.message : 'Unknown error';
+  }
+}
+
+/**
+ * Handles errors that come when handling macros
+ * @param error - The error that was thrown
+ * @param macro - The macro that caused the error
+ * @returns The error message that is valid adoc
+ */
+export function handleMacroError<T>(error: unknown, macro: Macro<T>): string {
+  if (error instanceof DHValidationError) {
+    return `Check json syntax of macro ${macro.name}: ${error.errors?.map((e) => e.message).join(', ')}`;
+  }
+  return `Error: ${error instanceof Error ? error.message : 'Unknown error'}`;
+}
+
+/**
+ *
+ */
+export function createHtmlPlaceholder(
+  macro: Macro<any>,
+  options: Record<string, string | undefined>,
+) {
+  return `++++\n<${macro.tagName} ${Object.keys(options)
+    .map((key) => `${key}=${options[key]}`)
+    .join(' ')}></${macro.tagName}>\n++++`;
+}

--- a/tools/data-handler/src/utils/macros/index.ts
+++ b/tools/data-handler/src/utils/macros/index.ts
@@ -76,6 +76,8 @@ export function registerMacros(instance: typeof Handlebars, mode: Mode) {
 
 /**
  * Handle the macros in the content
+ * @param content - The content to handle the macros in
+ * @param mode - The mode to handle the macros in. Inject mode will generate injectable placeholders for the macros while static mode will generate valid adoc
  */
 export function handleMacros(content: string, mode: Mode) {
   const handlebars = Handlebars.create();
@@ -138,7 +140,9 @@ export function handleMacroError(error: unknown, macro: Macro): string {
 }
 
 /**
- *
+ * Creates an injectable placeholder for a macro
+ * @param macro - The macro to create the placeholder for
+ * @param options - Options will be passed to the html element as attributes
  */
 export function createHtmlPlaceholder(
   macro: Macro,

--- a/tools/data-handler/src/utils/macros/index.ts
+++ b/tools/data-handler/src/utils/macros/index.ts
@@ -14,6 +14,7 @@ import Handlebars from 'handlebars';
 import createCards from './createCards.js';
 import { validateJson } from '../validate.js';
 import { DHValidationError } from '../../exceptions/index.js';
+import { AdmonitionType } from '../../interfaces/adoc.js';
 
 type Mode = 'static' | 'inject';
 
@@ -105,10 +106,11 @@ export function validateMacros(content: string): string | null {
  * @returns The error message that is valid adoc
  */
 export function handleMacroError<T>(error: unknown, macro: Macro<T>): string {
+  let message = `Error: ${error instanceof Error ? error.message : 'Unknown error'}`;
   if (error instanceof DHValidationError) {
-    return `Check json syntax of macro ${macro.name}: ${error.errors?.map((e) => e.message).join(', ')}`;
+    message = `Check json syntax of macro ${macro.name}: ${error.errors?.map((e) => e.message).join(', ')}`;
   }
-  return `Error: ${error instanceof Error ? error.message : 'Unknown error'}`;
+  return createAdmonition('WARNING', 'Macro Error', message);
 }
 
 /**
@@ -121,4 +123,19 @@ export function createHtmlPlaceholder(
   return `++++\n<${macro.tagName} ${Object.keys(options)
     .map((key) => `${key}=${options[key]}`)
     .join(' ')}></${macro.tagName}>\n++++`;
+}
+
+/**
+ * Creates an adoc admonition
+ * @param type - The type of admonition
+ * @param label - The label of the admonition
+ * @param content - The content of the admonition
+ * @returns The adoc admonition as a string
+ */
+export function createAdmonition(
+  type: AdmonitionType,
+  label: string,
+  content: string,
+) {
+  return `[${type}]\n.${label}\n====\n${content}\n====\n\n`;
 }

--- a/tools/data-handler/src/utils/macros/index.ts
+++ b/tools/data-handler/src/utils/macros/index.ts
@@ -1,3 +1,15 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import Handlebars from 'handlebars';
 import createCards from './createCards.js';
 import { validateJson } from '../validate.js';

--- a/tools/data-handler/src/utils/macros/index.ts
+++ b/tools/data-handler/src/utils/macros/index.ts
@@ -18,7 +18,7 @@ import { AdmonitionType } from '../../interfaces/adoc.js';
 
 type Mode = 'static' | 'inject';
 
-export interface Macro<T> {
+export interface Macro {
   /**
    * The name of the macro. This is the name that will be used in the content
    */
@@ -42,7 +42,7 @@ export interface Macro<T> {
   handleInject: (data: string) => string;
 }
 
-export function validateMacroContent<T>(macro: Macro<T>, data: string): T {
+export function validateMacroContent<T>(macro: Macro, data: string): T {
   if (!macro.schema) {
     throw new Error(`Macro ${macro.name} does not have a schema`);
   }
@@ -108,7 +108,7 @@ export function validateMacros(content: string): string | null {
  * @param macro - The macro that caused the error
  * @returns The error message that is valid adoc
  */
-export function handleMacroError<T>(error: unknown, macro: Macro<T>): string {
+export function handleMacroError(error: unknown, macro: Macro): string {
   let message = `Error: ${error instanceof Error ? error.message : 'Unknown error'}`;
   if (error instanceof DHValidationError) {
     message = `Check json syntax of macro ${macro.name}: ${error.errors?.map((e) => e.message).join(', ')}`;
@@ -120,7 +120,7 @@ export function handleMacroError<T>(error: unknown, macro: Macro<T>): string {
  *
  */
 export function createHtmlPlaceholder(
-  macro: Macro<any>,
+  macro: Macro,
   options: Record<string, string | undefined>,
 ) {
   return `++++\n<${macro.tagName} ${Object.keys(options)

--- a/tools/data-handler/src/utils/macros/index.ts
+++ b/tools/data-handler/src/utils/macros/index.ts
@@ -31,7 +31,7 @@ export interface Macro<T> {
   /**
    * The schema of the macro. This is used to validate the data passed to the macro
    */
-  schema: string;
+  schema?: string;
   /**
    * The function to handle the macro in static mode(when adoc is being generated)
    */
@@ -43,6 +43,9 @@ export interface Macro<T> {
 }
 
 export function validateMacroContent<T>(macro: Macro<T>, data: string): T {
+  if (!macro.schema) {
+    throw new Error(`Macro ${macro.name} does not have a schema`);
+  }
   return validateJson<T>(JSON.parse(data), macro.schema);
 }
 

--- a/tools/data-handler/src/utils/macros/index.ts
+++ b/tools/data-handler/src/utils/macros/index.ts
@@ -121,7 +121,7 @@ export function createHtmlPlaceholder(
   options: Record<string, string | undefined>,
 ) {
   return `++++\n<${macro.tagName} ${Object.keys(options)
-    .map((key) => `${key}=${options[key]}`)
+    .map((key) => `${key}="${options[key]}"`)
     .join(' ')}></${macro.tagName}>\n++++`;
 }
 

--- a/tools/data-handler/src/utils/schemas.ts
+++ b/tools/data-handler/src/utils/schemas.ts
@@ -1,0 +1,26 @@
+import cardBaseSchema from '../../../schema/card-base-schema.json';
+import cardDirectorySchema from '../../../schema/card-directory-schema.json';
+import cardsconfigSchema from '../../../schema/cardsconfig-schema.json';
+import cardtypeSchema from '../../../schema/cardtype-schema.json';
+import createCardsMacroSchema from '../../../schema/create-cards-macro-schema.json';
+import csvSchema from '../../../schema/csv-schema.json';
+import fieldTypeSchema from '../../../schema/field-type-schema.json';
+import linkTypeSchema from '../../../schema/link-type-schema.json';
+import templateSchema from '../../../schema/template-schema.json';
+import workflowSchema from '../../../schema/workflow-schema.json';
+import cardtreeDirectorySchema from '../../../schema/cardtree-directory-schema.json';
+
+export const schemas = [
+  cardBaseSchema,
+  cardDirectorySchema,
+  cardsconfigSchema,
+  cardtypeSchema,
+  createCardsMacroSchema,
+  csvSchema,
+  fieldTypeSchema,
+  linkTypeSchema,
+  templateSchema,
+  workflowSchema,
+];
+
+export const parentSchema = cardtreeDirectorySchema;

--- a/tools/data-handler/src/utils/schemas.ts
+++ b/tools/data-handler/src/utils/schemas.ts
@@ -10,17 +10,17 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import cardBaseSchema from '../../../schema/card-base-schema.json';
-import cardDirectorySchema from '../../../schema/card-directory-schema.json';
-import cardsconfigSchema from '../../../schema/cardsconfig-schema.json';
-import cardtypeSchema from '../../../schema/cardtype-schema.json';
-import createCardsMacroSchema from '../../../schema/create-cards-macro-schema.json';
-import csvSchema from '../../../schema/csv-schema.json';
-import fieldTypeSchema from '../../../schema/field-type-schema.json';
-import linkTypeSchema from '../../../schema/link-type-schema.json';
-import templateSchema from '../../../schema/template-schema.json';
-import workflowSchema from '../../../schema/workflow-schema.json';
-import cardtreeDirectorySchema from '../../../schema/cardtree-directory-schema.json';
+import cardBaseSchema from '../../../schema/card-base-schema.json' with { type: 'json' };
+import cardDirectorySchema from '../../../schema/card-directory-schema.json' with { type: 'json' };
+import cardsconfigSchema from '../../../schema/cardsconfig-schema.json' with { type: 'json' };
+import cardtypeSchema from '../../../schema/cardtype-schema.json' with { type: 'json' };
+import createCardsMacroSchema from '../../../schema/create-cards-macro-schema.json' with { type: 'json' };
+import csvSchema from '../../../schema/csv-schema.json' with { type: 'json' };
+import fieldTypeSchema from '../../../schema/field-type-schema.json' with { type: 'json' };
+import linkTypeSchema from '../../../schema/link-type-schema.json' with { type: 'json' };
+import templateSchema from '../../../schema/template-schema.json' with { type: 'json' };
+import workflowSchema from '../../../schema/workflow-schema.json' with { type: 'json' };
+import cardtreeDirectorySchema from '../../../schema/cardtree-directory-schema.json' with { type: 'json' };
 
 export const schemas = [
   cardBaseSchema,

--- a/tools/data-handler/src/utils/schemas.ts
+++ b/tools/data-handler/src/utils/schemas.ts
@@ -1,3 +1,15 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import cardBaseSchema from '../../../schema/card-base-schema.json';
 import cardDirectorySchema from '../../../schema/card-directory-schema.json';
 import cardsconfigSchema from '../../../schema/cardsconfig-schema.json';

--- a/tools/data-handler/src/utils/validate.ts
+++ b/tools/data-handler/src/utils/validate.ts
@@ -17,14 +17,24 @@ import { schemas } from './schemas.js';
  * Validates a JSON object against a schema
  * @param object The object to validate
  * @param schemaId The id of the schema to validate against
+ * @param validator An optional validator to use. If validator is not provided or does not contain any schemas, project schemas will be used
  * @returns The object casted to the type T if it is valid
  * @throws DHValidationError if the object is not valid
  * @throws SchemaNotFound if the schema with the given id is not found
  */
-export function validateJson<T>(object: unknown, schemaId: string): T {
-  const validator = new Validator();
+export function validateJson<T>(
+  object: unknown,
+  schemaId: string,
+  validator?: Validator,
+): T {
+  if (!validator) {
+    validator = new Validator();
+  }
 
-  const schema = schemas.find((s) => s.$id === schemaId);
+  const schema =
+    Object.keys(validator.schemas).length > 0
+      ? validator.schemas[schemaId]
+      : schemas.find((s) => s.$id === schemaId);
 
   if (!schema) {
     throw new SchemaNotFound(`Schema with id ${schemaId} not found`);

--- a/tools/data-handler/src/utils/validate.ts
+++ b/tools/data-handler/src/utils/validate.ts
@@ -1,3 +1,14 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
 import { Validator } from 'jsonschema';
 import { DHValidationError, SchemaNotFound } from '../exceptions/index.js';
 import { schemas } from './schemas.js';

--- a/tools/data-handler/src/utils/validate.ts
+++ b/tools/data-handler/src/utils/validate.ts
@@ -1,0 +1,27 @@
+import { Validator } from 'jsonschema';
+import { DHValidationError, SchemaNotFound } from '../exceptions/index.js';
+import { schemas } from './schemas.js';
+
+/**
+ * Validates a JSON object against a schema
+ * @param object The object to validate
+ * @param schemaId The id of the schema to validate against
+ * @returns The object casted to the type T if it is valid
+ * @throws DHValidationError if the object is not valid
+ * @throws SchemaNotFound if the schema with the given id is not found
+ */
+export function validateJson<T>(object: unknown, schemaId: string): T {
+  const validator = new Validator();
+
+  const schema = schemas.find((s) => s.$id === schemaId);
+
+  if (!schema) {
+    throw new SchemaNotFound(`Schema with id ${schemaId} not found`);
+  }
+  const result = validator.validate(object, schema);
+  if (!result.valid) {
+    throw new DHValidationError('Validation failed', result.errors);
+  }
+  // we know that the object is valid, so we can safely cast it to T
+  return object as T;
+}

--- a/tools/data-handler/test/utils/macros/index.test.ts
+++ b/tools/data-handler/test/utils/macros/index.test.ts
@@ -1,0 +1,124 @@
+// testing
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+// ismo
+import {
+  createAdmonition,
+  createHtmlPlaceholder,
+  handleMacros,
+  Macro,
+  registerMacros,
+  validateMacroContent,
+  validateMacros,
+} from '../../../src/utils/macros/index.js';
+import { Validator } from 'jsonschema';
+import Handlebars from 'handlebars';
+
+const macro: Macro = {
+  name: 'testName',
+  tagName: 'test-tag-name',
+  schema: 'test-schema',
+  handleStatic: (data: string) => {
+    return 'test-static: ' + data;
+  },
+  handleInject: (data: string) => {
+    return 'test-inject: ' + data;
+  },
+};
+
+const testSchema = {
+  $id: 'test-schema',
+  type: 'object',
+  properties: {
+    test: {
+      type: 'string',
+    },
+  },
+  required: ['test'],
+};
+
+const validator = new Validator();
+validator.addSchema(testSchema, 'test-schema');
+
+const validAdoc = `
+== Title
+{{{createCards '{"buttonLabel": "test-label", "template": "test-template", "cardKey": "test-key"}'}}}`;
+
+const invalidAdoc = `
+== Title
+{{{createCards '{"buttonLabel": "test-label", "template": "test-template", "cardKey": "test-key"}'`;
+
+describe('macros', () => {
+  describe('validateMacroContent', () => {
+    it('validateMacroContent (success)', () => {
+      const data = '{"test": "test"}';
+      const result = validateMacroContent(macro, data, validator);
+      expect(result).to.deep.equal({ test: 'test' });
+    });
+    it('try validateMacroContent using wrong value', () => {
+      const data = '{"test": 1}';
+      expect(() => validateMacroContent(macro, data, validator)).to.throw();
+    });
+    it('try validateMacroContent using wrong schema', () => {
+      const data = '{"test": "test"}';
+      macro.schema = 'wrong-schema';
+      expect(() => validateMacroContent(macro, data, validator)).to.throw();
+    });
+    it('try validateMacroContent using wrong data', () => {
+      const data = '{"test": "test"';
+      expect(() => validateMacroContent(macro, data, validator)).to.throw();
+    });
+    it('try validateMacroContent using wrong key', () => {
+      const data = '{"test2": "test"}';
+      expect(() => validateMacroContent(macro, data, validator)).to.throw();
+    });
+  });
+  describe('handleMacros', () => {
+    describe('createCards', () => {
+      it('createCards inject (success)', () => {
+        const result = handleMacros(validAdoc, 'inject');
+        expect(result).to.contain('<create-cards');
+      });
+      it('createCards static (success)', () => {
+        const result = handleMacros(validAdoc, 'static');
+        expect(result).to.not.contain('<create-cards>');
+      });
+    });
+  });
+  describe('validateMacros', () => {
+    it('validateMacros (success)', () => {
+      const result = validateMacros(validAdoc);
+      expect(result).to.be.null;
+    });
+    it('try validateMacros', () => {
+      const result = validateMacros(invalidAdoc);
+      expect(result).to.not.be.null;
+    });
+  });
+  describe('registerMacros', () => {
+    it('registerMacros (success)', () => {
+      const handlebars = Handlebars.create();
+      registerMacros(handlebars, 'inject');
+      expect(handlebars.helpers).to.have.property('createCards');
+    });
+  });
+  describe('adoc helpers', () => {
+    it('createHtmlPlaceholder (success)', () => {
+      const result = createHtmlPlaceholder(macro, { test: 'test-data' });
+      expect(result).to.equal(
+        '++++\n<test-tag-name test="test-data"></test-tag-name>\n++++',
+      );
+    });
+    it('createHtmlPlaceholder (success) without data', () => {
+      const result = createHtmlPlaceholder(macro, {});
+      expect(result).to.equal('++++\n<test-tag-name></test-tag-name>\n++++');
+    });
+    it('createAdmonition (success)', () => {
+      const result = createAdmonition('WARNING', 'test-title', 'test-content');
+      expect(result).to.equal(
+        '[WARNING]\n.test-title\n====\ntest-content\n====\n\n',
+      );
+    });
+  });
+});

--- a/tools/data-handler/test/utils/macros/index.test.ts
+++ b/tools/data-handler/test/utils/macros/index.test.ts
@@ -89,11 +89,11 @@ describe('macros', () => {
   describe('validateMacros', () => {
     it('validateMacros (success)', () => {
       const result = validateMacros(validAdoc);
-      expect(result).to.be.null;
+      expect(result).to.equal(null);
     });
     it('try validateMacros', () => {
       const result = validateMacros(invalidAdoc);
-      expect(result).to.not.be.null;
+      expect(result).to.not.equal(null);
     });
   });
   describe('registerMacros', () => {

--- a/tools/schema/create-cards-macro-schema.json
+++ b/tools/schema/create-cards-macro-schema.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "$id": "create-cards-macro-schema",
+  "properties": {
+    "buttonLabel": {
+      "type": "string",
+      "description": "The label of the button to create from this template. For example, 'Create a New Decision'."
+    },
+    "template": {
+      "type": "string",
+      "description": "The name of the template"
+    },
+    "cardKey": {
+      "type": "string",
+      "description": "The card key of the parent under which the template should be instantiated. If not given, the template will be instantiated under the card that includes this macro."
+    }
+  },
+  "additionalProperties": false,
+  "required": ["buttonLabel", "template"]
+}


### PR DESCRIPTION
This pull requests allows users to define macros:
Here's an example macro: {{{macroName '{"options1": "value1"}'}}}
Macros allow users to use predefined components, which will be rendered using React components.

Macros are defined in DH/src/utils/macros. They define a name(this is the name on the UI), tagName(html-tagname used for the component) and schema(Schema is the schema of its options).

React components for the macros are defined in app/components/macros.
The index file contains the components in key/value pairs, where the key should match a name of a macro defined in DH.

Even though the macros are defined in the data-handler, they imported to the app **directly** without any apis between. This was done because so the frontend would not have to send any requests to be able to show a preview. This also means that schemas are now available on the frontend. I made a script, which generates a typescript schemas file automatically.

If you think importing directly from DH is bad, we could have another module called common, which would contain things shared by both the DH and the app.

The data flows like so:
adoc read by DH from file --> sent to app via api --> app calls `handleMacros` directly -->  now the macros have been replaced with passthrough components --> asciidoctor generates html --> html is replaced with react components --> html is rendered

The same approach unfortunately doesn't work with the current export method, because it refers directly to the source adoc. I think we need to create a new ticket for this and decide whether we:
1. Keep the current method(macros can't be used and they will be ugly)
2. Paste the adoc contents manually and handle macros in between. Macros already have a second way of handling them, which is meant for exports

Note: I won't merge this to temp-main, but if I used main, this PR would've been a mess to review before temp-main has been merged to main