### PR TITLE
Generate links to for logic programming

### DIFF
--- a/tools/app/app/cards/[key]/page.tsx
+++ b/tools/app/app/cards/[key]/page.tsx
@@ -70,10 +70,18 @@ export default function Page({ params }: { params: { key: string } }) {
             project={project}
             onLinkFormSubmit={async (data) => {
               try {
+                const linkType = linkTypes?.find(
+                  (lt) => lt.name === data.linkType,
+                );
+                if (!linkType) {
+                  throw new Error('Link type not found');
+                }
                 await createLink(
                   data.cardKey,
                   data.linkType,
-                  data.linkDescription,
+                  linkType.enableLinkDescription
+                    ? data.linkDescription
+                    : undefined,
                 );
                 return true;
               } catch (error) {

--- a/tools/data-handler/src/calculate.ts
+++ b/tools/data-handler/src/calculate.ts
@@ -17,7 +17,7 @@ import { mkdir, opendir, readFile, writeFile } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 
 // ismo
-import { card } from './interfaces/project-interfaces.js';
+import { card, link } from './interfaces/project-interfaces.js';
 import { deleteFile, pathExists } from './utils/file-utils.js';
 import { Project } from './containers/project.js';
 
@@ -112,6 +112,10 @@ fieldtype(X, Field, "cardkeys") :- field(X, Field, _), card(Value) : field(X, Fi
           if (field === 'labels') {
             for (const label of value as Array<string>) {
               logicProgram += `label(${card.key}, "${label}").\n`;
+            }
+          } else if (field === 'links') {
+            for (const link of value as Array<link>) {
+              logicProgram += `link(${card.key}, ${link.cardKey}, "${link.linkType}"${link.linkDescription != null ? `, "${link.linkDescription}"` : ''}).\n`;
             }
           } else {
             logicProgram += `field(${card.key}, "${field}", "${value}").\n`;


### PR DESCRIPTION
Also fixed a bug: you couldn't make links in which the linkDescription was not enabled
Here's  a generated logic program with links:

% cisms_3
field(cisms_3, "title", "Asset inventory").
field(cisms_3, "cardtype", "page").
field(cisms_3, "workflowState", "Draft").
field(cisms_3, "rank", "0|g").
field(cisms_3, "lastUpdated", "2024-09-03T10:55:37.934Z").
link(cisms_3, cisms_17, "mitigates2", "").
link(cisms_3, cisms_17, "mitigates2", "fdsfsdfdssdfsfs").
link(cisms_3, cisms_17, "mitigates3").
