### PR TITLE
INTDE-477 Fix link type default content to use a proper name

### DIFF
--- a/tools/data-handler/src/utils/resource-utils.ts
+++ b/tools/data-handler/src/utils/resource-utils.ts
@@ -7,7 +7,6 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { assert } from 'node:console';
 import { parse } from 'node:path';
 
 interface ResourceName {
@@ -18,16 +17,27 @@ interface ResourceName {
 
 /**
  * Returns resource name parts (project prefix, type in plural, name of the resource).
- * @todo - add unit tests
  * @param resourceName Full name of the resource (e.g. <prefix>/<type>/<name>)
  * @returns resource name parts: project or module prefix, resource type (plural) and actual name of the resource.
  */
 export function resourceNameParts(resourceName: string): ResourceName {
   const parts = resourceName.split('/');
-  assert(parts.length === 3);
-  return {
-    prefix: parts[0],
-    type: parts[1],
-    name: parse(parts[2]).name,
-  };
+  // short name format - type and prefix are unknown
+  if (parts.length === 1 && parts.at(0) !== '') {
+    return {
+      prefix: '',
+      type: '',
+      name: resourceName,
+    };
+  }
+  // long name format
+  if (parts.length === 3) {
+    return {
+      prefix: parts[0],
+      type: parts[1],
+      name: parse(parts[2]).name,
+    };
+  }
+  // other formats are not accepted
+  throw new Error(`Name '${resourceName}' is not valid resource name`);
 }

--- a/tools/data-handler/test/utils/resource-utils.test.ts
+++ b/tools/data-handler/test/utils/resource-utils.test.ts
@@ -1,0 +1,31 @@
+// testing
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { resourceNameParts } from '../../src/utils/resource-utils.js';
+
+describe('resource utils', () => {
+  it('resourceNameParts with valid long resource name (success)', () => {
+    const resourceName = 'test/test/test';
+    // note that resource name util does not handle incorrect prefixes, or types
+    const { prefix, type, name } = resourceNameParts(resourceName);
+    expect(prefix).to.equal('test');
+    expect(type).to.equal('test');
+    expect(name).to.equal('test');
+  });
+  it('resourceNameParts with valid short resource name (success)', () => {
+    const resourceName = 'test';
+    const { prefix, type, name } = resourceNameParts(resourceName);
+    expect(prefix).to.equal('');
+    expect(type).to.equal('');
+    expect(name).to.equal('test');
+  });
+  it('resourceNameParts with invalid names', () => {
+    const invalidResourceNames = ['', 'test/test', 'test/test/test/test'];
+    for (const invalidName of invalidResourceNames) {
+      expect(() => {
+        resourceNameParts(invalidName);
+      }).to.throw();
+    }
+  });
+});


### PR DESCRIPTION
Fix default link type content when link type is created. As a fix link type will use 'full name' ((project prefix)/linkTypes/(name)).

`cyberismo create linkType test`
`cyberismo show cardType test`

==>

```
{
  "name": "project/linkTypes/test",
  "outboundDisplayName": "test",
  "inboundDisplayName": "test",
  "sourceCardTypes": [],
  "destinationCardTypes": [],
  "enableLinkDescription": false
}
```

Additionally, make function `private` (no need for others to share this).
Rename function from `getLinkTypeContent` to `defaultLinkTypeContent`.
