### PR TITLE
Change static macros import to dynamic to avoid warning

### DIFF
--- a/tools/data-handler/src/export.ts
+++ b/tools/data-handler/src/export.ts
@@ -26,7 +26,6 @@ import { sortItems } from './utils/lexorank.js';
 import { QueryResult } from './types/queries.js';
 import { Show } from './show.js';
 import { Calculate } from './calculate.js';
-import { evaluateMacros } from './macros/index.js';
 
 const attachmentFolder: string = 'a';
 
@@ -173,6 +172,7 @@ export class Export {
     let asciiDocContent = '';
     const projectPath = this.project.basePath;
     try {
+      const { evaluateMacros } = await import('./macros/index.js');
       asciiDocContent = await evaluateMacros(
         cardDetailsResponse.content || '',
         {


### PR DESCRIPTION
This is to silence the "ExperimentalWarning: Importing JSON modules is an experimental feature and might change at any time" warning. It will still appear when the export command is used. This is a intermediate fix that should be removed once we find a better way to deal with this.