### PR TITLE
INTDEV-500 direct app output to parent process stdio

### DIFF
--- a/tools/data-handler/src/calculate.ts
+++ b/tools/data-handler/src/calculate.ts
@@ -494,6 +494,7 @@ export class Calculate {
         encoding: 'utf8',
         input: data.query,
         timeout,
+        maxBuffer: 1024 * 1024 * 100,
       });
       // print the command
       console.log(`Ran command: ${this.logicBinaryName} ${args.join(' ')}`);

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -1285,7 +1285,11 @@ export class Commands {
     const projectPath = resolve(path);
 
     const args = [`start`, `--project_path="${projectPath}"`];
-    execFileSync(`npm`, args, { shell: true, cwd: `${appPath}` });
+    execFileSync(`npm`, args, {
+      shell: true,
+      cwd: `${appPath}`,
+      stdio: 'inherit',
+    });
 
     return { statusCode: 200 };
   }


### PR DESCRIPTION
When we run clingo on the command line, we have 3 processes:
* CLI-process
* App-process(child of cli)
* Clingo-processes(child of app)

Since we used the default option when starting the app from cli(stdio="pipe"), the app would crash if it printed too much output into stdout. The cli-process does not care about the app's output, but it might be useful for the user(or not?) so I set  stdio to "inherit", which causes app to write its stdout to cli-process's sdout.

We need the clingo processes stdout so this solution cannot be used there. While the clingo-process was not creating issues now, I also increased its buffer so that we wouldn't get issues with a larger project. I set it to 100MB for now.