### PR TITLE
INTDEV-599: Ignore stdio while running cyberismo app

### DIFF
--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -1257,7 +1257,7 @@ export class Commands {
     execFileSync(`npm`, args, {
       shell: true,
       cwd: `${appPath}`,
-      stdio: 'inherit',
+      stdio: 'ignore',
     });
 
     return { statusCode: 200 };


### PR DESCRIPTION
Currently when you start cyberismo app via CLI you get a bunch of Next.js output:

```
jaakko@11latoa unified-sdl % cyberismo app
Running Cyberismo app on http://localhost:3000/
Press Control+C to stop.
> @cyberismocom/app@0.1.0 start
> next start
   ▲ Next.js 15.0.3
   - Local:        http://localhost:3000
✓ Starting...
✓ Ready in 211ms
Opal already loaded. Loading twice can cause troubles, please fix your setup.
Opal already loaded. Loading twice can cause troubles, please fix your setup.
```

I propose we ignore the stdio in this case, user does not need to see these. Result:

```
jaakko@11latoa unified-sdl % cyberismo app
Running Cyberismo app on http://localhost:3000/
Press Control+C to stop.
```
