### PR TITLE
INTDEV-468 Make all resource folders optional

### DIFF
--- a/tools/app/__tests__/api.test.ts
+++ b/tools/app/__tests__/api.test.ts
@@ -14,11 +14,12 @@ import { GET as GET_TREE } from '../app/api/tree/route';
 import { NextRequest } from 'next/server';
 import {
   CardType,
-  FieldTypeDefinition,
+  FieldType,
   LinkType,
-  Template,
-} from '@cyberismocom/data-handler/interfaces/project-interfaces';
+} from '@cyberismocom/data-handler/interfaces/resource-interfaces';
+
 import { QueryResult } from '@cyberismocom/data-handler/types/queries';
+import { TemplateConfiguration } from '@cyberismocom/data-handler/interfaces/project-interfaces';
 
 // Testing env attempts to open project in "../data-handler/test/test-data/valid/decision-records"
 
@@ -105,7 +106,7 @@ test('fieldTypes endpoint returns proper data', async () => {
   const response = await GET_FIELD_TYPES();
   expect(response).not.toBe(null);
 
-  const result: FieldTypeDefinition[] = await response.json();
+  const result: FieldType[] = await response.json();
   expect(response.status).toBe(200);
   expect(result.length).toBe(9);
   expect(result[0].name).toBe('decision/fieldTypes/admins');
@@ -132,7 +133,7 @@ test('templates endpoint returns proper data', async () => {
   const response = await GET_TEMPLATES();
   expect(response).not.toBe(null);
 
-  const result: Template[] = await response.json();
+  const result: TemplateConfiguration[] = await response.json();
   expect(response.status).toBe(200);
   expect(result.length).toBe(3);
   expect(result[0].name).toBe('decision/templates/decision');

--- a/tools/app/__tests__/components.test.tsx
+++ b/tools/app/__tests__/components.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { TreeMenu } from '../app/components/TreeMenu';
 import { Project } from '@/app/lib/definitions';
 import StateSelector from '@/app/components/StateSelector';
-import { WorkflowCategory } from '../../data-handler/src/interfaces/project-interfaces';
+import { WorkflowCategory } from '../../data-handler/src/interfaces/resource-interfaces';
 import { useTranslation } from 'react-i18next';
 import { QueryResult } from '@cyberismocom/data-handler/types/queries';
 

--- a/tools/app/app/components/ContentArea.tsx
+++ b/tools/app/app/components/ContentArea.tsx
@@ -41,7 +41,6 @@ import {
 import { useTranslation } from 'react-i18next';
 import MetadataView from './MetadataView';
 import { findCard, flattenTree, getLinksForCard } from '../lib/utils';
-import { LinkType } from '@cyberismocom/data-handler/interfaces/project-interfaces';
 import { default as NextLink } from 'next/link';
 import { Add, Delete, Edit, Search } from '@mui/icons-material';
 import { Controller, useForm } from 'react-hook-form';

--- a/tools/app/app/components/MetadataView.tsx
+++ b/tools/app/app/components/MetadataView.tsx
@@ -25,7 +25,7 @@ import {
   CardMetadata,
   CustomField,
   DataType,
-  FieldTypeDefinition,
+  FieldType,
   MetadataValue,
 } from '../lib/definitions';
 import EditableField, { EditableFieldProps } from './EditableField';
@@ -161,9 +161,9 @@ function MetadataView({
     if (!fieldTypes) return [];
     return allFieldKeys
       .map((field: string) =>
-        fieldTypes?.find((f: FieldTypeDefinition) => f.name === field),
+        fieldTypes?.find((f: FieldType) => f.name === field),
       )
-      .filter((f) => f != null) as FieldTypeDefinition[];
+      .filter((f) => f != null) as FieldType[];
   }, [allFieldKeys, fieldTypes]);
 
   return (

--- a/tools/app/app/components/modals/NewCardModal.tsx
+++ b/tools/app/app/components/modals/NewCardModal.tsx
@@ -32,7 +32,7 @@ import { useCard, useTemplates } from '@/app/lib/api';
 import { useAppDispatch } from '@/app/lib/hooks';
 import { useAppRouter } from '@/app/lib/hooks';
 import { addNotification } from '@/app/lib/slices/notifications';
-import { Template } from '@cyberismocom/data-handler/interfaces/project-interfaces';
+import { TemplateConfiguration } from '@cyberismocom/data-handler/interfaces/project-interfaces';
 
 interface NewCardModalProps {
   open: boolean;
@@ -129,17 +129,16 @@ export function NewCardModal({ open, onClose, cardKey }: NewCardModalProps) {
   }, [open]);
 
   // divide templates into categories
-  const categories = (templates || []).reduce<Record<string, Template[]>>(
-    (acc, template) => {
-      const category = template.metadata.category || 'Uncategorized';
-      if (!acc[category]) {
-        acc[category] = [];
-      }
-      acc[category].push(template);
-      return acc;
-    },
-    {},
-  );
+  const categories = (templates || []).reduce<
+    Record<string, TemplateConfiguration[]>
+  >((acc, template) => {
+    const category = template.metadata.category || 'Uncategorized';
+    if (!acc[category]) {
+      acc[category] = [];
+    }
+    acc[category].push(template);
+    return acc;
+  }, {});
 
   return (
     <Modal open={open} onClose={onClose}>

--- a/tools/app/app/lib/api/types.ts
+++ b/tools/app/app/lib/api/types.ts
@@ -14,8 +14,8 @@ import { Project, CardDetails, FieldTypes } from '../definitions';
 import {
   CardType,
   LinkType,
-  Template,
-} from '@cyberismocom/data-handler/interfaces/project-interfaces';
+} from '@cyberismocom/data-handler/interfaces/resource-interfaces';
+import { TemplateConfiguration } from '@cyberismocom/data-handler/interfaces/project-interfaces';
 import { QueryResult } from '@cyberismocom/data-handler/types/queries';
 import { SWRResponse } from 'swr';
 
@@ -26,7 +26,7 @@ export type Resources = {
   };
   fieldTypes: FieldTypes;
   cardType: CardType;
-  templates: Template[];
+  templates: TemplateConfiguration[];
   linkTypes: LinkType[];
   tree: QueryResult<'tree'>[];
   cardQuery: QueryResult<'card'>;

--- a/tools/app/app/lib/definitions.ts
+++ b/tools/app/app/lib/definitions.ts
@@ -12,25 +12,25 @@
 
 // These are used within this file for additional definitions.
 import {
-  CardAttachment,
   CardType,
-  FieldTypeDefinition,
+  FieldType,
   Link,
   LinkType,
-  WorkflowMetadata as Workflow,
-} from '@cyberismocom/data-handler/interfaces/project-interfaces';
+  Workflow,
+} from '@cyberismocom/data-handler/interfaces/resource-interfaces';
+import { CardAttachment } from '@cyberismocom/data-handler/interfaces/project-interfaces';
 
 // These are exported as-is.
 export {
-  type CardAttachment,
   type CustomField,
   type DataType,
   type EnumDefinition,
-  type FieldTypeDefinition,
-  type WorkflowMetadata as Workflow,
+  type FieldType,
+  type Workflow,
   type WorkflowState,
   type WorkflowTransition,
-} from '@cyberismocom/data-handler/interfaces/project-interfaces';
+} from '@cyberismocom/data-handler/interfaces/resource-interfaces';
+export { type CardAttachment } from '@cyberismocom/data-handler/interfaces/project-interfaces';
 
 // Single card with metadata and children, but no content.
 // Used in displaying the tree menu view.
@@ -74,7 +74,7 @@ export interface CardView {
 }
 
 // Array of field types.
-export type FieldTypes = Array<FieldTypeDefinition>;
+export type FieldTypes = Array<FieldType>;
 
 // Field type key.
 export type FieldTypeKey = string;

--- a/tools/app/app/lib/utils.ts
+++ b/tools/app/app/lib/utils.ts
@@ -22,13 +22,12 @@ import {
   ParsedLink,
   Project,
   Workflow,
-  WorkflowState,
 } from './definitions';
 import { useForm } from 'react-hook-form';
 import {
   LinkType,
   WorkflowCategory,
-} from '@cyberismocom/data-handler/interfaces/project-interfaces';
+} from '@cyberismocom/data-handler/interfaces/resource-interfaces';
 import { QueryResult } from '@cyberismocom/data-handler/types/queries';
 
 /**

--- a/tools/data-handler/src/calculate.ts
+++ b/tools/data-handler/src/calculate.ts
@@ -16,7 +16,8 @@ import { mkdir, readFile } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
-import { Card, Link } from './interfaces/project-interfaces.js';
+import { Card } from './interfaces/project-interfaces.js';
+import { Link } from './interfaces/resource-interfaces.js';
 import {
   copyDir,
   deleteDir,

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -23,17 +23,20 @@ import {
   Card,
   CardAttachment,
   CardListContainer,
-  CardType,
-  FieldTypeDefinition,
-  LinkType,
+  FileContentType,
   ModuleSettings,
   ProjectMetadata,
   RemovableResourceTypes,
   ResourceTypes,
-  Template,
-  TemplateMetadata,
-  WorkflowMetadata,
+  TemplateConfiguration,
 } from './interfaces/project-interfaces.js';
+import {
+  CardType,
+  FieldType,
+  LinkType,
+  TemplateMetadata,
+  Workflow,
+} from './interfaces/resource-interfaces.js';
 import { resourceNameParts } from './utils/resource-utils.js';
 import { DefaultContent } from './create-defaults.js';
 import { CommandManager } from './command-manager.js';
@@ -769,7 +772,7 @@ export class Commands {
     }
     const content = templateContent
       ? (JSON.parse(templateContent) as TemplateMetadata)
-      : DefaultContent.templateContent();
+      : DefaultContent.templateContent(templateName);
     // Note that templateContent is validated in createTemplate()
     try {
       await this.commands?.createCmd.createTemplate(validTemplateName, content);
@@ -800,7 +803,7 @@ export class Commands {
       };
     }
     const content = workflowContent
-      ? (JSON.parse(workflowContent) as WorkflowMetadata)
+      ? (JSON.parse(workflowContent) as Workflow)
       : DefaultContent.workflowContent(validWorkflowName);
     content.name = validWorkflowName;
     try {
@@ -1072,12 +1075,12 @@ export class Commands {
       | CardAttachment[]
       | CardListContainer[]
       | CardType
-      | FieldTypeDefinition
+      | FieldType
       | LinkType
       | ModuleSettings
       | ProjectMetadata
-      | Template
-      | WorkflowMetadata
+      | TemplateConfiguration
+      | Workflow
       | string[]
       | undefined
     >;
@@ -1092,7 +1095,7 @@ export class Commands {
       case 'card':
         {
           const cardDetails = {
-            contentType: 'adoc',
+            contentType: 'adoc' as FileContentType,
             content: options?.details,
             metadata: true,
             children: options?.details,

--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -21,10 +21,11 @@ import {
   CardNameRegEx,
   DotSchemaItem,
   FetchCardDetails,
+  FileContentType,
   Resource,
-  Template as TemplateInterface,
-  TemplateMetadata,
+  TemplateConfiguration as TemplateInterface,
 } from '../interfaces/project-interfaces.js';
+import { TemplateMetadata } from '../interfaces/resource-interfaces.js';
 import { copyDir, pathExists, sepRegex } from '../utils/file-utils.js';
 import { readJsonFile, writeJsonFile } from '../utils/json.js';
 import { Project } from './project.js';
@@ -442,7 +443,11 @@ export class Template extends CardContainer {
     }
     const cardDetails = details
       ? details
-      : { content: true, contentType: 'adoc', metadata: true };
+      : {
+          content: true,
+          contentType: 'adoc' as FileContentType,
+          metadata: true,
+        };
     return super.cards(this.templateCardsPath, cardDetails);
   }
 

--- a/tools/data-handler/src/create-defaults.ts
+++ b/tools/data-handler/src/create-defaults.ts
@@ -13,14 +13,14 @@
 import {
   CardType,
   DataType,
-  FieldTypeDefinition,
+  FieldType,
   Link,
   LinkType,
   ReportMetadata,
   TemplateMetadata,
   WorkflowCategory,
-  WorkflowMetadata,
-} from './interfaces/project-interfaces.js';
+  Workflow,
+} from './interfaces/resource-interfaces.js';
 
 export abstract class DefaultContent {
   /**
@@ -45,10 +45,7 @@ export abstract class DefaultContent {
    * @param dataType data type for the field type
    * @returns Default content for field type.
    */
-  static fieldType(
-    fieldTypeName: string,
-    dataType: DataType,
-  ): FieldTypeDefinition {
+  static fieldType(fieldTypeName: string, dataType: DataType): FieldType {
     return {
       name: fieldTypeName,
       dataType: dataType,
@@ -100,8 +97,8 @@ export abstract class DefaultContent {
    * Default template content
    * @returns Default template content
    */
-  public static templateContent(): TemplateMetadata {
-    return {};
+  public static templateContent(templateName: string): TemplateMetadata {
+    return { name: templateName };
   }
 
   /**
@@ -109,7 +106,7 @@ export abstract class DefaultContent {
    * @param {string} workflowName workflow name
    * @returns Default content for workflow JSON values.
    */
-  public static workflowContent(workflowName: string): WorkflowMetadata {
+  public static workflowContent(workflowName: string): Workflow {
     return {
       name: workflowName,
       states: [

--- a/tools/data-handler/src/export.ts
+++ b/tools/data-handler/src/export.ts
@@ -14,16 +14,13 @@
 import { appendFile, copyFile, mkdir, truncate } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 
-import {
-  Card,
-  CardType,
-  FetchCardDetails,
-} from './interfaces/project-interfaces.js';
-import { pathExists } from './utils/file-utils.js';
-import { Project } from './containers/project.js';
-
 // asciidoctor
 import Processor from '@asciidoctor/core';
+
+import { Card, FetchCardDetails } from './interfaces/project-interfaces.js';
+import { CardType } from './interfaces/resource-interfaces.js';
+import { pathExists } from './utils/file-utils.js';
+import { Project } from './containers/project.js';
 
 import { sortItems } from './utils/lexorank.js';
 import { QueryResult } from './types/queries.js';

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -10,7 +10,7 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Schema } from 'jsonschema';
+import { Link, TemplateMetadata } from './resource-interfaces.js';
 
 // @todo: consider splitting this to several smaller files.
 
@@ -40,15 +40,6 @@ export interface CardListContainer {
   cards: string[];
 }
 
-// Card type content.
-export interface CardType {
-  name: string;
-  workflow: string;
-  customFields?: CustomField[];
-  alwaysVisibleFields?: string[];
-  optionallyVisibleFields?: string[];
-}
-
 // Card's index.json file content.
 export interface CardMetadata {
   title: string;
@@ -69,29 +60,6 @@ export type CSVRowRaw = {
   [key: string]: string;
 };
 
-// Custom field
-export interface CustomField {
-  name: string;
-  description?: string;
-  displayName?: string;
-  isEditable: boolean;
-}
-
-// Supported data types.
-export type DataType =
-  | 'shortText'
-  | 'longText'
-  | 'enum'
-  | 'date'
-  | 'number'
-  | 'integer'
-  | 'boolean'
-  | 'enum'
-  | 'list'
-  | 'date'
-  | 'dateTime'
-  | 'person';
-
 export interface DotSchemaItem {
   id: string;
   version: number;
@@ -99,49 +67,18 @@ export interface DotSchemaItem {
 }
 export type DotSchemaContent = DotSchemaItem[];
 
-// Custom field enum value
-export interface EnumDefinition {
-  enumValue: string;
-  enumDisplayValue: string;
-  enumDescription: string;
-}
-
 // Defines which details of a card are fetched.
 export interface FetchCardDetails {
   attachments?: boolean;
   calculations?: true;
   children?: boolean;
   content?: boolean;
-  contentType?: string; // 'adoc', 'html'
+  contentType?: FileContentType;
   metadata?: boolean;
   parent?: boolean;
 }
 
-// FieldType content.
-export interface FieldTypeDefinition {
-  name: string;
-  displayName?: string;
-  fieldDescription?: string;
-  dataType: DataType;
-  enumValues?: Array<EnumDefinition>;
-}
-
-// Link content.
-export interface Link {
-  linkType: string;
-  cardKey: string;
-  linkDescription?: string;
-}
-
-// Link type content.
-export interface LinkType {
-  name: string;
-  outboundDisplayName: string;
-  inboundDisplayName: string;
-  sourceCardTypes: string[];
-  destinationCardTypes: string[];
-  enableLinkDescription: boolean;
-}
+export type FileContentType = 'adoc' | 'html';
 
 // Metadata content type.
 export type MetadataContent =
@@ -172,12 +109,6 @@ export interface ProjectFile {
   name: string;
 }
 
-// Project's settings (=cardsConfig.json).
-export interface ProjectSettings {
-  cardKeyPrefix: string;
-  name: string;
-}
-
 // Project metadata details. @todo - this overlaps the above; check & merge
 export interface ProjectMetadata {
   name: string;
@@ -185,6 +116,22 @@ export interface ProjectMetadata {
   prefix: string;
   numberOfCards: number;
 }
+
+// Project's settings (=cardsConfig.json).
+export interface ProjectSettings {
+  cardKeyPrefix: string;
+  name: string;
+}
+
+// Resources that are possible to remove.
+// todo: add possibility to remove calculations, card types, field types, workflows and reports
+export type RemovableResourceTypes =
+  | 'attachment'
+  | 'card'
+  | 'link'
+  | 'linkType'
+  | 'module'
+  | 'template';
 
 // Project resource, such as workflow, template or card type as file system object.
 export interface Resource {
@@ -202,16 +149,6 @@ export type ResourceFolderType =
   | 'report'
   | 'template'
   | 'workflow';
-
-// Resources that are possible to remove.
-// todo: add possibility to remove calculations, card types, field types, workflows and reports
-export type RemovableResourceTypes =
-  | 'attachment'
-  | 'card'
-  | 'link'
-  | 'linkType'
-  | 'module'
-  | 'template';
 
 // All resource types; both singular and plural.
 export type ResourceTypes =
@@ -236,59 +173,11 @@ export type ResourceTypes =
   | 'workflows';
 
 // Template configuration details.
-export interface Template {
+export interface TemplateConfiguration {
   name: string;
   path: string;
   numberOfCards: number;
   metadata: TemplateMetadata;
-}
-
-// Template configuration content details.
-export interface TemplateMetadata {
-  displayName?: string;
-  description?: string;
-  category?: string;
-}
-
-// Workflow state categories.
-export enum WorkflowCategory {
-  initial = 'initial',
-  active = 'active',
-  closed = 'closed',
-}
-
-// Workflow's json file content.
-export interface WorkflowMetadata {
-  name: string;
-  states: WorkflowState[];
-  transitions: WorkflowTransition[];
-}
-
-// Workflow state.
-export interface WorkflowState {
-  name: string;
-  category?: WorkflowCategory;
-}
-
-// Workflow transition.
-export interface WorkflowTransition {
-  name: string;
-  fromState: string[];
-  toState: string;
-  requiredCardFields?: string[];
-}
-
-export interface ReportMetadata {
-  displayName: string;
-  description: string;
-  category: string;
-}
-
-export interface Report {
-  metadata: ReportMetadata;
-  contentTemplate: string;
-  queryTemplate: string;
-  schema?: Schema;
 }
 
 // Name for a card (consists of prefix and a random 8-character base36 string; e.g. 'test_abcd1234')

--- a/tools/data-handler/src/interfaces/resource-interfaces.ts
+++ b/tools/data-handler/src/interfaces/resource-interfaces.ts
@@ -1,0 +1,148 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Schema } from 'jsonschema';
+
+/**
+ * Each resource represents a file (or a folder in some cases) with metadata stored
+ * in JSON file. Name of the file is the name of the resource. Each resource is expected to be
+ * in a correct place in folder structure.
+ */
+
+// Calculation does not have own metadata.
+export type CalculationMetadata = ResourceBaseMetadata;
+
+// Card type content.
+export interface CardType extends ResourceBaseMetadata {
+  workflow: string;
+  customFields?: CustomField[];
+  alwaysVisibleFields?: string[];
+  optionallyVisibleFields?: string[];
+}
+
+// Custom field
+export interface CustomField {
+  name: string;
+  description?: string;
+  displayName?: string;
+  isEditable: boolean;
+}
+
+// Supported data types.
+export type DataType =
+  | 'shortText'
+  | 'longText'
+  | 'enum'
+  | 'date'
+  | 'number'
+  | 'integer'
+  | 'boolean'
+  | 'enum'
+  | 'list'
+  | 'date'
+  | 'dateTime'
+  | 'person';
+
+// Custom field enum value
+export interface EnumDefinition {
+  enumValue: string;
+  enumDisplayValue: string;
+  enumDescription: string;
+}
+
+// FieldType content.
+export interface FieldType extends ResourceBaseMetadata {
+  displayName?: string;
+  fieldDescription?: string;
+  dataType: DataType;
+  enumValues?: Array<EnumDefinition>;
+}
+
+// Link content.
+export interface Link {
+  linkType: string;
+  cardKey: string;
+  linkDescription?: string;
+}
+
+// Link type resource.
+export interface LinkType extends ResourceBaseMetadata {
+  outboundDisplayName: string;
+  inboundDisplayName: string;
+  sourceCardTypes: string[];
+  destinationCardTypes: string[];
+  enableLinkDescription: boolean;
+}
+
+// Report resource.
+export interface Report extends ResourceBaseMetadata {
+  metadata: ReportMetadata;
+  contentTemplate: string;
+  queryTemplate: string;
+  schema?: Schema;
+}
+
+// Metadata for report
+export interface ReportMetadata {
+  displayName: string;
+  description: string;
+  category: string;
+}
+
+// Base interface for all resources.
+interface ResourceBaseMetadata {
+  name: string;
+}
+
+// Resource's metadata. There are based from ResourceBaseMetadata.
+export type ResourceMetadataType =
+  | CalculationMetadata
+  | CardType
+  | FieldType
+  | LinkType
+  | Report
+  | TemplateMetadata
+  | Workflow;
+
+// Template configuration content details.
+export interface TemplateMetadata extends ResourceBaseMetadata {
+  displayName?: string;
+  description?: string;
+  category?: string;
+}
+
+// Workflow's json file content.
+export interface Workflow extends ResourceBaseMetadata {
+  states: WorkflowState[];
+  transitions: WorkflowTransition[];
+}
+
+// Workflow state categories.
+export enum WorkflowCategory {
+  initial = 'initial',
+  active = 'active',
+  closed = 'closed',
+}
+
+// Workflow state.
+export interface WorkflowState {
+  name: string;
+  category?: WorkflowCategory;
+}
+
+// Workflow transition.
+export interface WorkflowTransition {
+  name: string;
+  fromState: string[];
+  toState: string;
+  requiredCardFields?: string[];
+}

--- a/tools/data-handler/src/show.ts
+++ b/tools/data-handler/src/show.ts
@@ -20,15 +20,17 @@ import {
   CardAttachment,
   Card,
   CardListContainer,
-  CardType,
   FetchCardDetails,
-  FieldTypeDefinition,
-  LinkType,
   ModuleSettings,
   ProjectMetadata,
-  Template,
-  WorkflowMetadata,
+  TemplateConfiguration,
 } from './interfaces/project-interfaces.js';
+import {
+  CardType,
+  FieldType,
+  LinkType,
+  Workflow,
+} from './interfaces/resource-interfaces.js';
 import { Project } from './containers/project.js';
 import { spawn } from 'node:child_process';
 import { join, resolve } from 'node:path';
@@ -316,7 +318,7 @@ export class Show {
    */
   public async showFieldType(
     fieldTypeName: string,
-  ): Promise<FieldTypeDefinition | undefined> {
+  ): Promise<FieldType | undefined> {
     const fieldTypeDetails = await this.project.fieldType(fieldTypeName);
     if (fieldTypeDetails === undefined) {
       throw new Error(
@@ -386,7 +388,9 @@ export class Show {
    * @param {string} templateName template name
    * @returns template details
    */
-  public async showTemplate(templateName: string): Promise<Template> {
+  public async showTemplate(
+    templateName: string,
+  ): Promise<TemplateConfiguration> {
     const templateObject =
       await this.project.createTemplateObjectByName(templateName);
     if (!templateObject) {
@@ -413,14 +417,14 @@ export class Show {
    * @param {string} projectPath path to a project
    * @returns all templates in a project.
    */
-  public async showTemplatesWithDetails(): Promise<Template[]> {
+  public async showTemplatesWithDetails(): Promise<TemplateConfiguration[]> {
     const promiseContainer = (await this.project.templates()).map((template) =>
       this.project
         .createTemplateObjectByName(template.name)
         .then((t) => t?.show()),
     );
     const result = await Promise.all(promiseContainer);
-    return result.filter(Boolean) as Template[];
+    return result.filter(Boolean) as TemplateConfiguration[];
   }
 
   /**
@@ -428,7 +432,7 @@ export class Show {
    * @param {string} workflowName name of workflow
    * @returns workflow details
    */
-  public async showWorkflow(workflowName: string): Promise<WorkflowMetadata> {
+  public async showWorkflow(workflowName: string): Promise<Workflow> {
     if (workflowName === '') {
       throw new Error(`Must define workflow name to query its details.`);
     }
@@ -455,9 +459,7 @@ export class Show {
    * Shows all workflows with full details in a project.
    * @returns workflows with full details
    */
-  public async showWorkflowsWithDetails(): Promise<
-    (WorkflowMetadata | undefined)[]
-  > {
+  public async showWorkflowsWithDetails(): Promise<(Workflow | undefined)[]> {
     const promiseContainer = [];
     for (const workflow of await this.project.workflows()) {
       promiseContainer.push(this.project.workflow(workflow.name));

--- a/tools/data-handler/src/transition.ts
+++ b/tools/data-handler/src/transition.ts
@@ -15,7 +15,8 @@ import { EventEmitter } from 'node:events';
 import { join } from 'node:path';
 
 import { Calculate } from './calculate.js';
-import { Card, WorkflowState } from './interfaces/project-interfaces.js';
+import { Card } from './interfaces/project-interfaces.js';
+import { WorkflowState } from './interfaces/resource-interfaces.js';
 import { Project } from './containers/project.js';
 import { writeJsonFile } from './utils/json.js';
 import { Edit } from './edit.js';

--- a/tools/data-handler/src/types/queries.ts
+++ b/tools/data-handler/src/types/queries.ts
@@ -14,7 +14,7 @@
  * Types for query result
  */
 
-import { WorkflowCategory } from '../interfaces/project-interfaces.js';
+import { WorkflowCategory } from '../interfaces/resource-interfaces.js';
 
 export interface CalculationLink {
   key: string;

--- a/tools/data-handler/src/validate.ts
+++ b/tools/data-handler/src/validate.ts
@@ -28,16 +28,18 @@ import { resourceNameParts } from './utils/resource-utils.js';
 import { Project } from './containers/project.js';
 import {
   Card,
-  FieldTypeDefinition,
-  TemplateMetadata,
+  DotSchemaContent,
+  ProjectSettings,
+} from './interfaces/project-interfaces.js';
+import {
   CardType,
   CustomField,
-  DotSchemaContent,
+  FieldType,
   LinkType,
-  ProjectSettings,
-  WorkflowMetadata,
   ReportMetadata,
-} from './interfaces/project-interfaces.js';
+  TemplateMetadata,
+  Workflow,
+} from './interfaces/resource-interfaces.js';
 
 import * as EmailValidator from 'email-validator';
 
@@ -297,10 +299,10 @@ export class Validate {
       | CardType
       | CustomField
       | DotSchemaContent
-      | FieldTypeDefinition
+      | FieldType
       | LinkType
       | ProjectSettings
-      | WorkflowMetadata
+      | Workflow
       | ReportMetadata,
     projectPrefixes: string[],
   ): string[] {
@@ -317,9 +319,9 @@ export class Validate {
       const namedContent = content as
         | CardType
         | CustomField
-        | FieldTypeDefinition
+        | FieldType
         | LinkType
-        | WorkflowMetadata;
+        | Workflow;
       const { name, type, prefix } = resourceNameParts(namedContent.name);
       const filenameWithoutExtension = parse(file.name).name;
 
@@ -343,7 +345,7 @@ export class Validate {
   }
 
   // Validates that card's dataType can be used with JS types.
-  private validType<T>(value: T, fieldType: FieldTypeDefinition): boolean {
+  private validType<T>(value: T, fieldType: FieldType): boolean {
     const field = fieldType.dataType;
     const typeOfValue = typeof value;
 

--- a/tools/data-handler/test/calculate.test.ts
+++ b/tools/data-handler/test/calculate.test.ts
@@ -8,7 +8,7 @@ import { copyDir } from '../src/utils/file-utils.js';
 import { fileURLToPath } from 'node:url';
 import { Project } from '../src/containers/project.js';
 import { QueryResult } from '../src/types/queries.js';
-import { WorkflowCategory } from '../src/interfaces/project-interfaces.js';
+import { WorkflowCategory } from '../src/interfaces/resource-interfaces.js';
 
 use(chaiAsPromised);
 

--- a/tools/data-handler/test/command-handler-create.test.ts
+++ b/tools/data-handler/test/command-handler-create.test.ts
@@ -798,7 +798,7 @@ describe('create command', () => {
     expect(result.statusCode).to.equal(400);
   });
   it('access default parameters for template (success)', () => {
-    const defaultContent = DefaultContent.templateContent();
+    const defaultContent = DefaultContent.templateContent('testName');
     expect(defaultContent.displayName).to.equal(undefined);
     expect(defaultContent.category).to.equal(undefined);
     expect(defaultContent.description).to.equal(undefined);

--- a/tools/data-handler/test/project.test.ts
+++ b/tools/data-handler/test/project.test.ts
@@ -10,6 +10,7 @@ import { copyDir } from '../src/utils/file-utils.js';
 import { Project } from '../src/containers/project.js';
 import { ProjectConfiguration } from '../src/project-settings.js';
 import { fileURLToPath } from 'node:url';
+import { FileContentType } from '../src/interfaces/project-interfaces.js';
 
 describe('project', () => {
   // Create test artifacts in a temp folder.
@@ -214,7 +215,7 @@ describe('project', () => {
       expect(templatePath).to.equal('');
     }
     const details = {
-      contentType: 'adoc',
+      contentType: 'adoc' as FileContentType,
       content: true,
       metadata: true,
       children: true,

--- a/tools/data-handler/test/template.test.ts
+++ b/tools/data-handler/test/template.test.ts
@@ -7,7 +7,7 @@ import { mkdirSync, rmSync } from 'node:fs';
 import { dirname, join, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { Card } from '../src/interfaces/project-interfaces.js';
+import { Card, FileContentType } from '../src/interfaces/project-interfaces.js';
 import { copyDir } from '../src/utils/file-utils.js';
 import { Project } from '../src/containers/project.js';
 import { Template } from '../src/containers/template.js';
@@ -152,10 +152,11 @@ describe('template', () => {
     expect(attachments.length).to.equal(0);
   });
   it('check that template does not exist, then create it', async () => {
-    const template = new Template(project, { name: 'idontexistyet' });
+    const templateName = 'idontexistyet';
+    const template = new Template(project, { name: templateName });
 
     expect(template.isCreated()).to.equal(false);
-    const success = await template.create({});
+    const success = await template.create({ name: templateName });
     expect(template.isCreated()).to.equal(true);
     expect(success).to.not.equal(undefined);
   });
@@ -210,7 +211,7 @@ describe('template', () => {
       expect(templatePath).to.not.equal('');
     }
     const details = {
-      contentType: 'adoc',
+      contentType: 'adoc' as FileContentType,
       content: true,
       metadata: true,
       children: true,
@@ -297,7 +298,7 @@ describe('template', () => {
     expect(templateAttachments.length).to.equal(1);
 
     const details = {
-      contentType: 'adoc',
+      contentType: 'adoc' as FileContentType,
       content: true,
       metadata: true,
       children: true,

--- a/tools/schema/cardTreeDirectorySchema.json
+++ b/tools/schema/cardTreeDirectorySchema.json
@@ -205,13 +205,13 @@
                                       "additionalProperties": false,
                                       "properties": {
                                         ".schema": {},
+                                        ".gitkeep": {},
                                         "template.json": {
                                           "type": "object",
                                           "$comment": "Each file needs to be separately validated against 'contentSchema'",
                                           "contentSchema": "templateSchema.json"
                                         }
-                                      },
-                                      "required": [".schema", "template.json"]
+                                      }
                                     }
                                   }
                                 }
@@ -300,14 +300,7 @@
                             }
                           }
                         }
-                      },
-                      "required": [
-                        "cardTypes",
-                        "fieldTypes",
-                        "templates",
-                        "workflows",
-                        "reports"
-                      ]
+                      }
                     }
                   }
                 }
@@ -533,14 +526,14 @@
                                   "type": "object",
                                   "additionalProperties": false,
                                   "properties": {
+                                    ".gitkeep": {},
                                     ".schema": {},
                                     "template.json": {
                                       "type": "object",
                                       "$comment": "Each file needs to be separately validated against 'contentSchema'",
                                       "contentSchema": "templateSchema.json"
                                     }
-                                  },
-                                  "required": [".schema", "template.json"]
+                                  }
                                 }
                               }
                             }
@@ -564,13 +557,7 @@
                         }
                       }
                     }
-                  },
-                  "required": [
-                    "cardTypes",
-                    "fieldTypes",
-                    "templates",
-                    "workflows"
-                  ]
+                  }
                 },
                 "files": {
                   "type": "object",

--- a/tools/schema/templateSchema.json
+++ b/tools/schema/templateSchema.json
@@ -5,6 +5,7 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "name": {},
     "displayName": {
       "description": "The name of the template as it should be displayed in the user interface. For example, 'Decision'.",
       "type": "string"


### PR DESCRIPTION
Make all resource folders optional in the project.

Additionally, make file-based resources work use same implementation in `create.ts`. Remove resource-specific "exists" functions and provide one generic function. 
Additionally, split the "project interfaces" to two: project related interfaces and resource related interfaces. The latter will be moved to `Resource` class once we get to implement it. 
Finally, renamed the resource interface to be more or less similar; `Template` is an exception for now, as there is `Template` class that is exported.