### PR TITLE
Add new method to create template object from card

### DIFF
--- a/tools/data-handler/src/calculate.ts
+++ b/tools/data-handler/src/calculate.ts
@@ -262,7 +262,7 @@ export class Calculate {
   private async getCards(parentCard: Card | undefined): Promise<Card[]> {
     let cards: Card[] = [];
     if (parentCard) {
-      const card = await this.project.findSpecificCard(parentCard.key, {
+      const card = await this.project.findSpecificCard(parentCard, {
         metadata: true,
         children: true,
         content: false,


### PR DESCRIPTION
This is not related to any JIRA ticket directly. 

I branched this away from re-ranking template cards ticket (INTDEV-545) as I think it is easier to review new project methods separately.

These are the **new** APIs:
`cardPathParts` returns information from card path. There is no longer need to parse the card paths in random functions. This supports project cards, template cards and module template cards (read: all of them)
`createTemplateObjectFromCard` creates `Template` from given `Card`. If you have `Card` instance, there is no longer need to go through all of the `Templates` from a `Project` to get an `Template` instance based on card id.

Additionally, `findSpecificCard` now also supports `Card` as a parameter. Which might sound strange (why would you find a `Card` if you already have `Card` instance), but it is intended for cases where you want to get different details from the card. If you pass template `Card` here, it is using the new API (see above) which is somewhat faster.

There might be some other instances where using the new APIs might be more convenient or faster. Dear reviewers, if you have such code segments in mind, please provide a pointer.
