### PR TITLE
INTDEV-573, INTDEV-575, INTDEV-611 Rename expanded

### DIFF
--- a/tools/data-handler/test/command-handler-rename.test.ts
+++ b/tools/data-handler/test/command-handler-rename.test.ts
@@ -41,7 +41,9 @@ describe('rename command', () => {
 
   it('rename project (success)', async () => {
     const newName = 'decrec';
-    const result = await commandHandler.command(Cmd.rename, [newName], options);
+    let result = await commandHandler.command(Cmd.rename, [newName], options);
+    expect(result.statusCode).to.equal(200);
+    result = await commandHandler.command(Cmd.validate, [], options);
     expect(result.statusCode).to.equal(200);
   });
   it('rename project - no cards at all (success)', async () => {

--- a/tools/data-handler/test/project.test.ts
+++ b/tools/data-handler/test/project.test.ts
@@ -279,7 +279,7 @@ describe('project', () => {
     const cardTypeDetails = await project.cardType('i-dont-exist');
     expect(cardTypeDetails).to.equal(undefined);
   });
-  it('update metadata (success)', async () => {
+  it('update card metadata (success)', async () => {
     const decisionRecordsPath = join(testDir, 'valid/decision-records');
     const cardToOperateOn = 'decision_5';
 
@@ -308,7 +308,7 @@ describe('project', () => {
       await project.updateCardMetadataKey(card?.key, 'title', previousTitle);
     }
   });
-  it('try to update metadata with same content again', async () => {
+  it('try to update card metadata with same content again', async () => {
     const decisionRecordsPath = join(testDir, 'valid/decision-records');
     const cardToOperateOn = 'decision_5';
 
@@ -331,6 +331,61 @@ describe('project', () => {
       expect(previousTitle).to.equal(updatedCard?.metadata?.title);
       expect(previouslyUpdated).to.equal(updatedCard?.metadata?.lastUpdated);
       expect(updatedCard?.metadata?.title).to.equal(newTitle);
+    }
+  });
+  it('try to update card with invalid metadata', async () => {
+    const decisionRecordsPath = join(testDir, 'valid/decision-records');
+    const cardToOperateOn = 'decision_5';
+
+    const project = new Project(decisionRecordsPath);
+    const card = await project.cardDetailsById(cardToOperateOn, {
+      metadata: true,
+      content: true,
+    });
+    expect(card).to.not.equal(undefined);
+
+    if (card) {
+      // Trying to update wrong kind of data throws
+      await project
+        .updateCardMetadataKey(card?.key, 'workflowState', 'wrong-name')
+        .then(() => expect(false))
+        .catch(() => expect(true));
+    }
+  });
+  it('update card content (success)', async () => {
+    const decisionRecordsPath = join(testDir, 'valid/decision-records');
+    const cardToOperateOn = 'decision_5';
+
+    const project = new Project(decisionRecordsPath);
+    const card = await project.cardDetailsById(cardToOperateOn, {
+      metadata: true,
+      content: true,
+    });
+    expect(card).to.not.equal(undefined);
+
+    if (card) {
+      const previousContent = card.content;
+      card.content += '\naddition';
+      await project.updateCardContent(card.key, card.content!);
+      expect(card.content).not.to.equal(previousContent);
+    }
+  });
+  it('update card content and validate (success)', async () => {
+    const decisionRecordsPath = join(testDir, 'valid/decision-records');
+    const cardToOperateOn = 'decision_5';
+
+    const project = new Project(decisionRecordsPath);
+    const card = await project.cardDetailsById(cardToOperateOn, {
+      metadata: true,
+      content: true,
+    });
+    expect(card).to.not.equal(undefined);
+
+    if (card) {
+      const previousContent = card.content;
+      card.content += '\naddition';
+      await project.updateCardContent(card.key, card.content!, true);
+      expect(card.content).not.to.equal(previousContent);
     }
   });
 
@@ -611,6 +666,18 @@ describe('project', () => {
     } catch (error) {
       expect(true);
     }
+  });
+  it('collect all report handlebar files', async () => {
+    const decisionRecordsPath = join(testDir, `valid${sep}decision-records`);
+    const miniRecordsPath = join(testDir, `valid${sep}minimal`);
+    const projectDecision = new Project(decisionRecordsPath);
+    const miniDecision = new Project(miniRecordsPath);
+    let files = await projectDecision.reportHandlerBarFiles();
+    // There are two handlebar files in the test project
+    expect(files.length).to.equal(2);
+    files = await miniDecision.reportHandlerBarFiles();
+    // There are no handlebar files in the minimal report
+    expect(files.length).to.equal(0);
   });
 
   // @todo: tests needed:


### PR DESCRIPTION
Add renaming support to card macros, card xrefs and to report's handlebar files.

Macros are in the card content, and we want to avoid making unnecessary changes to the users content. 
Thus, content is first searched with `{{{...}}}` `RegExp` and then inside each of matches, content is replaced with another `RegExp` (using just `<prefix>/`).

xrefs that link to project cards, are also renamed (e.g. `xref:cisms_70[...]` -> `xref:ismo_70[...]`).

Report renaming now also renames references in the handle bar files.

Card content file is only updated, if there are changes to it. And once for all of the various renaming needs (not once per change).

Additionally, noticed that attachment renaming was at some point probably got broken; content should **not** be validated in-between a renaming operation (since some resources have been updated, and others not). Fixed the case so that validation is not performed from rename updates to card content.

Finally, added some logging messages for future, to see what the renaming is doing. These will only be seen in CLI stdout (app shouldn't do renames for now):
<img width="575" alt="Screenshot 2024-12-02 at 7 39 54" src="https://github.com/user-attachments/assets/62769ad8-d635-4909-9251-b298986dce66">

