### PR TITLE
INTDEV-575 Rename macro content

### DIFF
--- a/tools/data-handler/src/rename.ts
+++ b/tools/data-handler/src/rename.ts
@@ -23,6 +23,9 @@ import { resourceNameParts } from './utils/resource-utils.js';
 import { Template } from './containers/template.js';
 import { writeJsonFile } from './utils/json.js';
 
+// RE that helps find macros from card content.
+const macrosRe = /{{{(.*?)}}}/gs;
+
 /**
  * Class that handles 'rename' command.
  */
@@ -70,13 +73,12 @@ export class Rename extends EventEmitter {
     //   E.g. /Users/smith/projects/card-projects/smith-project/cardRoot/smith_sdhgsd7; change 'smith' card key to 'miller'
     //   --> only the last 'smith' should be replaced with 'miller'.
     const re = new RegExp(`${this.from}(?!.*${this.from})`);
-
     const sortedCards = cards.sort((a, b) => sortCards(a, b));
 
     // Cannot do this parallel, since cards deeper in the hierarchy needs to be renamed first.
-    // First update all the attachments and links.
+    // First update cards content and metadata
     for (const card of sortedCards) {
-      await this.updateCardAttachments(re, card);
+      await this.updateCardContent(re, card);
       await this.updateCardLinks(re, card);
     }
     // Then rename the cards
@@ -85,7 +87,6 @@ export class Rename extends EventEmitter {
     }
   }
 
-  // Update card's attachments.
   private async updateCardAttachments(re: RegExp, card: Card) {
     if (!Project.isTemplateCard(card)) {
       const attachments = card.attachments ? card.attachments : [];
@@ -105,11 +106,34 @@ export class Rename extends EventEmitter {
             attachmentRe,
             `image::${newAttachmentFileName}`,
           );
-          if (card.content) {
-            this.project.updateCardContent(card.key, card.content);
-          }
         }),
       );
+    }
+    return card.content;
+  }
+
+  // Update card's content. Ensures that cards that have been updated are the only ones saved to disk.
+  private async updateCardContent(re: RegExp, card: Card) {
+    // Ensure that modules are not updated.
+    if (card.path.includes(`${sep}modules${sep}`)) {
+      return;
+    }
+    if (!card.content) {
+      return;
+    }
+
+    const originalContent = card.content?.slice(0);
+
+    // Attachments
+    card.content = await this.updateCardAttachments(re, card);
+    // Macros
+    card.content = await this.updateCardMacros(card);
+    // XRefs
+    card.content = await this.updateCardXrefs(card);
+
+    // Update changed card's content.
+    if (card.content !== originalContent) {
+      await this.project.updateCardContent(card.key, card.content!, true);
     }
   }
 
@@ -126,11 +150,34 @@ export class Rename extends EventEmitter {
       const copyLinkType = link.linkType.slice(0);
       link.cardKey = link.cardKey.replace(re, this.to);
       link.linkType = link.linkType.replace(re, this.to);
-      changed = copyCardKey !== link.cardKey || copyLinkType !== link.linkType;
+      changed =
+        changed ||
+        copyCardKey !== link.cardKey ||
+        copyLinkType !== link.linkType;
     });
     if (card.metadata && changed) {
       this.project.updateCardMetadata(card, card.metadata, true);
     }
+  }
+
+  private async updateCardMacros(card: Card) {
+    if (macrosRe.test(card.content!)) {
+      // RegExp is stateful; reset search.
+      macrosRe.lastIndex = 0;
+      let hit;
+      while ((hit = macrosRe.exec(card.content!)) !== null) {
+        const begin: string = card.content!.substring(0, hit.index);
+        const end: string = card.content!.substring(
+          macrosRe.lastIndex,
+          card.content!.length,
+        );
+        const newContent: string = card
+          .content!.substring(hit.index, macrosRe.lastIndex)
+          .replace(`${this.from}/`, `${this.to}/`);
+        card.content = begin + newContent + end;
+      }
+    }
+    return card.content;
   }
 
   // Update card's metadata.
@@ -162,6 +209,12 @@ export class Rename extends EventEmitter {
     }
   }
 
+  // Update card content's xref links that refer to other cards.
+  private async updateCardXrefs(card: Card) {
+    const xrefsRe = new RegExp(`xref:${this.from}_`, 'g');
+    return card.content?.replace(xrefsRe, `xref:${this.to}_`);
+  }
+
   // Changes the name of a resource to match the new prefix.
   private updateResourceName(resourceName: string) {
     const { identifier, prefix, type } = resourceNameParts(resourceName);
@@ -178,7 +231,7 @@ export class Rename extends EventEmitter {
         `Calculation file's '${calculation.name}' path is not defined`,
       );
     }
-    const filename = join(calculation.path || '', basename(calculation.name));
+    const filename = join(calculation.path, basename(calculation.name));
     let content = (await readFile(filename)).toString();
     const conversionMap = new Map([
       [`${this.from}/calculations/`, `${this.to}/calculations/`],
@@ -300,6 +353,7 @@ export class Rename extends EventEmitter {
     const cardContent = {
       metadata: true,
       attachments: true,
+      content: true,
     };
 
     this.from = this.project.configuration.cardKeyPrefix;
@@ -313,6 +367,7 @@ export class Rename extends EventEmitter {
 
     // Change project prefix to project settings.
     await this.project.configuration.setCardPrefix(to);
+    console.info(`Rename: New prefix: '${this.project.projectPrefix}'`);
 
     // Rename resources - module content shall not be modified.
     // It is better to rename the resources in this order: card types, field types
@@ -322,23 +377,27 @@ export class Rename extends EventEmitter {
     for (const cardType of cardTypes) {
       await this.updateCardTypeMetadata(cardType.name);
     }
+    console.info('Updated card types');
 
     const workflows = await this.project.workflows(ResourcesFrom.localOnly);
     for (const workflow of workflows) {
       await this.updateWorkflowMetadata(workflow.name);
     }
+    console.info('Updated workflows');
 
     // Rename all field types.
     const fieldTypes = await this.project.fieldTypes(ResourcesFrom.localOnly);
     for (const fieldType of fieldTypes) {
       await this.updateFieldTypeMetadata(fieldType.name);
     }
+    console.info('Updated field types');
 
     // Rename all the link types.
     const linkTypes = await this.project.linkTypes(ResourcesFrom.localOnly);
     for (const linkType of linkTypes) {
       await this.updateLinkTypeMetadata(linkType.name);
     }
+    console.info('Updated link types');
 
     await this.updateReports();
 
@@ -349,6 +408,10 @@ export class Rename extends EventEmitter {
     for (const calculation of calculations) {
       await this.updateCalculationFile(calculation);
     }
+    console.info('Updated calculations');
+
+    this.project.collectLocalResources();
+    console.info('Collected renamed resources');
 
     // Rename all local template cards.
     const templates = await this.project.templates(ResourcesFrom.localOnly);
@@ -356,13 +419,14 @@ export class Rename extends EventEmitter {
       const templateObject = new Template(this.project, template);
       await this.renameCards(await templateObject.cards('', cardContent));
     }
+    console.info('Renamed template cards and updated the content');
 
     // Rename all project cards.
     await this.renameCards(
       await this.project.cards(this.project.paths.cardRootFolder, cardContent),
     );
+    console.info('Renamed project cards and updated the content');
 
-    this.project.collectLocalResources();
     this.emit('renamed');
   }
 }


### PR DESCRIPTION
Add renaming support to macros. 

Macros are in the content, and we might want to avoid making unnecessary changes to the users content. 
Thus, content is first searched with `{{{...}}}` `RegExp` and then inside each of matches, content is replaced with another `RegExp` (using just `<prefix>/`).

Additionally, noticed that attachment renaming was at some point probably got broken; content should not be validated in-between a renaming operation (since some resources have been updated, and others not). Fixed the case so that validation is NOT performed from rename updates to card content.

Finally, added some logging messages for future, to see what the renaming is doing. These will only be seen in CLI stdout (app shouldn't do renames for now).

Note that this is targeting INTDEV-573 branch (I plan on merging these at the same time). There's still *links* that are broken in rename operations, I think I will target them to the same branch as well.