### PR TITLE
INTDEV-443 Rename does not rename resources

### DIFF
--- a/tools/data-handler/src/containers/card-container.ts
+++ b/tools/data-handler/src/containers/card-container.ts
@@ -15,7 +15,7 @@ import { basename, join, sep } from 'node:path';
 import { readdir, readFile, writeFile } from 'node:fs/promises';
 
 // ismo
-import { formatJson } from '../utils/json.js';
+import { writeJsonFile } from '../utils/json.js';
 import { getFilesSync, pathExists } from '../utils/file-utils.js';
 
 // interfaces
@@ -341,7 +341,7 @@ export class CardContainer {
     }
     if (card.metadata) {
       const metadataFile = join(card.path, CardContainer.cardMetadataFile);
-      await writeFile(metadataFile, formatJson(card.metadata));
+      await writeJsonFile(metadataFile, card.metadata);
       return;
     }
     throw new Error(`No content for card ${card.key}`);
@@ -350,7 +350,7 @@ export class CardContainer {
   protected async saveCardMetadata(card: card) {
     if (card.metadata) {
       const metadataFile = join(card.path, CardContainer.cardMetadataFile);
-      await writeFile(metadataFile, formatJson(card.metadata));
+      await writeJsonFile(metadataFile, card.metadata);
       return;
     }
     throw new Error(`No metadata for card ${card.key}`);

--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -26,7 +26,7 @@ import {
   templateMetadata,
 } from '../interfaces/project-interfaces.js';
 import { copyDir, pathExists, sepRegex } from '../utils/file-utils.js';
-import { formatJson, readJsonFile } from '../utils/json.js';
+import { readJsonFile, writeJsonFile } from '../utils/json.js';
 import { Project } from './project.js';
 
 // Base class
@@ -50,10 +50,10 @@ export class Template extends CardContainer {
   private templateCardsPath: string;
   private project: Project;
 
-  private static dotSchemaContent: string = formatJson({
+  private static dotSchemaContent: object = {
     id: 'card-base-schema',
     version: 1,
-  });
+  };
 
   constructor(path: string, template: resource, project?: Project) {
     // Templates might come from modules. Remove module name from template name.
@@ -150,7 +150,7 @@ export class Template extends CardContainer {
       // Create temp-folder and schema file.
       const templatesFolder = this.templateFolder();
       await mkdir(tempDestination, { recursive: true });
-      await writeFile(
+      await writeJsonFile(
         join(tempDestination, Project.schemaContentFile),
         Template.dotSchemaContent,
       );
@@ -205,9 +205,9 @@ export class Template extends CardContainer {
           }
 
           await mkdir(card.path, { recursive: true });
-          await writeFile(
+          await writeJsonFile(
             join(card.path, Project.cardMetadataFile),
-            formatJson(card.metadata),
+            card.metadata,
           );
         }
 
@@ -353,9 +353,9 @@ export class Template extends CardContainer {
         : join(this.templateCardsPath, newCardKey);
 
       await mkdir(templateCardToCreate, { recursive: true });
-      await writeFile(
+      await writeJsonFile(
         join(templateCardToCreate, Project.cardMetadataFile),
-        formatJson(defaultContent),
+        defaultContent,
       );
       await writeFile(join(templateCardToCreate, Project.cardContentFile), '');
       await this.project.configuration.save();
@@ -446,15 +446,15 @@ export class Template extends CardContainer {
           recursive: true,
         }).then(async (name) => {
           await Promise.all([
-            writeFile(
+            writeJsonFile(
               this.templateConfigurationFilePath(),
-              formatJson(templateContent),
+              templateContent,
             ),
-            writeFile(
-              join(this.templatePath, Project.schemaContentFile),
-              formatJson({ id: 'template-schema', version: 1 }),
-            ),
-            writeFile(
+            writeJsonFile(join(this.templatePath, Project.schemaContentFile), {
+              id: 'template-schema',
+              version: 1,
+            }),
+            writeJsonFile(
               join(this.templateCardsPath, Project.schemaContentFile),
               Template.dotSchemaContent,
             ),

--- a/tools/data-handler/src/create.ts
+++ b/tools/data-handler/src/create.ts
@@ -32,7 +32,7 @@ import {
   workflowMetadata,
 } from './interfaces/project-interfaces.js';
 import { errorFunction } from './utils/log-utils.js';
-import { formatJson, readJsonFile } from './utils/json.js';
+import { readJsonFile, writeJsonFile } from './utils/json.js';
 import { Project } from './containers/project.js';
 import { Template } from './containers/template.js';
 import { Validate } from './validate.js';
@@ -341,7 +341,7 @@ export class Create extends EventEmitter {
 
     const content: cardtype = { name: fullName, workflow };
     const destinationFolder = join(projectPath, fullFileName);
-    await writeFile(destinationFolder, formatJson(content), {
+    await writeJsonFile(destinationFolder, content, {
       flag: 'wx',
     });
   }
@@ -378,7 +378,7 @@ export class Create extends EventEmitter {
       '.cards',
       `${content.name}.json`,
     );
-    await writeFile(destinationFolder, formatJson(content), {
+    await writeJsonFile(destinationFolder, content, {
       flag: 'wx',
     });
   }
@@ -415,7 +415,7 @@ export class Create extends EventEmitter {
       'linktypes',
       `${linkTypeName}.json`,
     );
-    await writeFile(destinationFolder, formatJson(linkTypeContent), {
+    await writeJsonFile(destinationFolder, linkTypeContent, {
       flag: 'wx',
     });
   }
@@ -515,7 +515,7 @@ export class Create extends EventEmitter {
       linkDescription,
     });
 
-    await project.updateCardMetadata(cardKey, 'links', links);
+    await project.updateCardMetadataKey(cardKey, 'links', links);
   }
 
   /**
@@ -572,9 +572,9 @@ export class Create extends EventEmitter {
       if (entry.content.name?.includes('$PROJECT-NAME')) {
         entry.content.name = projectName;
       }
-      await writeFile(
+      await writeJsonFile(
         join(parentFolderToCreate, entry.path, entry.name),
-        formatJson(entry.content),
+        entry.content,
       );
     });
 
@@ -664,7 +664,7 @@ export class Create extends EventEmitter {
     }
     const content = JSON.parse(JSON.stringify(workflow)) as workflowMetadata;
     const destinationFile = join(projectPath, fullFileName);
-    await writeFile(destinationFile, formatJson(content), { flag: 'wx' });
+    await writeJsonFile(destinationFile, content, { flag: 'wx' });
   }
 
   /**

--- a/tools/data-handler/src/edit.ts
+++ b/tools/data-handler/src/edit.ts
@@ -120,6 +120,6 @@ export class Edit {
     if (!changedKey) {
       throw new Error(`Changed key cannot be empty`);
     }
-    await Edit.project.updateCardMetadata(cardKey, changedKey, newValue);
+    await Edit.project.updateCardMetadataKey(cardKey, changedKey, newValue);
   }
 }

--- a/tools/data-handler/src/import.ts
+++ b/tools/data-handler/src/import.ts
@@ -90,14 +90,19 @@ export class Import {
         await project.updateCardContent(cardKey, description);
       }
 
+      // todo: could update all of the metadata values with single call to updateMetadataKey()
       if (labels) {
-        await project.updateCardMetadata(cardKey, 'labels', labels.split(' '));
+        await project.updateCardMetadataKey(
+          cardKey,
+          'labels',
+          labels.split(' '),
+        );
       }
 
-      await project.updateCardMetadata(cardKey, 'title', title);
+      await project.updateCardMetadataKey(cardKey, 'title', title);
       for (const [key, value] of Object.entries(customFields)) {
         if (cardType.customFields?.find((field) => field.name === key)) {
-          await project.updateCardMetadata(cardKey, key, value);
+          await project.updateCardMetadataKey(cardKey, key, value);
         }
       }
       console.log(`Successfully imported card ${title}`);

--- a/tools/data-handler/src/move.ts
+++ b/tools/data-handler/src/move.ts
@@ -115,7 +115,7 @@ export class Move {
       lastChild && lastChild.metadata
         ? getRankAfter(lastChild.metadata.rank)
         : FIRST_RANK;
-    await Move.project.updateCardMetadata(sourceCard.key, 'rank', rank);
+    await Move.project.updateCardMetadataKey(sourceCard.key, 'rank', rank);
     await copyDir(sourceCard.path, destinationPath);
     await deleteDir(sourceCard.path);
   }
@@ -177,13 +177,13 @@ export class Move {
     }
 
     if (beforeCardIndex === children.length - 1) {
-      await Move.project.updateCardMetadata(
+      await Move.project.updateCardMetadataKey(
         cardKey,
         'rank',
         getRankAfter(beforeCard.metadata?.rank as string),
       );
     } else {
-      await Move.project.updateCardMetadata(
+      await Move.project.updateCardMetadataKey(
         cardKey,
         'rank',
         getRankBetween(
@@ -266,15 +266,15 @@ export class Move {
         throw new Error(`Second rank not found`);
       }
       const rankBetween = getRankBetween(firstRank, secondRank);
-      await Move.project.updateCardMetadata(
+      await Move.project.updateCardMetadataKey(
         children[0].key,
         'rank',
         rankBetween,
       );
-      await Move.project.updateCardMetadata(cardKey, 'rank', firstRank);
+      await Move.project.updateCardMetadataKey(cardKey, 'rank', firstRank);
     } else {
       // if the card is not at the first rank, we just use the first rank
-      await Move.project.updateCardMetadata(cardKey, 'rank', FIRST_RANK);
+      await Move.project.updateCardMetadataKey(cardKey, 'rank', FIRST_RANK);
     }
   }
 
@@ -350,8 +350,7 @@ export class Move {
 
     for (let i = 0; i < cards.length; i++) {
       const card = cards[i];
-      // todo: this could be done parallel
-      await Move.project.updateCardMetadata(card.key, 'rank', ranks[i]);
+      await Move.project.updateCardMetadataKey(card.key, 'rank', ranks[i]);
     }
   }
 
@@ -362,7 +361,7 @@ export class Move {
 
     for (let i = 0; i < cards.length; i++) {
       const card = cards[i];
-      await Move.project.updateCardMetadata(card.key, 'rank', ranks[i]);
+      await Move.project.updateCardMetadataKey(card.key, 'rank', ranks[i]);
       if (card.children && card.children.length > 0) {
         await this.rebalanceProjectRecursively(card.children);
       }

--- a/tools/data-handler/src/project-settings.ts
+++ b/tools/data-handler/src/project-settings.ts
@@ -11,10 +11,10 @@
 */
 
 // node
-import { open, writeFile } from 'node:fs/promises';
+import { open } from 'node:fs/promises';
 
 // ismo
-import { formatJson } from './utils/json.js';
+import { writeJsonFile } from './utils/json.js';
 import { projectSettings } from './interfaces/project-interfaces.js';
 import { readJsonFileSync } from './utils/json.js';
 import { Validate } from './validate.js';
@@ -43,8 +43,8 @@ export class ProjectSettings implements projectSettings {
     }
     await open(this.settingPath, 'w').then(async (file) => {
       try {
-        await writeFile(file, formatJson(this.toJSON()));
-        await file.close();
+        await writeJsonFile(file, this.toJSON());
+        file.close();
       } catch (error) {
         if (error instanceof Error) {
           console.error(error.message);

--- a/tools/data-handler/src/remove.ts
+++ b/tools/data-handler/src/remove.ts
@@ -115,7 +115,11 @@ export class Remove extends EventEmitter {
         l.linkDescription !== linkDescription,
     );
 
-    await Remove.project.updateCardMetadata(sourceCardKey, 'links', newLinks);
+    await Remove.project.updateCardMetadataKey(
+      sourceCardKey,
+      'links',
+      newLinks,
+    );
   }
 
   /**

--- a/tools/data-handler/src/rename.ts
+++ b/tools/data-handler/src/rename.ts
@@ -11,20 +11,28 @@
 */
 
 // node
+import { assert } from 'node:console';
 import { EventEmitter } from 'node:events';
-import { join } from 'node:path';
-import { rename, writeFile } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+import { rename, readFile, writeFile } from 'node:fs/promises';
 
 // ismo
 import { Calculate } from './calculate.js';
-import { card } from './interfaces/project-interfaces.js';
+import { card, resource } from './interfaces/project-interfaces.js';
 import { Project } from './containers/project.js';
+import { resourceNameParts } from './utils/resource-utils.js';
 import { Template } from './containers/template.js';
+import { writeJsonFile } from './utils/json.js';
 
+/**
+ * Class that handles 'rename' command.
+ */
 export class Rename extends EventEmitter {
   static project: Project;
 
   private calculateCmd: Calculate;
+  private from: string = '';
+  private to: string = '';
 
   constructor(calculateCmd: Calculate) {
     super();
@@ -35,31 +43,58 @@ export class Rename extends EventEmitter {
     );
   }
 
-  // Sort cards by path length (so that renaming starts from children)
-  private sortCards(a: card, b: card) {
-    if (a.path.length > b.path.length) {
-      return -1;
-    }
-    if (a.path.length < b.path.length) {
-      return 1;
-    }
-    return 0;
+  // Renames a card and all of its attachments (if it is a project card).
+  private async renameCard(re: RegExp, card: card): Promise<void> {
+    // Update card's metadata
+    await this.updateCardMetadata(card);
+
+    // Then rename card file.
+    const newCardPath = card.path.replace(re, this.to);
+    await rename(card.path, newCardPath);
   }
 
-  // Helper that renames a card and all of its attachments (if it is a non-template card).
-  private async replaceCardPath(
-    re: RegExp,
-    to: string,
-    card: card,
-  ): Promise<string> {
-    const newCardPath = card.path.replace(re, to);
+  // Update all the cards in a container.
+  // Sort cards so that cards that deeper in file hierarchy are renamed first.
+  private async renameCards(cards: card[]): Promise<void> {
+    // Sort cards by path length (so that renaming starts from children)
+    function sortCards(a: card, b: card) {
+      if (a.path.length > b.path.length) {
+        return -1;
+      }
+      if (a.path.length < b.path.length) {
+        return 1;
+      }
+      return 0;
+    }
 
-    // First rename attachments (and fix references from content to the attachments).
+    // Ensure that only last occurrence is replaced, since path can contain "project prefixes" that are not to be touched.
+    //   E.g. /Users/smith/projects/card-projects/smith-project/cardroot/smith_sdhgsd7; change 'smith' cardkey to 'miller'
+    //   --> only the last 'smith' should be replaced with 'miller'.
+    const re = new RegExp(`${this.from}(?!.*${this.from})`);
+
+    const sortedCards = cards.sort((a, b) => sortCards(a, b));
+
+    // Cannot do this parallel, since cards deeper in the hierarchy needs to be renamed first.
+    // First update all the attachments
+    for (const card of sortedCards) {
+      await this.updateCardAttachments(re, card);
+    }
+    // Then rename the cards
+    for (const card of sortedCards) {
+      await this.renameCard(re, card);
+    }
+  }
+
+  // Update card's attachments.
+  private async updateCardAttachments(re: RegExp, card: card): Promise<void> {
     if (!Project.isTemplateCard(card)) {
       const attachments = card.attachments ? card.attachments : [];
       await Promise.all(
         attachments.map(async (attachment) => {
-          const newAttachmentFileName = attachment.fileName.replace(re, to);
+          const newAttachmentFileName = attachment.fileName.replace(
+            re,
+            this.to,
+          );
           await rename(
             join(attachment.path, attachment.fileName),
             join(attachment.path, newAttachmentFileName),
@@ -70,67 +105,219 @@ export class Rename extends EventEmitter {
             contentRe,
             `image::${newAttachmentFileName}`,
           );
-          await writeFile(join(card.path, 'index.adoc'), card.content || '');
+          if (card.content) {
+            Rename.project.updateCardContent(card.key, card.content);
+          }
         }),
       );
     }
+  }
 
-    // Then, rename the card file.
-    await rename(card.path, newCardPath);
-    return newCardPath;
+  // Update card's metadata.
+  private async updateCardMetadata(card: card): Promise<void> {
+    if (card.metadata?.cardtype && card.metadata?.cardtype.length > 0) {
+      const { prefix, type, name } = resourceNameParts(card.metadata.cardtype);
+      if (prefix === this.from) {
+        card.metadata.cardtype = `${Rename.project.configuration.cardkeyPrefix}/${type}/${name}`;
+        // Update card' custom fields
+        const keys = Object.keys(card.metadata);
+        for (const oldKey of keys) {
+          if (oldKey.startsWith(`${this.from}/fieldtypes`)) {
+            const newKey = this.updateResourceName(oldKey);
+            // one-liner to remove the old key and add a new one
+            delete Object.assign(card.metadata, {
+              [newKey]: card.metadata[oldKey],
+            })[oldKey];
+          }
+        }
+        const skipValidation = true;
+        await Rename.project.updateCardMetadata(
+          card,
+          card.metadata,
+          skipValidation,
+        );
+      }
+    }
+  }
+
+  // Changes the name of a resource to match the new prefix.
+  private updateResourceName(resourceName: string) {
+    const { prefix, type, name } = resourceNameParts(resourceName);
+    // do not rename module resources
+    return this.from === prefix
+      ? `${Rename.project.configuration.cardkeyPrefix}/${type}/${name}`
+      : resourceName;
+  }
+
+  // Updates single calculation file.
+  private async updateCalculationFile(calculation: resource) {
+    if (!calculation.path) {
+      throw new Error(
+        `Calculation file's '${calculation.name}' path is not defined`,
+      );
+    }
+    const filename = join(calculation.path || '', basename(calculation.name));
+    let content = (await readFile(filename)).toString();
+    const conversionMap = new Map([
+      [`${this.from}/calculations/`, `${this.to}/calculations/`],
+      [`${this.from}/cardtypes/`, `${this.to}/cardtypes/`],
+      [`${this.from}/fieldtypes/`, `${this.to}/fieldtypes/`],
+      [`${this.from}/linktypes/`, `${this.to}/linktypes/`],
+      [`${this.from}/templates/`, `${this.to}/templates/`],
+      [`${this.from}/workflows/`, `${this.to}/workflows/`],
+    ]);
+    for (const [key, value] of conversionMap) {
+      const re = new RegExp(key, 'g');
+      content = content.replace(re, value);
+    }
+    await writeFile(filename, content);
+  }
+
+  // Updates card type's metadata.
+  // todo: once 'name' is dropped; can be simplified.
+  private async updateCardTypeMetadata(cardTypeName: string) {
+    const cardType = await Rename.project.cardType(cardTypeName, true);
+    if (cardType) {
+      cardType.name = this.updateResourceName(cardTypeName);
+      cardType.workflow = this.updateResourceName(cardType.workflow);
+      cardType.customFields?.map(
+        (field) => (field.name = this.updateResourceName(field.name)),
+      );
+      cardType.alwaysVisibleFields = cardType.alwaysVisibleFields?.map((item) =>
+        this.updateResourceName(item),
+      );
+      const filename = join(
+        Rename.project.cardtypesFolder,
+        basename(cardTypeName),
+      );
+      await writeJsonFile(filename, cardType);
+    }
+  }
+
+  // Updates field type's metadata.
+  // todo: once 'name' is dropped; can be removed.
+  private async updateFieldTypeMetadata(fieldTypeName: string) {
+    const fieldType = await Rename.project.fieldType(fieldTypeName);
+    if (fieldType) {
+      fieldType.name = this.updateResourceName(fieldTypeName);
+      // Write file
+      const filename = join(
+        Rename.project.fieldtypesFolder,
+        basename(fieldTypeName),
+      );
+      await writeJsonFile(filename, fieldType);
+    }
+  }
+
+  // Updates field type's metadata.
+  // todo: once 'name' is dropped; can be simplified.
+  private async updateLinkTypeMetadata(linkTypeName: string) {
+    const linkType = await Rename.project.linkType(linkTypeName);
+    if (linkType) {
+      linkType.name = this.updateResourceName(linkTypeName);
+      linkType.sourceCardTypes = linkType.sourceCardTypes.map((item) =>
+        this.updateResourceName(item),
+      );
+      linkType.destinationCardTypes = linkType.destinationCardTypes.map(
+        (item) => this.updateResourceName(item),
+      );
+      // Write file
+      const filename = join(
+        Rename.project.linktypesFolder,
+        basename(linkTypeName),
+      );
+      await writeJsonFile(filename, linkType);
+    }
+  }
+
+  // Rename workflows.
+  // todo: once 'name' is dropped; can be removed.
+  private async updateWorkflowMetadata(workflowName: string) {
+    const workflow = await Rename.project.workflow(workflowName);
+    if (workflow) {
+      workflow.name = this.updateResourceName(workflowName);
+      // Write file
+      const filename = join(
+        Rename.project.workflowsFolder,
+        basename(workflowName),
+      );
+      await writeJsonFile(filename, workflow);
+    }
   }
 
   /**
    * Renames project prefix.
+   * @throws if trying to rename with current name
    * @param {string} projectPath Path to a project
    * @param {string} to Card id, or template name
    */
   public async rename(projectPath: string, to: string) {
     Rename.project = new Project(projectPath);
-    const from = Rename.project.configuration.cardkeyPrefix;
-    // Ensure that only last occurrence is replaced, since path can contain "project prefixes" that are not to be touched.
-    //   E.g. /Users/matti/projects/card-projects/matti-project/cardroot/matti_1; change 'matti' cardkey to 'teppo'
-    //   --> only the last 'matti' should be replaced with 'teppo'.
-    const re = new RegExp(`${from}(?!.*${from})`);
+    const cardContent = {
+      metadata: true,
+      attachments: true,
+    };
 
-    // First change project prefix to project settings.
-    await Rename.project.configuration.setCardPrefix(to);
+    this.from = Rename.project.configuration.cardkeyPrefix;
+    this.to = to;
+    assert(this.from !== '');
+    assert(this.to !== '');
 
-    // Then rename all project cards. Sort cards so that cards that deeper in file hierarchy are renamed first.
-    const projectCards = (
-      await Rename.project.cards(Rename.project.cardrootFolder, {
-        metadata: true,
-        attachments: true,
-      })
-    ).sort((a, b) => {
-      return this.sortCards(a, b);
-    });
-
-    // Cannot do this parallel, since cards deeper in the hierarchy needs to be renamed first.
-    for (const card of projectCards) {
-      await this.replaceCardPath(re, to, card);
+    if (this.from === this.to) {
+      throw new Error(`Project prefix is already '${this.from}'`);
     }
 
-    // Then rename all local template cards. Module templates are not to be modified.
-    // Sort cards so that cards that deeper in file hierarchy are renamed first.
-    const templates = await Rename.project.templates(true);
+    // Change project prefix to project settings.
+    await Rename.project.configuration.setCardPrefix(to);
+
+    // Rename resources - module content shall not be modified.
+    // It is better to rename the resources in this order: cardtypes, fieldtypes
+    const localResourcesOnly = true;
+
+    // Rename all card types and custom fields in them.
+    const cardTypes = await Rename.project.cardtypes(localResourcesOnly);
+    for (const cardType of cardTypes) {
+      await this.updateCardTypeMetadata(cardType.name);
+    }
+
+    const workflows = await Rename.project.workflows(localResourcesOnly);
+    for (const workflow of workflows) {
+      await this.updateWorkflowMetadata(workflow.name);
+    }
+
+    // Rename all field types.
+    const fieldTypes = await Rename.project.fieldtypes(localResourcesOnly);
+    for (const fieldType of fieldTypes) {
+      await this.updateFieldTypeMetadata(fieldType.name);
+    }
+
+    // Rename all the link types.
+    const linkTypes = await Rename.project.linkTypes(localResourcesOnly);
+    for (const linkType of linkTypes) {
+      await this.updateLinkTypeMetadata(linkType.name);
+    }
+
+    // Rename resource usage in all calculation files.
+    const calculations = await Rename.project.calculations(localResourcesOnly);
+    for (const calculation of calculations) {
+      await this.updateCalculationFile(calculation);
+    }
+
+    // Rename all local template cards.
+    const templates = await Rename.project.templates(localResourcesOnly);
     for (const template of templates) {
       const templateObject = new Template(
         projectPath,
         template,
         Rename.project,
       );
-      const templateCards = (
-        await templateObject.cards('', { metadata: true, attachments: true })
-      ).sort((a, b) => {
-        return this.sortCards(a, b);
-      });
-
-      // Cannot do this parallel, since cards deeper in the hierarchy needs to be renamed first.
-      for (const card of templateCards) {
-        await this.replaceCardPath(re, to, card);
-      }
+      await this.renameCards(await templateObject.cards('', cardContent));
     }
+
+    // Rename all project cards.
+    await this.renameCards(
+      await Rename.project.cards(Rename.project.cardrootFolder, cardContent),
+    );
 
     this.emit('renamed', Rename.project.basePath);
   }

--- a/tools/data-handler/src/transition.ts
+++ b/tools/data-handler/src/transition.ts
@@ -13,13 +13,12 @@
 // node
 import { EventEmitter } from 'node:events';
 import { join } from 'node:path';
-import { writeFileSync } from 'node:fs';
 
 // ismo
 import { Calculate } from './calculate.js';
 import { card, workflowState } from './interfaces/project-interfaces.js';
 import { Project } from './containers/project.js';
-import { formatJson } from './utils/json.js';
+import { writeJsonFile } from './utils/json.js';
 import { Edit } from './edit.js';
 
 export class Transition extends EventEmitter {
@@ -38,12 +37,12 @@ export class Transition extends EventEmitter {
   }
 
   // Sets card state
-  private setCardState(card: card, state: string) {
+  private async setCardState(card: card, state: string) {
     if (card.metadata) {
       card.metadata.workflowState = state;
-      writeFileSync(
+      await writeJsonFile(
         join(card.path, Project.cardMetadataFile),
-        formatJson(card.metadata),
+        card.metadata,
       );
     }
   }
@@ -122,7 +121,7 @@ export class Transition extends EventEmitter {
     }
 
     // Write new state and re-calculate.
-    this.setCardState(details, found.toState);
+    await this.setCardState(details, found.toState);
     await this.editCmd.editCardMetadata(
       Transition.project.basePath,
       details.key,

--- a/tools/data-handler/src/utils/json.ts
+++ b/tools/data-handler/src/utils/json.ts
@@ -11,7 +11,7 @@
 */
 
 import { readFileSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
+import { FileHandle, readFile, writeFile } from 'node:fs/promises';
 
 /**
  * Handles reading of a JSON file.
@@ -78,4 +78,18 @@ export function readADocFileSync(file: string) {
  */
 export function formatJson(json: object) {
   return JSON.stringify(json, null, 4);
+}
+
+/**
+ * Writes and formats a JSON file.
+ * @param filename file name (and path) to write.
+ * @param json JSON object to format.
+ * @param options Optional, write options
+ */
+export async function writeJsonFile(
+  filename: string | FileHandle,
+  json: object,
+  options?: object,
+) {
+  await writeFile(filename, formatJson(json), options);
 }

--- a/tools/data-handler/src/utils/resource-utils.ts
+++ b/tools/data-handler/src/utils/resource-utils.ts
@@ -1,0 +1,33 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { assert } from 'node:console';
+import { parse } from 'node:path';
+
+interface ResourceName {
+  prefix: string;
+  type: string;
+  name: string;
+}
+
+/**
+ * Returns resource name parts (project prefix, type in plural, name of the resource).
+ * @todo - add unit tests
+ * @param resourceName Full name of the resource (e.g. <prefix>/<type>/<name>)
+ * @returns resource name parts: project or module prefix, resource type (plural) and actual name of the resource.
+ */
+export function resourceNameParts(resourceName: string): ResourceName {
+  const parts = resourceName.split('/');
+  assert(parts.length === 3);
+  return {
+    prefix: parts[0],
+    type: parts[1],
+    name: parse(parts[2]).name,
+  };
+}

--- a/tools/data-handler/test/project.test.ts
+++ b/tools/data-handler/test/project.test.ts
@@ -298,7 +298,7 @@ describe('project', () => {
       const previousTitle = card?.metadata?.title;
       const previouslyUpdated = card?.metadata?.lastUpdated;
       const newTitle = 'TheTitle';
-      await project.updateCardMetadata(card?.key, 'title', newTitle);
+      await project.updateCardMetadataKey(card?.key, 'title', newTitle);
       const updatedCard = await project.cardDetailsById(cardToOperateOn, {
         metadata: true,
       });
@@ -310,7 +310,7 @@ describe('project', () => {
       );
       expect(updatedCard?.metadata?.title).to.equal(newTitle);
       // Change the title back
-      await project.updateCardMetadata(card?.key, 'title', previousTitle);
+      await project.updateCardMetadataKey(card?.key, 'title', previousTitle);
     }
   });
   it('try to update metadata with same content again', async () => {
@@ -327,7 +327,7 @@ describe('project', () => {
       const previousTitle = card?.metadata?.title;
       const previouslyUpdated = card?.metadata?.lastUpdated;
       const newTitle = 'Decision Records';
-      await project.updateCardMetadata(card?.key, 'title', newTitle);
+      await project.updateCardMetadataKey(card?.key, 'title', newTitle);
       const updatedCard = await project.cardDetailsById(cardToOperateOn, {
         metadata: true,
       });


### PR DESCRIPTION
Fix `rename` command after module naming support - INTDEV-420.

Rename now changes all cards and all related resources (card types. workflows, link types, calculations, templates, field types) to new project prefix. Since renaming never affects imported module content, I added to resource fetching from `Project` possibility to fetch just local resources.

Updated cards have their `lastUpdated` timestamps updated.

Additionally, added a check that if project prefix does not change (trying to rename to same prefix), it only complains about that.

Couple changes that are non-essential but I included in this PR:
1) Renamed the `updateMetadata` function from `Project` to `updateMetadataKey` since it only changes only key (and I introduced a new function that updates the whole metadata).
2) Introduce a new helper `writeJsonFile` so that caller doesn't have to remember to `formatJson` when writing JSON file.
3) Functions in `Project` have been reordered alphabetically (scoped by `public`, `protected`, `private`), to make them easier to find.
