### PR TITLE
INTDEV-516 prevent caching attachments

### DIFF
--- a/tools/app/app/api/cards/[key]/a/[attachment]/route.tsx
+++ b/tools/app/app/api/cards/[key]/a/[attachment]/route.tsx
@@ -76,6 +76,7 @@ export async function GET(request: NextRequest) {
       headers: {
         'Content-Type': payload.mimeType,
         'Content-Disposition': `attachment; filename="${filename}"`,
+        'Cache-Control': 'no-store',
       },
     });
   } catch (error) {


### PR DESCRIPTION
Browser caches images automatically, but it is now disabled.