### PR TITLE
INTDEV-536 Push validation to commands. Simplify CommandHandler

### DIFF
--- a/tools/app/app/api/cardTypes/route.tsx
+++ b/tools/app/app/api/cardTypes/route.tsx
@@ -47,7 +47,7 @@ export async function GET(request: NextRequest) {
     return new NextResponse('No card type', { status: 400 });
   }
 
-  const commands = CommandManager.getInstance(projectPath);
+  const commands = await CommandManager.getInstance(projectPath);
   const detailsResponse = await commands.showCmd.showCardTypeDetails(cardType);
 
   if (detailsResponse) {

--- a/tools/app/app/api/cards/[key]/a/[attachment]/route.tsx
+++ b/tools/app/app/api/cards/[key]/a/[attachment]/route.tsx
@@ -55,7 +55,7 @@ export async function GET(request: NextRequest) {
     return new NextResponse('Missing cardKey or filename', { status: 400 });
   }
 
-  const commands = CommandManager.getInstance(projectPath);
+  const commands = await CommandManager.getInstance(projectPath);
   try {
     const attachmentResponse = await commands.showCmd.showAttachment(
       cardKey,

--- a/tools/app/app/api/cards/[key]/a/route.tsx
+++ b/tools/app/app/api/cards/[key]/a/route.tsx
@@ -63,7 +63,7 @@ export async function POST(
       })),
   );
 
-  const commands = CommandManager.getInstance(projectPath);
+  const commands = await CommandManager.getInstance(projectPath);
 
   const succeeded = [];
   let error: Error | null = null;

--- a/tools/app/app/api/cards/[key]/route.tsx
+++ b/tools/app/app/api/cards/[key]/route.tsx
@@ -115,7 +115,7 @@ export async function PATCH(request: NextRequest) {
   if (!projectPath) {
     return new NextResponse('project_path not set', { status: 500 });
   }
-  const commands = CommandManager.getInstance(projectPath);
+  const commands = await CommandManager.getInstance(projectPath);
 
   // Last URL segment is the search parameter
   const key = request.nextUrl.pathname.split('/')?.pop();
@@ -210,7 +210,7 @@ async function getCardDetails(
     parent: false,
   };
 
-  const commands = CommandManager.getInstance(projectPath);
+  const commands = await CommandManager.getInstance(projectPath);
   try {
     const cardDetailsResponse = await commands.showCmd.showCardDetails(
       fetchCardDetails,
@@ -263,7 +263,7 @@ export async function DELETE(request: NextRequest) {
   if (!projectPath) {
     return new NextResponse('project_path not set', { status: 500 });
   }
-  const commands = CommandManager.getInstance(projectPath);
+  const commands = await CommandManager.getInstance(projectPath);
 
   const key = request.nextUrl.pathname.split('/')?.pop();
 
@@ -301,7 +301,7 @@ export async function POST(request: NextRequest) {
     });
   }
 
-  const commands = CommandManager.getInstance(projectPath);
+  const commands = await CommandManager.getInstance(projectPath);
 
   try {
     return NextResponse.json(

--- a/tools/app/app/api/cards/route.tsx
+++ b/tools/app/app/api/cards/route.tsx
@@ -38,7 +38,7 @@ export async function GET() {
     });
   }
 
-  const commands = CommandManager.getInstance(projectPath);
+  const commands = await CommandManager.getInstance(projectPath);
 
   let projectResponse: ProjectMetadata;
   try {

--- a/tools/app/app/api/fieldTypes/route.tsx
+++ b/tools/app/app/api/fieldTypes/route.tsx
@@ -36,7 +36,7 @@ export async function GET() {
       status: 500,
     });
   }
-  const commands = CommandManager.getInstance(projectPath);
+  const commands = await CommandManager.getInstance(projectPath);
 
   try {
     commands.showCmd.showProject();

--- a/tools/app/app/api/linkTypes/route.tsx
+++ b/tools/app/app/api/linkTypes/route.tsx
@@ -36,7 +36,7 @@ export async function GET() {
       status: 500,
     });
   }
-  const commands = CommandManager.getInstance(projectPath);
+  const commands = await CommandManager.getInstance(projectPath);
 
   try {
     commands.showCmd.showProject();

--- a/tools/app/app/api/templates/route.tsx
+++ b/tools/app/app/api/templates/route.tsx
@@ -36,7 +36,7 @@ export async function GET() {
       status: 500,
     });
   }
-  const commands = CommandManager.getInstance(projectPath);
+  const commands = await CommandManager.getInstance(projectPath);
 
   try {
     commands.showCmd.showProject();

--- a/tools/app/app/api/tree/route.tsx
+++ b/tools/app/app/api/tree/route.tsx
@@ -35,7 +35,7 @@ export async function GET() {
     });
   }
   try {
-    const commands = CommandManager.getInstance(projectPath);
+    const commands = await CommandManager.getInstance(projectPath);
     await commands.calculateCmd.generate();
     const tree = await commands.calculateCmd.runQuery('tree');
     return NextResponse.json(tree);

--- a/tools/app/app/lib/api/actions/attachments.ts
+++ b/tools/app/app/lib/api/actions/attachments.ts
@@ -19,7 +19,7 @@ export async function addAttachments(key: string, formData: FormData) {
     return new Error('project_path environment variable not set.');
   }
 
-  const commands = CommandManager.getInstance(projectPath);
+  const commands = await CommandManager.getInstance(projectPath);
   const createCommand = commands.createCmd;
   const removeCommand = commands.removeCmd;
 
@@ -70,7 +70,7 @@ export async function removeAttachment(key: string, filename: string) {
   if (!projectPath) {
     return new Error('project_path environment variable not set.');
   }
-  const commands = CommandManager.getInstance(projectPath);
+  const commands = await CommandManager.getInstance(projectPath);
   await commands.removeCmd.remove('attachment', key, filename);
 }
 
@@ -85,6 +85,6 @@ export async function openAttachment(key: string, filename: string) {
   if (!projectPath) {
     return new Error('project_path environment variable not set.');
   }
-  const commands = CommandManager.getInstance(projectPath);
+  const commands = await CommandManager.getInstance(projectPath);
   await commands.showCmd.openAttachment(key, filename);
 }

--- a/tools/app/app/lib/api/actions/link.ts
+++ b/tools/app/app/lib/api/actions/link.ts
@@ -23,7 +23,7 @@ export async function createLink(
   if (!projectPath) {
     return new Error('project_path environment variable not set.');
   }
-  const commands = CommandManager.getInstance(projectPath);
+  const commands = await CommandManager.getInstance(projectPath);
   await commands.createCmd.createLink(
     fromCard,
     toCard,
@@ -42,7 +42,7 @@ export async function removeLink(
   if (!projectPath) {
     return new Error('project_path environment variable not set.');
   }
-  const commands = CommandManager.getInstance(projectPath);
+  const commands = await CommandManager.getInstance(projectPath);
   await commands.removeCmd.remove(
     'link',
     fromCard,

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -16,13 +16,18 @@ import {
   CardsOptions,
   Cmd,
   Commands,
+  ExportFormats,
   requestStatus,
+  ShowTypes,
 } from '@cyberismocom/data-handler';
 
 // Handle the response object from data-handler
 function handleResponse(response: requestStatus) {
   if (response.statusCode === 200) {
     if (response.payload) {
+      if (response.message) {
+        console.log(response.message);
+      }
       console.log(JSON.stringify(response.payload, null, 2));
     } else if (response.message) {
       console.log(response.message);
@@ -45,7 +50,7 @@ function parseTypes(types: string[], value: string): string {
 
 // Parse allowed types for show command.
 function parseSupportedTypes(value: string): string {
-  return parseTypes(commandHandler.allAllowedTypes(), value);
+  return parseTypes(ShowTypes.all(), value);
 }
 
 // Commander
@@ -333,7 +338,9 @@ program
   .command('export')
   .description('Export a project or a card')
   .addArgument(
-    new Argument('<format>', 'Export format').choices(['adoc', 'html', 'site']),
+    new Argument('<format>', 'Export format').choices(
+      Object.values(ExportFormats),
+    ),
   )
   .argument('<output>', 'Output path')
   .argument('[cardKey]', 'Path to card')
@@ -341,7 +348,7 @@ program
   .action(
     async (
       format: string,
-      output: string,
+      output: ExportFormats,
       cardKey: string,
       options: CardsOptions,
     ) => {
@@ -389,8 +396,6 @@ importCmd
     );
     handleResponse(result);
   });
-
-// todo: Link command
 
 // Move command
 program
@@ -558,7 +563,6 @@ program
   });
 
 // Show command
-// todo: add later support for more types: link
 program
   .command('show')
   .description('Shows resource types in a project')

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -43,6 +43,7 @@ import { readJsonFile } from '../utils/json.js';
 import { Template } from './template.js';
 import { Validate } from '../validate.js';
 import { generateRandomString } from '../utils/random.js';
+import { identifierFromResourceName } from '../utils/resource-utils.js';
 
 // base class
 import { CardContainer } from './card-container.js';
@@ -394,7 +395,7 @@ export class Project extends CardContainer {
   public async createTemplateObject(
     template: Resource,
   ): Promise<Template | undefined> {
-    template.name = Template.normalizedTemplateName(template.name);
+    template.name = identifierFromResourceName(template.name);
 
     if (template.name === '' || !(await this.templateExists(template.name))) {
       return undefined;
@@ -866,7 +867,7 @@ export class Project extends CardContainer {
   /**
    * Checks if a given resource exists in the project already.
    * @param resourceType Type of resource as a string.
-   * @param name Name of the resource in long format.
+   * @param name Valid name of resource.
    * @returns boolean, true if resource exists; false otherwise.
    */
   public async resourceExists(

--- a/tools/data-handler/src/containers/project/project-paths.ts
+++ b/tools/data-handler/src/containers/project/project-paths.ts
@@ -97,19 +97,19 @@ export class ProjectPaths {
   }
 
   /**
-   * Returns full name of a resource.
+   * Returns valid name of a resource.
    * @param resourceType Type of resource
    * @param resourceName Resource name
-   * @returns full name of a resource (prefix/type/name)
+   * @returns name of a resource (prefix/type/name)
    */
   public resourceFullName(
     resourceType: ResourceFolderType,
     resourceName: string,
   ): string {
-    const { prefix, type, name } = resourceNameParts(resourceName);
+    const { identifier, prefix, type } = resourceNameParts(resourceName);
     const actualPrefix = prefix ? prefix : this.prefix;
     const actualType = type ? type : `${resourceType}s`;
-    return `${actualPrefix}/${actualType}s/${name}`;
+    return `${actualPrefix}/${actualType}s/${identifier}`;
   }
 
   /**

--- a/tools/data-handler/src/containers/project/resource-collector.ts
+++ b/tools/data-handler/src/containers/project/resource-collector.ts
@@ -312,7 +312,7 @@ export class ResourceCollector {
   /**
    * Returns resource's metadata.
    * @param type Type of resource (e.g. 'templates').
-   * @param name Name of the resource, in long name format.
+   * @param name Name of the resource.
    * @param from Defines where resources are collected from.
    * @returns Resources metadata, or undefined if resource was not found.
    * @note that caller need to convert this to specific type (e.g "as unknown as Workflow")
@@ -341,7 +341,7 @@ export class ResourceCollector {
   /**
    * Checks if resource of 'type' with 'name' exists.
    * @param type Type of resource (e.g. 'templates').
-   * @param name Name of the resource, in long name format.
+   * @param name Name of the resource.
    * @returns true, if resource exits, false otherwise.
    */
   public async resourceExists(type: string, name: string): Promise<boolean> {

--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -26,7 +26,7 @@ import {
   TemplateConfiguration as TemplateInterface,
 } from '../interfaces/project-interfaces.js';
 import { TemplateMetadata } from '../interfaces/resource-interfaces.js';
-import { copyDir, pathExists, sepRegex } from '../utils/file-utils.js';
+import { copyDir, pathExists } from '../utils/file-utils.js';
 import { readJsonFile, writeJsonFile } from '../utils/json.js';
 import { Project } from './project.js';
 
@@ -39,6 +39,7 @@ import {
   sortItems,
 } from '../utils/lexorank.js';
 import { logger } from '../utils/log-utils.js';
+import { identifierFromResourceName } from '../utils/resource-utils.js';
 
 // Simple mapping table for card instantiation
 interface mappingValue {
@@ -328,8 +329,7 @@ export class Template extends CardContainer {
 
   // Set path to template location.
   private setTemplatePath(templateName: string): string {
-    const normalizedTemplateName =
-      Template.normalizedTemplateName(templateName);
+    const normalizedTemplateName = identifierFromResourceName(templateName);
     if (normalizedTemplateName === '') {
       throw new Error(`Invalid template name: '${templateName}'`);
     }
@@ -578,24 +578,6 @@ export class Template extends CardContainer {
    */
   public async listCards(): Promise<Card[]> {
     return super.cards(this.templateCardsPath);
-  }
-
-  /**
-   * Returns template name without 'local'.
-   * @param templateName full template name.
-   * @returns template name without 'local' part, or empty string if name is invalid.
-   */
-  public static normalizedTemplateName(templateName: string): string {
-    const parts = templateName.split(sepRegex);
-    if (parts.length == 0 || parts.length > 3) {
-      return '';
-    }
-    if (parts.length === 3) {
-      if (parts[0] === 'local') {
-        return parts[2];
-      }
-    }
-    return templateName;
   }
 
   /**

--- a/tools/data-handler/src/export-site.ts
+++ b/tools/data-handler/src/export-site.ts
@@ -270,7 +270,7 @@ export class ExportSite extends Export {
     destination: string,
     cardKey?: string,
     options?: ExportOptions,
-  ) {
+  ): Promise<string> {
     this.options = options;
     const sourcePath: string = cardKey
       ? join(
@@ -282,6 +282,12 @@ export class ExportSite extends Export {
 
     // If doing a partial tree export, put the parent information as it would have already been gathered.
     if (cardKey) {
+      const card = await this.project.findSpecificCard(cardKey);
+      if (!card) {
+        throw new Error(
+          `Input validation error: cannot find card '${cardKey}'`,
+        );
+      }
       cards.push({
         key: cardKey,
         path: sourcePath,
@@ -311,5 +317,6 @@ export class ExportSite extends Export {
     }
 
     await this.export(destination, cards);
+    return '';
   }
 }

--- a/tools/data-handler/src/import.ts
+++ b/tools/data-handler/src/import.ts
@@ -18,6 +18,7 @@ import { Project } from './containers/project.js';
 import { readCsvFile } from './utils/csv.js';
 import { Validate } from './validate.js';
 import { Create } from './create.js';
+import { pathExists } from './utils/file-utils.js';
 
 export class Import {
   constructor(
@@ -97,8 +98,6 @@ export class Import {
           await this.project.updateCardMetadataKey(cardKey, key, value);
         }
       }
-      // NOTE: this is for the cli
-      console.log(`Successfully imported card ${title}`);
       importedCards.push(cardKey);
     }
     return importedCards;
@@ -112,6 +111,21 @@ export class Import {
    * @param destination Path to project that will receive the imported module
    */
   public async importProject(source: string, destination: string) {
+    if (!Validate.validateFolder(source)) {
+      throw new Error(
+        `Input validation error: folder name is invalid '${source}'`,
+      );
+    }
+    if (!pathExists(source)) {
+      throw new Error(
+        `Input validation error: cannot find project '${source}'`,
+      );
+    }
+    if (!pathExists(destination)) {
+      throw new Error(
+        `Input validation error: destination does not exist '${destination}'`,
+      );
+    }
     const destinationProject = new Project(destination);
     const sourceProject = new Project(source);
     const modulePrefix = sourceProject.projectPrefix;

--- a/tools/data-handler/src/index.ts
+++ b/tools/data-handler/src/index.ts
@@ -15,7 +15,17 @@ import {
   Cmd,
   Commands,
   CommandManager,
+  ExportFormats,
+  ShowTypes,
 } from './command-handler.js';
 import { requestStatus } from './interfaces/request-status-interfaces.js';
 
-export { CardsOptions, Cmd, CommandManager, Commands, requestStatus };
+export {
+  CardsOptions,
+  Cmd,
+  CommandManager,
+  Commands,
+  ExportFormats,
+  requestStatus,
+  ShowTypes,
+};

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -12,8 +12,6 @@
 
 import { Link, TemplateMetadata } from './resource-interfaces.js';
 
-// @todo: consider splitting this to several smaller files.
-
 // Single card; either in project or in template.
 export interface Card {
   key: string;

--- a/tools/data-handler/src/remove.ts
+++ b/tools/data-handler/src/remove.ts
@@ -162,7 +162,7 @@ export class Remove extends EventEmitter {
       throw new Error(`Module '${moduleName}' not found`);
     }
     await deleteDir(module);
-    // todo: update project
+    await this.project.collectModuleResources();
   }
 
   // Removes template from project
@@ -188,15 +188,31 @@ export class Remove extends EventEmitter {
 
   /**
    * Removes either attachment, card or template from project.
-   * @param {RemovableResourceTypes} type Type of resource
-   * @param {string} targetName Card id, or template name
-   * @param {string} args Additional arguments, such as attachment filename
+   * @param type Type of resource
+   * @param targetName Card id, or template name
+   * @param rest Additional arguments, such as attachment filename
    */
   public async remove(
     type: RemovableResourceTypes,
     targetName: string,
     ...rest: any[] // eslint-disable-line @typescript-eslint/no-explicit-any
   ) {
+    if (type === 'attachment' && rest.length !== 1 && !rest[0]) {
+      throw new Error(
+        `Input validation error: must pass argument 'detail' if requesting to remove attachment`,
+      );
+    }
+
+    if (
+      type === 'link' &&
+      [2, 3].includes(rest.length) &&
+      !rest[0] &&
+      !rest[1]
+    ) {
+      throw new Error(
+        `Input validation error: must pass arguments 'source', 'destination' and possibly 'linkType' if requesting to remove link`,
+      );
+    }
     switch (type) {
       case 'attachment':
         return this.removeAttachment(targetName, rest[0]);

--- a/tools/data-handler/src/rename.ts
+++ b/tools/data-handler/src/rename.ts
@@ -115,9 +115,11 @@ export class Rename extends EventEmitter {
   // Update card's metadata.
   private async updateCardMetadata(card: Card): Promise<void> {
     if (card.metadata?.cardType && card.metadata?.cardType.length > 0) {
-      const { prefix, type, name } = resourceNameParts(card.metadata.cardType);
+      const { identifier, prefix, type } = resourceNameParts(
+        card.metadata.cardType,
+      );
       if (prefix === this.from) {
-        card.metadata.cardType = `${this.project.configuration.cardKeyPrefix}/${type}/${name}`;
+        card.metadata.cardType = `${this.project.configuration.cardKeyPrefix}/${type}/${identifier}`;
         // Update card' custom fields
         const keys = Object.keys(card.metadata);
         for (const oldKey of keys) {
@@ -141,10 +143,10 @@ export class Rename extends EventEmitter {
 
   // Changes the name of a resource to match the new prefix.
   private updateResourceName(resourceName: string) {
-    const { prefix, type, name } = resourceNameParts(resourceName);
+    const { identifier, prefix, type } = resourceNameParts(resourceName);
     // do not rename module resources
     return this.from === prefix
-      ? `${this.project.configuration.cardKeyPrefix}/${type}/${name}`
+      ? `${this.project.configuration.cardKeyPrefix}/${type}/${identifier}`
       : resourceName;
   }
 
@@ -253,10 +255,14 @@ export class Rename extends EventEmitter {
 
   /**
    * Renames project prefix.
+   * @throws if trying to use empty 'to'
    * @throws if trying to rename with current name
    * @param to Card id, or template name
    */
   public async rename(to: string) {
+    if (!to) {
+      throw new Error(`Input validation error: empty 'to' is not allowed`);
+    }
     const cardContent = {
       metadata: true,
       attachments: true,

--- a/tools/data-handler/src/show.ts
+++ b/tools/data-handler/src/show.ts
@@ -304,7 +304,7 @@ export class Show {
    * @returns all available field-types
    */
   public async showFieldTypes(): Promise<string[]> {
-    // todo: make a common function that strips away the extension. Or use basename().
+    // todo: make a common function that strips away the extension.
     const fieldTypes = (await this.project.fieldTypes())
       .map((item) => item.name.split('.').slice(0, -1).join('.'))
       .sort();

--- a/tools/data-handler/src/utils/resource-utils.ts
+++ b/tools/data-handler/src/utils/resource-utils.ts
@@ -8,39 +8,73 @@
 */
 
 import { parse } from 'node:path';
+import { sepRegex } from './file-utils.js';
 
 // Resource name parts are:
 // - prefix; name of the project this resource is part of
 // - type; type of resource; in plural
-// - name; actual name for the resource
+// - identifier; unique name (within a project/module) for the resource
 interface ResourceName {
   prefix: string;
   type: string;
-  name: string;
+  identifier: string;
+}
+
+// Indexes of resource name parts
+const PREFIX_INDEX = 0;
+const TYPE_INDEX = 1;
+const IDENTIFIER_INDEX = 2;
+// Valid resource name has three parts
+const RESOURCE_NAME_PARTS = 3;
+
+const LOCAL_RESOURCE = 'local';
+
+// Checks if name is valid (3 parts, separated by '/').
+export function isResourceName(name: string): boolean {
+  const partsCount = name.split('/').length;
+  return partsCount === RESOURCE_NAME_PARTS;
+}
+
+/**
+ * Returns resource name as identifier. In error cases, returns empty resource.
+ * @param resourceName Name of the resource.
+ * @returns resource name as identifier.
+ */
+export function identifierFromResourceName(resourceName: string): string {
+  const parts = resourceName.split(sepRegex);
+  if (parts.length == 0 || parts.length > RESOURCE_NAME_PARTS) {
+    return '';
+  }
+  if (parts.length === RESOURCE_NAME_PARTS) {
+    if (parts[PREFIX_INDEX] === LOCAL_RESOURCE) {
+      return parts[IDENTIFIER_INDEX];
+    }
+  }
+  return resourceName;
 }
 
 /**
  * Returns resource name parts (project prefix, type in plural, name of the resource).
- * @param resourceName Full name of the resource (e.g. <prefix>/<type>/<name>)
+ * @param resourceName Name of the resource (e.g. <prefix>/<type>/<name>)
  * @throws if 'resourceName' is not valid resource name.
  * @returns resource name parts: project or module prefix, resource type (plural) and actual name of the resource.
  */
 export function resourceNameParts(resourceName: string): ResourceName {
   const parts = resourceName.split('/');
-  // short name format - type and prefix are unknown
+  // just resource identifier - type and prefix are unknown
   if (parts.length === 1 && parts.at(0) !== '') {
     return {
       prefix: '',
       type: '',
-      name: resourceName,
+      identifier: resourceName,
     };
   }
-  // long name format
-  if (parts.length === 3) {
+  // resource name
+  if (parts.length === RESOURCE_NAME_PARTS) {
     return {
-      prefix: parts[0],
-      type: parts[1],
-      name: parse(parts[2]).name,
+      prefix: parts[PREFIX_INDEX],
+      type: parts[TYPE_INDEX],
+      identifier: parse(parts[IDENTIFIER_INDEX]).name,
     };
   }
   // other formats are not accepted

--- a/tools/data-handler/test/command-handler-create.test.ts
+++ b/tools/data-handler/test/command-handler-create.test.ts
@@ -640,7 +640,7 @@ describe('create command', () => {
       ['report', reportName],
       optionsMini,
     );
-    expect(result.statusCode).to.equal(500);
+    expect(result.statusCode).to.equal(400);
   });
   // template
   it('template (success)', async () => {
@@ -754,22 +754,8 @@ describe('create command', () => {
     );
     expect(result.statusCode).to.equal(400);
   });
-  // todo: same as test on row 701?
-  it('template invalid template name (reserved Windows filename)', async () => {
-    const templateName = 'aux';
-    const templateContent = '{}';
-    const testOptions = { projectPath: join(testDir, 'test-template.json') };
-    const result = await commandHandler.command(
-      Cmd.create,
-      ['template', templateName, templateContent],
-      testOptions,
-    );
-    expect(result.statusCode).to.equal(400);
-  });
-
   // workflow
   it('workflow (success)', async () => {
-    // todo: SME
     const workflowName = 'uniqueWorkflowName';
     const content = `
         {

--- a/tools/data-handler/test/command-handler-import.test.ts
+++ b/tools/data-handler/test/command-handler-import.test.ts
@@ -1,5 +1,6 @@
 // testing
 import { assert, expect } from 'chai';
+import * as sinon from 'sinon';
 
 // node
 import { mkdirSync, rmSync } from 'node:fs';
@@ -171,14 +172,21 @@ describe('import module', () => {
     });
     */
     it('try to import module - no source', async () => {
+      const stubProjectPath = sinon
+        .stub(commandHandler, 'setProjectPath')
+        .resolves('path');
       const result = await commandHandler.command(
         Cmd.import,
         ['module', ''],
         optionsMini,
       );
       expect(result.statusCode).to.equal(400);
+      stubProjectPath.restore();
     });
     it('try to import module - no destination', async () => {
+      const stubProjectPath = sinon
+        .stub(commandHandler, 'setProjectPath')
+        .resolves('path');
       let result = { statusCode: 0 };
       const invalidOptions = { projectPath: '' };
       try {
@@ -193,7 +201,8 @@ describe('import module', () => {
           // this block is here for linter
         }
       }
-      expect(result.statusCode).to.equal(0);
+      expect(result.statusCode).to.equal(400);
+      stubProjectPath.restore();
     });
     it('try to import module - twice the same module', async () => {
       const result1 = await commandHandler.command(

--- a/tools/data-handler/test/command-handler-remove.test.ts
+++ b/tools/data-handler/test/command-handler-remove.test.ts
@@ -54,7 +54,6 @@ describe('remove command', () => {
       rmSync(testDir, { recursive: true, force: true });
     });
 
-    // @todo: Test case commented out for now;
     // the event emitter from create is creating the files after the content should have been destroyed.
     it('remove card', async () => {
       const card = await createCard(commandHandler);
@@ -69,29 +68,29 @@ describe('remove command', () => {
     it('remove linkType', async () => {
       const name = 'test';
       await createLinkType(commandHandler, name);
-      const fullName = 'decision/linkTypes/' + name;
+      const resourceName = 'decision/linkTypes/' + name;
       const result = await commandHandler.command(
         Cmd.remove,
-        ['linkType', fullName],
+        ['linkType', resourceName],
         options,
       );
       expect(result.statusCode).to.equal(200);
     });
     it('remove link (success)', async () => {
       const linkName = 'test';
-      const linkFullName = 'decision/linkTypes/' + linkName;
+      const resourceName = 'decision/linkTypes/' + linkName;
       await createLinkType(commandHandler, linkName);
       const card = await createCard(commandHandler);
       const cardId = card.affectsCards![0];
       await commandHandler.command(
         Cmd.create,
-        ['link', 'decision_5', cardId, linkFullName],
+        ['link', 'decision_5', cardId, resourceName],
         options,
       );
 
       const result = await commandHandler.command(
         Cmd.remove,
-        ['link', 'decision_5', cardId, linkFullName],
+        ['link', 'decision_5', cardId, resourceName],
         options,
       );
       expect(result.statusCode).to.equal(200);
@@ -100,7 +99,7 @@ describe('remove command', () => {
     // Check that link has disappeared from the first card as well.
     it('removing card removes links (success)', async () => {
       const linkName = 'test';
-      const linkFullName = 'decision/linkTypes/' + linkName;
+      const resourceName = 'decision/linkTypes/' + linkName;
       await createLinkType(commandHandler, linkName);
       const card = await createCard(commandHandler);
       const card2 = await createCard(commandHandler);
@@ -108,7 +107,7 @@ describe('remove command', () => {
       const cardId2 = card2.affectsCards![0];
       let result = await commandHandler.command(
         Cmd.create,
-        ['link', cardId2, cardId, linkFullName],
+        ['link', cardId2, cardId, resourceName],
         options,
       );
       result = await commandHandler.command(
@@ -155,11 +154,11 @@ describe('remove command', () => {
         ['attachment', attachmentPath],
         options,
       );
-      const attachmentFullName = `${cardId}-${attachment}`;
+      const attachmentNameWithCardId = `${cardId}-${attachment}`;
 
       const result = await commandHandler.command(
         Cmd.remove,
-        ['attachment', cardId, attachmentFullName],
+        ['attachment', cardId, attachmentNameWithCardId],
         options,
       );
       expect(result.statusCode).to.equal(200);

--- a/tools/data-handler/test/command-handler-transition.test.ts
+++ b/tools/data-handler/test/command-handler-transition.test.ts
@@ -1,5 +1,6 @@
 // testing
 import { assert, expect } from 'chai';
+import * as sinon from 'sinon';
 
 // node
 import { mkdirSync, rmSync } from 'node:fs';
@@ -67,6 +68,9 @@ describe('transition command', () => {
     expect(result.statusCode).to.equal(200);
   });
   it('missing project', async () => {
+    const stubProjectPath = sinon
+      .stub(commandHandler, 'setProjectPath')
+      .resolves('path');
     try {
       await commandHandler.command(
         Cmd.transition,
@@ -80,6 +84,7 @@ describe('transition command', () => {
         expect(true);
       }
     }
+    stubProjectPath.restore();
   });
   it('missing card', async () => {
     const result = await commandHandler.command(

--- a/tools/data-handler/test/command-handler-validate.test.ts
+++ b/tools/data-handler/test/command-handler-validate.test.ts
@@ -1,5 +1,6 @@
 // testing
 import { assert, expect } from 'chai';
+import * as sinon from 'sinon';
 
 // node
 import { join } from 'node:path';
@@ -16,6 +17,9 @@ const testDir = join(baseDir, 'test/test-data');
 
 describe('command-handler: validate command', () => {
   it('missing path', async () => {
+    const stubProjectPath = sinon
+      .stub(commandHandler, 'setProjectPath')
+      .resolves('path');
     let result: requestStatus = { statusCode: 500 };
     try {
       result = await commandHandler.command(Cmd.validate, [], {});
@@ -25,7 +29,8 @@ describe('command-handler: validate command', () => {
         // this block is here for linter
       }
     }
-    expect(result.statusCode).to.equal(500);
+    expect(result.statusCode).to.equal(400);
+    stubProjectPath.restore();
   });
   it('valid schema', async () => {
     const result = await commandHandler.command(Cmd.validate, [], {

--- a/tools/data-handler/test/export.test.ts
+++ b/tools/data-handler/test/export.test.ts
@@ -49,6 +49,7 @@ describe('export command', () => {
   before(async () => {
     mkdirSync(testDir, { recursive: true });
     await copyDir('test/test-data/', testDir);
+    optionsMini.projectPath = minimalPath;
   });
 
   after(() => {
@@ -92,38 +93,32 @@ describe('export command', () => {
     expect(result.message).to.be.equal(undefined);
     expect(result.statusCode).to.equal(200);
   });
-  it('invalid format', async () => {
-    optionsMini.format = 'wrong';
-    optionsMini.output = join(testDirForExport, 'output');
-    const result = await commandHandler.command(Cmd.export, [], optionsMini);
-    expect(result.statusCode).to.equal(400);
-  });
   it('missing project', async () => {
-    optionsMini.format = 'html';
-    optionsMini.output = join(testDirForExport, 'test/output/');
-    optionsMini.projectPath = 'valid/i-do-not-exist';
-    const result = await commandHandler.command(Cmd.export, [], optionsMini);
+    optionsMini.projectPath = join(testDirForExport, 'valid/i-do-not-exist');
+    const output = 'test/output/';
+    const result = await commandHandler.command(
+      Cmd.export,
+      ['html', output],
+      optionsMini,
+    );
     expect(result.statusCode).to.equal(400);
   });
   it('missing parent card', async () => {
-    optionsMini.format = 'html';
-    optionsMini.output = join(testDirForExport, 'test/output/');
-    optionsMini.projectPath = minimalPath;
+    const output = join(testDirForExport, 'test/output/');
     const card = 'decision_999';
     const result = await commandHandler.command(
       Cmd.export,
-      [card],
+      ['html', output, card],
       optionsMini,
     );
     expect(result.statusCode).to.equal(400);
   });
   it('inaccessible destination', async () => {
-    optionsMini.format = 'html';
-    optionsMini.output = join(testDirForExport, '/i-do-not-exist/output');
+    const output = join(testDirForExport, '/i-do-not-exist/output');
     const card = 'decision_1';
     const result = await commandHandler.command(
       Cmd.export,
-      [card],
+      ['html', output, card],
       optionsMini,
     );
     expect(result.statusCode).to.equal(400);

--- a/tools/data-handler/test/template.test.ts
+++ b/tools/data-handler/test/template.test.ts
@@ -358,21 +358,6 @@ describe('template', () => {
     expect(templateDetails.metadata.category).to.equal('category');
     expect(templateDetails.metadata.displayName).to.equal('Decision');
   });
-  it('normalize template name', () => {
-    const empty = Template.normalizedTemplateName('');
-    const localDecision = Template.normalizedTemplateName(
-      'local/templates/decision',
-    );
-    const decision = Template.normalizedTemplateName('decision');
-    const invalidName = Template.normalizedTemplateName(
-      'more/folders/than/allowed',
-    );
-
-    expect(empty).to.equal('');
-    expect(localDecision).to.equal('decision');
-    expect(decision).to.equal('decision');
-    expect(invalidName).to.equal('');
-  });
   it('list template cards', async () => {
     const decisionRecordsPath = join(testDir, 'valid/decision-records');
     const project = new Project(decisionRecordsPath);

--- a/tools/data-handler/test/utils/resource-utils.test.ts
+++ b/tools/data-handler/test/utils/resource-utils.test.ts
@@ -2,23 +2,26 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
-import { resourceNameParts } from '../../src/utils/resource-utils.js';
+import {
+  identifierFromResourceName,
+  resourceNameParts,
+} from '../../src/utils/resource-utils.js';
 
 describe('resource utils', () => {
   it('resourceNameParts with valid long resource name (success)', () => {
     const resourceName = 'test/test/test';
     // note that resource name util does not handle incorrect prefixes, or types
-    const { prefix, type, name } = resourceNameParts(resourceName);
+    const { identifier, prefix, type } = resourceNameParts(resourceName);
     expect(prefix).to.equal('test');
     expect(type).to.equal('test');
-    expect(name).to.equal('test');
+    expect(identifier).to.equal('test');
   });
   it('resourceNameParts with valid short resource name (success)', () => {
     const resourceName = 'test';
-    const { prefix, type, name } = resourceNameParts(resourceName);
+    const { identifier, prefix, type } = resourceNameParts(resourceName);
     expect(prefix).to.equal('');
     expect(type).to.equal('');
-    expect(name).to.equal('test');
+    expect(identifier).to.equal('test');
   });
   it('resourceNameParts with invalid names', () => {
     const invalidResourceNames = ['', 'test/test', 'test/test/test/test'];
@@ -27,5 +30,18 @@ describe('resource utils', () => {
         resourceNameParts(invalidName);
       }).to.throw();
     }
+  });
+  it('normalize resource name', () => {
+    const empty = identifierFromResourceName('');
+    const localDecision = identifierFromResourceName(
+      'local/templates/decision',
+    );
+    const decision = identifierFromResourceName('decision');
+    const invalidName = identifierFromResourceName('more/folders/than/allowed');
+
+    expect(empty).to.equal('');
+    expect(localDecision).to.equal('decision');
+    expect(decision).to.equal('decision');
+    expect(invalidName).to.equal('');
   });
 });


### PR DESCRIPTION
Push as much as possible of input validation to happen in commands themselves. This way both the `CommandHandler` and `CommandManager` both are using the same validation.

Additionally, change all sorts of random things in `CommandHandler`: 
- throw errors from internal methods and only catch them in `commands` method
- remove all the other layers of trap-harnesses
- exit process if no path has been set and cannot be figured out
- fix all command parameter orders to be similar for all commands
- do not pass `this` (or `this.something`) around, but use them directly in the methods
- some logging with stdout has been changed so that the messages are part of `requestStatus`

All references with "long/full name" have been replaced with "(valid) resource name". 
All references with "short name", or "long name"'s name , have been replaced with "identifier".