### PR TITLE
Allow card creation to root from app

### DIFF
--- a/tools/app/app/api/cards/[key]/route.tsx
+++ b/tools/app/app/api/cards/[key]/route.tsx
@@ -305,7 +305,11 @@ export async function POST(request: NextRequest) {
 
   try {
     return NextResponse.json(
-      await createCommand.createCard(projectPath, res.template, key),
+      await createCommand.createCard(
+        projectPath,
+        res.template,
+        key === 'root' ? undefined : key,
+      ),
     );
   } catch (error) {
     if (error instanceof Error) {

--- a/tools/app/app/lib/api/card.ts
+++ b/tools/app/app/lib/api/card.ts
@@ -39,7 +39,7 @@ export const useCard = (key: string | null, options?: SWRConfiguration) => {
       dispatch(cardDeleted(key));
     },
     createCard: async (template: string) =>
-      (key && (await callUpdate(() => createCard(key, template)))) || null,
+      await callUpdate(() => createCard(key ?? 'root', template)),
     updateWorkFlowState: async (state: string) =>
       (key &&
         (await callUpdate(() =>

--- a/tools/app/app/lib/hooks/redux.ts
+++ b/tools/app/app/lib/hooks/redux.ts
@@ -84,17 +84,14 @@ export function useUpdating(key: string | null) {
 
   return {
     isUpdating: useAppSelector(
-      (state) => (key && state.swr.additionalProps[key]?.isUpdating) || false,
+      (state) => state.swr.additionalProps[key ?? 'root']?.isUpdating ?? false,
     ),
     call: async <T>(fn: () => Promise<T>) => {
-      if (!key) {
-        return;
-      }
-      dispatch(setIsUpdating({ key, isUpdating: true }));
+      dispatch(setIsUpdating({ key: key ?? 'root', isUpdating: true }));
       try {
         return await fn();
       } finally {
-        dispatch(setIsUpdating({ key, isUpdating: false }));
+        dispatch(setIsUpdating({ key: key ?? 'root', isUpdating: false }));
       }
     },
   };


### PR DESCRIPTION
Card key is null on the /cards page. createCard-function used to ignore function calls where null was used. Null was replaced with 'root', because the api call is made to `/api/cards/{key}`. It shouldn't be possible to have cards, which have "root" as the key, so there shouldn't be any collisions