### PR TITLE
Add separate class to handle paths for Project class

### DIFF
--- a/tools/data-handler/src/containers/project/project-paths.ts
+++ b/tools/data-handler/src/containers/project/project-paths.ts
@@ -1,0 +1,124 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { join } from 'node:path';
+
+import { ResourceFolderType } from '../../interfaces/project-interfaces.js';
+import { resourceNameParts } from '../../utils/resource-utils.js';
+
+/**
+ * Handles paths for a project.
+ */
+export class ProjectPaths {
+  private pathMap: Map<ResourceFolderType, string>;
+
+  constructor(
+    private path: string,
+    private prefix: string,
+  ) {
+    this.pathMap = new Map([
+      ['calculation', this.calculationProjectFolder],
+      ['cardType', this.cardTypesFolder],
+      ['fieldType', this.fieldTypesFolder],
+      ['linkType', this.linkTypesFolder],
+      ['module', this.modulesFolder],
+      ['report', this.reportsFolder],
+      ['template', this.templatesFolder],
+      ['workflow', this.workflowsFolder],
+    ]);
+  }
+
+  public get calculationCardsFolder(): string {
+    return join(this.calculationFolder, 'cards');
+  }
+
+  public get calculationFolder(): string {
+    return join(this.path, '.calc');
+  }
+
+  public get calculationProjectFolder(): string {
+    return join(this.resourcesFolder, 'calculations');
+  }
+
+  public get calculationResourcesFolder(): string {
+    return join(this.calculationFolder, 'resources');
+  }
+
+  public get cardRootFolder(): string {
+    return join(this.path, 'cardRoot');
+  }
+
+  public get cardTypesFolder(): string {
+    return join(this.resourcesFolder, 'cardTypes');
+  }
+
+  public get fieldTypesFolder(): string {
+    return join(this.resourcesFolder, 'fieldTypes');
+  }
+
+  public get linkTypesFolder(): string {
+    return join(this.resourcesFolder, 'linkTypes');
+  }
+
+  public get modulesFolder(): string {
+    return join(this.path, '.cards', 'modules');
+  }
+
+  public get resourcesFolder(): string {
+    return join(this.path, '.cards', 'local');
+  }
+
+  public get reportsFolder(): string {
+    return join(this.resourcesFolder, 'reports');
+  }
+
+  public get tempCardFolder(): string {
+    return join(this.cardRootFolder, 'temp');
+  }
+
+  public get templatesFolder(): string {
+    return join(this.resourcesFolder, 'templates');
+  }
+
+  public get workflowsFolder(): string {
+    return join(this.resourcesFolder, 'workflows');
+  }
+
+  /**
+   * Returns full name of a resource.
+   * @param resourceType Type of resource
+   * @param resourceName Resource name
+   * @returns full name of a resource (prefix/type/name)
+   */
+  public resourceFullName(
+    resourceType: ResourceFolderType,
+    resourceName: string,
+  ): string {
+    const { prefix, type, name } = resourceNameParts(resourceName);
+    const actualPrefix = prefix ? prefix : this.prefix;
+    const actualType = type ? type : `${resourceType}s`;
+    return `${actualPrefix}/${actualType}s/${name}`;
+  }
+
+  /**
+   * Return path to a resource type folder.
+   * @param resourceType Type of resource
+   * @returns path to a resources folder (e.g. '.cards/local/cardTypes')
+   */
+  public resourcePath(resourceType: ResourceFolderType): string {
+    const resourcePath = this.pathMap.get(resourceType);
+    if (!resourcePath) {
+      throw new Error(`unknown resourceType: ${resourceType}`);
+    }
+    return resourcePath;
+  }
+}

--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -15,7 +15,6 @@ import { basename, join, resolve, sep } from 'node:path';
 import { copyFile, mkdir, rm, writeFile } from 'node:fs/promises';
 import { readdirSync } from 'node:fs';
 
-// ismo
 import {
   Card,
   CardAttachment,
@@ -90,7 +89,7 @@ export class Template extends CardContainer {
     parentCard?: Card,
   ): Promise<Card[]> {
     const templateIDMap: mappingValue[] = [];
-    const tempDestination = join(this.project.cardRootFolder, 'temp');
+    const tempDestination = this.project.paths.tempCardFolder;
 
     // First, create a mapping table.
     for (const card of cards) {
@@ -252,7 +251,7 @@ export class Template extends CardContainer {
         await mkdir(parentCard.path, { recursive: true });
         await copyDir(tempDestination, parentCard.path);
       } else {
-        await copyDir(tempDestination, this.project.cardRootFolder);
+        await copyDir(tempDestination, this.project.paths.cardRootFolder);
       }
       // Finally, delete temp folder.
       await rm(tempDestination, { recursive: true, force: true });
@@ -269,10 +268,10 @@ export class Template extends CardContainer {
 
   // fetches path to module.
   private moduleTemplatePath(templateName: string): string {
-    if (!pathExists(this.project.modulesFolder)) {
+    if (!pathExists(this.project.paths.modulesFolder)) {
       return '';
     }
-    const files = readdirSync(this.project.modulesFolder, {
+    const files = readdirSync(this.project.paths.modulesFolder, {
       withFileTypes: true,
     });
     const modules = files.filter((item) => item.isDirectory());
@@ -310,7 +309,7 @@ export class Template extends CardContainer {
 
     // Template can either be local ...
     const localTemplate = join(
-      this.project.templatesFolder,
+      this.project.paths.templatesFolder,
       normalizedTemplateName,
     );
     const createdLocalTemplate = pathExists(resolve(localTemplate));

--- a/tools/data-handler/src/create.ts
+++ b/tools/data-handler/src/create.ts
@@ -20,7 +20,6 @@ import {
 } from 'node:fs/promises';
 import { EventEmitter } from 'node:events';
 
-// ismo
 import { Calculate } from './calculate.js';
 import {
   CardType,
@@ -589,7 +588,7 @@ export class Create extends EventEmitter {
       ],
       [],
     ];
-    const parentFolderToCreate = join(projectPath);
+    const parentFolderToCreate = join(projectPath); // todo: could be removed
 
     if (Project.isCreated(projectPath)) {
       throw new Error('Project already exists');
@@ -633,15 +632,15 @@ export class Create extends EventEmitter {
     try {
       const project = new Project(projectPath);
       await writeFile(
-        join(project.calculationProjectFolder, '.gitkeep'),
+        join(project.paths.calculationProjectFolder, '.gitkeep'),
         this.gitKeepContent,
       );
       await writeFile(
-        join(project.fieldTypesFolder, '.gitkeep'),
+        join(project.paths.fieldTypesFolder, '.gitkeep'),
         this.gitKeepContent,
       );
       await writeFile(
-        join(project.reportsFolder, '.gitkeep'),
+        join(project.paths.reportsFolder, '.gitkeep'),
         this.gitKeepContent,
       );
     } catch (error) {
@@ -739,7 +738,7 @@ export class Create extends EventEmitter {
 
     await copyDir(
       this.defaultReportLocation,
-      join(project.reportsFolder, name),
+      join(project.paths.reportsFolder, name),
     );
   }
 

--- a/tools/data-handler/src/edit.ts
+++ b/tools/data-handler/src/edit.ts
@@ -45,7 +45,7 @@ export class Edit {
     ).getPreferences();
 
     // Construct paths for the card components (json and adoc)
-    const cardDirPath = join(Edit.project.cardRootFolder, cardPath);
+    const cardDirPath = join(Edit.project.paths.cardRootFolder, cardPath);
     const cardContentPath = join(cardDirPath, Project.cardContentFile);
     const cardJsonPath = join(cardDirPath, Project.cardMetadataFile);
 

--- a/tools/data-handler/src/export-site.ts
+++ b/tools/data-handler/src/export-site.ts
@@ -22,7 +22,6 @@ import { fileURLToPath } from 'node:url';
 import git from 'isomorphic-git';
 import { dump } from 'js-yaml';
 
-// ismo
 import { Card } from './interfaces/project-interfaces.js';
 import { errorFunction } from './utils/log-utils.js';
 import { Export } from './export.js';
@@ -251,8 +250,11 @@ export class ExportSite extends Export {
   ) {
     Export.project = new Project(source);
     const sourcePath: string = cardKey
-      ? join(Export.project.cardRootFolder, Export.project.pathToCard(cardKey))
-      : Export.project.cardRootFolder;
+      ? join(
+          Export.project.paths.cardRootFolder,
+          Export.project.pathToCard(cardKey),
+        )
+      : Export.project.paths.cardRootFolder;
     const cards: Card[] = [];
 
     // If doing a partial tree export, put the parent information as it would have already been gathered.

--- a/tools/data-handler/src/export.ts
+++ b/tools/data-handler/src/export.ts
@@ -20,7 +20,6 @@ import {
 } from 'node:fs/promises';
 import { basename, dirname, join, resolve, sep } from 'node:path';
 
-// ismo
 import {
   Card,
   CardNameRegEx,
@@ -242,7 +241,7 @@ export class Export {
     cardKey?: string,
   ) {
     Export.project = new Project(source);
-    const sourcePath: string = Export.project.cardRootFolder;
+    const sourcePath: string = Export.project.paths.cardRootFolder;
     let cards: Card[] = [];
 
     // If doing a partial tree export, put the parent information as it would have already been gathered.

--- a/tools/data-handler/src/import.ts
+++ b/tools/data-handler/src/import.ts
@@ -13,10 +13,8 @@
 // node
 import { join } from 'node:path';
 
-// ismo
 import { copyDir } from './utils/file-utils.js';
 import { Project } from './containers/project.js';
-
 import { readCsvFile } from './utils/csv.js';
 import { Validate } from './validate.js';
 import { Create } from './create.js';
@@ -123,10 +121,10 @@ export class Import {
     const sourceProject = new Project(source);
     const modulePrefix = sourceProject.projectPrefix;
     const destinationPath = join(
-      destinationProject.modulesFolder,
+      destinationProject.paths.modulesFolder,
       modulePrefix,
     );
-    const sourcePath = sourceProject.resourcesFolder;
+    const sourcePath = sourceProject.paths.resourcesFolder;
 
     // Do not allow modules with same prefixes.
     const currentlyUsedPrefixes = await destinationProject.projectPrefixes();

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -192,6 +192,17 @@ export interface Resource {
   path?: string;
 }
 
+// Resources that have own folders.
+export type ResourceFolderType =
+  | 'calculation'
+  | 'cardType'
+  | 'fieldType'
+  | 'linkType'
+  | 'module'
+  | 'report'
+  | 'template'
+  | 'workflow';
+
 // Template configuration details.
 export interface Template {
   name: string;

--- a/tools/data-handler/src/move.ts
+++ b/tools/data-handler/src/move.ts
@@ -13,7 +13,6 @@
 // node
 import { join, sep } from 'node:path';
 
-// ismo
 import { copyDir, deleteDir } from './utils/file-utils.js';
 import { Card } from './interfaces/project-interfaces.js';
 import { Project } from './containers/project.js';
@@ -45,7 +44,7 @@ export class Move {
     } else {
       const returnObject: Card = {
         key: '',
-        path: Move.project.cardRootFolder,
+        path: Move.project.paths.cardRootFolder,
       };
       promiseContainer.push(Promise.resolve(returnObject));
     }
@@ -80,7 +79,7 @@ export class Move {
 
     const destinationPath =
       destination === 'root'
-        ? join(Move.project.cardRootFolder, sourceCard.key)
+        ? join(Move.project.paths.cardRootFolder, sourceCard.key)
         : join(destinationCard.path, 'c', sourceCard.key);
 
     // if the card is already in the destination, do nothing

--- a/tools/data-handler/src/project-settings.ts
+++ b/tools/data-handler/src/project-settings.ts
@@ -13,10 +13,8 @@
 // node
 import { open } from 'node:fs/promises';
 
-// ismo
-import { writeJsonFile } from './utils/json.js';
 import { ProjectSettings } from './interfaces/project-interfaces.js';
-import { readJsonFileSync } from './utils/json.js';
+import { readJsonFileSync, writeJsonFile } from './utils/json.js';
 import { Validate } from './validate.js';
 
 /**

--- a/tools/data-handler/src/remove.ts
+++ b/tools/data-handler/src/remove.ts
@@ -14,7 +14,6 @@
 import { EventEmitter } from 'node:events';
 import { basename, join, sep } from 'node:path';
 
-// ismo
 import { Calculate } from './calculate.js';
 import { deleteDir, deleteFile } from './utils/file-utils.js';
 import { Project } from './containers/project.js';
@@ -65,9 +64,12 @@ export class Remove extends EventEmitter {
     }
 
     // If card is destination of a link, remove the link.
-    const allCards = await Remove.project.cards(Remove.project.cardRootFolder, {
-      metadata: true,
-    });
+    const allCards = await Remove.project.cards(
+      Remove.project.paths.cardRootFolder,
+      {
+        metadata: true,
+      },
+    );
     const promiseContainer: Promise<void>[] = [];
     allCards.filter((item) => {
       item.metadata?.links?.forEach(async (link) => {

--- a/tools/data-handler/src/rename.ts
+++ b/tools/data-handler/src/rename.ts
@@ -16,7 +16,6 @@ import { EventEmitter } from 'node:events';
 import { basename, join } from 'node:path';
 import { rename, readFile, writeFile } from 'node:fs/promises';
 
-// ismo
 import { Calculate } from './calculate.js';
 import { Card, Resource } from './interfaces/project-interfaces.js';
 import { Project } from './containers/project.js';
@@ -187,7 +186,7 @@ export class Rename extends EventEmitter {
         this.updateResourceName(item),
       );
       const filename = join(
-        Rename.project.cardTypesFolder,
+        Rename.project.paths.cardTypesFolder,
         basename(cardTypeName),
       );
       await writeJsonFile(filename, cardType);
@@ -202,7 +201,7 @@ export class Rename extends EventEmitter {
       fieldType.name = this.updateResourceName(fieldTypeName);
       // Write file
       const filename = join(
-        Rename.project.fieldTypesFolder,
+        Rename.project.paths.fieldTypesFolder,
         basename(fieldTypeName),
       );
       await writeJsonFile(filename, fieldType);
@@ -223,7 +222,7 @@ export class Rename extends EventEmitter {
       );
       // Write file
       const filename = join(
-        Rename.project.linkTypesFolder,
+        Rename.project.paths.linkTypesFolder,
         basename(linkTypeName),
       );
       await writeJsonFile(filename, linkType);
@@ -238,7 +237,7 @@ export class Rename extends EventEmitter {
       workflow.name = this.updateResourceName(workflowName);
       // Write file
       const filename = join(
-        Rename.project.workflowsFolder,
+        Rename.project.paths.workflowsFolder,
         basename(workflowName),
       );
       await writeJsonFile(filename, workflow);
@@ -316,7 +315,10 @@ export class Rename extends EventEmitter {
 
     // Rename all project cards.
     await this.renameCards(
-      await Rename.project.cards(Rename.project.cardRootFolder, cardContent),
+      await Rename.project.cards(
+        Rename.project.paths.cardRootFolder,
+        cardContent,
+      ),
     );
 
     this.emit('renamed', Rename.project.basePath);

--- a/tools/data-handler/src/show.ts
+++ b/tools/data-handler/src/show.ts
@@ -337,6 +337,7 @@ export class Show {
    */
   public async showFieldTypes(projectPath: string): Promise<string[]> {
     Show.project = new Project(projectPath);
+    // todo: make a common function that strips away the extension. Or use basename().
     const fieldTypes = (await Show.project.fieldTypes())
       .map((item) => item.name.split('.').slice(0, -1).join('.'))
       .sort();

--- a/tools/data-handler/src/transition.ts
+++ b/tools/data-handler/src/transition.ts
@@ -14,7 +14,6 @@
 import { EventEmitter } from 'node:events';
 import { join } from 'node:path';
 
-// ismo
 import { Calculate } from './calculate.js';
 import { Card, WorkflowState } from './interfaces/project-interfaces.js';
 import { Project } from './containers/project.js';

--- a/tools/data-handler/src/utils/resource-utils.ts
+++ b/tools/data-handler/src/utils/resource-utils.ts
@@ -9,6 +9,10 @@
 
 import { parse } from 'node:path';
 
+// Resource name parts are:
+// - prefix; name of the project this resource is part of
+// - type; type of resource; in plural
+// - name; actual name for the resource
 interface ResourceName {
   prefix: string;
   type: string;
@@ -18,6 +22,7 @@ interface ResourceName {
 /**
  * Returns resource name parts (project prefix, type in plural, name of the resource).
  * @param resourceName Full name of the resource (e.g. <prefix>/<type>/<name>)
+ * @throws if 'resourceName' is not valid resource name.
  * @returns resource name parts: project or module prefix, resource type (plural) and actual name of the resource.
  */
 export function resourceNameParts(resourceName: string): ResourceName {

--- a/tools/data-handler/test/export.test.ts
+++ b/tools/data-handler/test/export.test.ts
@@ -32,7 +32,7 @@ describe('export-site', () => {
     const project = new Project(decisionRecordsPath);
 
     const exportSite = new ExportSite();
-    const projectRoot = join(project.cardRootFolder, '..');
+    const projectRoot = join(project.paths.cardRootFolder, '..');
     await exportSite.exportToSite(projectRoot, '/tmp/foo');
     expect(true).to.equal(true);
   });

--- a/tools/data-handler/test/project.test.ts
+++ b/tools/data-handler/test/project.test.ts
@@ -6,7 +6,6 @@ import { after, before, describe, it } from 'mocha';
 import { mkdirSync, rmSync } from 'node:fs';
 import { basename, dirname, join, resolve, sep } from 'node:path';
 
-// ismo
 import { copyDir } from '../src/utils/file-utils.js';
 import { Project } from '../src/containers/project.js';
 import { ProjectConfiguration } from '../src/project-settings.js';
@@ -31,12 +30,12 @@ describe('project', () => {
     const project = new Project(decisionRecordsPath);
     expect(project).to.not.equal(undefined);
 
-    const cardRootFolder = project.cardRootFolder;
-    const cardTypesFolder = project.cardTypesFolder;
-    const templatesFolder = project.templatesFolder;
-    const workflowsFolder = project.workflowsFolder;
-    const resourcesFolder = project.resourcesFolder;
-    const modulesFolder = project.modulesFolder;
+    const cardRootFolder = project.paths.cardRootFolder;
+    const cardTypesFolder = project.paths.cardTypesFolder;
+    const templatesFolder = project.paths.templatesFolder;
+    const workflowsFolder = project.paths.workflowsFolder;
+    const resourcesFolder = project.paths.resourcesFolder;
+    const modulesFolder = project.paths.modulesFolder;
 
     expect(cardRootFolder).to.include('cardRoot');
     expect(cardTypesFolder).to.include('cardTypes');
@@ -112,7 +111,9 @@ describe('project', () => {
     const projectDetails = await project.show();
     expect(projectDetails.name).to.equal(project.projectName);
     expect(projectDetails.prefix).to.equal(project.projectPrefix);
-    expect(projectDetails.path).to.equal(resolve(project.cardRootFolder, '..'));
+    expect(projectDetails.path).to.equal(
+      resolve(project.paths.cardRootFolder, '..'),
+    );
     expect(projectDetails.numberOfCards).to.equal(2);
   });
 


### PR DESCRIPTION
Split away from original INTDEV-468 PR. 

A new class that handles resource paths for Project class. 
Encapsulates paths and simplifies Project. In the future (after few PRs) will be responsible for providing basic needs in resource creation. The new methods are not yet used.