### PR TITLE
INTDEV-475 Allow creation of resource with long and short names

### DIFF
--- a/tools/data-handler/test/command-handler-create.test.ts
+++ b/tools/data-handler/test/command-handler-create.test.ts
@@ -518,7 +518,8 @@ describe('create command', () => {
     );
     expect(result.statusCode).to.equal(200);
   });
-  it('template with "local" (success)', async () => {
+  it('template with "local"', async () => {
+    // local is no longer a valid name part.
     const templateName = 'local/templates/template-name_second';
     const templateContent = '{}';
     const result = await commandHandler.command(
@@ -526,7 +527,7 @@ describe('create command', () => {
       ['template', templateName, templateContent],
       optionsMini,
     );
-    expect(result.statusCode).to.equal(200);
+    expect(result.statusCode).to.equal(400);
   });
   it('template with default parameters (success)', async () => {
     const templateName = 'validname';


### PR DESCRIPTION
Allow creation operations to use both long and short names:

`cyberismo create workflow test`
`cyberismo create workflow <prefix>/workflows/test`

Validates that all long name parts match the project prefix and to-be-created resource type.

Drop `local` name part usage from CLI. It is still used internally as a location for local project's resources, but it cannot be referred from CLI commands and shouldn't be visible, other than file paths.