### PR TITLE
INTDEV-576 Fix renaming crash

### DIFF
--- a/tools/data-handler/src/rename.ts
+++ b/tools/data-handler/src/rename.ts
@@ -181,13 +181,16 @@ export class Rename extends EventEmitter {
       true,
     );
     if (cardType) {
-      //cardType.name = this.updateResourceName(cardTypeName);
+      cardType.name = this.updateResourceName(cardTypeName);
       cardType.workflow = this.updateResourceName(cardType.workflow);
       cardType.customFields.map(
         (field) => (field.name = this.updateResourceName(field.name)),
       );
       cardType.alwaysVisibleFields = cardType.alwaysVisibleFields.map((item) =>
         this.updateResourceName(item),
+      );
+      cardType.optionallyVisibleFields = cardType.optionallyVisibleFields.map(
+        (item) => this.updateResourceName(item),
       );
       const filename = join(
         this.project.paths.cardTypesFolder,
@@ -318,6 +321,6 @@ export class Rename extends EventEmitter {
     );
 
     this.project.collectLocalResources();
-    this.emit('renamed', this.project.basePath);
+    this.emit('renamed');
   }
 }


### PR DESCRIPTION
When `Rename` emitted that data had been changed, it still used a project path parameter, which was removed when `CommandManager` was added. `Calculate` interpreted the parameter as a card key and it led to unhandled property reference. 

Fixed by removing the parameter from emit.


Additionally, added additional, related fixes:
- uncomment the code line that renames cardType `name` . I don't know why it was commented. It leaves the `name` with previous name unless it is changed. 
- rename also the `optionallyVisibleFields`