### PR TITLE
INTDEV-525 Remove stdout/stderr prints from export-site unit tests

### DIFF
--- a/tools/data-handler/src/export-site.ts
+++ b/tools/data-handler/src/export-site.ts
@@ -28,6 +28,10 @@ import { Export } from './export.js';
 import { Project } from './containers/project.js';
 import { sortItems } from './utils/lexorank.js';
 
+interface ExportOptions {
+  silent: boolean;
+}
+
 export class ExportSite extends Export {
   private tmpDir: string = '';
   private moduleDir: string = '';
@@ -36,6 +40,7 @@ export class ExportSite extends Export {
   private playbookDir: string = '';
   private playbookFile: string = '';
   private navFile: string = '';
+  private options: ExportOptions | undefined;
 
   // todo: change this so that split temp folder creation to its own method.
   // then parallelize this and export() as much as you can.
@@ -67,9 +72,13 @@ export class ExportSite extends Export {
 
   // Generate the site from the source files using Antora.
   private generate(outputPath: string) {
-    // Use spawnsync to npx execute the program "antora", with the argument this.playbookFile
+    const additionalArguments = ['--to-dir', outputPath, this.playbookFile];
+    if (this.options && this.options?.silent) {
+      additionalArguments.unshift('--silent');
+    }
+    // Use spawnsync to npx execute the program "antora"
     try {
-      spawnSync('npx', ['antora', '--to-dir', outputPath, this.playbookFile], {
+      spawnSync('npx', ['antora', ...additionalArguments], {
         stdio: 'inherit',
       });
     } catch (error) {
@@ -247,7 +256,9 @@ export class ExportSite extends Export {
     source: string,
     destination: string,
     cardKey?: string,
+    options?: ExportOptions,
   ) {
+    this.options = options;
     Export.project = new Project(source);
     const sourcePath: string = cardKey
       ? join(

--- a/tools/data-handler/test/export.test.ts
+++ b/tools/data-handler/test/export.test.ts
@@ -28,12 +28,14 @@ describe('export-site', () => {
     rmSync(testDir, { recursive: true, force: true });
     rmSync(testDirForExport, { recursive: true, force: true });
   });
-  it('export site - initialise', async () => {
+  it('export site (success)', async () => {
     const project = new Project(decisionRecordsPath);
 
     const exportSite = new ExportSite();
     const projectRoot = join(project.paths.cardRootFolder, '..');
-    await exportSite.exportToSite(projectRoot, '/tmp/foo');
+    await exportSite.exportToSite(projectRoot, '/tmp/foo', undefined, {
+      silent: true,
+    });
     expect(true).to.equal(true);
   });
 });


### PR DESCRIPTION
Add optional `options` to `ExportSite` command. 
There are a lot of options that we could support for `Antora`, but let's for now just support `--silent`. 

This way unit tests can call site exporting with silent (we are not really interested in if it complains about something) and human users get the full output. 

There is no way to provide the `silent` flag with CLI at the moment. If there is a need for it , let's make a ticket.

Unit tests now look clean:
<img width="561" alt="Screenshot 2024-10-22 at 14 33 53" src="https://github.com/user-attachments/assets/432928c7-c17a-49aa-9458-7aebb56ccb64">
(note that I also renamed the unit test as the original name didn't make any sense)