### PR TITLE
INTDEV-601 Enable tests that check resource removals

### DIFF
--- a/tools/cli/test/cli.test.ts
+++ b/tools/cli/test/cli.test.ts
@@ -350,18 +350,20 @@ describe('Cli BAT test', function () {
       },
     );
   });
-  //  INTDEV-601
-  //  it('Remove the link', function (done) {
-  //    exec(`cd ../../.tmp/cyberismo-cli&&cyberismo remove link ${pageCardKey} ${newPageCardKey} cli/linkTypes/linkTypeTest&&cyberismo validate`, (error, stdout, _stderr) => {
-  //    if (error != null) {log(error);}
-  //      log(error);
-  //      log(stdout);
-  //      expect(error).to.be.null;
-  //      expect(stdout).to.include('Done');
-  //      expect(stdout).to.include('Project structure validated');
-  //      done();
-  //    });
-  //  });
+  it('Remove the link', function (done) {
+    exec(
+      `cd ../../.tmp/cyberismo-cli&&cyberismo remove link ${pageCardKey} ${newPageCardKey} cli/linkTypes/linkTypeTest&&cyberismo validate`,
+      (error, stdout, _stderr) => {
+        if (error != null) {
+          log(error);
+        }
+        expect(error).to.be.null;
+        expect(stdout).to.include('Done');
+        expect(stdout).to.include('Project structure validated');
+        done();
+      },
+    );
+  });
   it('Remove all cards of the new cardtype', function (done) {
     exec(
       `cd ../../.tmp/cyberismo-cli&&cyberismo remove card ${newPageCardKey}&&cyberismo validate`,
@@ -369,7 +371,6 @@ describe('Cli BAT test', function () {
         if (error != null) {
           log(error);
         }
-
         expect(error).to.be.null;
         expect(stdout).to.include('Done');
         expect(stdout).to.include('Project structure validated');
@@ -391,26 +392,34 @@ describe('Cli BAT test', function () {
       },
     );
   });
-  //  INTDEV-602
-  //  it('Remove the cardtype', function (done) {
-  //    exec(`cd ../../.tmp/cyberismo-cli&&cyberismo remove cardtype cli/cardTypes/cardTypeTest&&cyberismo validate`, (error, stdout, _stderr) => {
-  //      if (error != null) {log(error);}
-  //      expect(error).to.be.null;
-  //      expect(stdout).to.include('Done');
-  //      expect(stdout).to.include('Project structure validated');
-  //      done();
-  //    });
-  //  });
-  //  INTDEV-602
-  //  it('Remove the workflow', function (done) {
-  //    exec(`cd ../../.tmp/cyberismo-cli&&cyberismo remove workflow workflowTest&&cyberismo validate`, (error, stdout, _stderr) => {
-  //      if (error != null) {log(error);}
-  //      expect(error).to.be.null;
-  //      expect(stdout).to.include('Done');
-  //      expect(stdout).to.include('Project structure validated');
-  //      done();
-  //    });
-  //  });
+  it('Remove the cardtype', function (done) {
+    exec(
+      `cd ../../.tmp/cyberismo-cli&&cyberismo remove cardType cli/cardTypes/cardTypeTest&&cyberismo validate`,
+      (error, stdout, _stderr) => {
+        if (error != null) {
+          log(error);
+        }
+        expect(error).to.be.null;
+        expect(stdout).to.include('Done');
+        expect(stdout).to.include('Project structure validated');
+        done();
+      },
+    );
+  });
+  it('Remove the workflow', function (done) {
+    exec(
+      `cd ../../.tmp/cyberismo-cli&&cyberismo remove workflow cli/workflows/workflowTest&&cyberismo validate`,
+      (error, stdout, _stderr) => {
+        if (error != null) {
+          log(error);
+        }
+        expect(error).to.be.null;
+        expect(stdout).to.include('Done');
+        expect(stdout).to.include('Project structure validated');
+        done();
+      },
+    );
+  });
   it('Remove the linktype', function (done) {
     exec(
       `cd ../../.tmp/cyberismo-cli&&cyberismo remove linkType cli/linkTypes/linkTypeTest&&cyberismo validate`,


### PR DESCRIPTION
BAT tests now successfully check that all resource types are removed.

<img width="1098" alt="Screenshot 2024-12-02 at 17 43 48" src="https://github.com/user-attachments/assets/fdd2ac10-e4b5-4c7c-834b-67f8a43424df">

(I removed the console.log after taking the screenshot)