### PR TITLE
INTDEV-616 Crash importing modules that don't have all resource folders

### DIFF
--- a/tools/data-handler/src/containers/project/resource-collector.ts
+++ b/tools/data-handler/src/containers/project/resource-collector.ts
@@ -68,6 +68,9 @@ export class ResourceCollector {
           resource.name,
           requestedType,
         );
+        if (!pathExists(resourcePath)) {
+          continue;
+        }
         const files = await readdir(resourcePath, { withFileTypes: true });
         const filteredFiles = filteredDirectories
           ? files.filter((item) => item.isDirectory())

--- a/tools/data-handler/test/test-data/valid/minimal/.cards/local/linkTypes/.schema
+++ b/tools/data-handler/test/test-data/valid/minimal/.cards/local/linkTypes/.schema
@@ -1,5 +1,0 @@
-[{
-  "id": "linkTypeSchema",
-  "version": 1
-}
-]


### PR DESCRIPTION
This is regression from resource collector implementation: [https://github.com/CyberismoCom/cyberismo/pull/259](https://github.com/CyberismoCom/cyberismo/pull/259) 

The implementation does not check if a local folder exists before it tries to find files related to it.
There might be other ways to reach the same crash than importing.

As a fix add the folder check.

Also: Removed few empty folders from 'minimal' test project. This causes crash in one test when running without this fix; with the fix, the crash is removed.