### PR TITLE
INTDEV-603 CLI shows wrong name

### DIFF
--- a/tools/cli/bin/run
+++ b/tools/cli/bin/run
@@ -2,6 +2,9 @@
 
 import program from '@cyberismocom/cli';
 
+// Don't show any warnings when running CLI.
+process.removeAllListeners('warning');
+
 program.parseAsync(process.argv).catch((error) => {
   console.error(error.message);
   process.exit(1);

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cyberismocom/cli",
   "version": "1.0.0",
-  "description": "",
+  "description": "CLI tool to handle tasks.",
   "main": "dist/index.js",
   "bin": {
     "cyberismo": "bin/run"


### PR DESCRIPTION
Fix the old name use.

Additionally fetch CLI project details from `package.json` instead of duplicating them in the `index.ts` file.
This normally shows `Experimental warning`, but I decided to suppress all warnings in CLI (we really don't need to show users deprecation, or experimental warnings when running CLI).
Finally, fixed some help texts in the CLI.