### PR TITLE
Regression fix: Validation complains about imported module resources

### DIFF
--- a/tools/data-handler/src/validate.ts
+++ b/tools/data-handler/src/validate.ts
@@ -119,6 +119,7 @@ export class Validate {
         );
 
       let activeJsonSchema: Schema = {};
+      const prefixes = await project.projectPrefixes();
       for (const file of fileNames) {
         const fullFileNameWithPath = this.fullPath(file);
         if (file.name === Validate.schemaConfigurationFile) {
@@ -140,7 +141,7 @@ export class Validate {
             fullFileNameWithPath,
             file,
             content,
-            project.projectPrefix,
+            prefixes,
           );
           if (nameErrors) {
             message.push(...nameErrors);
@@ -172,7 +173,7 @@ export class Validate {
       | LinkType
       | ProjectSettings
       | WorkflowMetadata,
-    projectPrefix: string,
+    projectPrefixes: string[],
   ): string[] {
     const errors: string[] = [];
     // Exclude cardsConfig.json, .schemas and template.json.
@@ -190,9 +191,9 @@ export class Validate {
       const { name, type, prefix } = resourceNameParts(namedContent.name);
       const filenameWithoutExtension = parse(file.name).name;
 
-      if (projectPrefix !== prefix) {
+      if (!projectPrefixes.includes(prefix)) {
         errors.push(
-          `Wrong prefix in resource '${namedContent.name}'. Project prefix is '${projectPrefix}'`,
+          `Wrong prefix in resource '${namedContent.name}'. Project prefixes are '[${projectPrefixes.join(', ')}]'`,
         );
       }
       if (name !== filenameWithoutExtension) {

--- a/tools/data-handler/test/0_validate.test.ts
+++ b/tools/data-handler/test/0_validate.test.ts
@@ -312,7 +312,7 @@ describe('validate cmd tests', () => {
     const errors = await validateCmd.validate(project.basePath);
     const separatedErrors = errors.split('\n');
     const expectWrongPrefix =
-      "Wrong prefix in resource 'wrong/cardTypesWrong/decisionWrong'. Project prefix is 'decision'";
+      "Wrong prefix in resource 'wrong/cardTypesWrong/decisionWrong'. Project prefixes are '[decision]'";
     const expectWrongName = `Resource 'name' wrong/cardTypesWrong/decisionWrong mismatch with file path 'test${sep}test-data${sep}invalid${sep}invalid-wrong-resource-names${sep}.cards${sep}local${sep}cardTypes${sep}decision.json'`;
     const expectWrongType = `Wrong type name in resource 'wrong/cardTypesWrong/decisionWrong'. Should match filename path: 'test${sep}test-data${sep}invalid${sep}invalid-wrong-resource-names${sep}.cards${sep}local${sep}cardTypes${sep}decision.json'`;
     expect(separatedErrors[0]).to.equal(expectWrongPrefix);


### PR DESCRIPTION
Validation complains about resource names if module has been imported.