### PR TITLE
INTDEV-527 Fix clingo parser

### DIFF
--- a/tools/data-handler/src/utils/clingo-parser.ts
+++ b/tools/data-handler/src/utils/clingo-parser.ts
@@ -357,9 +357,7 @@ class ClingoParser {
       }
 
       if (char === ')' && !insideQuote) {
-        if (currentArg) {
-          args.push(currentArg);
-        }
+        args.push(currentArg);
         return {
           args,
           endPosition: i + 1,

--- a/tools/data-handler/test/utils/clingo-parser.test.ts
+++ b/tools/data-handler/test/utils/clingo-parser.test.ts
@@ -76,7 +76,7 @@ describe('ClingoParser', () => {
     expect(result.results[0].fieldName).to.equal(fieldValue);
   });
 
-  it('should parser field correctly when last argument is an empty string', async () => {
+  it('should parse field correctly when last argument is an empty string', async () => {
     const fieldValue = '';
     const input = `result("key1")\nfield("key1", "fieldName", "${encodeClingoValue(fieldValue)}")`;
     const result = await parser.parseInput(input);

--- a/tools/data-handler/test/utils/clingo-parser.test.ts
+++ b/tools/data-handler/test/utils/clingo-parser.test.ts
@@ -76,6 +76,13 @@ describe('ClingoParser', () => {
     expect(result.results[0].fieldName).to.equal(fieldValue);
   });
 
+  it('should parser field correctly when last argument is an empty string', async () => {
+    const fieldValue = '';
+    const input = `result("key1")\nfield("key1", "fieldName", "${encodeClingoValue(fieldValue)}")`;
+    const result = await parser.parseInput(input);
+    expect(result.results[0].fieldName).to.equal(fieldValue);
+  });
+
   it('should parse label correctly', async () => {
     const input = 'result("key1")\nlabel("key1", "label1")';
     const result = await parser.parseInput(input);


### PR DESCRIPTION
Removed condition of clingo parser, which caused empty strings to become undefined. This also happened only if the empty string was the last argument