### PR TITLE
INTDEV-604 Fix card creation when same identifier in templates

### DIFF
--- a/tools/data-handler/test/template.test.ts
+++ b/tools/data-handler/test/template.test.ts
@@ -35,7 +35,7 @@ describe('template', () => {
       new Template(project, { name: '' });
     } catch (error) {
       if (error instanceof Error) {
-        expect(error.message).to.contain('Invalid');
+        expect(error.message).to.contain("Name '' is not valid resource name");
       }
     }
   });


### PR DESCRIPTION
When a card is created from a template, the template name is first normalised (removes 'local' if used, and checks the name format), then it is checked where the template is from. Unfortunately, name normalisation removes the prefix and type (it only returns the identifier; last part of the name). Thus, if there is a template with same identifier in both the local and import modules, it picks up always the local one. 

As a fix, do not use `normalizeTemplateName` when trying to use template. Instead use `resourceNameParts` utility function and use the data it returns to deduce is it a local or module template. Also pass the full template name to `setTemplatePath` function.

I think the whole normalisation function could be removed, but I didn't include it in this PR. I'll do a separate ticket for it.