### PR TITLE
INTDEV-487 Collect attachments from one folder only, not from children

### DIFF
--- a/tools/data-handler/src/containers/card-container.ts
+++ b/tools/data-handler/src/containers/card-container.ts
@@ -14,7 +14,6 @@
 import { basename, join, sep } from 'node:path';
 import { readdir, readFile, writeFile } from 'node:fs/promises';
 
-// ismo
 import { writeJsonFile } from '../utils/json.js';
 import { getFilesSync, pathExists } from '../utils/file-utils.js';
 
@@ -172,8 +171,7 @@ export class CardContainer {
     return foundCards;
   }
 
-  // Collects all attachments from container.
-  // Function collects attachments from one folder and recurses to valid, potential folders.
+  // Function collects attachments from all cards in one folder.
   private async doCollectAttachments(
     folder: string,
     attachments: CardAttachment[],
@@ -184,8 +182,11 @@ export class CardContainer {
         (item) => item.isDirectory(),
       );
       for (const entry of entries) {
-        if (CardNameRegEx.test(entry.name) || entry.name === 'c') {
+        if (CardNameRegEx.test(entry.name)) {
           currentPaths.push(join(entry.path, entry.name));
+        } else if (entry.name === 'c') {
+          // If the entry would continue to children, stop.
+          continue;
         } else {
           // Set paths.
           const attachmentFolder = join(entry.path, entry.name);
@@ -215,7 +216,6 @@ export class CardContainer {
         this.doCollectAttachments(item, attachments),
       );
       await Promise.all(promises);
-      return attachments;
     }
     return attachments;
   }


### PR DESCRIPTION
Change `doCollectAttachments` to collect only from a given folder (and its non-children-card subfolders). 