### PR TITLE
INTDEV-445: Fix to 'Metadata and custom fields do not work in the ISMS project'

### DIFF
--- a/tools/app/__tests__/api.test.ts
+++ b/tools/app/__tests__/api.test.ts
@@ -6,7 +6,9 @@ import { Card, CardDetails, Project } from '@/app/lib/definitions';
 import { GET as GET_PROJECT } from '../app/api/cards/route';
 import { GET as GET_CARD } from '../app/api/cards/[key]/route';
 import { GET as GET_ATTACHMENT } from '../app/api/cards/[key]/a/[attachment]/route';
+import { GET as GET_CARDTYPE } from '../app/api/cardtypes/route';
 import { NextRequest } from 'next/server';
+import { cardtype } from '@cyberismocom/data-handler/interfaces/project-interfaces';
 
 // Testing env attempts to open project in "../data-handler/test/test-data/valid/decision-records"
 
@@ -71,4 +73,17 @@ test('non-existing attachment file returns an error', async () => {
   const response = await GET_ATTACHMENT(request);
   expect(response).not.toBe(null);
   expect(response.status).toBe(404);
+});
+
+test('cardtypes endpoint returns cardtype pbject', async () => {
+  const request = new NextRequest(
+    'http://localhost:3000/api/cards/cardtypes?name=decision/cardtypes/decision-cardtype',
+  );
+  const response = await GET_CARDTYPE(request);
+  expect(response).not.toBe(null);
+
+  const result: cardtype = await response.json();
+  expect(response.status).toBe(200);
+  expect(result.name).toBe('decision/cardtypes/decision-cardtype');
+  expect(result.workflow).toBe('decision/workflows/decision-workflow');
 });

--- a/tools/app/app/api/cardtypes/route.tsx
+++ b/tools/app/app/api/cardtypes/route.tsx
@@ -20,7 +20,7 @@ export const dynamic = 'force-dynamic';
  * /api/cardtypes/{key}:
  *   get:
  *     summary: Returns the full content of a specific card type.
- *     description: The key parameter is the unique identifier ("cardTypeKey") of the card type. The response includes the card type details.
+ *     description: The key parameter is the unique identifier ("cardtype") of the card type. The response includes the card type details.
  *     responses:
  *       200:
  *        description: Object containing card type details. See definitions.ts/CardType for the structure.
@@ -35,19 +35,20 @@ export async function GET(request: NextRequest) {
     return new NextResponse('project_path not set', { status: 500 });
   }
 
-  // Last URL segment is the search parameter
-  const key = request.nextUrl.pathname.split('/')?.pop();
-  if (key == null) {
-    return new NextResponse('No search key', { status: 400 });
+  // Cardtype name delivered in url parameter 'name' because it usually contains a path
+  const url = new URL(request.nextUrl);
+  const cardtype = url.searchParams.get('name');
+  if (!cardtype) {
+    return new NextResponse('No cardtype', { status: 400 });
   }
 
   const show = new Show();
-  const detailsResponse = await show.showCardTypeDetails(projectPath, key);
+  const detailsResponse = await show.showCardTypeDetails(projectPath, cardtype);
 
   if (detailsResponse) {
     return NextResponse.json(detailsResponse);
   } else {
-    return new NextResponse(`No card type details found for card key ${key}`, {
+    return new NextResponse(`No card type details found for ${cardtype}`, {
       status: 500,
     });
   }

--- a/tools/app/app/api/cardtypes/route.tsx
+++ b/tools/app/app/api/cardtypes/route.tsx
@@ -17,10 +17,15 @@ export const dynamic = 'force-dynamic';
 
 /**
  * @swagger
- * /api/cardtypes/{key}:
+ * /api/cardtypes:
  *   get:
  *     summary: Returns the full content of a specific card type.
  *     description: The key parameter is the unique identifier ("cardtype") of the card type. The response includes the card type details.
+ *     parameters:
+ *       - name: name
+ *         in: query
+ *         required: true
+ *         description: name of cardtype, including path (such as /project/cardtypes/page)
  *     responses:
  *       200:
  *        description: Object containing card type details. See definitions.ts/CardType for the structure.

--- a/tools/app/app/lib/api/cardtype.ts
+++ b/tools/app/app/lib/api/cardtype.ts
@@ -15,9 +15,12 @@ import { apiPaths } from '../swr';
 
 import { SWRConfiguration } from 'swr';
 
-export const useCardType = (key: string | null, options?: SWRConfiguration) =>
+export const useCardType = (
+  cardtype: string | null,
+  options?: SWRConfiguration,
+) =>
   useSWRHook<'cardType'>(
-    key ? apiPaths.cardType(key) : null,
+    cardtype ? apiPaths.cardType(cardtype) : null,
     'cardType',
     options,
   );

--- a/tools/app/app/lib/swr.ts
+++ b/tools/app/app/lib/swr.ts
@@ -83,7 +83,7 @@ export const apiPaths = {
   project: () => '/api/cards',
   card: (key: string) => `/api/cards/${key}`,
   fieldTypes: () => '/api/fieldtypes',
-  cardType: (key: string) => `/api/cardtypes/${key}`,
+  cardType: (cardtype: string) => `/api/cardtypes?name=${cardtype}`,
   templates: () => '/api/templates',
   attachment: (cardKey: string, attachment: string) =>
     `/api/cards/${cardKey}/a/${attachment}`,


### PR DESCRIPTION
Fix app cardtype endpoint to support new resource naming scheme.
Pass the cardtype name as url parameter because it typically contains a path.
So the API call is now like:
GET /api/cardtypes?name=cisms/cardtypes/task

Added API test for this.