### PR TITLE
INTDEV-531 do not mutate template name parameter

### DIFF
--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -66,15 +66,15 @@ export class Template extends CardContainer {
 
   constructor(path: string, template: Resource, project?: Project) {
     // Templates might come from modules. Remove module name from template name.
-    template.name = basename(template.name);
-    super(path, template.name);
+    const templateName = basename(template.name);
+    super(path, templateName);
 
     // prevent constructing a new project object, if one is passed to this class.
     this.project = project ? project : new Project(this.basePath);
     // optimization - if template.path is set - use it
     this.templatePath =
       template.path && template.path.length > 0
-        ? join(template.path, template.name)
+        ? join(template.path, templateName)
         : this.setTemplatePath(this.containerName);
     this.templateCardsPath = join(this.templatePath, 'c');
   }


### PR DESCRIPTION
Noticed this after some serious debugging when doing the "new command handler" (INTDEV-531).

The bug causes `Project` template names turn into to using short name format. Which leads to all sorts of nasty "not found" cases.

Ie. first templates are `[decision/templates/decision, decision/templates/simplePage, devision/templates/empty]`. 
Once 'decision' is instantiated, the templates then are `[decision, decision/templates/simplePage, devision/templates/empty]` and so on. 
