### PR TITLE
INTDEV-535 Make 'path' mandatory in 'Resource'

### DIFF
--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -414,7 +414,7 @@ export class Project extends CardContainer {
   public async createTemplateObjectByName(
     templateName: string,
   ): Promise<Template | undefined> {
-    return this.createTemplateObject({ name: templateName });
+    return this.createTemplateObject({ name: templateName, path: '' });
   }
 
   /**

--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -480,7 +480,7 @@ export class Template extends CardContainer {
   /**
    * Creates a new template to a project.
    * todo: it would make more sense if Project would have this function
-   * @returns operation details
+   * @returns message text with details of creating; or empty string when template was already created.
    */
   public async create(templateContent: TemplateMetadata): Promise<string> {
     const isCreated = this.isCreated();

--- a/tools/data-handler/src/create.ts
+++ b/tools/data-handler/src/create.ts
@@ -145,6 +145,7 @@ export class Create extends EventEmitter {
         if (resourceType === 'template') {
           const template = new Template(this.project, {
             name: resourceContent.name,
+            path: '',
           });
           await template.create(resourceContent);
         }
@@ -194,7 +195,7 @@ export class Create extends EventEmitter {
     }
     const templateObject = new Template(
       this.project,
-      { name: templateName }, // Template can deduce its own path
+      { name: templateName, path: '' }, // Template can deduce its own path
     );
 
     const specificCard = card

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -134,7 +134,7 @@ export type RemovableResourceTypes =
 // Project resource, such as workflow, template or card type as file system object.
 export interface Resource {
   name: string;
-  path?: string;
+  path: string;
 }
 
 // Resources that have own folders.

--- a/tools/data-handler/test/template.test.ts
+++ b/tools/data-handler/test/template.test.ts
@@ -32,7 +32,7 @@ after(() => {
 describe('template', () => {
   it('try to create template with no name', () => {
     try {
-      new Template(project, { name: '' });
+      new Template(project, { name: '', path: '' });
     } catch (error) {
       if (error instanceof Error) {
         expect(error.message).to.contain("Name '' is not valid resource name");
@@ -42,6 +42,7 @@ describe('template', () => {
   it('list template cards', async () => {
     const template = new Template(project, {
       name: 'decision/templates/simplepage',
+      path: '',
     });
     const cards = await template.cards();
     expect(cards.length).to.equal(3);
@@ -49,6 +50,7 @@ describe('template', () => {
   it('list template cards from empty template', async () => {
     const template = new Template(project, {
       name: 'decision/templates/empty',
+      path: '',
     });
     const cards = await template.cards();
     expect(cards.length).to.equal(0);
@@ -57,6 +59,7 @@ describe('template', () => {
   it('try to create all cards from an empty template', async () => {
     const template = new Template(project, {
       name: 'decision/templates/empty',
+      path: '',
     });
     const cards = await template.cards();
     template
@@ -72,6 +75,7 @@ describe('template', () => {
   it('create template card to a specific card from a project', async () => {
     const template = new Template(project, {
       name: 'decision/templates/simplepage',
+      path: '',
     });
 
     // Choose specific card so that it does not have currently child cards.
@@ -95,6 +99,7 @@ describe('template', () => {
   it('try to create a specific card from an empty template', async () => {
     const template = new Template(project, {
       name: 'decision/templates/empty',
+      path: '',
     });
     const cards = await template.cards();
     const nonExistingCard: Card = {
@@ -118,6 +123,7 @@ describe('template', () => {
   it('add new card to a template', async () => {
     const template = new Template(project, {
       name: 'decision/templates/decision',
+      path: '',
     });
     const cardsBefore = await template.cards();
     await template
@@ -133,6 +139,7 @@ describe('template', () => {
   it('list attachments from a template (no attachments in template)', async () => {
     const template = new Template(project, {
       name: 'decision/templates/simplepage',
+      path: '',
     });
     const attachments = await template.attachments();
     expect(attachments.length).to.equal(0);
@@ -140,6 +147,7 @@ describe('template', () => {
   it('list attachments from a template', async () => {
     const template = new Template(project, {
       name: 'decision/templates/decision',
+      path: '',
     });
     const attachments = await template.attachments();
     expect(attachments.length).to.equal(1);
@@ -147,13 +155,14 @@ describe('template', () => {
   it('list attachments from an empty template', async () => {
     const template = new Template(project, {
       name: 'decision/templates/empty',
+      path: '',
     });
     const attachments = await template.attachments();
     expect(attachments.length).to.equal(0);
   });
   it('check that template does not exist, then create it', async () => {
     const templateName = 'idontexistyet';
-    const template = new Template(project, { name: templateName });
+    const template = new Template(project, { name: templateName, path: '' });
 
     expect(template.isCreated()).to.equal(false);
     const success = await template.create({ name: templateName });
@@ -163,6 +172,7 @@ describe('template', () => {
   it('check template paths', async () => {
     const template = new Template(project, {
       name: 'decision/templates/decision',
+      path: '',
     });
     const templateMain = template.templateFolder();
     const templateCards = template.templateCardsFolder();
@@ -177,6 +187,7 @@ describe('template', () => {
   it('add card to a template', async () => {
     const template = new Template(project, {
       name: 'decision/templates/decision',
+      path: '',
     });
     const parentCard: Card = {
       key: 'decision_1',
@@ -196,6 +207,7 @@ describe('template', () => {
   it('access card details by id', async () => {
     const template = new Template(project, {
       name: 'decision/templates/decision',
+      path: '',
     });
     const cardToOperateOn = 'decision_1';
     const cardExists = template.hasCard(cardToOperateOn);
@@ -237,7 +249,7 @@ describe('template', () => {
     }
   });
   it('try to add card to a template that does not exist on disk', async () => {
-    const template = new Template(project, { name: 'i-dont-exist' });
+    const template = new Template(project, { name: 'i-dont-exist', path: '' });
 
     await template
       .addCard('decision/cardTypes/decision')
@@ -251,6 +263,7 @@ describe('template', () => {
   it('try to add card to a template from card type that does not exist', async () => {
     const template = new Template(project, {
       name: 'decision/templates/decision',
+      path: '',
     });
 
     await template
@@ -265,6 +278,7 @@ describe('template', () => {
   it('try to add card to a template to a parent card that does not exist', async () => {
     const template = new Template(project, {
       name: 'decision/templates/decision',
+      path: '',
     });
     const parentCard: Card = {
       key: 'i-dont-exist',
@@ -285,6 +299,7 @@ describe('template', () => {
   it('check all the attachments', async () => {
     const template = new Template(project, {
       name: 'decision/templates/decision',
+      path: '',
     });
 
     // Project can fetch the template's attachment's folder.
@@ -325,8 +340,12 @@ describe('template', () => {
   it('check if template is created', () => {
     const template = new Template(project, {
       name: 'decision/templates/decision',
+      path: '',
     });
-    const nonExistingTemplate = new Template(project, { name: 'idontExist' });
+    const nonExistingTemplate = new Template(project, {
+      name: 'idontExist',
+      path: '',
+    });
 
     expect(template.isCreated()).to.equal(true);
     expect(nonExistingTemplate.isCreated()).to.equal(false);
@@ -334,6 +353,7 @@ describe('template', () => {
   it('find certain card from template', async () => {
     const template = new Template(project, {
       name: 'decision/templates/decision',
+      path: '',
     });
 
     const nonExistingCard = await template.findSpecificCard('idontexist');
@@ -345,6 +365,7 @@ describe('template', () => {
   it('show template details', async () => {
     const template = new Template(project, {
       name: 'decision/templates/decision',
+      path: '',
     });
 
     const templateProject = template.templateProject;
@@ -363,6 +384,7 @@ describe('template', () => {
     const project = new Project(decisionRecordsPath);
     const template = new Template(project, {
       name: 'decision/templates/decision',
+      path: '',
     });
     const templateCards = await template.listCards();
     expect(templateCards.length).to.be.greaterThan(0);


### PR DESCRIPTION
Make `path` mandatory in `Resource`. 

I also thought about making own extended interface type for `Template` (without path) but it would cause more changes and in some cases the path is already set correctly when template is being constructed. 