### PR TITLE
fix loading issue with edit page

### DIFF
--- a/tools/app/app/cards/[key]/edit/page.tsx
+++ b/tools/app/app/cards/[key]/edit/page.tsx
@@ -201,7 +201,6 @@ export default function Page({ params }: { params: { key: string } }) {
   if (isLoadingCard || isLoadingProject || isLoadingLinkTypes) {
     return <Box>{t('loading')}</Box>;
   }
-  console.log(linkTypes);
   // If any of the data is missing, just show a message that the card was not found
   if (!card || !card.metadata || !previewCard || !project || !linkTypes) {
     return (

--- a/tools/app/app/locales/en/translation.json
+++ b/tools/app/app/locales/en/translation.json
@@ -85,5 +85,6 @@
     "button": "Add link"
   },
   "deleteLink": "Delete Link",
-  "deleteLinkConfirm": "Are you sure you want to delete this link?"
+  "deleteLinkConfirm": "Are you sure you want to delete this link?",
+  "failedToLoad": "Failed to load"
 }


### PR DESCRIPTION
Preview was shown because edit-page assumed card is always loaded to memory. Now it'll correctly wait for things to load and if they do not load, the page will show an error.