### PR TITLE
Make Windows CI tests more stable

### DIFF
--- a/tools/app/cypress/e2e/app.cy.ts
+++ b/tools/app/cypress/e2e/app.cy.ts
@@ -6,6 +6,7 @@
 // Run these tests with ´npm run e2e:headless´
 
 describe('Navigation', () => {
+  Cypress.config('defaultCommandTimeout', 10000);
   beforeEach(() => {
     cy.visit('http://localhost:3000');
   });
@@ -44,6 +45,7 @@ describe('Navigation', () => {
 });
 
 describe('Modify project', () => {
+  Cypress.config('defaultCommandTimeout', 10000);
   before(() => {
     // Make a backup copy of the base test data
     cy.task('makeTestDataBackup');

--- a/tools/data-handler/test/command-handler-rank.test.ts
+++ b/tools/data-handler/test/command-handler-rank.test.ts
@@ -30,7 +30,15 @@ describe('rank command', () => {
   });
 
   after(() => {
-    rmSync(testDir, { recursive: true, force: true });
+    try {
+      rmSync(testDir, { recursive: true, force: true, maxRetries: 5 });
+    } catch (error) {
+      if (error instanceof Error) {
+        console.error(
+          `There was an issue cleaning up after "rank" tests: ${error.message}`,
+        );
+      }
+    }
   });
 
   beforeEach(async () => {
@@ -107,6 +115,9 @@ describe('rank command', () => {
 
       expect(details.metadata?.rank).to.equal('0|a');
     });
+  });
+
+  describe('rank attempts - test data is not cleaned', () => {
     it('try rank card - project missing', async () => {
       const rankBefore = 'decision_6';
       const invalidProject = { projectPath: 'idontexist' };
@@ -146,6 +157,7 @@ describe('rank command', () => {
       expect(result.statusCode).to.equal(400);
     });
   });
+
   // note: these tests could be more detailed
   describe('rebalance', () => {
     it('rebalance (success)', async () => {


### PR DESCRIPTION
1. `try-catch` in problematic tests test data cleaning. Ignore errors.
2. increase timeout for certain cypress-tests.
3. Put tests that don't need test-data to their own sets and do not fiddle with test data in those (saves some time running tests).