### PR TITLE
Empty 'person' fieldtype causes perplexing validation error

### DIFF
--- a/tools/data-handler/src/validate.ts
+++ b/tools/data-handler/src/validate.ts
@@ -206,6 +206,7 @@ export class Validate {
     if (field === 'person') {
       // Accept empty names
       return (
+        value === undefined ||
         EmailValidator.validate(<string>value) ||
         this.length(<string>value) === 0
       );


### PR DESCRIPTION
Running validation in our "isms" content repo causes perplexing `Cannot read properties of undefined (reading 'length')` error. This is caused by empty `person` data-type in one of the field types. 

To avoid data-type validation to fail, check that the object exists.