### PR TITLE
INTDEV-501 Change resource collection functions signature

### DIFF
--- a/tools/data-handler/src/calculate.ts
+++ b/tools/data-handler/src/calculate.ts
@@ -243,8 +243,8 @@ export class Calculate {
       Calculate.modulesFileName,
     );
     let modulesContent: string = '';
-    // Collect and return all available calculations
-    const calculations = await Calculate.project.calculations(false);
+    // Collect all available calculations
+    const calculations = await Calculate.project.calculations();
 
     // write the modules.lp
     for (const calculationFile of calculations) {

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -47,6 +47,18 @@ import { generateRandomString } from '../utils/random.js';
 import { CardContainer } from './card-container.js';
 
 /**
+ * Defines where resources are collected from.
+ * all - everywhere
+ * importOnly - only from imported modules
+ * localOnly - only from the project itself; excluding imported modules
+ */
+export enum ResourcesFrom {
+  all = 'all',
+  importedOnly = 'imported',
+  localOnly = 'local',
+}
+
+/**
  * Represents project folder.
  */
 export class Project extends CardContainer {
@@ -115,6 +127,21 @@ export class Project extends CardContainer {
       }
     }
     return collectedResources;
+  }
+
+  // Returns resources from certain location(s).
+  private collectedResources(
+    from: ResourcesFrom,
+    localCollection: Resource[],
+    moduleCollection: Resource[],
+  ) {
+    if (from === ResourcesFrom.localOnly) {
+      return localCollection;
+    }
+    if (from === ResourcesFrom.importedOnly) {
+      return moduleCollection;
+    }
+    return [...localCollection, ...moduleCollection];
   }
 
   // Collect resources from modules
@@ -304,15 +331,20 @@ export class Project extends CardContainer {
 
   /**
    * Returns an array of all the calculation files (*.lp) in the project.
-   * @param {boolean} localOnly Return local calculations, or all calculations (includes module calculations)
+   * @param from Defines where resources are collected from.
    * @returns array of all calculation files in the project.
+   * todo: make just one function
    */
-  public async calculations(localOnly: boolean = true): Promise<Resource[]> {
+  public async calculations(
+    from: ResourcesFrom = ResourcesFrom.localOnly,
+  ): Promise<Resource[]> {
     const moduleCalculations =
       await this.collectResourcesFromModules('calculations');
-    return localOnly
-      ? this.localCalculations
-      : [...this.localCalculations, ...moduleCalculations];
+    return this.collectedResources(
+      from,
+      this.localCalculations,
+      moduleCalculations,
+    );
   }
 
   /**
@@ -441,14 +473,14 @@ export class Project extends CardContainer {
 
   /**
    * Returns an array of all the card types in the project.
-   * @param {boolean} localOnly Return local card types, or all card types (includes module card types)
+   * @param from Defines where resources are collected from.
    * @returns array of all card types in the project.
    */
-  public async cardTypes(localOnly: boolean = false): Promise<Resource[]> {
+  public async cardTypes(
+    from: ResourcesFrom = ResourcesFrom.all,
+  ): Promise<Resource[]> {
     const moduleCardTypes = await this.collectResourcesFromModules('cardTypes');
-    return localOnly
-      ? this.localCardTypes
-      : [...this.localCardTypes, ...moduleCardTypes];
+    return this.collectedResources(from, this.localCardTypes, moduleCardTypes);
   }
 
   /**
@@ -518,15 +550,19 @@ export class Project extends CardContainer {
 
   /**
    * Returns an array of all the field types in the project.
-   * @param {boolean} localOnly Return local field types, or all field types (includes module field types)
+   * @param from Defines where resources are collected from.
    * @returns array of all field types in the project.
    */
-  public async fieldTypes(localOnly: boolean = false): Promise<Resource[]> {
+  public async fieldTypes(
+    from: ResourcesFrom = ResourcesFrom.all,
+  ): Promise<Resource[]> {
     const moduleFieldTypes =
       await this.collectResourcesFromModules('fieldTypes');
-    return localOnly
-      ? this.localFieldTypes
-      : [...this.localFieldTypes, ...moduleFieldTypes];
+    return this.collectedResources(
+      from,
+      this.localFieldTypes,
+      moduleFieldTypes,
+    );
   }
 
   /**
@@ -667,14 +703,14 @@ export class Project extends CardContainer {
   }
   /**
    * Returns an array of all the link types in the project.
-   * @param {boolean} localOnly Return local link types, or all link types (includes module link types)
+   * @param from Defines where resources are collected from.
    * @returns array of all link types in the project.
    */
-  public async linkTypes(localOnly: boolean = false): Promise<Resource[]> {
+  public async linkTypes(
+    from: ResourcesFrom = ResourcesFrom.all,
+  ): Promise<Resource[]> {
     const moduleLinkTypes = await this.collectResourcesFromModules('linkTypes');
-    return localOnly
-      ? this.localLinkTypes
-      : [...this.localLinkTypes, ...moduleLinkTypes];
+    return this.collectedResources(from, this.localLinkTypes, moduleLinkTypes);
   }
 
   /**
@@ -889,6 +925,18 @@ export class Project extends CardContainer {
   }
 
   /**
+   * Array of reports in the project.
+   * @param from Defines where resources are collected from.
+   * @returns array of all reports in the project.
+   */
+  public async reports(
+    from: ResourcesFrom = ResourcesFrom.all,
+  ): Promise<Resource[]> {
+    const moduleReports = await this.collectResourcesFromModules('reports');
+    return this.collectedResources(from, this.localReports, moduleReports);
+  }
+
+  /**
    * Shows details of a project.
    * @returns details of a project.
    */
@@ -975,14 +1023,14 @@ export class Project extends CardContainer {
 
   /**
    * Array of templates in the project.
-   * @param {boolean} localOnly Return local templates, or all templates (includes module templates)
+   * @param from Defines where resources are collected from.
    * @returns array of all templates in the project.
    */
-  public async templates(localOnly: boolean = false): Promise<Resource[]> {
+  public async templates(
+    from: ResourcesFrom = ResourcesFrom.all,
+  ): Promise<Resource[]> {
     const moduleTemplates = await this.collectResourcesFromModules('templates');
-    return localOnly
-      ? this.localTemplates
-      : [...this.localTemplates, ...moduleTemplates];
+    return this.collectedResources(from, this.localTemplates, moduleTemplates);
   }
 
   /**
@@ -1115,27 +1163,16 @@ export class Project extends CardContainer {
 
   /**
    * Array of workflows in the project.
-   * @param {boolean} localOnly Return local workflows, or all workflows (includes module workflows)
+   * @param from Defines where resources are collected from.
    * @returns array of all workflows in the project.
    */
-  public async workflows(localOnly: boolean = false): Promise<Resource[]> {
+  public async workflows(
+    from: ResourcesFrom = ResourcesFrom.all,
+  ): Promise<Resource[]> {
     const moduleWorkflows = await this.collectResourcesFromModules('workflows');
-    return localOnly
-      ? this.localWorkflows
-      : [...this.localWorkflows, ...moduleWorkflows];
+    return this.collectedResources(from, this.localWorkflows, moduleWorkflows);
   }
 
-  /**
-   * Array of reports in the project.
-   * @param {boolean} localOnly Return local reports, or all reports (includes module reports)
-   * @returns array of all reports in the project.
-   */
-  public async reports(localOnly: boolean = false): Promise<Resource[]> {
-    const moduleReports = await this.collectResourcesFromModules('reports');
-    return localOnly
-      ? this.localReports
-      : [...this.localReports, ...moduleReports];
-  }
   /**
    * Returns details of certain report.
    * @param {string} reportName Name of the report (either filename (including .json extension), or report name).

--- a/tools/data-handler/src/move.ts
+++ b/tools/data-handler/src/move.ts
@@ -15,7 +15,7 @@ import { join, sep } from 'node:path';
 
 import { copyDir, deleteDir } from './utils/file-utils.js';
 import { Card } from './interfaces/project-interfaces.js';
-import { Project } from './containers/project.js';
+import { Project, ResourcesFrom } from './containers/project.js';
 import {
   EMPTY_RANK,
   FIRST_RANK,
@@ -290,7 +290,7 @@ export class Move {
     await this.rebalanceProjectRecursively(cards);
 
     // rebalance templates
-    const templates = await Move.project.templates(true);
+    const templates = await Move.project.templates(ResourcesFrom.localOnly);
     for (const template of templates) {
       const templateObject = await Move.project.createTemplateObject(template);
 

--- a/tools/data-handler/src/rename.ts
+++ b/tools/data-handler/src/rename.ts
@@ -18,7 +18,7 @@ import { rename, readFile, writeFile } from 'node:fs/promises';
 
 import { Calculate } from './calculate.js';
 import { Card, Resource } from './interfaces/project-interfaces.js';
-import { Project } from './containers/project.js';
+import { Project, ResourcesFrom } from './containers/project.js';
 import { resourceNameParts } from './utils/resource-utils.js';
 import { Template } from './containers/template.js';
 import { writeJsonFile } from './utils/json.js';
@@ -271,39 +271,40 @@ export class Rename extends EventEmitter {
 
     // Rename resources - module content shall not be modified.
     // It is better to rename the resources in this order: card types, field types
-    const localResourcesOnly = true;
 
     // Rename all card types and custom fields in them.
-    const cardTypes = await Rename.project.cardTypes(localResourcesOnly);
+    const cardTypes = await Rename.project.cardTypes(ResourcesFrom.localOnly);
     for (const cardType of cardTypes) {
       await this.updateCardTypeMetadata(cardType.name);
     }
 
-    const workflows = await Rename.project.workflows(localResourcesOnly);
+    const workflows = await Rename.project.workflows(ResourcesFrom.localOnly);
     for (const workflow of workflows) {
       await this.updateWorkflowMetadata(workflow.name);
     }
 
     // Rename all field types.
-    const fieldTypes = await Rename.project.fieldTypes(localResourcesOnly);
+    const fieldTypes = await Rename.project.fieldTypes(ResourcesFrom.localOnly);
     for (const fieldType of fieldTypes) {
       await this.updateFieldTypeMetadata(fieldType.name);
     }
 
     // Rename all the link types.
-    const linkTypes = await Rename.project.linkTypes(localResourcesOnly);
+    const linkTypes = await Rename.project.linkTypes(ResourcesFrom.localOnly);
     for (const linkType of linkTypes) {
       await this.updateLinkTypeMetadata(linkType.name);
     }
 
     // Rename resource usage in all calculation files.
-    const calculations = await Rename.project.calculations(localResourcesOnly);
+    const calculations = await Rename.project.calculations(
+      ResourcesFrom.localOnly,
+    );
     for (const calculation of calculations) {
       await this.updateCalculationFile(calculation);
     }
 
     // Rename all local template cards.
-    const templates = await Rename.project.templates(localResourcesOnly);
+    const templates = await Rename.project.templates(ResourcesFrom.localOnly);
     for (const template of templates) {
       const templateObject = new Template(
         projectPath,


### PR DESCRIPTION
Get rid of single boolean parameter in the resource collection functions (`Project.calculations()`) and friends).

Single boolean parameters cause confusion when reading the code. 
Additionally, provide means to collect resources from just modules.

Curiously, `calculations()` has different default parameter than the other ones. I didn't change this, as I didn't want to modify the calls that use default values. Maybe something to check a bit later.


BACKGROUND:
A simplified example of why single boolean parameters are bad for reading the code:

```
this.install(false);
```

There is no way of knowing what the parameter does unless you go and check the `install` function itself.
Compare this with: 

```
this.install(Install.skipValidation); 
```

You can immediately see that this call skips validation. 