### PR TITLE
INTDEV-476 Remove all possible resources

### DIFF
--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -463,7 +463,6 @@ rank
 
 // Remove command
 const remove = program.command('remove');
-
 remove
   .command('attachment')
   .argument('<cardKey>', 'cardKey of the owning card')
@@ -477,6 +476,7 @@ remove
     );
     handleResponse(result);
   });
+
 remove
   .command('card')
   .argument('<cardKey>', 'Card key of card to remove')
@@ -485,6 +485,32 @@ remove
     const result = await commandHandler.command(
       Cmd.remove,
       ['card', cardKey],
+      options,
+    );
+    handleResponse(result);
+  });
+
+remove
+  .command('cardType')
+  .argument('<name>', 'Name of the card type to remove')
+  .option('-p, --project-path [path]', `${pathGuideline}`)
+  .action(async (name: string, options: CardsOptions) => {
+    const result = await commandHandler.command(
+      Cmd.remove,
+      ['cardType', name],
+      options,
+    );
+    handleResponse(result);
+  });
+
+remove
+  .command('fieldType')
+  .argument('<name>', 'Name of the field type to remove')
+  .option('-p, --project-path [path]', `${pathGuideline}`)
+  .action(async (name: string, options: CardsOptions) => {
+    const result = await commandHandler.command(
+      Cmd.remove,
+      ['fieldType', name],
       options,
     );
     handleResponse(result);
@@ -514,7 +540,7 @@ remove
 
 remove
   .command('linkType')
-  .argument('<name>', 'Name of the linkType to remove')
+  .argument('<name>', 'Name of the link type to remove')
   .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (name: string, options: CardsOptions) => {
     const result = await commandHandler.command(
@@ -539,6 +565,19 @@ remove
   });
 
 remove
+  .command('report')
+  .argument('<name>', 'Name of the report to remove')
+  .option('-p, --project-path [path]', `${pathGuideline}`)
+  .action(async (name: string, options: CardsOptions) => {
+    const result = await commandHandler.command(
+      Cmd.remove,
+      ['report', name],
+      options,
+    );
+    handleResponse(result);
+  });
+
+remove
   .command('template')
   .argument('<name>', 'Name of the template to remove')
   .option('-p, --project-path [path]', `${pathGuideline}`)
@@ -546,6 +585,19 @@ remove
     const result = await commandHandler.command(
       Cmd.remove,
       ['template', name],
+      options,
+    );
+    handleResponse(result);
+  });
+
+remove
+  .command('workflow')
+  .argument('<name>', 'Name of the workflow to remove')
+  .option('-p, --project-path [path]', `${pathGuideline}`)
+  .action(async (name: string, options: CardsOptions) => {
+    const result = await commandHandler.command(
+      Cmd.remove,
+      ['workflow', name],
       options,
     );
     handleResponse(result);

--- a/tools/data-handler/src/containers/project/resource-collector.ts
+++ b/tools/data-handler/src/containers/project/resource-collector.ts
@@ -232,6 +232,7 @@ export class ResourceCollector {
         this.localFieldTypes.push(resource);
         break;
       case 'linkTypes':
+        resource.name = resource.name + '.json'; //todo: hack "fix", needs a proper fix.
         this.localLinkTypes.push(resource);
         break;
       case 'reports':

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -122,14 +122,17 @@ export interface ProjectSettings {
 }
 
 // Resources that are possible to remove.
-// todo: add possibility to remove calculations, card types, field types, workflows and reports
 export type RemovableResourceTypes =
   | 'attachment'
   | 'card'
+  | 'cardType'
+  | 'fieldType'
   | 'link'
   | 'linkType'
   | 'module'
-  | 'template';
+  | 'report'
+  | 'template'
+  | 'workflow';
 
 // Project resource, such as workflow, template or card type as file system object.
 export interface Resource {
@@ -155,19 +158,15 @@ export type ResourceTypes =
   | 'calculation'
   | 'calculations'
   | 'cards'
-  | 'cardType'
   | 'cardTypes'
-  | 'fieldType'
   | 'fieldTypes'
   | 'links'
   | 'linkTypes'
   | 'modules'
   | 'project'
   | 'projects'
-  | 'report'
   | 'reports'
   | 'templates'
-  | 'workflow'
   | 'workflows';
 
 // Template configuration details.

--- a/tools/data-handler/test/command-handler-import.test.ts
+++ b/tools/data-handler/test/command-handler-import.test.ts
@@ -232,8 +232,20 @@ describe('import module', () => {
   });
 
   describe('modifying imported module content is forbidden', () => {
+    beforeEach(async () => {
+      await commandHandler.command(
+        Cmd.import,
+        ['module', minimalPath],
+        options,
+      );
+      await commandHandler.command(
+        Cmd.import,
+        ['module', decisionRecordsPath],
+        optionsMini,
+      );
+    });
     it('try to add card to module template', async () => {
-      const templateName = 'minimal';
+      const templateName = 'mini/templates/test-template';
       const cardType = 'decision/cardTypes/decision';
       const cardKey = '';
       const result = await commandHandler.command(
@@ -241,12 +253,10 @@ describe('import module', () => {
         [templateName, cardType, cardKey],
         options,
       );
-      // todo: the reason why this fails is due to a bug where templates with names without module
-      //       name are the same (one local, one imported)
       expect(result.statusCode).to.equal(400);
     });
     it('try to add child card to a module card', async () => {
-      const templateName = 'decision';
+      const templateName = 'decision/templates/decision';
       const cardType = 'decision/cardTypes/decision';
       const cardKey = 'decision_2';
       // try to add new card to decision_2 when 'decision-records' has been imported to 'minimal'
@@ -255,11 +265,8 @@ describe('import module', () => {
         [templateName, cardType, cardKey],
         optionsMini,
       );
-      // todo: the reason why this fails is due to a bug where templates with names without module
-      //       name are the same (one local, one imported)
       expect(result.statusCode).to.equal(400);
     });
-
     it('try to create attachment to a module card', async () => {
       const attachmentPath = join(testDir, 'attachments/the-needle.heic');
       const cardKey = 'decision_2';
@@ -272,10 +279,11 @@ describe('import module', () => {
     });
 
     it('try to move a module card to another template', async () => {
-      const cardKey = 'decision_2';
+      const moduleCardKey = 'decision_2';
+      const templateCardKey = 'decision_1';
       const result = await commandHandler.command(
         Cmd.move,
-        ['attachment', cardKey, 'root'],
+        [templateCardKey, moduleCardKey, 'root'],
         optionsMini,
       );
       expect(result.statusCode).to.equal(400);
@@ -289,11 +297,47 @@ describe('import module', () => {
       );
       expect(result.statusCode).to.equal(400);
     });
+    it('try to remove cardType from a module', async () => {
+      const cardType = 'decision/cardTypes/decision';
+      const result = await commandHandler.command(
+        Cmd.remove,
+        ['cardType', cardType],
+        optionsMini,
+      );
+      expect(result.statusCode).to.equal(400);
+    });
+    it('try to remove fieldType from a module', async () => {
+      const fieldType = 'decision/fieldTypes/finished';
+      const result = await commandHandler.command(
+        Cmd.remove,
+        ['fieldType', fieldType],
+        optionsMini,
+      );
+      expect(result.statusCode).to.equal(400);
+    });
+    it('try to remove report from a module', async () => {
+      const report = 'decision/reports/testReport';
+      const result = await commandHandler.command(
+        Cmd.remove,
+        ['report', report],
+        optionsMini,
+      );
+      expect(result.statusCode).to.equal(400);
+    });
     it('try to remove template from a module', async () => {
       const template = 'decision/templates/decision';
       const result = await commandHandler.command(
         Cmd.remove,
         ['template', template],
+        optionsMini,
+      );
+      expect(result.statusCode).to.equal(400);
+    });
+    it('try to remove workflow from a module', async () => {
+      const workflow = 'decision/workflows/decision';
+      const result = await commandHandler.command(
+        Cmd.remove,
+        ['workflow', workflow],
         optionsMini,
       );
       expect(result.statusCode).to.equal(400);

--- a/tools/schema/cardTreeDirectorySchema.json
+++ b/tools/schema/cardTreeDirectorySchema.json
@@ -94,6 +94,40 @@
                             }
                           ]
                         },
+                        "fieldTypes": {
+                          "type": "object",
+                          "allOf": [
+                            {
+                              "properties": {
+                                "directories": {
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "files": {
+                                  "type": "object",
+                                  "$comment": "Each file needs to be separately validated against 'contentSchema'",
+                                  "contentSchema": "cardTypeSchema.json"
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "files": {
+                                  "type": "object",
+                                  "properties": {
+                                    ".schema": {},
+                                    ".gitkeep": {}
+                                  },
+                                  "required": [".schema"]
+                                }
+                              }
+                            }
+                          ]
+                        },
                         "linkTypes": {
                           "type": "object",
                           "allOf": [
@@ -128,39 +162,45 @@
                             }
                           ]
                         },
-                        "fieldTypes": {
+                        "reports": {
                           "type": "object",
-                          "allOf": [
-                            {
-                              "properties": {
-                                "directories": {
-                                  "type": "object",
-                                  "additionalProperties": false
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "files": {
-                                  "type": "object",
-                                  "$comment": "Each file needs to be separately validated against 'contentSchema'",
-                                  "contentSchema": "cardTypeSchema.json"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "files": {
+                          "properties": {
+                            "additionalProperties": false,
+                            "directories": {
+                              "type": "object",
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                ".+": {
                                   "type": "object",
                                   "properties": {
-                                    ".schema": {},
-                                    ".gitkeep": {}
-                                  },
-                                  "required": [".schema"]
+                                    "files": {
+                                      "type": "object",
+                                      "properties": {
+                                        "index.adoc.hbs": {
+                                          "type": "object"
+                                        },
+                                        "query.lp.hbs": {
+                                          "type": "object"
+                                        },
+                                        "report.json": {
+                                          "type": "object",
+                                          "contentSchema": "reportSchema.json"
+                                        },
+                                        "parametersSchema.json": {
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [
+                                        "index.adoc.hbs",
+                                        "query.lp.hbs",
+                                        "report.json"
+                                      ]
+                                    }
+                                  }
                                 }
                               }
                             }
-                          ]
+                          }
                         },
                         "templates": {
                           "type": "object",
@@ -259,46 +299,6 @@
                               }
                             }
                           ]
-                        },
-                        "reports": {
-                          "type": "object",
-                          "properties": {
-                            "additionalProperties": false,
-                            "directories": {
-                              "type": "object",
-                              "additionalProperties": false,
-                              "patternProperties": {
-                                ".+": {
-                                  "type": "object",
-                                  "properties": {
-                                    "files": {
-                                      "type": "object",
-                                      "properties": {
-                                        "index.adoc.hbs": {
-                                          "type": "object"
-                                        },
-                                        "query.lp.hbs": {
-                                          "type": "object"
-                                        },
-                                        "report.json": {
-                                          "type": "object",
-                                          "contentSchema": "reportSchema.json"
-                                        },
-                                        "parametersSchema.json": {
-                                          "type": "object"
-                                        }
-                                      },
-                                      "required": [
-                                        "index.adoc.hbs",
-                                        "query.lp.hbs",
-                                        "report.json"
-                                      ]
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
                         }
                       }
                     }


### PR DESCRIPTION
Now is is possible to remove all four file based resources (cardType, fieldType, linkType and workflow), and two folder based resources (reports and templates). They mainly share the same code for the removing.
Additionally, fixed some unit tests.


OPEN: Should 'calculations' be removable as well?

There were some issues with remove-unit tests, for me, the project does not seem to be fresh in each test.
Should be investigated in its own ticket.