### PR TITLE
INTDEV-615 'show modules' shows duplicates

### DIFF
--- a/tools/data-handler/src/containers/project/resource-collector.ts
+++ b/tools/data-handler/src/containers/project/resource-collector.ts
@@ -58,10 +58,14 @@ export class ResourceCollector {
     requestedType: string, // should be a type
   ): Promise<Resource[]> {
     const collectedResources: Resource[] = [];
-    const filteredDirectories = requestedType === 'templates' ? true : false;
+    const filteredDirectories =
+      requestedType === 'templates' || requestedType === 'reports'
+        ? true
+        : false;
     for (const resource of resources) {
       if (requestedType === 'modules') {
         collectedResources.push(...resources);
+        break;
       } else {
         const resourcePath = join(
           this.paths.modulesFolder,

--- a/tools/data-handler/test/command-handler-import.test.ts
+++ b/tools/data-handler/test/command-handler-import.test.ts
@@ -150,10 +150,7 @@ describe('import module', () => {
       );
       expect(result.statusCode).to.equal(200);
     });
-    /*
-    // Issues with Windows build slave make this fail rather often.
-    // Let's comment it for now.
-    it('create empty project and import module', async () => {
+    it('create empty project and import two modules', async () => {
       const prefix = 'proj';
       const name = 'test-project';
       const projectDir = join(testDir, name);
@@ -162,15 +159,33 @@ describe('import module', () => {
         .command(Cmd.create, ['project', name, prefix], testOptions)
         .then(async (data) => {
           expect(data.statusCode).to.equal(200);
-          const result = await commandHandler.command(
+          let result = await commandHandler.command(
             Cmd.import,
             ['module', decisionRecordsPath],
             testOptions,
           );
           expect(result.statusCode).to.equal(200);
+          result = await commandHandler.command(
+            Cmd.import,
+            ['module', minimalPath],
+            testOptions,
+          );
+
+          expect(result.statusCode).to.equal(200);
+          result = await commandHandler.command(
+            Cmd.show,
+            ['modules'],
+            testOptions,
+          );
+          expect(result.statusCode).to.equal(200);
+          if (result.payload) {
+            const modules = Object.values(result.payload);
+            expect(modules.length).to.equal(2);
+            expect(modules).to.contain('mini');
+            expect(modules).to.contain('decision');
+          }
         });
     });
-    */
     it('try to import module - no source', async () => {
       const stubProjectPath = sinon
         .stub(commandHandler, 'setProjectPath')


### PR DESCRIPTION
Current implementation lists all modules with each loop iteration of for-statement.
Thus, with two modules --> shows 4 modules;
with three modules --> shows 9 modules and so on.

Since all modules can be listed in a single iteration, break the loop after first one.

Uncommented a relevant unit test. Let's see if our better Windows slaves can now handle the new files.