### PR TITLE
Attachment actions

### DIFF
--- a/tools/app/app/cards/[key]/edit/page.tsx
+++ b/tools/app/app/cards/[key]/edit/page.tsx
@@ -30,6 +30,7 @@ import {
   Grid,
   IconButton,
   Link,
+  Tooltip,
 } from '@mui/joy';
 
 import CodeMirror, { ReactCodeMirrorRef } from '@uiw/react-codemirror';
@@ -81,6 +82,8 @@ function AttachmentPreviewCard({
 
   const dispatch = useAppDispatch();
 
+  const { t } = useTranslation();
+
   return (
     <Card
       onMouseEnter={() => setIsHovered(true)}
@@ -101,52 +104,60 @@ function AttachmentPreviewCard({
             transition: 'top 0.3s',
           }}
         >
-          <IconButton
-            color="danger"
-            variant="solid"
-            loading={isUpdating}
-            onClick={async (e) => {
-              setIsUpdating(true);
-              await removeAttachment(name);
-              setIsUpdating(false);
-            }}
-          >
-            <Delete />
-          </IconButton>
-          <IconButton variant="solid" color="primary">
-            <Link
-              endDecorator={<Download />}
-              href={apiPaths.attachment(cardKey, name)}
-              download
+          <Tooltip title={t('delete')}>
+            <IconButton
+              color="danger"
               variant="solid"
-            />
-          </IconButton>
-          <IconButton
-            variant="solid"
-            color="primary"
-            onClick={async (e) => {
-              e.stopPropagation();
-              try {
-                await openAttachment(cardKey, name);
-              } catch (error) {
-                dispatch(
-                  addNotification({
-                    message: error instanceof Error ? error.message : '',
-                    type: 'error',
-                  }),
-                );
-              }
-            }}
-          >
-            <Edit />
-          </IconButton>
-          <IconButton
-            variant="solid"
-            color="primary"
-            onClick={(e) => onInsert && onInsert()}
-          >
-            <AddLink />
-          </IconButton>
+              loading={isUpdating}
+              onClick={async (e) => {
+                setIsUpdating(true);
+                await removeAttachment(name);
+                setIsUpdating(false);
+              }}
+            >
+              <Delete />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title={t('saveCopy')}>
+            <IconButton variant="solid" color="primary">
+              <Link
+                endDecorator={<Download />}
+                href={apiPaths.attachment(cardKey, name)}
+                download
+                variant="solid"
+              />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title={t('openInEditor')}>
+            <IconButton
+              variant="solid"
+              color="primary"
+              onClick={async (e) => {
+                e.stopPropagation();
+                try {
+                  await openAttachment(cardKey, name);
+                } catch (error) {
+                  dispatch(
+                    addNotification({
+                      message: error instanceof Error ? error.message : '',
+                      type: 'error',
+                    }),
+                  );
+                }
+              }}
+            >
+              <Edit />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title={t('insertToContent')}>
+            <IconButton
+              variant="solid"
+              color="primary"
+              onClick={(e) => onInsert && onInsert()}
+            >
+              <AddLink />
+            </IconButton>
+          </Tooltip>
         </Box>
         <AspectRatio
           ratio="1"

--- a/tools/app/app/cards/[key]/edit/page.tsx
+++ b/tools/app/app/cards/[key]/edit/page.tsx
@@ -47,7 +47,13 @@ import { useAppDispatch, useAppRouter } from '@/app/lib/hooks';
 import { addNotification } from '@/app/lib/slices/notifications';
 import MetadataView from '@/app/components/MetadataView';
 import Image from 'next/image';
-import { Delete, Download, Edit, InsertDriveFile } from '@mui/icons-material';
+import {
+  AddLink,
+  Delete,
+  Download,
+  Edit,
+  InsertDriveFile,
+} from '@mui/icons-material';
 import { addAttachment } from '@/app/lib/codemirror';
 import { apiPaths } from '@/app/lib/swr';
 import { useAttachments } from '@/app/lib/api/attachments';
@@ -61,10 +67,12 @@ function AttachmentPreviewCard({
   name,
   children,
   cardKey,
+  onInsert,
 }: {
   name: string;
   children?: React.ReactNode;
   cardKey: string;
+  onInsert?: () => void;
 }) {
   const { removeAttachment } = useAttachments(cardKey);
   const [isUpdating, setIsUpdating] = React.useState(false);
@@ -80,7 +88,6 @@ function AttachmentPreviewCard({
       sx={{
         width: '100%',
         gap: 0,
-        cursor: 'pointer',
         overflow: 'hidden',
       }}
     >
@@ -99,7 +106,6 @@ function AttachmentPreviewCard({
             variant="solid"
             loading={isUpdating}
             onClick={async (e) => {
-              e.stopPropagation();
               setIsUpdating(true);
               await removeAttachment(name);
               setIsUpdating(false);
@@ -107,11 +113,7 @@ function AttachmentPreviewCard({
           >
             <Delete />
           </IconButton>
-          <IconButton
-            variant="solid"
-            color="primary"
-            onClick={(e) => e.stopPropagation()}
-          >
+          <IconButton variant="solid" color="primary">
             <Link
               endDecorator={<Download />}
               href={apiPaths.attachment(cardKey, name)}
@@ -137,6 +139,13 @@ function AttachmentPreviewCard({
             }}
           >
             <Edit />
+          </IconButton>
+          <IconButton
+            variant="solid"
+            color="primary"
+            onClick={(e) => onInsert && onInsert()}
+          >
+            <AddLink />
           </IconButton>
         </Box>
         <AspectRatio
@@ -405,19 +414,19 @@ export default function Page({ params }: { params: { key: string } }) {
                         display="flex"
                         justifyContent="center"
                         width={146}
-                        onClick={() => {
-                          if (editor.current && editor.current.view && card) {
-                            addAttachment(
-                              editor.current.view,
-                              attachment,
-                              card.key,
-                            );
-                          }
-                        }}
                       >
                         <AttachmentPreviewCard
                           name={attachment.fileName}
                           cardKey={params.key}
+                          onInsert={() => {
+                            if (editor.current && editor.current.view && card) {
+                              addAttachment(
+                                editor.current.view,
+                                attachment,
+                                card.key,
+                              );
+                            }
+                          }}
                         >
                           {attachment.mimeType?.startsWith('image') ? (
                             <Image

--- a/tools/app/app/lib/api/actions/attachments.ts
+++ b/tools/app/app/lib/api/actions/attachments.ts
@@ -92,29 +92,5 @@ export async function openAttachment(key: string, filename: string) {
   // get path of attachment
   const show = new Show();
 
-  const card = await show.showCardDetails(
-    projectPath || '',
-    {
-      attachments: true,
-    },
-    key,
-  );
-
-  const attachment = card.attachments?.find((a) => a.fileName === filename);
-
-  if (!attachment) {
-    throw new Error('Attachment not found');
-  }
-
-  const path = resolve(join(attachment.path, filename));
-
-  if (process.platform === 'win32') {
-    spawn(`start`, ['cmd.exe', '/c', 'start', '""', `"${path}"`], {
-      shell: true,
-    });
-  } else if (process.platform === 'darwin') {
-    spawn('open', [path]);
-  } else {
-    spawn('xdg-open', [path]);
-  }
+  await show.openAttachment(projectPath || '', key, filename);
 }

--- a/tools/app/app/lib/codemirror/index.ts
+++ b/tools/app/app/lib/codemirror/index.ts
@@ -142,7 +142,7 @@ export function addAttachment(
     editor.dispatch({
       changes: {
         from: target,
-        insert: `${isFirstChar(editor, target) || hasCharAt(editor, ' ', target - 1) ? '' : '\n'}link:${encodeURI(apiPaths.attachment(cardKey, fileName))}[${fileName}]${isLastChar(editor, target) || hasCharAt(editor, ' ', target) ? '' : '\n'}`,
+        insert: `${isFirstChar(editor, target) || hasCharAt(editor, ' ', target - 1) ? '' : '\n'}link:${encodeURI(apiPaths.attachment(cardKey, fileName))}["${fileName}",window=_blank]${isLastChar(editor, target) || hasCharAt(editor, ' ', target) ? '' : '\n'}`,
       },
     });
   }

--- a/tools/app/app/locales/en/translation.json
+++ b/tools/app/app/locales/en/translation.json
@@ -90,5 +90,8 @@
   "deleteLink": "Delete Link",
   "deleteLinkConfirm": "Are you sure you want to delete this link?",
   "failedToLoad": "Failed to load",
-  "unknownError": "An unknown error occurred"
+  "unknownError": "An unknown error occurred",
+  "insertToContent": "Insert to content",
+  "openInEditor": "Open in editor",
+  "saveCopy": "Save copy"
 }

--- a/tools/data-handler/src/show.ts
+++ b/tools/data-handler/src/show.ts
@@ -183,6 +183,7 @@ export class Show {
    */
   private async openUsingDefaultApplication(path: string) {
     if (process.platform === 'win32') {
+      // This is a workaround to get windows to open the file in foreground
       spawn(`start`, ['cmd.exe', '/c', 'start', '""', `"${path}"`], {
         shell: true,
       });

--- a/tools/data-handler/src/show.ts
+++ b/tools/data-handler/src/show.ts
@@ -122,7 +122,10 @@ export class Show {
     const prefs = new UserPreferences(
       join(homedir(), '.cyberismo', 'cards.prefs.json'),
     ).getPreferences();
-    const attachmentEditors = prefs.attachmentEditors[process.platform];
+    const attachmentEditors =
+      prefs.attachmentEditors && process.platform in prefs.attachmentEditors
+        ? prefs.attachmentEditors[process.platform]
+        : [];
 
     const editor = attachmentEditors.find(
       (editor) => editor.mimeType === attachment.mimeType,

--- a/tools/data-handler/src/utils/user-preferences.ts
+++ b/tools/data-handler/src/utils/user-preferences.ts
@@ -86,11 +86,13 @@ export class UserPreferences {
         },
         {
           mimeType: 'image/png',
-          command: 'C:Program Files...draw.io {{attachmentPath}}',
+          command:
+            '"C:\\Program Files\\draw.io\\draw.io.exe" "{{attachmentPath}}"',
         },
         {
           mimeType: 'image/svg+xml',
-          command: 'C:Program Files...draw.io {{attachmentPath}}',
+          command:
+            '"C:\\Program Files\\draw.io\\draw.io.exe" "{{attachmentPath}}"',
         },
       ],
     },

--- a/tools/data-handler/src/utils/user-preferences.ts
+++ b/tools/data-handler/src/utils/user-preferences.ts
@@ -14,6 +14,20 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { formatJson } from './json.js';
 import { dirname } from 'path';
 
+export interface UserPreferencesObject {
+  editCommand: {
+    [platform: string]: {
+      command: string;
+      args: string[];
+    };
+  };
+  attachmentEditors: {
+    [platform: string]: {
+      mimeType: string;
+      command: string;
+    }[];
+  };
+}
 /**
  * The class checks if the preferences file exists when instantiated, and if not, creates it with a default JSON object.
  * The getPreferences() method simply reads and parses the file to return the preferences object.
@@ -21,7 +35,7 @@ import { dirname } from 'path';
 export class UserPreferences {
   // If preferences do not exist, they are initialised
   // with these defaults.
-  static defaults: object = {
+  static defaults = {
     editCommand: {
       darwin: {
         command: 'code',
@@ -35,6 +49,50 @@ export class UserPreferences {
         command: 'notepad.exe',
         args: ['{{cardContentPath}}', '{{cardJsonPath}}'],
       },
+    },
+    attachmentEditors: {
+      darwin: [
+        {
+          mimeType: 'image/png',
+          command: "open -a draw.io '{{attachmentPath}}'",
+        },
+        {
+          mimeType: 'image/svg+xml',
+          command: "open -a draw.io '{{attachmentPath}}'",
+        },
+        {
+          mimeType: 'application/pdf',
+          command: 'open -a Preview "{{attachmentPath}}"',
+        },
+      ],
+      linux: [
+        {
+          mimeType: 'text/plain',
+          command: 'vim {{attachmentPath}}',
+        },
+        {
+          mimeType: 'image/png',
+          command: 'draw.io {{attachmentPath}}',
+        },
+        {
+          mimeType: 'image/svg+xml',
+          command: 'draw.io {{attachmentPath}}',
+        },
+      ],
+      win32: [
+        {
+          mimeType: 'text/plain',
+          command: 'notepad.exe {{attachmentPath}}',
+        },
+        {
+          mimeType: 'image/png',
+          command: 'C:Program Files...draw.io {{attachmentPath}}',
+        },
+        {
+          mimeType: 'image/svg+xml',
+          command: 'C:Program Files...draw.io {{attachmentPath}}',
+        },
+      ],
     },
   };
 
@@ -57,7 +115,7 @@ export class UserPreferences {
     }
   }
 
-  public getPreferences() {
+  public getPreferences(): UserPreferencesObject {
     // Read and parse the preferences file
     try {
       return JSON.parse(readFileSync(this.prefsFilePath, 'utf8'));

--- a/tools/data-handler/src/utils/user-preferences.ts
+++ b/tools/data-handler/src/utils/user-preferences.ts
@@ -42,7 +42,7 @@ export class UserPreferences {
         args: ['{{cardContentPath}}', '{{cardJsonPath}}'],
       },
       linux: {
-        command: 'vim',
+        command: 'vi',
         args: ['{{cardContentPath}}', '{{cardJsonPath}}'],
       },
       win32: {
@@ -67,16 +67,12 @@ export class UserPreferences {
       ],
       linux: [
         {
-          mimeType: 'text/plain',
-          command: 'vim {{attachmentPath}}',
-        },
-        {
           mimeType: 'image/png',
-          command: 'draw.io {{attachmentPath}}',
+          command: 'drawio {{attachmentPath}}',
         },
         {
           mimeType: 'image/svg+xml',
-          command: 'draw.io {{attachmentPath}}',
+          command: 'drawio {{attachmentPath}}',
         },
       ],
       win32: [


### PR DESCRIPTION
Adds the following actions:
- Download
- Open in editor

Also, the icons are now hidden by default.

If a command is defined in user preferences, it will try to launch that, otherwise it will use the default app selector of the OS.

It'll wait 1 second for the custom app to start and if it has exited with a non-zero exit code, it will use the default app selector of the OS.

There wasn't a good option for starting an app on windows. Windows seemed to put the app to background. I used a workaround, which starts a cmd prompt and it does work but the user will see a cmd window pop up and destroy itself.

Security:
Custom commands are not escaped in anyway and a shell is used so it is possible to do anything. But it doesn't matter, because these are defined by the user.

Starting the default app is safe on mac/linux, since no shell is used.
Windows version does use a shell, but since "-characters are not valid filenames on windows, it should be safe to use, because the path is read from the filesystem.


Functionality has been tested on windows/linux, but not on MacOS

The app will use a default system OS also, if the user preferences file doesn't contain the given platform. In general, it would probably be smarter to validate the user-preferences file and overwrite it using defaults if it is not valid.