### PR TITLE
INTDEV-473 prevent linking to itself

### DIFF
--- a/tools/app/app/components/ContentArea.tsx
+++ b/tools/app/app/components/ContentArea.tsx
@@ -79,6 +79,7 @@ interface LinkFormProps {
   cards: Project['cards'];
   cardType: string | undefined;
   onSubmit?: (data: LinkFormSubmitData) => boolean | Promise<boolean>;
+  cardKey: string;
 }
 
 const NO_LINK_TYPE = -1;
@@ -88,6 +89,7 @@ export function LinkForm({
   linkTypes,
   onSubmit,
   cardType,
+  cardKey,
 }: LinkFormProps) {
   const { control, handleSubmit, reset, watch } = useForm<LinkFormData>({
     defaultValues: { linkType: NO_LINK_TYPE, cardKey: '', linkDescription: '' },
@@ -130,7 +132,7 @@ export function LinkForm({
   const selectedLinkType = handledLinkTypes.find((t) => t.id === linkType);
 
   const usableCards = flattenTree(cards).filter((card) => {
-    if (!selectedLinkType) return false;
+    if (!selectedLinkType || card.key === cardKey) return false;
     if (selectedLinkType.direction === 'outbound') {
       return (
         selectedLinkType.destinationCardTypes.includes(
@@ -419,6 +421,7 @@ export const ContentArea: React.FC<ContentAreaProps> = ({
               linkTypes={linkTypes}
               onSubmit={onLinkFormSubmit}
               cardType={card.metadata?.cardType}
+              cardKey={card.key}
             />
           )}
           {links.length > 0 && (

--- a/tools/data-handler/src/create.ts
+++ b/tools/data-handler/src/create.ts
@@ -483,6 +483,10 @@ export class Create extends EventEmitter {
   ) {
     const project = new Project(projectPath);
 
+    if (cardKey === destinationCardKey) {
+      throw new Error('Cannot link card to itself');
+    }
+
     // Determine the card path
     const card = await project.findSpecificCard(cardKey, {
       metadata: true,

--- a/tools/data-handler/test/command-handler-create.test.ts
+++ b/tools/data-handler/test/command-handler-create.test.ts
@@ -314,7 +314,7 @@ describe('create command', () => {
     );
     expect(result.statusCode).to.equal(400);
   });
-  // link - three tests commented out for now (see INTDEV-512)
+  // link - three tests commented out for now (see INTDEV-512). When doing INTDEV-512, also add a test which makes sure createLink fails if source and destination cards are the same
   // it('create link (success)', async () => {
   //   const result = await commandHandler.command(
   //     Cmd.create,


### PR DESCRIPTION
createLink throws an error if trying to link to itself. UI doesn't show itself in the dropdown. Since link tests are disabled, I added I comment that states that this behaviour should be tested in DH when INTDEV-512 is done.