### PR TITLE
Fix: Create project fails because of missing linktypes directory

### DIFF
--- a/tools/data-handler/src/create.ts
+++ b/tools/data-handler/src/create.ts
@@ -501,7 +501,14 @@ export class Create extends EventEmitter {
     projectPath = resolve(projectPath);
     const projectFolders: string[] = ['.cards/local', 'cardroot'];
     const projectSubFolders: string[][] = [
-      ['calculations', 'cardtypes', 'fieldtypes', 'templates', 'workflows'],
+      [
+        'calculations',
+        'cardtypes',
+        'fieldtypes',
+        'linktypes',
+        'templates',
+        'workflows',
+      ],
       [],
     ];
     const parentFolderToCreate = join(projectPath);


### PR DESCRIPTION
Fixed it by creating a linktypes-directory and a .schema-file in that directory during create-command