### PR TITLE
INTDEV-399: Unique identifiers

### DIFF
--- a/examples/decision-records/.cards/local/cardsconfig.json
+++ b/examples/decision-records/.cards/local/cardsconfig.json
@@ -1,5 +1,4 @@
 {
     "cardkeyPrefix": "decision",
-    "name": "decision",
-    "nextAvailableCardNumber": 7
+    "name": "decision"
 }

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -423,15 +423,23 @@ export class Commands {
       };
     }
     try {
+      const addedCards = await this.createCmd.addCards(
+        path,
+        cardTypeName,
+        templateName,
+        cardKey,
+        repeat,
+      );
+
+      const messageTxt =
+        addedCards.length > 1
+          ? `${addedCards.length} cards were added to the template '${templateName} : ${JSON.stringify(addedCards)}'`
+          : `card '${addedCards[0]}' was added to the template '${templateName}'`;
+
       return {
         statusCode: 200,
-        message: await this.createCmd.addCards(
-          path,
-          cardTypeName,
-          templateName,
-          cardKey,
-          repeat,
-        ),
+        affectsCards: addedCards,
+        message: messageTxt,
       };
     } catch (e) {
       return {
@@ -536,6 +544,7 @@ export class Commands {
       );
       return {
         statusCode: 200,
+        affectsCards: createdCards,
         message: `Created cards ${JSON.stringify(createdCards)}`,
       };
     } catch (e) {

--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -86,7 +86,7 @@ export class Template extends CardContainer {
     for (const card of cards) {
       templateIDMap.push({
         from: card.key,
-        to: this.project.configuration.newCardKey(),
+        to: await this.project.newCardKey(),
       });
     }
 
@@ -246,11 +246,10 @@ export class Template extends CardContainer {
       }
       // Finally, delete temp folder.
       await rm(tempDestination, { recursive: true, force: true });
-      await this.project.configuration.commit();
+      await this.project.configuration.save();
     } catch (error) {
       if (error instanceof Error) {
-        this.project.configuration.rollback();
-        // If card creation causes an exception, remove 'temp' and reset the cardkey id value.
+        // If card creation causes an exception, remove 'temp'.
         await rm(tempDestination, { recursive: true, force: true });
         throw new Error(error.message);
       }
@@ -348,7 +347,7 @@ export class Template extends CardContainer {
         );
       }
 
-      newCardKey = this.project.configuration.newCardKey();
+      newCardKey = await this.project.newCardKey();
       const templateCardToCreate = parentCard
         ? join(destinationCardPath, newCardKey)
         : join(this.templateCardsPath, newCardKey);
@@ -359,11 +358,10 @@ export class Template extends CardContainer {
         formatJson(defaultContent),
       );
       await writeFile(join(templateCardToCreate, Project.cardContentFile), '');
-      await this.project.configuration.commit();
+      await this.project.configuration.save();
     } catch (error) {
       if (error instanceof Error) {
         // todo: does this ever really throw?
-        this.project.configuration.rollback();
         // todo: use temp folder and destroy everything from there.
         throw new Error(error.message);
       }

--- a/tools/data-handler/src/create.ts
+++ b/tools/data-handler/src/create.ts
@@ -71,7 +71,6 @@ export class Create extends EventEmitter {
       content: {
         name: '$PROJECT-NAME',
         cardkeyPrefix: '$PROJECT-PREFIX',
-        nextAvailableCardNumber: 1,
       },
       name: Project.projectConfigFileName,
     },
@@ -155,7 +154,7 @@ export class Create extends EventEmitter {
    * @param {string} templateName Template name to add cards into.
    * @param {string} card Optional, if defined adds a new child-card under the card.
    * @param {number} count How many cards to add. By default one.
-   * @returns string with information about the operation
+   * @returns non-empty string array with ids of added cards
    */
   public async addCards(
     projectPath: string,
@@ -163,7 +162,7 @@ export class Create extends EventEmitter {
     templateName: string,
     card?: string,
     count: number = 1,
-  ): Promise<string> {
+  ): Promise<string[]> {
     // Use slice to get a copy of a string.
     const origTemplateName = templateName.slice(0);
     templateName = Template.normalizedTemplateName(templateName);
@@ -209,11 +208,7 @@ export class Create extends EventEmitter {
     }
 
     if (promisesResult === undefined) {
-      const messageTxt =
-        count > 1
-          ? `${count} cards were added to the template '${templateName} : ${JSON.stringify(cardsContainer)}'`
-          : `card '${cardsContainer[0]}' was added to the template '${templateName}'`;
-      return messageTxt;
+      return cardsContainer;
     } else {
       throw new Error('Unknown error');
     }

--- a/tools/data-handler/src/export.ts
+++ b/tools/data-handler/src/export.ts
@@ -34,6 +34,7 @@ import { readADocFileSync, readJsonFileSync } from './utils/json.js';
 import Processor from '@asciidoctor/core';
 
 import mime from 'mime-types';
+import { sortItems } from './utils/lexorank.js';
 
 const attachmentFolder: string = 'a';
 
@@ -244,7 +245,7 @@ export class Export {
   ) {
     Export.project = new Project(source);
     const sourcePath: string = Export.project.cardrootFolder;
-    const cards: card[] = [];
+    let cards: card[] = [];
 
     // If doing a partial tree export, put the parent information as it would have already been gathered.
     if (cardkey) {
@@ -255,13 +256,9 @@ export class Export {
     }
     await this.readCardTreeToMemory(sourcePath, cards);
 
-    // Return cards in numeric order.
-    cards.sort((a, b) => {
-      const aIDNumberPart = Number(a.key.slice(a.key.indexOf('_') + 1));
-      const bIDNumberPart = Number(b.key.slice(b.key.indexOf('_') + 1));
-      if (aIDNumberPart > bIDNumberPart) return 1;
-      if (aIDNumberPart < bIDNumberPart) return -1;
-      return 0;
+    // Sort the cards by rank
+    cards = sortItems(cards, function (card) {
+      return card.metadata?.rank || '1|z';
     });
 
     await mkdir(join(destination, attachmentFolder), { recursive: true });

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -19,7 +19,6 @@ export interface dotSchemaContent {
   version: number;
   cardkeyPrefix?: never;
   name?: never;
-  nextAvailableCardNumber?: never;
 }
 
 // Project's settings (=cardsconfig.json).
@@ -28,7 +27,6 @@ export interface projectSettings {
   version?: never;
   cardkeyPrefix: string;
   name: string;
-  nextAvailableCardNumber: number;
 }
 
 // Module content
@@ -121,7 +119,6 @@ export interface project {
   name: string;
   path: string;
   prefix: string;
-  nextAvailableCardNumber: number;
   numberOfCards: number;
 }
 
@@ -203,8 +200,8 @@ export interface attachmentDetails {
   mimeType: string | null;
 }
 
-// Name for a card (consists of prefix and running number; e.g. 'test_1')
-export const cardNameRegEx = new RegExp(/^[a-z]+_[0-9]+$/);
+// Name for a card (consists of prefix and a random 8-character base36 string; e.g. 'test_abcd1234')
+export const cardNameRegEx = new RegExp(/^[a-z]+_[0-9a-z]+$/);
 
 // Define which details of a card are fetched.
 export interface fetchCardDetails {

--- a/tools/data-handler/src/interfaces/request-status-interfaces.ts
+++ b/tools/data-handler/src/interfaces/request-status-interfaces.ts
@@ -19,6 +19,7 @@ enum httpStatusCode {
 export interface requestStatus {
   statusCode: httpStatusCode;
   message?: string;
+  affectsCards?: string[];
   payload?: object | attachmentPayload;
 }
 

--- a/tools/data-handler/src/utils/random.ts
+++ b/tools/data-handler/src/utils/random.ts
@@ -1,0 +1,19 @@
+/**
+ * Returns a random string in given base with given length (padded with 0's if necessary)
+ * @param {number} base which base to be used, e.g. 36 for base-36, must be an integer
+ * @param {number} length length of string, must be an integer
+ * @returns a random string
+ * @throws if parameters are not integer numbers
+ */
+export function generateRandomString(base: number, length: number): string {
+  if (!Number.isInteger(base) || !Number.isInteger(length)) {
+    throw 'parameters must be integers';
+  }
+
+  // Generate a random number between 0 and given base max number - 1
+  const maxBaseNumber = Math.pow(base, length);
+  const randomNum = Math.floor(Math.random() * maxBaseNumber);
+
+  // Convert the number to a given base string and pad it with leading zeros if necessary
+  return randomNum.toString(base).padStart(length, '0');
+}

--- a/tools/data-handler/test/project.test.ts
+++ b/tools/data-handler/test/project.test.ts
@@ -113,7 +113,6 @@ describe('project', () => {
     expect(projectDetails.name).to.equal(project.projectName);
     expect(projectDetails.prefix).to.equal(project.projectPrefix);
     expect(projectDetails.path).to.equal(resolve(project.cardrootFolder, '..'));
-    expect(projectDetails.nextAvailableCardNumber).to.equal(7);
     expect(projectDetails.numberOfCards).to.equal(2);
   });
 
@@ -132,99 +131,10 @@ describe('project', () => {
     expect(projectSettings).to.not.equal(undefined);
 
     const prefix = projectSettings.cardkeyPrefix;
-    const nextNumber = projectSettings.nextAvailableCardNumber;
     expect(prefix).to.equal('decision');
-    expect(nextNumber).to.equal(7);
-
-    const expectedCardKey = `${prefix}_${nextNumber}`;
-    const nextCardKey = projectSettings.newCardKey();
-    expect(nextCardKey).to.equal(expectedCardKey);
 
     const prefixes = await project.projectPrefixes();
     expect(prefixes).to.contain(prefix);
-
-    // to avoid impacting other tests, rollback
-    projectSettings.rollback();
-  });
-
-  it('increment project settings IDs', async () => {
-    const decisionRecordsPath = join(testDir, 'valid/decision-records');
-    const project = new Project(decisionRecordsPath);
-    expect(project).to.not.equal(undefined);
-
-    const configFile = join(
-      decisionRecordsPath,
-      '.cards',
-      'local',
-      Project.projectConfigFileName,
-    );
-    const projectSettings = ProjectSettings.getInstance(configFile);
-
-    // Make four calls -> ID raises by four (three after first call);
-    const valueFirst = projectSettings.newCardKey();
-    const valuePartsFirst = valueFirst.split('_');
-    projectSettings.newCardKey();
-    projectSettings.newCardKey();
-    const valueLater = projectSettings.newCardKey();
-    const valuePartsLater = valueLater.split('_');
-    expect(valuePartsFirst[0]).to.equal(valuePartsLater[0]);
-    expect(Number(valuePartsFirst[1]) + 3).to.equal(Number(valuePartsLater[1]));
-
-    // to avoid impacting other tests, rollback
-    projectSettings.rollback();
-  });
-
-  it('rollback project settings changes', async () => {
-    const decisionRecordsPath = join(testDir, 'valid/decision-records');
-    const project = new Project(decisionRecordsPath);
-    expect(project).to.not.equal(undefined);
-
-    const configFile = join(
-      decisionRecordsPath,
-      '.cards',
-      'local',
-      Project.projectConfigFileName,
-    );
-    const projectSettings = ProjectSettings.getInstance(configFile);
-
-    // Make a call, but then rollback -> values are same
-    const valueFirst = projectSettings.newCardKey();
-    const valuePartsFirst = valueFirst.split('_');
-    projectSettings.rollback();
-    const valueLater = projectSettings.newCardKey();
-    const valuePartsLater = valueLater.split('_');
-    expect(valuePartsFirst[0]).to.equal(valuePartsLater[0]);
-    expect(Number(valuePartsFirst[1])).to.equal(Number(valuePartsLater[1]));
-
-    // to avoid impacting other tests, rollback
-    projectSettings.rollback();
-  });
-
-  it('commit project settings changes', async () => {
-    const decisionRecordsPath = join(testDir, 'valid/decision-records');
-    const project = new Project(decisionRecordsPath);
-    expect(project).to.not.equal(undefined);
-
-    const configFile = join(
-      decisionRecordsPath,
-      '.cards',
-      'local',
-      Project.projectConfigFileName,
-    );
-    const projectSettings = ProjectSettings.getInstance(configFile);
-
-    // Make a call, then commit.
-    // Calling rollback will not revert the setting values.
-    const valueFirst = projectSettings.newCardKey();
-    const valuePartsFirst = Number(valueFirst.split('_')[1]);
-    await projectSettings.commit();
-    projectSettings.rollback();
-    const valueLater = projectSettings.newCardKey();
-    const valuePartsLater = Number(valueLater.split('_')[1]);
-    expect(valuePartsFirst + 1).to.equal(valuePartsLater);
-
-    // to avoid impacting other tests, rollback
-    projectSettings.rollback();
   });
 
   it('multiple instances of settings class', async () => {
@@ -258,31 +168,6 @@ describe('project', () => {
     expect(projectSettings2.cardkeyPrefix).to.equal(
       projectSettings3.cardkeyPrefix,
     );
-    expect(projectSettings1.nextAvailableCardNumber).to.not.equal(
-      projectSettings2.nextAvailableCardNumber,
-    );
-    expect(projectSettings2.nextAvailableCardNumber).to.equal(
-      projectSettings3.nextAvailableCardNumber,
-    );
-
-    // Create new keys from the settings and ensure that instances behave correctly.
-    const key1_1 = projectSettings1.newCardKey();
-    const key1_2 = projectSettings1.newCardKey();
-    const key2_1 = projectSettings2.newCardKey();
-    const key2_2 = projectSettings2.newCardKey();
-    const key3_1 = projectSettings3.newCardKey();
-    const key3_2 = projectSettings3.newCardKey();
-
-    expect(key1_1).to.equal('decision_8');
-    expect(key1_2).to.equal('decision_9');
-    expect(key2_1).to.equal('mini_1');
-    expect(key2_2).to.equal('mini_2');
-    expect(key3_1).to.equal('mini_3');
-    expect(key3_2).to.equal('mini_4');
-
-    // to avoid impacting other tests, rollback
-    projectSettings1.rollback();
-    projectSettings2.rollback();
   });
 
   it('create class - card operation (success)', async () => {

--- a/tools/data-handler/test/test-data/invalid/invalid-card-has-wrong-state/.cards/local/cardsconfig.json
+++ b/tools/data-handler/test/test-data/invalid/invalid-card-has-wrong-state/.cards/local/cardsconfig.json
@@ -1,5 +1,4 @@
 {
     "cardkeyPrefix": "decision",
-    "name": "decision",
-    "nextAvailableCardNumber": 7
+    "name": "decision"
 }

--- a/tools/data-handler/test/test-data/invalid/missing-.cards-subfolder-local/.cards/cardsconfig.json
+++ b/tools/data-handler/test/test-data/invalid/missing-.cards-subfolder-local/.cards/cardsconfig.json
@@ -1,5 +1,4 @@
 {
     "cardkeyPrefix": "testmissing",
-    "name":"missing",
-    "nextAvailableCardNumber": 1
+    "name":"missing"
 }

--- a/tools/data-handler/test/test-data/invalid/missing-.cards-subfolders/.cards/local/cardsconfig.json
+++ b/tools/data-handler/test/test-data/invalid/missing-.cards-subfolders/.cards/local/cardsconfig.json
@@ -1,5 +1,4 @@
 {
     "cardkeyPrefix": "testmissing",
-    "name":"missing",
-    "nextAvailableCardNumber": 1
+    "name":"missing"
 }

--- a/tools/data-handler/test/test-data/invalid/missing-cardroot/.cards/cardsconfig.json
+++ b/tools/data-handler/test/test-data/invalid/missing-cardroot/.cards/cardsconfig.json
@@ -1,5 +1,4 @@
 {
     "cardkeyPrefix":"testmissing",
-    "name":"missing",
-    "nextAvailableCardNumber":1
+    "name":"missing"
 }

--- a/tools/data-handler/test/test-data/invalid/missing-cardtypes-subfolder/.cards/local/cardsconfig.json
+++ b/tools/data-handler/test/test-data/invalid/missing-cardtypes-subfolder/.cards/local/cardsconfig.json
@@ -1,5 +1,4 @@
 {
     "cardkeyPrefix": "testmissing",
-    "name":"missing",
-    "nextAvailableCardNumber": 1
+    "name":"missing"
 }

--- a/tools/data-handler/test/test-data/invalid/missing-templates-subfolder/.cards/local/cardsconfig.json
+++ b/tools/data-handler/test/test-data/invalid/missing-templates-subfolder/.cards/local/cardsconfig.json
@@ -1,5 +1,4 @@
 {
     "cardkeyPrefix": "testmissing",
-    "name":"missing",
-    "nextAvailableCardNumber": 1
+    "name":"missing"
 }

--- a/tools/data-handler/test/test-data/invalid/missing-workflows-subfolder/.cards/local/cardsconfig.json
+++ b/tools/data-handler/test/test-data/invalid/missing-workflows-subfolder/.cards/local/cardsconfig.json
@@ -1,5 +1,4 @@
 {
     "cardkeyPrefix": "testmissing",
-    "name":"missing",
-    "nextAvailableCardNumber": 1
+    "name":"missing"
 }

--- a/tools/data-handler/test/test-data/invalid/no-.schema-in-.cards-cardtypes/.cards/local/cardsconfig.json
+++ b/tools/data-handler/test/test-data/invalid/no-.schema-in-.cards-cardtypes/.cards/local/cardsconfig.json
@@ -1,5 +1,4 @@
 {
     "cardkeyPrefix": "testmissing",
-    "name":"missing",
-    "nextAvailableCardNumber": 1
+    "name":"missing"
 }

--- a/tools/data-handler/test/test-data/invalid/no-.schema-in-.cards-local/.cards/local/cardsconfig.json
+++ b/tools/data-handler/test/test-data/invalid/no-.schema-in-.cards-local/.cards/local/cardsconfig.json
@@ -1,5 +1,4 @@
 {
     "cardkeyPrefix": "testmissing",
-    "name":"missing",
-    "nextAvailableCardNumber": 1
+    "name":"missing"
 }

--- a/tools/data-handler/test/test-data/invalid/no-.schema-in-.cards-templates-subfolder/.cards/local/cardsconfig.json
+++ b/tools/data-handler/test/test-data/invalid/no-.schema-in-.cards-templates-subfolder/.cards/local/cardsconfig.json
@@ -1,5 +1,4 @@
 {
     "cardkeyPrefix": "testmissing",
-    "name":"missing",
-    "nextAvailableCardNumber": 1
+    "name":"missing"
 }

--- a/tools/data-handler/test/test-data/invalid/no-.schema-in-.cards-workflows/.cards/local/cardsconfig.json
+++ b/tools/data-handler/test/test-data/invalid/no-.schema-in-.cards-workflows/.cards/local/cardsconfig.json
@@ -1,5 +1,4 @@
 {
     "cardkeyPrefix": "testmiss",
-    "name":"missing",
-    "nextAvailableCardNumber": 1
+    "name":"missing"
 }

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/cardsconfig.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/cardsconfig.json
@@ -1,5 +1,4 @@
 {
     "cardkeyPrefix": "decision",
-    "name": "decision",
-    "nextAvailableCardNumber": 7
+    "name": "decision"
 }

--- a/tools/data-handler/test/test-data/valid/minimal/.cards/local/cardsconfig.json
+++ b/tools/data-handler/test/test-data/valid/minimal/.cards/local/cardsconfig.json
@@ -1,5 +1,4 @@
 {
     "cardkeyPrefix":"mini",
-    "name":"minimal",
-    "nextAvailableCardNumber":1
+    "name":"minimal"
 }

--- a/tools/data-handler/test/utils/random.test.ts
+++ b/tools/data-handler/test/utils/random.test.ts
@@ -1,0 +1,49 @@
+import { expect } from 'chai';
+import { generateRandomString } from '../../src/utils/random.js';
+
+describe('generate random string', () => {
+  it('base36', () => {
+    const base36Regex = /^[0-9a-z]+$/;
+    const result = generateRandomString(36, 8);
+    expect(result.length).to.equal(8);
+    expect(result).to.match(base36Regex);
+
+    const result2 = generateRandomString(36, 1);
+    expect(result2.length).to.equal(1);
+    expect(result2).to.match(base36Regex);
+
+    const result3 = generateRandomString(36, 15);
+    expect(result3.length).to.equal(15);
+    expect(result3).to.match(base36Regex);
+  });
+
+  it('base10', () => {
+    const base10Regex = /^[0-9]+$/;
+    const result = generateRandomString(10, 8);
+    expect(result.length).to.equal(8);
+    expect(result).to.match(base10Regex);
+
+    const result2 = generateRandomString(10, 1);
+    expect(result2.length).to.equal(1);
+    expect(result2).to.match(base10Regex);
+
+    const result3 = generateRandomString(10, 15);
+    expect(result3.length).to.equal(15);
+    expect(result3).to.match(base10Regex);
+  });
+
+  it('base16', () => {
+    const base16Regex = /^[0-9a-f]+$/;
+    const result = generateRandomString(16, 8);
+    expect(result.length).to.equal(8);
+    expect(result).to.match(base16Regex);
+
+    const result2 = generateRandomString(16, 1);
+    expect(result2.length).to.equal(1);
+    expect(result2).to.match(base16Regex);
+
+    const result3 = generateRandomString(16, 15);
+    expect(result3.length).to.equal(15);
+    expect(result3).to.match(base16Regex);
+  });
+});

--- a/tools/schema/card-base-schema.json
+++ b/tools/schema/card-base-schema.json
@@ -52,7 +52,7 @@
             "type": "string",
             "minLength": 3,
             "maxLength": 20,
-            "pattern": "^[a-z]+_[0-9]+$"
+            "pattern": "^[a-z]+_[0-9a-z]+$"
           },
           "linktype": {
             "description": "The linktype is named according to the from-to direction. In user interfaces, the naming according to the linktype is shown in the 'from' card.",

--- a/tools/schema/card-directory-schema.json
+++ b/tools/schema/card-directory-schema.json
@@ -11,7 +11,7 @@
     "name": {
       "description": "The name of the card directory is the card key, for example ABC-123",
       "type": "string",
-      "pattern": "^[a-z]+_[0-9]+$"
+      "pattern": "^[a-z]+_[0-9a-z]+$"
     },
     "files": {
       "type": "object",
@@ -45,7 +45,7 @@
             "directories": {
               "type": "object",
               "patternProperties": {
-                "^[a-z]+_[0-9]+$": {
+                "^[a-z]+_[0-9a-z]+$": {
                   "description": "A directory that contains a child card. The name of the directory is the cardkey, for example ABC-123.",
                   "$ref": "#"
                 }

--- a/tools/schema/cardsconfig-schema.json
+++ b/tools/schema/cardsconfig-schema.json
@@ -16,12 +16,7 @@
       "type": "string",
       "minLength": 1,
       "pattern": "^[A-Za-z ._-]+$"
-    },
-    "nextAvailableCardNumber": {
-      "description": "The next available card key number, or the second component of the card key.",
-      "type": "integer",
-      "min": 1
     }
   },
-  "required": ["cardkeyPrefix", "nextAvailableCardNumber"]
+  "required": ["cardkeyPrefix"]
 }

--- a/tools/schema/cardtree-directory-schema.json
+++ b/tools/schema/cardtree-directory-schema.json
@@ -153,7 +153,7 @@
                                               "type": "object",
                                               "additionalProperties": false,
                                               "patternProperties": {
-                                                "^[a-z]+_[0-9]+$": {
+                                                "^[a-z]+_[0-9a-z]+$": {
                                                   "type": "object",
                                                   "$ref": "#/$defs/card-directory-schema#"
                                                 }
@@ -238,7 +238,7 @@
               "type": "object",
               "additionalProperties": false,
               "patternProperties": {
-                "^[a-z]+_[0-9]+$": {
+                "^[a-z]+_[0-9a-z]+$": {
                   "type": "object",
                   "$ref": "#/$defs/card-directory-schema#"
                 }
@@ -405,7 +405,7 @@
                                           "type": "object",
                                           "additionalProperties": false,
                                           "patternProperties": {
-                                            "^[a-z]+_[0-9]+$": {
+                                            "^[a-z]+_[0-9a-z]+$": {
                                               "$ref": "#/$defs/card-directory-schema#"
                                             }
                                           }
@@ -489,7 +489,7 @@
           "type": "string",
           "minLength": 5,
           "maxLength": 20,
-          "pattern": "^[a-z]+_[0-9]+$"
+          "pattern": "^[a-z]+_[0-9a-z]+$"
         },
         "files": {
           "type": "object",


### PR DESCRIPTION
- Remove nextAvailableCardNumber based card key generation system
- Add random & unique 8-character base36 id instead (resulting in card keys like prefix_1234abcd)
- Update tests accordingly

Key generation moved from projectSettings to Project so that ID clashes can be checked (and because the running number does not need to be saved to disk anymore).

New card creation functions updated to return new cardKey(s) (via affectedCards field) so that tests can use them.