### PR TITLE
INTDEV-589 Do not create unnecessary '.schema' files

### DIFF
--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -162,10 +162,6 @@ export class Template extends CardContainer {
       // Create temp-folder and schema file.
       const templatesFolder = this.templateFolder();
       await mkdir(tempDestination, { recursive: true });
-      await writeJsonFile(
-        join(tempDestination, Project.schemaContentFile),
-        Template.DotSchemaContentForCard,
-      );
 
       // Create cards to the temp-folder.
       // @todo: new function - fetch the workflow of a card


### PR DESCRIPTION
Template sub-directories in a project should have two `.schema` files for each template. 
One in the "main" template folder where `template.json` file is, and another one in the "template root" where the cards are (`"main"/c`). 
`.schema` files are used for dynamic validation of the project sources. 

Using these files, the binary version of `cyberismo` is not dependent on project structure version. We can use whichever binary of `cyberismo` to validate any project (compare it with, if valid project structure would be part of binary; old versions of application couldn't validate upcoming versions, and we would need to keep some sort of history support also in the binary. Yuck.)
 
The current implementation creates an extra `.schema` file for each card added to the template. 
**As a fix, remove the unnecessary file creation.** 

Once this is merged to main, fix all content repositories by removing the extra files.