### PR TITLE
INTDEV-465 When template card is added, generate rank for it

### DIFF
--- a/tools/data-handler/test/command-handler-add.test.ts
+++ b/tools/data-handler/test/command-handler-add.test.ts
@@ -36,6 +36,21 @@ describe('add command', () => {
       options,
     );
     expect(result.statusCode).to.equal(200);
+
+    // Check that the added card received a rank.
+    if (result.affectsCards?.at(0)) {
+      const addedCard = result.affectsCards?.at(0) || '';
+      const showResult = await commandHandler.command(
+        Cmd.show,
+        ['card', addedCard],
+        options,
+      );
+      if (showResult.statusCode === 200) {
+        const newRank = Object(showResult.payload)['metadata']['rank'];
+        expect(newRank).not.to.equal('');
+        expect(newRank).not.to.equal(undefined);
+      }
+    }
   });
   it('add template card to under a parent (success)', async () => {
     const result = await commandHandler.command(


### PR DESCRIPTION
When new card is added to a template (using `cyberismo add`) , add "rank" for the card.

**Note** that "rank" operation is not handled in this PR, see [INTDEV-545](https://cyberismo.atlassian.net/browse/INTDEV-545), this only affects "add".

Removed the `save()` calls to project configuration when new template cards were generated.