### PR TITLE
INTDEV-510: Use Clingo query to generate site/html/adoc export

### DIFF
--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -333,13 +333,7 @@ program
   .command('export')
   .description('Export a project or a card')
   .addArgument(
-    new Argument('<format>', 'Export format').choices([
-      'adoc',
-      'csv',
-      'html',
-      'pdf',
-      'site',
-    ]),
+    new Argument('<format>', 'Export format').choices(['adoc', 'html', 'site']),
   )
   .argument('<output>', 'Output path')
   .argument('[cardKey]', 'Path to card')


### PR DESCRIPTION
- Use same query as in app to generate list of cards to show in site/html/adoc export. This guarantees the same content as in app and enables usage of calculated fields in site export
- Tree query results are translated to Card objects since the export functionality uses that internally
- Show progress in site tree menu
- Show additional metadata in site export content area