### PR TITLE
Use specified types instead strings when working with resources

### DIFF
--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -30,6 +30,8 @@ import { Validate } from './validate.js';
 import { fileURLToPath } from 'node:url';
 import { errorFunction } from './utils/log-utils.js';
 import {
+  RemovableResourceTypes,
+  ResourceTypes,
   TemplateMetadata,
   WorkflowMetadata,
 } from './interfaces/project-interfaces.js';
@@ -291,7 +293,7 @@ export class Commands {
         }
       }
       if (command === Cmd.create) {
-        const target = args.splice(0, 1)[0];
+        const target: ResourceTypes = args.splice(0, 1)[0] as ResourceTypes;
         if (target === 'attachment') {
           const [cardKey, attachment] = args;
           return this.createAttachment(cardKey, attachment, this.projectPath);
@@ -399,7 +401,9 @@ export class Commands {
       }
       if (command === Cmd.remove) {
         const [type, target, ...rest] = args;
-        return this.remove(type, target, rest, this.projectPath);
+        const removedType: RemovableResourceTypes =
+          type as RemovableResourceTypes;
+        return this.remove(removedType, target, rest, this.projectPath);
       }
       if (command === Cmd.rename) {
         const [to] = args;
@@ -407,8 +411,9 @@ export class Commands {
       }
       if (command === Cmd.show) {
         const [type, detail] = args;
+        const shownTypes: ResourceTypes = type as ResourceTypes;
         options.projectPath = this.projectPath;
-        return this.show(type, detail, options);
+        return this.show(shownTypes, detail, options);
       }
       if (command === Cmd.start) {
         return this.startApp(this.projectPath);
@@ -1007,7 +1012,7 @@ export class Commands {
 
   /**
    * Removes a card (single card, or parent card and children), or an attachment.
-   * @param {string} type Type of resource to remove (attachment, card, template)
+   * @param {RemovableResourceTypes} type Type of resource to remove (attachment, card, template)
    * @param {string} targetName What will be removed. Either card-id or templateName
    * @param {string} args Additional detail of removal, such as attachment name
    * @param {string} path Path to the project. If omitted, project is set from current path.
@@ -1016,7 +1021,7 @@ export class Commands {
    *  <br> statusCode 400 when target was not removed.
    */
   private async remove(
-    type: string,
+    type: RemovableResourceTypes,
     targetName: string,
     args: string[],
     path: string,
@@ -1075,7 +1080,7 @@ export class Commands {
 
   /**
    * Shows wanted resources from a project / template.
-   * @param {string} type type of resources to list
+   * @param {ResourceTypes} type type of resources to list
    * @param {string} typeDetail additional information about the resource (for example a card key for 'show card <cardKey>')
    * @param {CardsOptions} options Optional parameters. If options.path is omitted, project path is assumed to be current path (or it one of its parents).
    * @returns {requestStatus}
@@ -1083,7 +1088,7 @@ export class Commands {
    *  <br> statusCode 400 when input validation failed
    */
   private async show(
-    type: string,
+    type: ResourceTypes,
     typeDetail: string,
     options: CardsOptions,
   ): Promise<requestStatus> {

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -32,6 +32,7 @@ import {
   Report,
   ReportMetadata,
   Resource,
+  ResourceFolderType,
   WorkflowMetadata,
 } from '../interfaces/project-interfaces.js';
 import { getFilesSync, pathExists } from '../utils/file-utils.js';
@@ -189,7 +190,10 @@ export class Project extends CardContainer {
   }
 
   // Collects certain kinds of resources.
-  private resourcesSync(type: string, requirement: string): Resource[] {
+  private resourcesSync(
+    type: ResourceFolderType,
+    requirement: string,
+  ): Resource[] {
     let resourceFolder: string;
     if (type === 'calculation') {
       resourceFolder = this.paths.calculationProjectFolder;

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -203,6 +203,38 @@ export type ResourceFolderType =
   | 'template'
   | 'workflow';
 
+// Resources that are possible to remove.
+// todo: add possibility to remove calculations, card types, field types, workflows and reports
+export type RemovableResourceTypes =
+  | 'attachment'
+  | 'card'
+  | 'link'
+  | 'linkType'
+  | 'module'
+  | 'template';
+
+// All resource types; both singular and plural.
+export type ResourceTypes =
+  | RemovableResourceTypes
+  | 'attachments'
+  | 'calculation'
+  | 'calculations'
+  | 'cards'
+  | 'cardType'
+  | 'cardTypes'
+  | 'fieldType'
+  | 'fieldTypes'
+  | 'links'
+  | 'linkTypes'
+  | 'modules'
+  | 'project'
+  | 'projects'
+  | 'report'
+  | 'reports'
+  | 'templates'
+  | 'workflow'
+  | 'workflows';
+
 // Template configuration details.
 export interface Template {
   name: string;

--- a/tools/data-handler/src/remove.ts
+++ b/tools/data-handler/src/remove.ts
@@ -17,6 +17,7 @@ import { basename, join, sep } from 'node:path';
 import { Calculate } from './calculate.js';
 import { deleteDir, deleteFile } from './utils/file-utils.js';
 import { Project } from './containers/project.js';
+import { RemovableResourceTypes } from './interfaces/project-interfaces.js';
 
 export class Remove extends EventEmitter {
   static project: Project;
@@ -147,7 +148,7 @@ export class Remove extends EventEmitter {
   private async removeLinkType(linkTypeName: string) {
     const path = await Remove.project.linkTypePath(linkTypeName);
     if (!path) {
-      throw new Error(`Linktype '${linkTypeName}' not found`);
+      throw new Error(`Link type '${linkTypeName}' not found`);
     }
     await deleteFile(path);
   }
@@ -184,12 +185,13 @@ export class Remove extends EventEmitter {
   /**
    * Removes either attachment, card or template from project.
    * @param {string} projectPath Path to a project
+   * @param {RemovableResourceTypes} type Type of resource
    * @param {string} targetName Card id, or template name
    * @param {string} args Additional arguments, such as attachment filename
    */
   public async remove(
     projectPath: string,
-    type: string,
+    type: RemovableResourceTypes,
     targetName: string,
     ...rest: any[] // eslint-disable-line @typescript-eslint/no-explicit-any
   ) {

--- a/tools/data-handler/test/command-handler-remove.test.ts
+++ b/tools/data-handler/test/command-handler-remove.test.ts
@@ -274,19 +274,6 @@ describe('remove command', () => {
       );
       expect(result.statusCode).to.equal(400);
     });
-    it('remove() - try to remove unknown type', async () => {
-      const cardId = 'decision_5';
-      const calculateCmd = new Calculate();
-      const removeCmd = new Remove(calculateCmd);
-      await removeCmd
-        .remove(decisionRecordsPath, 'i-dont-exist', cardId)
-        .then(() => {
-          expect(false);
-        })
-        .catch(() => {
-          expect(true);
-        });
-    });
     it('remove() - try to remove non-existing attachment', async () => {
       const cardId = 'decision_5';
       const calculateCmd = new Calculate();


### PR DESCRIPTION
Add interfaces for `ResourceTypes` and `RemovableResourceTypes` (not all resources can be removed).
Use these instead of `strings` when handling resources.

This is another one of changes split away from INTDEV-468.