### PR TITLE
Always write JSON files through same interface; use defaults

### DIFF
--- a/tools/data-handler/src/calculate.ts
+++ b/tools/data-handler/src/calculate.ts
@@ -90,12 +90,7 @@ export class Calculate {
       // write card-specific logic program file
       const filename = join(destinationFileBase, card.key);
       const cardLogicFile = `${filename}.lp`;
-      promiseContainer.push(
-        writeFile(cardLogicFile, logicProgram, {
-          encoding: 'utf-8',
-          flag: 'w',
-        }),
-      );
+      promiseContainer.push(writeFile(cardLogicFile, logicProgram));
     }
     await Promise.all(promiseContainer);
   }
@@ -123,10 +118,7 @@ export class Calculate {
     for await (const file of files) {
       cardTreeContent += `#include "cards/${removeExtension(file)}.lp".\n`;
     }
-    await writeFile(destinationFile, cardTreeContent, {
-      encoding: 'utf-8',
-      flag: 'w',
-    });
+    await writeFile(destinationFile, cardTreeContent);
   }
 
   // Write all common files which are not card specific.
@@ -161,10 +153,7 @@ export class Calculate {
         modulesContent += `#include "${moduleLogicFile}".\n`;
       }
     }
-    await writeFile(destinationFile, modulesContent, {
-      encoding: 'utf-8',
-      flag: 'w',
-    });
+    await writeFile(destinationFile, modulesContent);
   }
 
   // Gets either all the cards (no parent), or a subtree.
@@ -292,7 +281,7 @@ export class Calculate {
       cardTreeContent = cardTreeContent.replace(removeRow, '');
     }
     if (calculationsForTreeExist) {
-      await writeFile(cardTreeFile, cardTreeContent, 'utf-8');
+      await writeFile(cardTreeFile, cardTreeContent);
     }
   }
 

--- a/tools/data-handler/src/create.ts
+++ b/tools/data-handler/src/create.ts
@@ -353,7 +353,6 @@ export class Create extends EventEmitter {
     const content: cardtype = { name: fullName, workflow };
     const destinationFolder = join(projectPath, fullFileName);
     await writeFile(destinationFolder, formatJson(content), {
-      encoding: 'utf-8',
       flag: 'wx',
     });
   }
@@ -391,7 +390,6 @@ export class Create extends EventEmitter {
       `${content.name}.json`,
     );
     await writeFile(destinationFolder, formatJson(content), {
-      encoding: 'utf-8',
       flag: 'wx',
     });
   }
@@ -428,8 +426,7 @@ export class Create extends EventEmitter {
       'linktypes',
       `${linkTypeName}.json`,
     );
-    await writeFile(destinationFolder, JSON.stringify(linkTypeContent), {
-      encoding: 'utf-8',
+    await writeFile(destinationFolder, formatJson(linkTypeContent), {
       flag: 'wx',
     });
   }


### PR DESCRIPTION
1. Always use function `formatJson()` to write JSON files (makes JSON look similar in all our files).
2. Do not pass default values to fs/promises read/write methods. (interestingly non-promise based fs functions have for example `encoding` null)