### PR TITLE
INTDEV-573 When renaming project, rename report references

### DIFF
--- a/tools/data-handler/test/command-handler-rename.test.ts
+++ b/tools/data-handler/test/command-handler-rename.test.ts
@@ -41,7 +41,9 @@ describe('rename command', () => {
 
   it('rename project (success)', async () => {
     const newName = 'decrec';
-    const result = await commandHandler.command(Cmd.rename, [newName], options);
+    let result = await commandHandler.command(Cmd.rename, [newName], options);
+    expect(result.statusCode).to.equal(200);
+    result = await commandHandler.command(Cmd.validate, [], options);
     expect(result.statusCode).to.equal(200);
   });
   it('rename project - no cards at all (success)', async () => {


### PR DESCRIPTION
When renaming a project, also rename resource references from report handlebar (.hbs) files.
Renaming should only affect local resources, not imported content.

We don't currently have these types of references in the test data; there are only reports with static (non-references) values.

TODO: I will expand this PR with few unit tests to new `Project` api `reportHandlerBarFiles`.