### PR TITLE
Encode clingo values

### DIFF
--- a/tools/data-handler/src/calculate.ts
+++ b/tools/data-handler/src/calculate.ts
@@ -78,7 +78,7 @@ export class Calculate {
       content += `field("${cardType.name}", "workflow", "${cardType.workflow}").\n`;
 
       for (const customField of cardType.customFields || []) {
-        content += `customField("${cardType.name}", "${customField.name}", "${customField.displayName}", "${customField.isEditable ? 'true' : 'false'}").\n`;
+        content += `customField("${cardType.name}", "${encodeClingoValue(customField.name)}", "${encodeClingoValue(customField.displayName || '')}", "${customField.isEditable ? 'true' : 'false'}").\n`;
       }
       const cardTypeFile = join(
         this.getResourceFolder(),
@@ -167,18 +167,18 @@ export class Calculate {
         for (const [field, value] of Object.entries(card.metadata)) {
           if (field === 'labels') {
             for (const label of value as Array<string>) {
-              logicProgram += `label(${card.key}, "${label}").\n`;
+              logicProgram += `label(${card.key}, "${encodeClingoValue(label)}").\n`;
             }
           } else if (field === 'links') {
             for (const link of value as Array<link>) {
-              logicProgram += `link(${card.key}, ${link.cardKey}, "${link.linkType}"${link.linkDescription != null ? `, "${link.linkDescription}"` : ''}).\n`;
+              logicProgram += `link(${card.key}, ${link.cardKey}, "${encodeClingoValue(link.linkType)}"${link.linkDescription != null ? `, "${encodeClingoValue(link.linkDescription)}"` : ''}).\n`;
             }
           } else {
             // Do not write null values
             if (value === null) {
               continue;
             }
-            logicProgram += `field(${card.key}, "${field}", "${value !== undefined ? encodeClingoValue(value.toString()) : undefined}").\n`;
+            logicProgram += `field(${card.key}, "${encodeClingoValue(field)}", "${value !== undefined ? encodeClingoValue(value.toString()) : undefined}").\n`;
           }
         }
       }

--- a/tools/data-handler/src/calculate.ts
+++ b/tools/data-handler/src/calculate.ts
@@ -26,7 +26,7 @@ import {
 } from './utils/file-utils.js';
 import { Project } from './containers/project.js';
 import { fileURLToPath } from 'node:url';
-import ClingoParser from './utils/clingo-parser.js';
+import ClingoParser, { encodeClingoValue } from './utils/clingo-parser.js';
 import {
   BaseResult,
   ParseResult,
@@ -178,7 +178,7 @@ export class Calculate {
             if (value === null) {
               continue;
             }
-            logicProgram += `field(${card.key}, "${field}", "${value !== undefined ? value.toString().replace('\n', '') : undefined}").\n`;
+            logicProgram += `field(${card.key}, "${field}", "${value !== undefined ? encodeClingoValue(value.toString()) : undefined}").\n`;
           }
         }
       }

--- a/tools/data-handler/src/utils/clingo-parser.ts
+++ b/tools/data-handler/src/utils/clingo-parser.ts
@@ -13,6 +13,21 @@
 import { Project } from '../containers/project.js';
 import { BaseResult, ParseResult } from '../types/queries.js';
 
+export const CLINGO_VALUE_ENCODING = 'base64url';
+
+export function encodeClingoValue(value: string) {
+  return value.replace(/[^a-zA-Z0-9 \/]/g, (char) => {
+    const code = char.charCodeAt(0);
+    return `'u${('0000' + code.toString(16)).slice(-4)}`;
+  });
+}
+
+export function decodeClingoValue(value: string) {
+  return value.replace(/'u([0-9a-fA-F]{4})/g, (match, code) => {
+    return String.fromCharCode(parseInt(code, 16));
+  });
+}
+
 class ClingoParser {
   private keywords = [
     'queryError',
@@ -83,7 +98,7 @@ class ClingoParser {
     },
     field: (key: string, fieldName: string, fieldValue: string) => {
       const res = this.getOrInitResult(key);
-      res[fieldName] = fieldValue;
+      res[fieldName] = decodeClingoValue(fieldValue);
     },
     label: (key: string, label: string) => {
       const res = this.getOrInitResult(key);

--- a/tools/data-handler/src/utils/clingo-parser.ts
+++ b/tools/data-handler/src/utils/clingo-parser.ts
@@ -16,14 +16,14 @@ import { BaseResult, ParseResult } from '../types/queries.js';
 export const CLINGO_VALUE_ENCODING = 'base64url';
 
 export function encodeClingoValue(value: string) {
-  return value.replace(/[^a-zA-Z0-9 \/]/g, (char) => {
+  return value.replace(/[^a-zA-Z0-9 /|:.]/g, (char) => {
     const code = char.charCodeAt(0);
-    return `'u${('0000' + code.toString(16)).slice(-4)}`;
+    return `\\u${('0000' + code.toString(16)).slice(-4)}`;
   });
 }
 
 export function decodeClingoValue(value: string) {
-  return value.replace(/'u([0-9a-fA-F]{4})/g, (match, code) => {
+  return value.replace(/\\u([0-9a-fA-F]{4})/g, (match, code) => {
     return String.fromCharCode(parseInt(code, 16));
   });
 }

--- a/tools/data-handler/src/utils/clingo-parser.ts
+++ b/tools/data-handler/src/utils/clingo-parser.ts
@@ -13,12 +13,19 @@
 import { Project } from '../containers/project.js';
 import { BaseResult, ParseResult } from '../types/queries.js';
 
+/**
+ * This function takes care of encoding chars, which might produce issues in clingo
+ * This should be done for user provided values
+ */
 export function encodeClingoValue(value: string) {
   return value.replace(/[\n\\"]/g, (char) => {
     return `\\${char}`;
   });
 }
 
+/**
+ * This function reverses the encoding made by the "encodeClingoValue" function
+ */
 export function decodeClingoValue(value: string) {
   return value.replace(/\\([\n\\"])/g, (match, char) => {
     return char;
@@ -242,31 +249,127 @@ class ClingoParser {
     this.sortByLevel(this.result.results);
   }
 
+  /**
+   * This methods is responsible for converting clingo output to a parsed object
+   * @param input clingo input to parse
+   * @returns
+   */
   public async parseInput(input: string): Promise<ParseResult<BaseResult>> {
-    const regex = new RegExp(`(${this.keywords.join('|')})\\(([^)]*)\\)`);
-    const lines = input.split('\n');
+    let position = 0;
 
-    for (const line of lines) {
-      const match = line.match(regex);
-      if (match && match.length === 3) {
-        const command = match[1];
-        const args = match[2].split(',').map((x) => x.trim());
+    while (position < input.length) {
+      const keywordMatch = this.findKeyword(input, position);
 
-        // Sanitize the arguments to remove extra quotes
-        const sanitizedArgs = args.map((arg) => arg.replace(/^"(.*)"$/, '$1'));
+      if (!keywordMatch) {
+        break;
+      }
 
+      const { keyword, endIndex } = keywordMatch;
+      position = endIndex;
+
+      const parsed = this.parseArguments(input, position);
+      if (parsed) {
         // Apply the command handler with sanitized arguments
-        await this.commandHandlers[command](...sanitizedArgs);
+        await this.commandHandlers[keyword](...parsed.args);
+        position = parsed.endPosition; // move position after the argument closing parenthesis
       }
     }
 
     this.applyResultProcessing();
     const result = this.result;
 
-    // reset the parser state
+    // Reset the parser state
     this.reset();
 
-    return result; // We can assume
+    return result;
+  }
+
+  /**
+   * This method finds the next keyword in a string after a specified point
+   * @param input The string which it being searched
+   * @param start The position from which to start the search from
+   * @returns
+   */
+  private findKeyword(
+    input: string,
+    start: number,
+  ): { keyword: string; startIndex: number; endIndex: number } | null {
+    // Create a regex dynamically from the keywords list
+    const regex = new RegExp(`(${this.keywords.join('|')})\\(`, 'g');
+
+    // Apply the regex starting from the current position
+    regex.lastIndex = start;
+    const match = regex.exec(input);
+
+    if (match) {
+      return {
+        keyword: match[1], // The matched keyword (first capture group)
+        startIndex: match.index, // Position of the matched keyword
+        endIndex: match.index + match[0].length, // Position after the keyword and opening parenthesis
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * This method is a custom parser, which takes in the whole clingo output and parses the arguments.
+   * @param input Clingo output
+   * @param position Position of the command being parsed inside the string
+   * @returns
+   */
+  private parseArguments(
+    input: string,
+    position: number,
+  ): { args: string[]; endPosition: number } | null {
+    let currentArg = '';
+    const args: string[] = [];
+    let insideQuote = false;
+    let escapeNext = false;
+
+    for (let i = position; i < input.length; i++) {
+      const char = input[i];
+
+      if (escapeNext) {
+        currentArg += char; // Add the escaped character
+        escapeNext = false;
+        continue;
+      }
+
+      if (char === '\\') {
+        escapeNext = true; // Set flag to escape the next character
+        continue;
+      }
+
+      if (char === '"') {
+        if (!insideQuote) {
+          // We can ignore the chars, which are before a quoted string
+          currentArg = '';
+        }
+        insideQuote = !insideQuote; // Toggle inside/outside quotes
+        continue;
+      }
+
+      if (char === ',' && !insideQuote) {
+        args.push(currentArg);
+        currentArg = '';
+        continue;
+      }
+
+      if (char === ')' && !insideQuote) {
+        if (currentArg) {
+          args.push(currentArg);
+        }
+        return {
+          args,
+          endPosition: i + 1,
+        };
+      }
+
+      currentArg += char;
+    }
+
+    return null; // No valid arguments found
   }
 }
 

--- a/tools/data-handler/src/utils/clingo-parser.ts
+++ b/tools/data-handler/src/utils/clingo-parser.ts
@@ -13,18 +13,15 @@
 import { Project } from '../containers/project.js';
 import { BaseResult, ParseResult } from '../types/queries.js';
 
-export const CLINGO_VALUE_ENCODING = 'base64url';
-
 export function encodeClingoValue(value: string) {
-  return value.replace(/[^a-zA-Z0-9 /|:.]/g, (char) => {
-    const code = char.charCodeAt(0);
-    return `\\u${('0000' + code.toString(16)).slice(-4)}`;
+  return value.replace(/[\n\\"]/g, (char) => {
+    return `\\${char}`;
   });
 }
 
 export function decodeClingoValue(value: string) {
-  return value.replace(/\\u([0-9a-fA-F]{4})/g, (match, code) => {
-    return String.fromCharCode(parseInt(code, 16));
+  return value.replace(/\\([\n\\"])/g, (match, char) => {
+    return char;
   });
 }
 

--- a/tools/data-handler/test/utils/clingo-parser.test.ts
+++ b/tools/data-handler/test/utils/clingo-parser.test.ts
@@ -48,6 +48,13 @@ describe('ClingoParser', () => {
     expect(result.results[0].fieldName).to.equal('fieldValue');
   });
 
+  it('should parse field correctly which has special characeters', async () => {
+    const fieldValue = 'fieldValueä)"()="()()()=\n';
+    const input = `result("key1")\nfield("key1", "fieldName", "${encodeClingoValue(fieldValue)}")`;
+    const result = await parser.parseInput(input);
+    expect(result.results[0].fieldName).to.equal(fieldValue);
+  });
+
   it('should parse label correctly', async () => {
     const input = 'result("key1")\nlabel("key1", "label1")';
     const result = await parser.parseInput(input);

--- a/tools/data-handler/test/utils/clingo-parser.test.ts
+++ b/tools/data-handler/test/utils/clingo-parser.test.ts
@@ -1,5 +1,7 @@
 import { expect } from 'chai';
-import ClingoParser from '../../src/utils/clingo-parser.js';
+import ClingoParser, {
+  encodeClingoValue,
+} from '../../src/utils/clingo-parser.js';
 import { Project } from '../../src/containers/project.js';
 
 describe('ClingoParser', () => {
@@ -41,7 +43,7 @@ describe('ClingoParser', () => {
   });
 
   it('should parse field correctly', async () => {
-    const input = 'result("key1")\nfield("key1", "fieldName", "fieldValue")';
+    const input = `result("key1")\nfield("key1", "fieldName", "${encodeClingoValue('fieldValue')}")`;
     const result = await parser.parseInput(input);
     expect(result.results[0].fieldName).to.equal('fieldValue');
   });
@@ -162,8 +164,8 @@ describe('ClingoParser', () => {
     const input = `
             result("key1")
             result("key2")
-            field("key1", "field", "b")
-            field("key2", "field", "a")
+            field("key1", "field", "${encodeClingoValue('b')}")
+            field("key2", "field", "${encodeClingoValue('a')}")
             order("1", "0", "field", "ASC")`;
     const result = await parser.parseInput(input);
 
@@ -176,8 +178,8 @@ describe('ClingoParser', () => {
     const input = `
             result("key1")
             result("key2")
-            field("key1", "field", "b")
-            field("key2", "field", "a")
+            field("key1", "field", "${encodeClingoValue('a')}")
+            field("key2", "field", "${encodeClingoValue('b')}")
             order("1", "0", "field", "DESC")`;
     const result = await parser.parseInput(input);
 
@@ -190,11 +192,11 @@ describe('ClingoParser', () => {
     const input = `
         result("key1")
         childResult("key1", "key2")
-        field("key2", "field", "b")
+        field("key2", "field", "${encodeClingoValue('b')}")
         childResult("key1", "key3")
-        field("key3", "field", "a")
+        field("key3", "field", "${encodeClingoValue('a')}")
         childResult("key1", "key4")
-        field("key4", "field", "c")
+        field("key4", "field", "${encodeClingoValue('c')}")
         order(2, 1, "field", "ASC")
     `;
 
@@ -209,11 +211,11 @@ describe('ClingoParser', () => {
     const input = `
         result("key1")
         childResult("key1", "key2")
-        field("key2", "field", "b")
+        field("key2", "field", "${encodeClingoValue('b')}")
         childResult("key1", "key3")
-        field("key3", "field", "a")
+        field("key3", "field", "${encodeClingoValue('a')}")
         childResult("key1", "key4")
-        field("key4", "field", "c")
+        field("key4", "field", "${encodeClingoValue('c')}")
         order(2, 1, "field", "DESC")
     `;
 
@@ -231,11 +233,11 @@ describe('ClingoParser', () => {
         childResult("key1", "key2")
         childResult("key2", "key3")
         childResult("key3", "key4")
-        field("key4", "field", "b")
+        field("key4", "field", "${encodeClingoValue('b')}")
         childResult("key3", "key5")
-        field("key5", "field", "a")
+        field("key5", "field", "${encodeClingoValue('a')}")
         childResult("key3", "key6")
-        field("key6", "field", "c")
+        field("key6", "field", "${encodeClingoValue('c')}")
         order(4, 1, "field", "ASC")
     `;
 
@@ -258,7 +260,7 @@ describe('ClingoParser', () => {
   it('should handle multiple commands correctly', async () => {
     const input = `
             result("key1")
-            field("key1", "fieldName", "fieldValue")
+            field("key1", "fieldName", "${encodeClingoValue('fieldValue')}")
             label("key1", "label1")
             link("key1", "cardKey", "linkType", "linkDescription")
             transitionDenied("key1", "transitionName", "errorMessage")


### PR DESCRIPTION
I considered a few options for encoding clingo characters. Since I didn't yet a good idea of characters we could whitelist/blacklist, I ended thinking of encoding/decoding fieldValues for clingo. I considered:
1. Base64
Issue with base64 is that the queries interact with the values and it would be annoying to use base64 for referencing thos e values.
2. Replacing all but certain characters with a formatted string.
I ended up going with this

I put a few things into the whitelist: a-z, A-Z, 0-9 and a few special chars(/, space, |, : and .)

Here's what the generated version looks like:
![image](https://github.com/user-attachments/assets/3c1aa4ce-057f-4c6d-ac58-6535a3f4fbef)

