### PR TITLE
INTDEV-508 return root instead of the template name in case of a root template card

### DIFF
--- a/tools/data-handler/src/containers/card-container.ts
+++ b/tools/data-handler/src/containers/card-container.ts
@@ -51,7 +51,11 @@ export class CardContainer {
   // Finds parent
   private parentCard(cardPath: string) {
     const pathParts = cardPath.split(sep);
-    if (pathParts.at(pathParts.length - 2) === 'cardRoot') {
+    if (
+      pathParts.at(pathParts.length - 2) === 'cardRoot' ||
+      (pathParts.length > 3 &&
+        pathParts.at(pathParts.length - 4) === 'templates')
+    ) {
       return 'root';
     } else {
       return pathParts.at(pathParts.length - 3);

--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -103,7 +103,7 @@ export class Template extends CardContainer {
     // here we want to insert the cards after the last card, but not after a card that has no rank
     // for clarity: These are the "root" template cards
     const parentCards = sortItems(
-      cards.filter((c) => c.parent === this.containerName),
+      cards.filter((c) => c.parent === 'root'),
       (c) => c?.metadata?.rank || '',
     );
 

--- a/tools/data-handler/src/create.ts
+++ b/tools/data-handler/src/create.ts
@@ -39,7 +39,6 @@ import { Validate } from './validate.js';
 import { EMPTY_RANK, sortItems } from './utils/lexorank.js';
 import { fileURLToPath } from 'node:url';
 import { copyDir } from './utils/file-utils.js';
-import { resourceNameParts } from './utils/resource-utils.js';
 
 // todo: Is there a easy to way to make JSON schema into a TypeScript interface/type?
 //       Check this out: https://www.npmjs.com/package/json-schema-to-ts
@@ -331,13 +330,12 @@ export class Create extends EventEmitter {
       throw new Error(`Card '${parentCardKey}' not found from project`);
     }
 
-    const { name } = resourceNameParts(templateName);
     const createdCards = await templateObject.createCards(specificCard);
     if (createdCards.length > 0) {
       this.emit('created', createdCards);
       // Note: This assumes that parent keys will be ahead of 'a' in the sort order.
       const sorted = sortItems(createdCards, (item) => {
-        return `${item.parent === name ? 'a' : item.parent}${item.metadata?.rank || EMPTY_RANK}`;
+        return `${item.parent === 'root' ? 'a' : item.parent}${item.metadata?.rank || EMPTY_RANK}`;
       });
       return sorted.map((item) => item.key);
     }

--- a/tools/data-handler/test/template.test.ts
+++ b/tools/data-handler/test/template.test.ts
@@ -219,7 +219,7 @@ describe('template', () => {
       );
       expect(additionalCardDetails.metadata?.workflowState).to.equal('Draft');
       expect(additionalCardDetails.children!.length > 0);
-      expect(additionalCardDetails.parent).to.equal('decision');
+      expect(additionalCardDetails.parent).to.equal('root');
       expect(additionalCardDetails.content).to.not.equal(undefined);
     }
   });


### PR DESCRIPTION
Now parentPath returns "root" also for parents of root template cards. Now it's more easier to know whether a template card is a root card or not