### PR TITLE
INTDEV-622 Safer way to launch 'cyberismo app'

### DIFF
--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -653,11 +653,11 @@ export class Commands {
 
     // since current working directory changes, we need to resolve the project path
     const projectPath = resolve(this.projectPath);
+    const projectPathArg = `--project_path=${projectPath}`;
 
-    const args = [`start`, `--project_path="${projectPath}"`];
+    const args = [`start`, projectPathArg];
     execFileSync(`npm`, args, {
-      shell: true,
-      cwd: `${appPath}`,
+      cwd: appPath,
       stdio: 'ignore',
     });
   }

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -653,12 +653,13 @@ export class Commands {
 
     // since current working directory changes, we need to resolve the project path
     const projectPath = resolve(this.projectPath);
-    const projectPathArg = `--project_path=${projectPath}`;
 
-    const args = [`start`, projectPathArg];
+    const args = [`start`];
     execFileSync(`npm`, args, {
+      shell: true,
       cwd: appPath,
       stdio: 'ignore',
+      env: { ...process.env, npm_config_project_path: projectPath },
     });
   }
 


### PR DESCRIPTION
To remove `shell: true`, the parameters need to be passed as an array without string literals.
Also make `cwd` to use directly the value, instead of wrapping it to a string literal.

See more from: https://github.com/CyberismoCom/cyberismo/security/code-scanning/7
Note that copilot provided fix didn't work for us; the  `cyberismo app` (which leads to `npm start`)  would fail.