### PR TITLE
INTDEV-491 Collect attachments correctly even with empty attachment folders

### DIFF
--- a/tools/data-handler/src/containers/card-container.ts
+++ b/tools/data-handler/src/containers/card-container.ts
@@ -182,18 +182,15 @@ export class CardContainer {
         (item) => item.isDirectory(),
       );
       for (const entry of entries) {
+        // Investigate the content of card folders' attachment folders, but do not continue to children cards.
+        // For each attachment folder, collect all files.
         if (CardNameRegEx.test(entry.name)) {
           currentPaths.push(join(entry.path, entry.name));
         } else if (entry.name === 'c') {
-          // If the entry would continue to children, stop.
           continue;
-        } else {
-          // Set paths.
+        } else if (entry.name === 'a') {
           const attachmentFolder = join(entry.path, entry.name);
-          const childrenFolder = join(entry.path, 'c');
           const cardItem = basename(entry.path) || '';
-
-          // Collect all attachments.
           const entryAttachments = await readdir(attachmentFolder, {
             withFileTypes: true,
           });
@@ -205,9 +202,6 @@ export class CardContainer {
               mimeType: mime.lookup(attachment.name) || null,
             }),
           );
-          if (pathExists(childrenFolder)) {
-            currentPaths.push(childrenFolder);
-          }
         }
       }
     }


### PR DESCRIPTION
Simplify attachment collecting. Ignore empty 'a' folders.

<img width="842" alt="Screenshot 2024-10-09 at 14 40 41" src="https://github.com/user-attachments/assets/72142fed-5c18-47b3-99c6-36f73d9a8c3f">
<img width="608" alt="Screenshot 2024-10-09 at 14 40 55" src="https://github.com/user-attachments/assets/329cc796-3e8d-4dab-a111-70d7c0c50990">
<img width="856" alt="Screenshot 2024-10-09 at 14 41 10" src="https://github.com/user-attachments/assets/435cd257-bce2-4c12-863b-ffba2bf67f14">
<img width="838" alt="Screenshot 2024-10-09 at 14 41 24" src="https://github.com/user-attachments/assets/173a9f82-56e2-4b95-985a-e0691c29bc66">
<img width="855" alt="Screenshot 2024-10-09 at 14 41 58" src="https://github.com/user-attachments/assets/bd973623-cbb9-4752-8293-0d3da2b374bd">
