### PR TITLE
Support for links

### DIFF
--- a/tools/app/app/cards/[key]/page.tsx
+++ b/tools/app/app/cards/[key]/page.tsx
@@ -73,6 +73,7 @@ export default function Page({ params }: { params: { key: string } }) {
                 data.cardKey,
                 data.linkType,
                 data.linkDescription,
+                data.direction,
               );
               return true;
             } catch (error) {

--- a/tools/app/app/components/ContentArea.tsx
+++ b/tools/app/app/components/ContentArea.tsx
@@ -211,21 +211,21 @@ export function LinkForm({
             )}
           />
         </Stack>
-        <Controller
-          name="linkDescription"
-          control={control}
-          disabled={
-            !selectedLinkType || !selectedLinkType.enableLinkDescription
-          }
-          render={({ field }) => (
-            <Input
-              {...field}
-              color="primary"
-              startDecorator={<Edit />}
-              placeholder={t('linkForm.writeDescription')}
-            />
-          )}
-        />
+
+        {selectedLinkType && selectedLinkType.enableLinkDescription && (
+          <Controller
+            name="linkDescription"
+            control={control}
+            render={({ field }) => (
+              <Input
+                {...field}
+                color="primary"
+                startDecorator={<Edit />}
+                placeholder={t('linkForm.writeDescription')}
+              />
+            )}
+          />
+        )}
         <Button
           type="submit"
           sx={{

--- a/tools/app/app/components/ContentArea.tsx
+++ b/tools/app/app/components/ContentArea.tsx
@@ -188,7 +188,7 @@ export function LinkForm({
                 required={true}
                 placeholder={t('linkForm.searchCard')}
                 options={usableCards.map((c) => ({
-                  label: `${c.metadata?.title}(${c.key})`,
+                  label: `${c.metadata?.title} (${c.key})`,
                   value: c.key,
                 }))}
                 isOptionEqualToValue={(option, value) =>

--- a/tools/app/app/components/ContentArea.tsx
+++ b/tools/app/app/components/ContentArea.tsx
@@ -76,6 +76,8 @@ interface LinkFormProps {
   onSubmit?: (data: LinkFormSubmitData) => boolean | Promise<boolean>;
 }
 
+const NO_LINK_TYPE = -1;
+
 export function LinkForm({
   cards,
   linkTypes,
@@ -83,7 +85,7 @@ export function LinkForm({
   cardType,
 }: LinkFormProps) {
   const { control, handleSubmit, reset, watch } = useForm<LinkFormData>({
-    defaultValues: { linkType: -1, cardKey: '', linkDescription: '' },
+    defaultValues: { linkType: NO_LINK_TYPE, cardKey: '', linkDescription: '' },
   });
   const { t } = useTranslation();
 

--- a/tools/app/app/components/ContentArea.tsx
+++ b/tools/app/app/components/ContentArea.tsx
@@ -36,7 +36,7 @@ import {
 } from '@mui/joy';
 import { useTranslation } from 'react-i18next';
 import MetadataView from './MetadataView';
-import { findCard, getLinksForCard } from '../lib/utils';
+import { findCard, flattenTree, getLinksForCard } from '../lib/utils';
 import { linktype } from '@cyberismocom/data-handler/interfaces/project-interfaces';
 import { default as NextLink } from 'next/link';
 import { Add, Delete, Edit, Search } from '@mui/icons-material';
@@ -60,23 +60,96 @@ interface LinkFormSubmitData {
   linkType: string;
   cardKey: string;
   linkDescription: string;
+  direction: 'inbound' | 'outbound';
+}
+
+interface LinkFormData {
+  linkType: number;
+  cardKey: string;
+  linkDescription: string;
 }
 
 interface LinkFormProps {
   linkTypes: linktype[];
   cards: Project['cards'];
+  cardType: string | undefined;
   onSubmit?: (data: LinkFormSubmitData) => boolean | Promise<boolean>;
 }
 
-export function LinkForm({ cards, linkTypes, onSubmit }: LinkFormProps) {
-  const { control, handleSubmit, reset } = useForm<LinkFormSubmitData>({
-    defaultValues: { linkType: '', cardKey: '', linkDescription: '' },
+export function LinkForm({
+  cards,
+  linkTypes,
+  onSubmit,
+  cardType,
+}: LinkFormProps) {
+  const { control, handleSubmit, reset, watch } = useForm<LinkFormData>({
+    defaultValues: { linkType: -1, cardKey: '', linkDescription: '' },
   });
   const { t } = useTranslation();
+
+  const handledLinkTypes: (linktype & {
+    direction: 'inbound' | 'outbound';
+    id: number;
+  })[] = [];
+
+  let id = 0;
+  for (const type of linkTypes) {
+    if (!cardType) continue;
+    // Check if this card is in from or to list
+    if (
+      type.sourceCardTypes.includes(cardType) ||
+      type.sourceCardTypes.length === 0
+    ) {
+      handledLinkTypes.push({
+        ...type,
+        direction: 'outbound',
+        id: id++,
+      });
+    }
+    if (
+      type.destinationCardTypes.includes(cardType) ||
+      type.destinationCardTypes.length === 0
+    ) {
+      handledLinkTypes.push({
+        ...type,
+        direction: 'inbound',
+        id: id++,
+      });
+    }
+  }
+
+  // find chosen link type
+  const linkType = watch('linkType');
+  const selectedLinkType = handledLinkTypes.find((t) => t.id === linkType);
+
+  const usableCards = flattenTree(cards).filter((card) => {
+    if (!selectedLinkType) return false;
+    if (selectedLinkType.direction === 'outbound') {
+      return (
+        selectedLinkType.destinationCardTypes.includes(
+          card.metadata?.cardtype || '',
+        ) || selectedLinkType.destinationCardTypes.length === 0
+      );
+    } else {
+      return (
+        selectedLinkType.sourceCardTypes.includes(
+          card.metadata?.cardtype || '',
+        ) || selectedLinkType.sourceCardTypes.length === 0
+      );
+    }
+  });
+
   return (
     <form
       onSubmit={handleSubmit(async (data) => {
-        const success = await onSubmit?.(data);
+        const linkType = handledLinkTypes.find((t) => t.id === data.linkType);
+        if (!linkType) return;
+        const success = await onSubmit?.({
+          linkType: linkType.name,
+          cardKey: data.cardKey,
+          linkDescription: data.linkDescription,
+          direction: linkType.direction,
+        });
         if (success) reset();
       })}
     >
@@ -96,9 +169,11 @@ export function LinkForm({ cards, linkTypes, onSubmit }: LinkFormProps) {
                 }}
                 required={true}
               >
-                {linkTypes.map((linkType) => (
-                  <Option key={linkType.name} value={linkType.name}>
-                    {linkType.name}
+                {handledLinkTypes.map((linkType) => (
+                  <Option key={linkType.id} value={linkType.id}>
+                    {linkType.direction === 'outbound'
+                      ? linkType.outboundDisplayName
+                      : linkType.inboundDisplayName}
                   </Option>
                 ))}
               </Select>
@@ -112,8 +187,8 @@ export function LinkForm({ cards, linkTypes, onSubmit }: LinkFormProps) {
                 color="primary"
                 required={true}
                 placeholder={t('linkForm.searchCard')}
-                options={cards.map((c) => ({
-                  label: c.metadata?.title || c.key,
+                options={usableCards.map((c) => ({
+                  label: `${c.metadata?.title}(${c.key})`,
                   value: c.key,
                 }))}
                 isOptionEqualToValue={(option, value) =>
@@ -123,7 +198,7 @@ export function LinkForm({ cards, linkTypes, onSubmit }: LinkFormProps) {
                 value={
                   value
                     ? {
-                        label: findCard(cards, value)?.metadata?.title || value,
+                        label: `${findCard(cards, value)?.metadata?.title}(${value})`,
                         value,
                       }
                     : null
@@ -139,6 +214,9 @@ export function LinkForm({ cards, linkTypes, onSubmit }: LinkFormProps) {
         <Controller
           name="linkDescription"
           control={control}
+          disabled={
+            !selectedLinkType || !selectedLinkType.enableLinkDescription
+          }
           render={({ field }) => (
             <Input
               {...field}
@@ -176,7 +254,6 @@ export const ContentArea: React.FC<ContentAreaProps> = ({
 }) => {
   const [visibleHeaderId, setVisibleHeaderId] = useState<string | null>(null);
 
-  const [isLinkFormVisible, setLinkFormVisible] = useState(false);
   const [isDeleteLinkModalVisible, setDeleteLinkModalVisible] = useState(false); // replace with usemodals if you add more modals
   const [deleteLinkData, setDeleteLinkData] = useState<ParsedLink | null>(null);
 
@@ -188,7 +265,7 @@ export const ContentArea: React.FC<ContentAreaProps> = ({
         {t('cardNotFound')} ({error})
       </Box>
     );
-  if (!card || !linkTypes) return <Box>{t('loading')}</Box>;
+  if (!card || !linkTypes || !project?.cards) return <Box>{t('loading')}</Box>;
 
   const links: ParsedLink[] = (card.metadata?.links || [])
     .map((l) => ({
@@ -257,17 +334,22 @@ export const ContentArea: React.FC<ContentAreaProps> = ({
             {(links.length > 0 || linksVisible) && (
               <Typography level="title-sm">{t('linkedCards')}</Typography>
             )}
-            {!preview && (links.length > 0 || linksVisible) && (
-              <IconButton onClick={onLinkToggle}>
-                {linksVisible ? <ChipDelete /> : <Add />}
-              </IconButton>
-            )}
+            {!preview &&
+              (links.length > 0 || linksVisible) &&
+              (linksVisible ? (
+                <ChipDelete onDelete={onLinkToggle} />
+              ) : (
+                <IconButton onClick={onLinkToggle}>
+                  <Add />
+                </IconButton>
+              ))}
           </Stack>
           {!preview && linksVisible && (
             <LinkForm
               cards={project?.cards ?? []}
               linkTypes={linkTypes}
               onSubmit={onLinkFormSubmit}
+              cardType={card.metadata?.cardtype}
             />
           )}
           <Stack>
@@ -310,8 +392,8 @@ export const ContentArea: React.FC<ContentAreaProps> = ({
                     <Stack direction="row" alignItems="center">
                       <Typography level="body-sm" paddingRight={2}>
                         {link.cardKey === card.key
-                          ? linkType.outboundDisplayName
-                          : linkType.inboundDisplayName}
+                          ? linkType.inboundDisplayName
+                          : linkType.outboundDisplayName}
                       </Typography>
                       <NextLink href={`/cards/${otherCard?.key}`}>
                         <Link component={'div'}>{otherCard?.key}</Link>

--- a/tools/app/app/lib/api/card.ts
+++ b/tools/app/app/lib/api/card.ts
@@ -52,10 +52,16 @@ export const useCard = (key: string | null, options?: SWRConfiguration) => {
       target: string,
       type: string,
       linkDescription?: string,
+      direction: 'inbound' | 'outbound' = 'outbound',
     ) =>
       (key &&
         (await callUpdate(() =>
-          createLink(key, target, type, linkDescription).then(() => {
+          createLink(
+            direction === 'outbound' ? key : target,
+            direction === 'outbound' ? target : key,
+            type,
+            linkDescription,
+          ).then(() => {
             mutate(apiPaths.card(key));
             mutate(apiPaths.project());
           }),

--- a/tools/app/app/locales/en/translation.json
+++ b/tools/app/app/locales/en/translation.json
@@ -77,7 +77,7 @@
   "addAttachment": "Add Attachment",
   "add": "Add",
   "navigationDialogMsg": "You have unsaved changes. Are you sure you want to leave?",
-  "linkedCards": "Linked Cards",
+  "linkedCards": "Linked cards",
   "linkForm": {
     "selectLinkType": "Select Link Type",
     "searchCard": "Search card",

--- a/tools/data-handler/test/command-handler.test.ts
+++ b/tools/data-handler/test/command-handler.test.ts
@@ -939,6 +939,25 @@ describe('create command', () => {
     expect(result.statusCode).to.equal(400);
   });
 
+  it('try create link - card type not valid', async () => {
+    const result = await commandHandler.command(
+      Cmd.create,
+      ['link', 'decision_5', 'decision_6', 'test-types'],
+      options,
+    );
+
+    expect(result.message).to.contain('cannot be linked');
+  });
+
+  it('try create link - link description provided but not allowed', async () => {
+    const result = await commandHandler.command(
+      Cmd.create,
+      ['link', 'decision_5', 'decision_6', 'test-types', 'description2'],
+      options,
+    );
+    expect(result.message).to.contain('does not allow');
+  });
+
   // linktype
   it('linktype (success)', async () => {
     const name = 'lt_name';

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/linktypes/test-types.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/linktypes/test-types.json
@@ -1,0 +1,1 @@
+{"name":"test-types","outboundDisplayName":"test","inboundDisplayName":"test","sourceCardTypes":["decision-cardtype"],"destinationCardTypes":["simplepage-cardtype"],"enableLinkDescription":false}

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/linktypes/test.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/linktypes/test.json
@@ -1,1 +1,1 @@
-{"name":"test","outboundDisplayName":"test","inboundDisplayName":"test","sourceCardTypes":[],"destinationCardTypes":[],"enableLinkDescription":false}
+{"name":"test","outboundDisplayName":"test","inboundDisplayName":"test","sourceCardTypes":[],"destinationCardTypes":[],"enableLinkDescription": true}


### PR DESCRIPTION
Added the following rules:
- Cannot add description if it is not allowed
- Cannot create a link if source is not defined in source card types(empty means any is allowed)
- Cannot creata a link if destination is not defined in destination card types(empty means any is allowed)

On the UI:
- Display only link types, which can be created for the specific card type
- After link type is chosen, only show destinations, which are defined in the configs
- After link type is chose, enable linkDescription box, if link type permits it

Note: Remember to change base branch to main after temp-main has been merged