### PR TITLE
Correct configure name for modules

### DIFF
--- a/tools/schema/cardtree-directory-schema.json
+++ b/tools/schema/cardtree-directory-schema.json
@@ -520,7 +520,7 @@
                   "additionalProperties": false,
                   "properties": {
                     ".schema": {},
-                    "cardsconfig.json": {
+                    "cardsConfig.json": {
                       "type": "object"
                     }
                   },


### PR DESCRIPTION
Schema still has old name for the module configuration.
