### PR TITLE
INTDEV-498 Create links with direction (inbound|outbound)

### DIFF
--- a/tools/app/app/cards/[key]/page.tsx
+++ b/tools/app/app/cards/[key]/page.tsx
@@ -93,6 +93,7 @@ export default function Page({ params }: { params: { key: string } }) {
                   linkType.enableLinkDescription
                     ? data.linkDescription
                     : undefined,
+                  data.direction,
                 );
                 return true;
               } catch (error) {


### PR DESCRIPTION
`direction` was not included when `createLink` was called.