### PR TITLE
INTDEV-486 fix  move card dialog

### DIFF
--- a/tools/app/app/components/TreeMenu.tsx
+++ b/tools/app/app/components/TreeMenu.tsx
@@ -11,11 +11,11 @@
 */
 
 'use client';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { getStateColor } from '../lib/utils';
 import { Box, Chip, Stack, Typography } from '@mui/joy';
-import { Tree, NodeRendererProps, NodeApi } from 'react-arborist';
+import { Tree, NodeRendererProps, NodeApi, TreeApi } from 'react-arborist';
 import useResizeObserver from 'use-resize-observer';
 import { FiberManualRecord } from '@mui/icons-material';
 import { QueryResult } from '@cyberismocom/data-handler/types/queries';
@@ -131,6 +131,15 @@ export const TreeMenu: React.FC<TreeMenuProps> = ({
   tree,
 }) => {
   const { ref, width, height } = useResizeObserver();
+  const treeRef = useRef();
+
+  useEffect(() => {
+    // unfortunately react arborist does not provide a type for the ref
+    const tree = treeRef.current as unknown as TreeApi<QueryResult<'tree'>>;
+    if (tree) {
+      tree.select(selectedCardKey);
+    }
+  }, [selectedCardKey, tree]);
 
   return (
     <Stack
@@ -152,10 +161,10 @@ export const TreeMenu: React.FC<TreeMenuProps> = ({
         ref={ref}
       >
         <Tree
+          ref={treeRef}
           data={tree}
           openByDefault={false}
           idAccessor={(node) => node.key}
-          selection={selectedCardKey || undefined}
           childrenAccessor="results"
           indent={16}
           width={(width || 0) - 1}

--- a/tools/app/app/components/modals/MoveCardModal.tsx
+++ b/tools/app/app/components/modals/MoveCardModal.tsx
@@ -30,11 +30,7 @@ import {
 } from '@mui/joy';
 import { useTranslation } from 'react-i18next';
 import { useCard, useProject } from '../../lib/api';
-import {
-  useAppRouter,
-  useAppSelector,
-  useMoveableCards,
-} from '../../lib/hooks';
+import { useAppSelector, useMoveableCards } from '../../lib/hooks';
 import {
   deepCopy,
   filterCards,
@@ -72,7 +68,6 @@ export function MoveCardModal({ open, onClose, cardKey }: MoveCardModalProps) {
 
   const { updateCard } = useCard(cardKey);
   const recents = useAppSelector((state) => state.recentlyViewed.pages);
-  const router = useAppRouter();
 
   const dispatch = useDispatch();
 
@@ -91,8 +86,6 @@ export function MoveCardModal({ open, onClose, cardKey }: MoveCardModalProps) {
           }),
         );
         onClose();
-        // this line refreshes the tree menu
-        router.push(`/cards/${selected}`);
       } catch (error) {
         dispatch(
           addNotification({
@@ -102,7 +95,7 @@ export function MoveCardModal({ open, onClose, cardKey }: MoveCardModalProps) {
         );
       }
     }
-  }, [selected, updateCard, t, onClose, dispatch, router]);
+  }, [selected, updateCard, t, onClose, dispatch]);
 
   const moveableCards = useMoveableCards(cardKey);
 


### PR DESCRIPTION
When you moved the card via move card dialog, user was being redirected to the parent card and treemenu was not updated. Now it stays on the page and updates treemenu.