### PR TITLE
INTDEV-503 Allow .gitkeep in resource directories

### DIFF
--- a/tools/schema/cardTreeDirectorySchema.json
+++ b/tools/schema/cardTreeDirectorySchema.json
@@ -85,7 +85,8 @@
                                 "files": {
                                   "type": "object",
                                   "properties": {
-                                    ".schema": {}
+                                    ".schema": {},
+                                    ".gitkeep": {}
                                   },
                                   "required": [".schema"]
                                 }
@@ -118,7 +119,8 @@
                                 "files": {
                                   "type": "object",
                                   "properties": {
-                                    ".schema": {}
+                                    ".schema": {},
+                                    ".gitkeep": {}
                                   },
                                   "required": [".schema"]
                                 }
@@ -151,7 +153,8 @@
                                 "files": {
                                   "type": "object",
                                   "properties": {
-                                    ".schema": {}
+                                    ".schema": {},
+                                    ".gitkeep": {}
                                   },
                                   "required": [".schema"]
                                 }
@@ -216,6 +219,9 @@
                             },
                             "files": {
                               "type": "object",
+                              "properties": {
+                                ".gitkeep": {}
+                              },
                               "additionalProperties": false
                             }
                           }
@@ -245,7 +251,8 @@
                                 "files": {
                                   "type": "object",
                                   "properties": {
-                                    ".schema": {}
+                                    ".schema": {},
+                                    ".gitkeep": {}
                                   },
                                   "required": [".schema"]
                                 }
@@ -438,7 +445,8 @@
                             "files": {
                               "type": "object",
                               "properties": {
-                                ".schema": {}
+                                ".schema": {},
+                                ".gitkeep": {}
                               },
                               "required": [".schema"]
                             }
@@ -466,7 +474,8 @@
                             "files": {
                               "type": "object",
                               "properties": {
-                                ".schema": {}
+                                ".schema": {},
+                                ".gitkeep": {}
                               },
                               "required": [".schema"]
                             }
@@ -535,6 +544,9 @@
                         },
                         "files": {
                           "type": "object",
+                          "properties": {
+                            ".gitkeep": {}
+                          },
                           "additionalProperties": false
                         }
                       }


### PR DESCRIPTION
Allow any of the resource directories (either under `.cards/local` or `.cards/modules`) to have `.gitkeep` file in them.

<img width="552" alt="Screenshot 2024-10-16 at 16 58 44" src="https://github.com/user-attachments/assets/24f925d9-68f8-4f50-a9dd-5edd0f256446">
<img width="517" alt="Screenshot 2024-10-16 at 16 58 53" src="https://github.com/user-attachments/assets/ed0ee116-1391-497e-b4fb-749e2784bbaa">
<img width="415" alt="Screenshot 2024-10-16 at 16 59 01" src="https://github.com/user-attachments/assets/6e872162-294a-4dd3-bf88-a63d8c62f002">
