### PR TITLE
INTDEV-524 Remove ESLint compatibility warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4496,16 +4496,16 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.8.0.tgz",
-      "integrity": "sha512-wORFWjU30B2WJ/aXBfOm1LX9v9nyt9D3jsSOxC3cCaTQGCW5k4jNpmjFv3U7p/7s4yvdjHzwtv2Sd2dOyhjS0A==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.11.0.tgz",
+      "integrity": "sha512-KhGn2LjW1PJT2A/GfDpiyOfS4a8xHQv2myUagTM5+zsormOmBlYsnQ6pobJ8XxJmh6hnHwa2Mbe3fPrDJoDhbA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.8.0",
-        "@typescript-eslint/type-utils": "8.8.0",
-        "@typescript-eslint/utils": "8.8.0",
-        "@typescript-eslint/visitor-keys": "8.8.0",
+        "@typescript-eslint/scope-manager": "8.11.0",
+        "@typescript-eslint/type-utils": "8.11.0",
+        "@typescript-eslint/utils": "8.11.0",
+        "@typescript-eslint/visitor-keys": "8.11.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -4529,15 +4529,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.8.0.tgz",
-      "integrity": "sha512-uEFUsgR+tl8GmzmLjRqz+VrDv4eoaMqMXW7ruXfgThaAShO9JTciKpEsB+TvnfFfbg5IpujgMXVV36gOJRLtZg==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.11.0.tgz",
+      "integrity": "sha512-lmt73NeHdy1Q/2ul295Qy3uninSqi6wQI18XwSpm8w0ZbQXUpjCAWP1Vlv/obudoBiIjJVjlztjQ+d/Md98Yxg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.8.0",
-        "@typescript-eslint/types": "8.8.0",
-        "@typescript-eslint/typescript-estree": "8.8.0",
-        "@typescript-eslint/visitor-keys": "8.8.0",
+        "@typescript-eslint/scope-manager": "8.11.0",
+        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/typescript-estree": "8.11.0",
+        "@typescript-eslint/visitor-keys": "8.11.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -4557,13 +4557,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.8.0.tgz",
-      "integrity": "sha512-EL8eaGC6gx3jDd8GwEFEV091210U97J0jeEHrAYvIYosmEGet4wJ+g0SYmLu+oRiAwbSA5AVrt6DxLHfdd+bUg==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.11.0.tgz",
+      "integrity": "sha512-Uholz7tWhXmA4r6epo+vaeV7yjdKy5QFCERMjs1kMVsLRKIrSdM6o21W2He9ftp5PP6aWOVpD5zvrvuHZC0bMQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.8.0",
-        "@typescript-eslint/visitor-keys": "8.8.0"
+        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/visitor-keys": "8.11.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4574,13 +4574,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.8.0.tgz",
-      "integrity": "sha512-IKwJSS7bCqyCeG4NVGxnOP6lLT9Okc3Zj8hLO96bpMkJab+10HIfJbMouLrlpyOr3yrQ1cA413YPFiGd1mW9/Q==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.11.0.tgz",
+      "integrity": "sha512-ItiMfJS6pQU0NIKAaybBKkuVzo6IdnAhPFZA/2Mba/uBjuPQPet/8+zh5GtLHwmuFRShZx+8lhIs7/QeDHflOg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.8.0",
-        "@typescript-eslint/utils": "8.8.0",
+        "@typescript-eslint/typescript-estree": "8.11.0",
+        "@typescript-eslint/utils": "8.11.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -4598,9 +4598,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.8.0.tgz",
-      "integrity": "sha512-QJwc50hRCgBd/k12sTykOJbESe1RrzmX6COk8Y525C9l7oweZ+1lw9JiU56im7Amm8swlz00DRIlxMYLizr2Vw==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.11.0.tgz",
+      "integrity": "sha512-tn6sNMHf6EBAYMvmPUaKaVeYvhUsrE6x+bXQTxjQRp360h1giATU0WvgeEys1spbvb5R+VpNOZ+XJmjD8wOUHw==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4611,13 +4611,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.8.0.tgz",
-      "integrity": "sha512-ZaMJwc/0ckLz5DaAZ+pNLmHv8AMVGtfWxZe/x2JVEkD5LnmhWiQMMcYT7IY7gkdJuzJ9P14fRy28lUrlDSWYdw==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.11.0.tgz",
+      "integrity": "sha512-yHC3s1z1RCHoCz5t06gf7jH24rr3vns08XXhfEqzYpd6Hll3z/3g23JRi0jM8A47UFKNc3u/y5KIMx8Ynbjohg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.8.0",
-        "@typescript-eslint/visitor-keys": "8.8.0",
+        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/visitor-keys": "8.11.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -4639,15 +4639,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.8.0.tgz",
-      "integrity": "sha512-QE2MgfOTem00qrlPgyByaCHay9yb1+9BjnMFnSFkUKQfu7adBXDTnCAivURnuPPAG/qiB+kzKkZKmKfaMT0zVg==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.11.0.tgz",
+      "integrity": "sha512-CYiX6WZcbXNJV7UNB4PLDIBtSdRmRI/nb0FMyqHPTQD1rMjA0foPLaPUV39C/MxkTd/QKSeX+Gb34PPsDVC35g==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.8.0",
-        "@typescript-eslint/types": "8.8.0",
-        "@typescript-eslint/typescript-estree": "8.8.0"
+        "@typescript-eslint/scope-manager": "8.11.0",
+        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/typescript-estree": "8.11.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4661,12 +4661,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.8.0.tgz",
-      "integrity": "sha512-8mq51Lx6Hpmd7HnA2fcHQo3YgfX1qbccxQOgZcb4tvasu//zXRaA1j5ZRFeCw/VRAdFi4mRM9DnZw0Nu0Q2d1g==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.11.0.tgz",
+      "integrity": "sha512-EaewX6lxSjRJnc+99+dqzTeoDZUfyrA52d2/HRrkI830kgovWsmIiTfmr0NZorzqic7ga+1bS60lRBUgR3n/Bw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.8.0",
+        "@typescript-eslint/types": "8.11.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -17851,14 +17851,14 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.8.0.tgz",
-      "integrity": "sha512-BjIT/VwJ8+0rVO01ZQ2ZVnjE1svFBiRczcpr1t1Yxt7sT25VSbPfrJtDsQ8uQTy2pilX5nI9gwxhUyLULNentw==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.11.0.tgz",
+      "integrity": "sha512-cBRGnW3FSlxaYwU8KfAewxFK5uzeOAp0l2KebIlPDOT5olVi65KDG/yjBooPBG0kGW/HLkoz1c/iuBFehcS3IA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.8.0",
-        "@typescript-eslint/parser": "8.8.0",
-        "@typescript-eslint/utils": "8.8.0"
+        "@typescript-eslint/eslint-plugin": "8.11.0",
+        "@typescript-eslint/parser": "8.11.0",
+        "@typescript-eslint/utils": "8.11.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -19081,10 +19081,12 @@
         "cyberismo": "bin/run"
       },
       "devDependencies": {
-        "@types/node": "^22.5.0",
-        "eslint": "^9",
+        "@types/node": "^22.4.1",
+        "@typescript-eslint/parser": "^8.1.0",
+        "eslint": "9.12.0",
         "eslint-config-prettier": "^9.1.0",
-        "typescript": "^5.4.2"
+        "typescript": "^5.4.5",
+        "typescript-eslint": "^8.11.0"
       }
     },
     "tools/cli/node_modules/commander": {
@@ -19129,7 +19131,7 @@
         "mocha-suppress-logs": "^0.5.1",
         "ts-node": "^10.9.1",
         "typescript": "^5.4.5",
-        "typescript-eslint": "^8.2.0"
+        "typescript-eslint": "^8.11.0"
       }
     }
   }

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -23,10 +23,12 @@
     "commander": "^12.0.0"
   },
   "devDependencies": {
-    "@types/node": "^22.5.0",
-    "eslint": "^9",
+    "@types/node": "^22.4.1",
+    "@typescript-eslint/parser": "^8.1.0",
+    "eslint": "9.12.0",
     "eslint-config-prettier": "^9.1.0",
-    "typescript": "^5.4.2"
+    "typescript": "^5.4.5",
+    "typescript-eslint": "^8.11.0"
   },
   "types": "dist/index.d.ts",
   "type": "module"

--- a/tools/data-handler/package.json
+++ b/tools/data-handler/package.json
@@ -39,7 +39,7 @@
     "mocha-suppress-logs": "^0.5.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.4.5",
-    "typescript-eslint": "^8.2.0"
+    "typescript-eslint": "^8.11.0"
   },
   "dependencies": {
     "async-mutex": "^0.5.0",


### PR DESCRIPTION
First, update to newer “typescript-eslint” version.
Then, ensure that data-handler and CLI have same versions of libraries that they share.