### PR TITLE
INTDEV-526 Suppress experimental warnings

### DIFF
--- a/tools/data-handler/package.json
+++ b/tools/data-handler/package.json
@@ -16,7 +16,7 @@
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm cache clean --force",
     "lint": "npx eslint .",
     "posttest": "npm run lint",
-    "test": "mocha --require mocha-suppress-logs --forbid-only \"./test/**/*.test.ts\"",
+    "test": "mocha --require mocha-suppress-logs --disable-warning=ExperimentalWarning --forbid-only \"./test/**/*.test.ts\"",
     "test-coverage": "c8 npm run test"
   },
   "exports": {


### PR DESCRIPTION
Using `mocha` with `ts-node` causes experimental warning for importing JSON file.

<img width="1197" alt="Screenshot 2024-10-22 at 10 09 50" src="https://github.com/user-attachments/assets/7b26ce0d-28fc-45ff-9aa2-ec32ce64c43f">

It is coming from `mocha` or `ts-node`. We don't really care about the warning (it is fine to import JSON file), so just suppress all experimental warnings. We live on the edge. :)