### PR TITLE
INTDEV-557 Separate resource handling to its own class

### DIFF
--- a/tools/data-handler/src/containers/project/resource-collector.ts
+++ b/tools/data-handler/src/containers/project/resource-collector.ts
@@ -1,0 +1,374 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+import { Dirent, readdirSync } from 'node:fs';
+import { readdir } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+
+import { CardContainer } from '../card-container.js';
+import { readJsonFile } from '../../utils/json.js';
+import { pathExists } from '../../utils/file-utils.js';
+import { resourceNameParts } from '../../utils/resource-utils.js';
+import { ProjectPaths } from './project-paths.js';
+import {
+  Resource,
+  ResourceFolderType,
+} from '../../interfaces/project-interfaces.js';
+
+/**
+ * Defines where resources are collected from.
+ * all - everywhere
+ * importOnly - only from imported modules
+ * localOnly - only from the project itself; excluding imported modules
+ */
+export enum ResourcesFrom {
+  all = 'all',
+  importedOnly = 'imported',
+  localOnly = 'local',
+}
+
+/**
+ * This class handles local and modules resources.
+ */
+export class ResourceCollector {
+  private localCalculations: Resource[] = [];
+  private localCardTypes: Resource[] = [];
+  private localFieldTypes: Resource[] = [];
+  private localLinkTypes: Resource[] = [];
+  private localTemplates: Resource[] = [];
+  private localWorkflows: Resource[] = [];
+  private localReports: Resource[] = [];
+
+  constructor(
+    private prefix: string,
+    private paths: ProjectPaths,
+  ) {}
+
+  // Add resources of a given type to an array.
+  private async addResources(
+    resources: Dirent[],
+    requestedType: string, // should be a type
+  ): Promise<Resource[]> {
+    const collectedResources: Resource[] = [];
+    const filteredDirectories = requestedType === 'templates' ? true : false;
+    for (const resource of resources) {
+      if (requestedType === 'modules') {
+        collectedResources.push(...resources);
+      } else {
+        const resourcePath = join(
+          this.paths.modulesFolder,
+          resource.name,
+          requestedType,
+        );
+        const files = await readdir(resourcePath, { withFileTypes: true });
+        const filteredFiles = filteredDirectories
+          ? files.filter((item) => item.isDirectory())
+          : files.filter(
+              (item) =>
+                item.name !== CardContainer.schemaContentFile &&
+                item.name !== '.gitkeep',
+            );
+
+        filteredFiles.forEach((item) => {
+          item.name = `${resource.name}/${requestedType}/${item.name}`;
+          collectedResources.push({ name: item.name, path: item.parentPath });
+        });
+      }
+    }
+    return collectedResources;
+  }
+
+  // Adds a resource type from all modules.
+  private async addResourcesFromModules(type: string): Promise<Resource[]> {
+    if (!pathExists(this.paths.modulesFolder)) {
+      return [];
+    }
+
+    const moduleDirectories = await readdir(this.paths.modulesFolder, {
+      withFileTypes: true,
+    });
+    const modules = moduleDirectories.filter((item) => item.isDirectory());
+
+    return [...(await this.addResources(modules, type))];
+  }
+
+  // Joins local resources and module resources together to one array.
+  private joinResources(
+    from: ResourcesFrom,
+    localCollection: Resource[],
+    moduleCollection: Resource[],
+  ) {
+    if (from === ResourcesFrom.localOnly) {
+      return localCollection;
+    }
+    if (from === ResourcesFrom.importedOnly) {
+      return moduleCollection;
+    }
+    return [...localCollection, ...moduleCollection];
+  }
+
+  // Returns local resources of a given type.
+  private localResources(type: string) {
+    if (type === 'calculations') {
+      return this.localCalculations;
+    } else if (type === 'cardTypes') {
+      return this.localCardTypes;
+    } else if (type === 'fieldTypes') {
+      return this.localFieldTypes;
+    } else if (type === 'linkTypes') {
+      return this.localLinkTypes;
+    } else if (type === 'modules') {
+      return [];
+    } else if (type === 'reports') {
+      return this.localReports;
+    } else if (type === 'templates') {
+      return this.localTemplates;
+    } else if (type === 'workflows') {
+      return this.localWorkflows;
+    }
+    throw new Error('Incorrect resource type ' + type);
+  }
+
+  // Collects certain kinds of resources.
+  private resourcesSync(
+    type: ResourceFolderType,
+    requirement: string,
+  ): Resource[] {
+    // todo: this type of mapping should exist somewhere else. Resource utils?
+    let resourceFolder: string;
+    if (type === 'calculation') {
+      resourceFolder = this.paths.calculationProjectFolder;
+    } else if (type === 'cardType') {
+      resourceFolder = this.paths.cardTypesFolder;
+    } else if (type === 'fieldType') {
+      resourceFolder = this.paths.fieldTypesFolder;
+    } else if (type === 'linkType') {
+      resourceFolder = this.paths.linkTypesFolder;
+    } else if (type === 'template') {
+      resourceFolder = this.paths.templatesFolder;
+    } else if (type === 'workflow') {
+      resourceFolder = this.paths.workflowsFolder;
+    } else if (type === 'report') {
+      resourceFolder = this.paths.reportsFolder;
+    } else {
+      return [];
+    }
+
+    const resources: Resource[] = [];
+    if (!pathExists(resourceFolder)) {
+      // for some reason, the specific resource folder does not exists
+      console.error(`Cannot find folder '${resourceFolder}'`);
+      return [];
+    }
+    const entries = readdirSync(resourceFolder, { withFileTypes: true });
+    resources.push(
+      ...entries
+        .filter((entry) => {
+          return !(
+            entry.isFile() && entry.name === CardContainer.schemaContentFile
+          );
+        })
+        .filter((entry) => {
+          return !(entry.isFile() && entry.name === '.gitkeep');
+        })
+        .filter((entry) => {
+          return requirement === 'folder'
+            ? entry.isDirectory()
+            : requirement === 'file'
+              ? entry.isFile()
+              : false;
+        })
+        .map((entry) => {
+          return {
+            name: `${this.prefix}/${type}s/${entry.name}`,
+            path: entry.parentPath,
+          };
+        }),
+    );
+
+    return resources;
+  }
+
+  /**
+   * Collects all local resources.
+   */
+  public collectLocalResources() {
+    this.localCalculations = this.resourcesSync('calculation', 'file');
+    this.localCardTypes = this.resourcesSync('cardType', 'file');
+    this.localFieldTypes = this.resourcesSync('fieldType', 'file');
+    this.localLinkTypes = this.resourcesSync('linkType', 'file');
+    this.localReports = this.resourcesSync('report', 'folder');
+    this.localTemplates = this.resourcesSync('template', 'folder');
+    this.localWorkflows = this.resourcesSync('workflow', 'file');
+  }
+
+  /**
+   * Collect specific resource from modules.
+   * @param type Type of resource (e.g. 'templates').
+   * @returns array of collected items.
+   */
+  public async collectResourcesFromModules(type: string) {
+    return (await this.addResourcesFromModules(type)).map((item) => item.name);
+  }
+
+  /**
+   * Add a given 'resource' to the local resource arrays.
+   * @param resource Resource to add.
+   */
+  public add(resource: Resource) {
+    const { type } = resourceNameParts(resource.name);
+    // todo: should prevent duplicates
+    switch (type) {
+      case 'cardTypes':
+        this.localCardTypes.push(resource);
+        break;
+      case 'fieldTypes':
+        this.localFieldTypes.push(resource);
+        break;
+      case 'linkTypes':
+        this.localLinkTypes.push(resource);
+        break;
+      case 'reports':
+        this.localReports.push(resource);
+        break;
+      case 'templates':
+        this.localTemplates.push(resource);
+        break;
+      case 'workflows':
+        this.localWorkflows.push(resource);
+        break;
+      default: {
+        throw new Error(`Resource type '${type}' not handled in 'addResource'`);
+      }
+    }
+  }
+
+  /**
+   * Re-collects local resources.
+   */
+  public changed() {
+    this.collectLocalResources();
+  }
+
+  /**
+   * Re-collects imported module resources.
+   */
+  public async moduleImported() {
+    const promises = [];
+    promises.push(this.collectResourcesFromModules('calculations'));
+    promises.push(this.collectResourcesFromModules('cardTypes'));
+    promises.push(this.collectResourcesFromModules('fieldTypes'));
+    promises.push(this.collectResourcesFromModules('linkTypes'));
+    promises.push(this.collectResourcesFromModules('reports'));
+    promises.push(this.collectResourcesFromModules('templates'));
+    promises.push(this.collectResourcesFromModules('workflows'));
+    Promise.all(promises);
+  }
+
+  /**
+   * Removes a resource from Project.
+   * @param resource Resource to remove.
+   */
+  public remove(resource: Resource) {
+    const { type } = resourceNameParts(resource.name);
+    let arrayToModify: Resource[];
+    switch (type) {
+      case 'cardTypes':
+        arrayToModify = this.localCardTypes;
+        break;
+      case 'fieldTypes':
+        arrayToModify = this.localFieldTypes;
+        break;
+      case 'linkTypes':
+        arrayToModify = this.localLinkTypes;
+        break;
+      case 'reports':
+        arrayToModify = this.localReports;
+        break;
+      case 'templates':
+        arrayToModify = this.localTemplates;
+        break;
+      case 'workflows':
+        arrayToModify = this.localWorkflows;
+        break;
+      default: {
+        throw new Error(
+          `Resource type '${type}' not handled in 'removeResource'`,
+        );
+      }
+    }
+    const index = arrayToModify.indexOf(resource, 0);
+    if (index > -1) {
+      arrayToModify.splice(index, 1);
+    }
+  }
+
+  /**
+   * Returns resource's metadata.
+   * @param type Type of resource (e.g. 'templates').
+   * @param name Name of the resource, in long name format.
+   * @param from Defines where resources are collected from.
+   * @returns Resources metadata, or undefined if resource was not found.
+   * @note that caller need to convert this to specific type (e.g "as unknown as Workflow")
+   */
+  public async resource(
+    type: string,
+    name: string,
+    from: ResourcesFrom,
+  ): Promise<object | undefined> {
+    if (!name) {
+      return undefined;
+    }
+    if (!name.endsWith('.json')) {
+      name += '.json';
+    }
+    const found = (await this.resources(type, from)).find(
+      (item) => item.name === name && item.path,
+    );
+    if (!found || !found.path) {
+      return undefined;
+    }
+    const file = await readJsonFile(join(found.path, basename(found.name)));
+    return file;
+  }
+
+  /**
+   * Checks if resource of 'type' with 'name' exists.
+   * @param type Type of resource (e.g. 'templates').
+   * @param name Name of the resource, in long name format.
+   * @returns true, if resource exits, false otherwise.
+   */
+  public async resourceExists(type: string, name: string): Promise<boolean> {
+    if (!name) {
+      return false;
+    }
+    return (await this.resources(type)).some((item) => item.name === name);
+  }
+
+  /**
+   * Returns resources of 'type'. Returned resources are either local, or from modules or all of them.
+   * @param type Type of resource (e.g. 'templates').
+   * @param from Defines where resources are collected from.
+   * @returns Array of resources.
+   */
+  public async resources(
+    type: string,
+    from: ResourcesFrom = ResourcesFrom.all,
+  ): Promise<Resource[]> {
+    const moduleResources =
+      from !== ResourcesFrom.localOnly
+        ? await this.addResourcesFromModules(type)
+        : [];
+
+    const localResourcesOfType = this.localResources(type);
+    return this.joinResources(from, localResourcesOfType, moduleResources);
+  }
+}

--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -179,7 +179,9 @@ export class Template extends CardContainer {
           card.path = card.path.replace(templatesFolder, tempDestination);
         }
         // @todo: could just fetch initial state based on card
-        const cardType = await this.project.cardType(card.metadata?.cardType);
+        const cardType = await this.project.cardType(
+          card.metadata?.cardType || '',
+        );
         if (!cardType) {
           throw new Error(
             `Card type '${card.metadata?.cardType}' of card ${card.key} cannot be found`,
@@ -353,8 +355,8 @@ export class Template extends CardContainer {
 
   /**
    * Adds a new card to template.
-   * @param {string} cardType card type
-   * @param {string} parentCard parent card; optional - if missing will create a top-level card
+   * @param cardType card type
+   * @param parentCard parent card; optional - if missing will create a top-level card
    * @returns next available card key ID
    */
   public async addCard(cardType: string, parentCard?: Card): Promise<string> {
@@ -430,8 +432,8 @@ export class Template extends CardContainer {
 
   /**
    * Returns details (as defined by cardDetails) of a card.
-   * @param {string} cardKey card key (project prefix and a number, e.g. test_1)
-   * @param {FetchCardDetails} cardDetails which card details are returned.
+   * @param cardKey card key (project prefix and a number, e.g. test_1)
+   * @param cardDetails which card details are returned.
    * @returns Card details, or undefined if the card cannot be found.
    */
   public async cardDetailsById(
@@ -543,7 +545,7 @@ export class Template extends CardContainer {
   /**
    * Returns specific card.
    * @param cardKey Card key to find from template.
-   * @param cardDetails Card details to include in return value.
+   * @param details Card details to include in return value.
    * @returns specific card details
    */
   public async findSpecificCard(
@@ -641,7 +643,7 @@ export class Template extends CardContainer {
 
   /**
    * Returns template's project.
-   * @returns {Project} Template's project.
+   * @returns Template's project.
    */
   public get templateProject(): Project {
     return this.project;

--- a/tools/data-handler/src/import.ts
+++ b/tools/data-handler/src/import.ts
@@ -70,7 +70,9 @@ export class Import {
       const card = await this.project.findSpecificCard(cardKey, {
         metadata: true,
       });
-      const cardType = await this.project.cardType(card?.metadata?.cardType);
+      const cardType = await this.project.cardType(
+        card?.metadata?.cardType || '',
+      );
 
       if (!cardType) {
         throw new Error(`Card type not found for card ${cardKey}`);
@@ -129,5 +131,8 @@ export class Import {
 
     // Copy files.
     await copyDir(sourcePath, destinationPath);
+
+    // Update the resources.
+    await this.project.collectModuleResources();
   }
 }

--- a/tools/data-handler/src/rename.ts
+++ b/tools/data-handler/src/rename.ts
@@ -175,7 +175,11 @@ export class Rename extends EventEmitter {
   // Updates card type's metadata.
   // todo: once 'name' is dropped; can be simplified.
   private async updateCardTypeMetadata(cardTypeName: string) {
-    const cardType = await this.project.cardType(cardTypeName, true);
+    const cardType = await this.project.cardType(
+      cardTypeName,
+      ResourcesFrom.localOnly,
+      true,
+    );
     if (cardType) {
       //cardType.name = this.updateResourceName(cardTypeName);
       cardType.workflow = this.updateResourceName(cardType.workflow);
@@ -247,7 +251,7 @@ export class Rename extends EventEmitter {
   /**
    * Renames project prefix.
    * @throws if trying to rename with current name
-   * @param {string} to Card id, or template name
+   * @param to Card id, or template name
    */
   public async rename(to: string) {
     const cardContent = {

--- a/tools/data-handler/src/validate.ts
+++ b/tools/data-handler/src/validate.ts
@@ -528,8 +528,8 @@ export class Validate {
 
   /**
    * Validate schema that matches schemaId from path.
-   * @param {string} projectPath path to schema
-   * @param {string} schemaId schema's id
+   * @param projectPath path to schema
+   * @param schemaId schema's id
    * @returns string containing all validation errors
    */
   public async validateSchema(
@@ -638,8 +638,8 @@ export class Validate {
   /**
    * Checks if card's current workflow state matches workflow that card's card type is using.
    * Template cards are expected to have empty workflow state.
-   * @param {Project} project Project object.
-   * @param {card} card Card object to validate
+   * @param project Project object.
+   * @param card Card object to validate
    * @returns string containing all validation errors
    */
   public async validateWorkflowState(
@@ -654,7 +654,7 @@ export class Validate {
       );
     }
 
-    const cardType = await project.cardType(card.metadata?.cardType);
+    const cardType = await project.cardType(card.metadata?.cardType || '');
     if (!cardType) {
       validationErrors.push(
         `Card '${card.key}' has invalid card type '${card.metadata?.cardType}'`,


### PR DESCRIPTION
Separate resource handling from `Project` to its own class.  
From now on, `Project` is basically a stack of cards (`CardContainer`) and `ResourceCollector` owner. 
This change is not visible to other parts of the sources; the changes to various commands is due to fixing the `cardType` api (INTDEV-548) in this PR as well.