### PR TITLE
INTDEV-509: Support macros in exports

### DIFF
--- a/tools/data-handler/src/macros/report/index.ts
+++ b/tools/data-handler/src/macros/report/index.ts
@@ -28,10 +28,9 @@ class ReportMacro extends BaseMacro {
   constructor() {
     super(macroMetadata);
   }
-  async handleStatic() {
-    // Buttons aren't supported in static mode
-    return '';
-  }
+  handleStatic = async (context: MacroGenerationContext, data: string) => {
+    return this.handleInject(context, data);
+  };
 
   handleInject = async (context: MacroGenerationContext, data: string) => {
     if (!data || typeof data !== 'string') {

--- a/tools/data-handler/test/test-data/valid/decision-records/cardRoot/decision_5/index.adoc
+++ b/tools/data-handler/test/test-data/valid/decision-records/cardRoot/decision_5/index.adoc
@@ -2,10 +2,10 @@
 
 To create a new decision, click this button:
 
-cards:create_from_template[decision]
+{{{ createCards '{"template": "decision/templates/simplepage", "buttonLabel": "Create a new page"}'}}}
 
 == Decisions
 
 The following decisions have been made:
 
-cards::list_cards[query TBD]
+{{{ report '{"name": "decision/reports/testReport", "key3": "key"}'}}}


### PR DESCRIPTION
- Run validateMacros for all content to be exported
- Report macros are shown as is, button macros are hidden
- Add valid macros to test data
- Improve html and adoc export layout