### PR TITLE
INTDEV-533 Simplify Template constructor

### DIFF
--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -454,7 +454,6 @@ export class Commands {
     }
     try {
       const addedCards = await this.commands?.createCmd.addCards(
-        path,
         cardTypeName,
         templateName,
         cardKey,

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -554,7 +554,7 @@ export class Project extends CardContainer {
       return undefined;
     }
 
-    const templateObject = new Template(this.basePath, template, this);
+    const templateObject = new Template(this, template);
     await templateObject.create({});
     return templateObject;
   }

--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -64,10 +64,10 @@ export class Template extends CardContainer {
     },
   ];
 
-  constructor(path: string, template: Resource, project: Project) {
+  constructor(project: Project, template: Resource) {
     // Templates might come from modules. Remove module name from template name.
     const templateName = basename(template.name);
-    super(path, templateName);
+    super(template.path!, templateName);
 
     // prevent constructing a new project object, if one is passed to this class.
     this.project = project ? project : new Project(this.basePath);

--- a/tools/data-handler/src/create.ts
+++ b/tools/data-handler/src/create.ts
@@ -170,7 +170,6 @@ export class Create extends EventEmitter {
    * @returns non-empty string array with ids of added cards
    */
   public async addCards(
-    projectPath: string,
     cardTypeName: string,
     templateName: string,
     card?: string,
@@ -183,9 +182,8 @@ export class Create extends EventEmitter {
       throw Error(`Template '${origTemplateName}' is invalid template name`);
     }
     const templateObject = new Template(
-      projectPath,
-      { name: templateName },
       this.project,
+      { name: templateName }, // Template can deduce its own path
     );
 
     const specificCard = card
@@ -668,11 +666,7 @@ export class Create extends EventEmitter {
     // then remove the path handling from Template constructor
     // see INTDEV-533
 
-    const template = new Template(
-      this.project.basePath,
-      resource,
-      this.project,
-    );
+    const template = new Template(this.project, resource);
     await template.create(templateContent);
 
     this.project.addResource(resource);

--- a/tools/data-handler/src/rename.ts
+++ b/tools/data-handler/src/rename.ts
@@ -304,11 +304,7 @@ export class Rename extends EventEmitter {
     // Rename all local template cards.
     const templates = await this.project.templates(ResourcesFrom.localOnly);
     for (const template of templates) {
-      const templateObject = new Template(
-        this.project.basePath,
-        template,
-        this.project,
-      );
+      const templateObject = new Template(this.project, template);
       await this.renameCards(await templateObject.cards('', cardContent));
     }
 

--- a/tools/data-handler/test/template.test.ts
+++ b/tools/data-handler/test/template.test.ts
@@ -32,41 +32,32 @@ after(() => {
 describe('template', () => {
   it('try to create template with no name', () => {
     try {
-      new Template(path, { name: '' }, project);
+      new Template(project, { name: '' });
     } catch (error) {
       if (error instanceof Error) {
         expect(error.message).to.contain('Invalid');
       }
     }
   });
-  const path = join(testDir, 'valid/decision-records');
   it('list template cards', async () => {
-    const template = new Template(
-      path,
-      {
-        name: 'decision/templates/simplepage',
-      },
-      project,
-    );
+    const template = new Template(project, {
+      name: 'decision/templates/simplepage',
+    });
     const cards = await template.cards();
     expect(cards.length).to.equal(3);
   });
   it('list template cards from empty template', async () => {
-    const template = new Template(
-      path,
-      { name: 'decision/templates/empty' },
-      project,
-    );
+    const template = new Template(project, {
+      name: 'decision/templates/empty',
+    });
     const cards = await template.cards();
     expect(cards.length).to.equal(0);
   });
 
   it('try to create all cards from an empty template', async () => {
-    const template = new Template(
-      path,
-      { name: 'decision/templates/empty' },
-      project,
-    );
+    const template = new Template(project, {
+      name: 'decision/templates/empty',
+    });
     const cards = await template.cards();
     template
       .createCards()
@@ -79,13 +70,9 @@ describe('template', () => {
       });
   });
   it('create template card to a specific card from a project', async () => {
-    const template = new Template(
-      path,
-      {
-        name: 'decision/templates/simplepage',
-      },
-      project,
-    );
+    const template = new Template(project, {
+      name: 'decision/templates/simplepage',
+    });
 
     // Choose specific card so that it does not have currently child cards.
     const fetchCardDetails = {
@@ -106,11 +93,9 @@ describe('template', () => {
     expect(cardAfter?.children?.length).to.equal(2);
   });
   it('try to create a specific card from an empty template', async () => {
-    const template = new Template(
-      path,
-      { name: 'decision/templates/empty' },
-      project,
-    );
+    const template = new Template(project, {
+      name: 'decision/templates/empty',
+    });
     const cards = await template.cards();
     const nonExistingCard: Card = {
       key: '1111',
@@ -129,13 +114,9 @@ describe('template', () => {
       });
   });
   it('add new card to a template', async () => {
-    const template = new Template(
-      path,
-      {
-        name: 'decision/templates/decision',
-      },
-      project,
-    );
+    const template = new Template(project, {
+      name: 'decision/templates/decision',
+    });
     const cardsBefore = await template.cards();
     await template
       .addCard('decision/cardTypes/decision')
@@ -148,40 +129,30 @@ describe('template', () => {
       });
   });
   it('list attachments from a template (no attachments in template)', async () => {
-    const template = new Template(
-      path,
-      {
-        name: 'decision/templates/simplepage',
-      },
-      project,
-    );
+    const template = new Template(project, {
+      name: 'decision/templates/simplepage',
+    });
     const attachments = await template.attachments();
 
     expect(attachments.length).to.equal(0);
   });
   it('list attachments from a template', async () => {
-    const template = new Template(
-      path,
-      {
-        name: 'decision/templates/decision',
-      },
-      project,
-    );
+    const template = new Template(project, {
+      name: 'decision/templates/decision',
+    });
     const attachments = await template.attachments();
 
     expect(attachments.length).to.equal(1);
   });
   it('list attachments from an empty template', async () => {
-    const template = new Template(
-      path,
-      { name: 'decision/templates/empty' },
-      project,
-    );
+    const template = new Template(project, {
+      name: 'decision/templates/empty',
+    });
     const attachments = await template.attachments();
     expect(attachments.length).to.equal(0);
   });
   it('check that template does not exist, then create it', async () => {
-    const template = new Template(path, { name: 'idontexistyet' }, project);
+    const template = new Template(project, { name: 'idontexistyet' });
 
     expect(template.isCreated()).to.equal(false);
     const success = await template.create({});
@@ -189,13 +160,9 @@ describe('template', () => {
     expect(success).to.not.equal(undefined);
   });
   it('check template paths', async () => {
-    const template = new Template(
-      path,
-      {
-        name: 'decision/templates/decision',
-      },
-      project,
-    );
+    const template = new Template(project, {
+      name: 'decision/templates/decision',
+    });
     const templateMain = template.templateFolder();
     const templateCards = template.templateCardsFolder();
     const configFile = template.templateConfigurationFilePath();
@@ -207,13 +174,9 @@ describe('template', () => {
     expect(configFile).to.contain('template.json');
   });
   it('add card to a template', async () => {
-    const template = new Template(
-      path,
-      {
-        name: 'decision/templates/decision',
-      },
-      project,
-    );
+    const template = new Template(project, {
+      name: 'decision/templates/decision',
+    });
     const parentCard: Card = {
       key: 'decision_1',
       path: join(template.templateCardsFolder(), 'decision_1'),
@@ -228,13 +191,9 @@ describe('template', () => {
       });
   });
   it('access card details by id', async () => {
-    const template = new Template(
-      path,
-      {
-        name: 'decision/templates/decision',
-      },
-      project,
-    );
+    const template = new Template(project, {
+      name: 'decision/templates/decision',
+    });
     const cardToOperateOn = 'decision_1';
     const cardExists = template.hasCard(cardToOperateOn);
     expect(cardExists).to.equal(true);
@@ -275,7 +234,7 @@ describe('template', () => {
     }
   });
   it('try to add card to a template that does not exist on disk', async () => {
-    const template = new Template(path, { name: 'i-dont-exist' }, project);
+    const template = new Template(project, { name: 'i-dont-exist' });
 
     await template
       .addCard('decision/cardTypes/decision')
@@ -287,11 +246,9 @@ describe('template', () => {
       });
   });
   it('try to add card to a template from card type that does not exist', async () => {
-    const template = new Template(
-      path,
-      { name: 'decision/templates/decision' },
-      project,
-    );
+    const template = new Template(project, {
+      name: 'decision/templates/decision',
+    });
 
     await template
       .addCard('i-dont-exist')
@@ -303,11 +260,9 @@ describe('template', () => {
       });
   });
   it('try to add card to a template to a parent card that does not exist', async () => {
-    const template = new Template(
-      path,
-      { name: 'decision/templates/decision' },
-      project,
-    );
+    const template = new Template(project, {
+      name: 'decision/templates/decision',
+    });
     const parentCard: Card = {
       key: 'i-dont-exist',
       path: join(template.templateCardsFolder(), 'decision_1'),
@@ -323,11 +278,9 @@ describe('template', () => {
       });
   });
   it('check all the attachments', async () => {
-    const template = new Template(
-      path,
-      { name: 'decision/templates/decision' },
-      project,
-    );
+    const template = new Template(project, {
+      name: 'decision/templates/decision',
+    });
 
     // Project can fetch the template's attachment's folder.
     const attachmentFolder1 = await project.cardAttachmentFolder('decision_1');
@@ -365,26 +318,18 @@ describe('template', () => {
     }
   });
   it('check if template is created', () => {
-    const template = new Template(
-      path,
-      { name: 'decision/templates/decision' },
-      project,
-    );
-    const nonExistingTemplate = new Template(
-      path,
-      { name: 'idontExist' },
-      project,
-    );
+    const template = new Template(project, {
+      name: 'decision/templates/decision',
+    });
+    const nonExistingTemplate = new Template(project, { name: 'idontExist' });
 
     expect(template.isCreated()).to.equal(true);
     expect(nonExistingTemplate.isCreated()).to.equal(false);
   });
   it('find certain card from template', async () => {
-    const template = new Template(
-      path,
-      { name: 'decision/templates/decision' },
-      project,
-    );
+    const template = new Template(project, {
+      name: 'decision/templates/decision',
+    });
 
     const nonExistingCard = await template.findSpecificCard('idontexist');
     expect(nonExistingCard).to.equal(undefined);
@@ -393,11 +338,9 @@ describe('template', () => {
     expect(existingCard).to.not.equal(undefined);
   });
   it('show template details', async () => {
-    const template = new Template(
-      path,
-      { name: 'decision/templates/decision' },
-      project,
-    );
+    const template = new Template(project, {
+      name: 'decision/templates/decision',
+    });
 
     const templateProject = template.templateProject;
     expect(templateProject).to.equal(project);
@@ -428,11 +371,9 @@ describe('template', () => {
   it('list template cards', async () => {
     const decisionRecordsPath = join(testDir, 'valid/decision-records');
     const project = new Project(decisionRecordsPath);
-    const template = new Template(
-      path,
-      { name: 'decision/templates/decision' },
-      project,
-    );
+    const template = new Template(project, {
+      name: 'decision/templates/decision',
+    });
     const templateCards = await template.listCards();
     expect(templateCards.length).to.be.greaterThan(0);
   });


### PR DESCRIPTION
Remove extra `path` parameter as unnecessary. 
Make `Project` the first parameter, so that the parameter order is similar to `Commands`.