### PR TITLE
INTDEV-459 Delete old .calc folder before starting new calculations

### DIFF
--- a/tools/data-handler/src/calculate.ts
+++ b/tools/data-handler/src/calculate.ts
@@ -20,6 +20,7 @@ import { fileURLToPath } from 'node:url';
 import { Card, Link } from './interfaces/project-interfaces.js';
 import {
   copyDir,
+  deleteDir,
   deleteFile,
   getFilesSync,
   pathExists,
@@ -317,6 +318,9 @@ export class Calculate {
    */
   public async generate(projectPath: string, cardKey?: string) {
     Calculate.project = new Project(projectPath);
+
+    // Cleanup old calculations before starting new ones.
+    await deleteDir(Calculate.project.calculationFolder);
 
     let card: Card | undefined;
     if (cardKey) {


### PR DESCRIPTION
Remove old folder as first stage of calculations. The subroutines already automatically create folder(s) if they are missing.