### PR TITLE
INTDEV-450 Hide link button in edit mode

### DIFF
--- a/tools/app/app/components/ContentToolbar.tsx
+++ b/tools/app/app/components/ContentToolbar.tsx
@@ -77,16 +77,18 @@ const ContentToolbar: React.FC<ContentToolbarProps> = ({
 
       <CardContextMenu cardKey={cardKey} />
 
-      <Tooltip title={t('linkTooltip')}>
-        <IconButton
-          onClick={onInsertLink}
-          size="sm"
-          variant="plain"
-          style={{ marginRight: 8, minWidth: 40 }}
-        >
-          <InsertLink />
-        </IconButton>
-      </Tooltip>
+      {mode === CardMode.VIEW && (
+        <Tooltip title={t('linkTooltip')}>
+          <IconButton
+            onClick={onInsertLink}
+            size="sm"
+            variant="plain"
+            style={{ marginRight: 8, minWidth: 40 }}
+          >
+            <InsertLink />
+          </IconButton>
+        </Tooltip>
+      )}
 
       <StatusSelector
         currentState={currentState}


### PR DESCRIPTION
Decided to hide it, because edit mode only shows links on the preview tab