### PR TITLE
INTDEV-605 replace old function with new

### DIFF
--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -43,7 +43,10 @@ import { readJsonFile } from '../utils/json.js';
 import { Template } from './template.js';
 import { Validate } from '../validate.js';
 import { generateRandomString } from '../utils/random.js';
-import { identifierFromResourceName } from '../utils/resource-utils.js';
+import {
+  resourceNameParts,
+  resourceNameToString,
+} from '../utils/resource-utils.js';
 
 // base class
 import { CardContainer } from './card-container.js';
@@ -458,9 +461,11 @@ export class Project extends CardContainer {
   public async createTemplateObject(
     template: Resource,
   ): Promise<Template | undefined> {
-    template.name = identifierFromResourceName(template.name);
-
-    if (template.name === '' || !(await this.templateExists(template.name))) {
+    if (!template.name) {
+      return undefined;
+    }
+    template.name = resourceNameToString(resourceNameParts(template.name));
+    if (!(await this.templateExists(template.name))) {
       return undefined;
     }
 

--- a/tools/data-handler/src/create.ts
+++ b/tools/data-handler/src/create.ts
@@ -45,9 +45,9 @@ import { EMPTY_RANK, sortItems } from './utils/lexorank.js';
 import { fileURLToPath } from 'node:url';
 import { copyDir, pathExists } from './utils/file-utils.js';
 import {
-  identifierFromResourceName,
   isResourceName,
   resourceNameParts,
+  resourceNameToString,
 } from './utils/resource-utils.js';
 import { DefaultContent } from './create-defaults.js';
 
@@ -189,10 +189,7 @@ export class Create extends EventEmitter {
     }
     // Use slice to get a copy of a string.
     const origTemplateName = templateName.slice(0);
-    templateName = identifierFromResourceName(templateName);
-    if (templateName === '') {
-      throw Error(`Template '${origTemplateName}' is invalid template name`);
-    }
+    templateName = resourceNameToString(resourceNameParts(templateName));
     const templateObject = new Template(
       this.project,
       { name: templateName, path: '' }, // Template can deduce its own path
@@ -643,7 +640,9 @@ export class Create extends EventEmitter {
       ? (JSON.parse(templateContent) as TemplateMetadata)
       : DefaultContent.templateContent(templateName);
 
-    validTemplateName = identifierFromResourceName(validTemplateName);
+    validTemplateName = resourceNameToString(
+      resourceNameParts(validTemplateName),
+    );
 
     const validJson = this.validateCmd.validateJson(content, 'templateSchema');
     if (validJson.length !== 0) {

--- a/tools/data-handler/src/utils/resource-utils.ts
+++ b/tools/data-handler/src/utils/resource-utils.ts
@@ -8,13 +8,12 @@
 */
 
 import { parse } from 'node:path';
-import { sepRegex } from './file-utils.js';
 
 // Resource name parts are:
 // - prefix; name of the project this resource is part of
 // - type; type of resource; in plural
 // - identifier; unique name (within a project/module) for the resource
-interface ResourceName {
+export interface ResourceName {
   prefix: string;
   type: string;
   identifier: string;
@@ -27,30 +26,10 @@ const IDENTIFIER_INDEX = 2;
 // Valid resource name has three parts
 const RESOURCE_NAME_PARTS = 3;
 
-const LOCAL_RESOURCE = 'local';
-
 // Checks if name is valid (3 parts, separated by '/').
 export function isResourceName(name: string): boolean {
   const partsCount = name.split('/').length;
   return partsCount === RESOURCE_NAME_PARTS;
-}
-
-/**
- * Returns resource name as identifier. In error cases, returns empty resource.
- * @param resourceName Name of the resource.
- * @returns resource name as identifier.
- */
-export function identifierFromResourceName(resourceName: string): string {
-  const parts = resourceName.split(sepRegex);
-  if (parts.length == 0 || parts.length > RESOURCE_NAME_PARTS) {
-    return '';
-  }
-  if (parts.length === RESOURCE_NAME_PARTS) {
-    if (parts[PREFIX_INDEX] === LOCAL_RESOURCE) {
-      return parts[IDENTIFIER_INDEX];
-    }
-  }
-  return resourceName;
 }
 
 /**
@@ -79,4 +58,36 @@ export function resourceNameParts(resourceName: string): ResourceName {
   }
   // other formats are not accepted
   throw new Error(`Name '${resourceName}' is not valid resource name`);
+}
+
+/**
+ * Returns ResourceName as a single string.
+ * @param resourceName ResourceName to convert.
+ * @returns resource name as a single string.
+ * @note that valid resource names are: empty string, identifier alone and prefix/type/identifier combination.
+ */
+export function resourceNameToString(resourceName: ResourceName): string {
+  if (!resourceName.prefix && !resourceName.type && !resourceName.identifier) {
+    return '';
+  }
+  if (resourceName.identifier === '') {
+    throw new Error(`Not a valid resource name. Identifier is missing.`);
+  }
+  if (
+    resourceName.prefix &&
+    resourceName.identifier &&
+    resourceName.type === ''
+  ) {
+    throw new Error(`Not a valid resource name. Type is missing.`);
+  }
+  if (
+    resourceName.prefix === '' &&
+    resourceName.identifier &&
+    resourceName.type
+  ) {
+    throw new Error(`Not a valid resource name. Prefix is missing.`);
+  }
+  return resourceName.prefix && resourceName.type && resourceName.prefix
+    ? `${resourceName.prefix}/${resourceName.type}/${resourceName.identifier}`
+    : `${resourceName.identifier}`;
 }

--- a/tools/data-handler/test/utils/resource-utils.test.ts
+++ b/tools/data-handler/test/utils/resource-utils.test.ts
@@ -3,12 +3,13 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import {
-  identifierFromResourceName,
+  ResourceName,
   resourceNameParts,
+  resourceNameToString,
 } from '../../src/utils/resource-utils.js';
 
 describe('resource utils', () => {
-  it('resourceNameParts with valid long resource name (success)', () => {
+  it('resourceNameParts with valid resource name (success)', () => {
     const resourceName = 'test/test/test';
     // note that resource name util does not handle incorrect prefixes, or types
     const { identifier, prefix, type } = resourceNameParts(resourceName);
@@ -16,7 +17,7 @@ describe('resource utils', () => {
     expect(type).to.equal('test');
     expect(identifier).to.equal('test');
   });
-  it('resourceNameParts with valid short resource name (success)', () => {
+  it('resourceNameParts with valid identifier (success)', () => {
     const resourceName = 'test';
     const { identifier, prefix, type } = resourceNameParts(resourceName);
     expect(prefix).to.equal('');
@@ -31,17 +32,45 @@ describe('resource utils', () => {
       }).to.throw();
     }
   });
-  it('normalize resource name', () => {
-    const empty = identifierFromResourceName('');
-    const localDecision = identifierFromResourceName(
-      'local/templates/decision',
-    );
-    const decision = identifierFromResourceName('decision');
-    const invalidName = identifierFromResourceName('more/folders/than/allowed');
-
-    expect(empty).to.equal('');
-    expect(localDecision).to.equal('decision');
-    expect(decision).to.equal('decision');
-    expect(invalidName).to.equal('');
+  it('resourceNameToString with valid resource name', () => {
+    const resourceName: ResourceName = {
+      prefix: 'test',
+      type: 'test',
+      identifier: 'test',
+    };
+    const stringName = resourceNameToString(resourceName);
+    expect(stringName).to.equal('test/test/test');
+  });
+  it('resourceNameToString with valid identifier', () => {
+    const resourceName: ResourceName = {
+      prefix: '',
+      type: '',
+      identifier: 'test',
+    };
+    const stringName = resourceNameToString(resourceName);
+    expect(stringName).to.equal('test');
+  });
+  it('resourceNameToString with empty string', () => {
+    const resourceName: ResourceName = {
+      prefix: '',
+      type: '',
+      identifier: '',
+    };
+    const stringName = resourceNameToString(resourceName);
+    expect(stringName).to.equal('');
+  });
+  it('resourceNameToString with invalid values', () => {
+    const invalidResourceNames: ResourceName[] = [
+      { prefix: 'a', type: '', identifier: 'a' },
+      { prefix: 'a', type: '', identifier: '' },
+      { prefix: '', type: 'a', identifier: '' },
+      { prefix: '', type: 'a', identifier: 'a' },
+    ];
+    for (const invalidName of invalidResourceNames) {
+      console.error(invalidName);
+      expect(() => {
+        resourceNameToString(invalidName);
+      }).to.throw();
+    }
   });
 });


### PR DESCRIPTION
Remove old `identifierFromResourceName` function (it was rather recently renamed from `normaliseTemplateName`).

Replace the old function use with functions; `resourceNameParts` and new function `resourceNameToString`.

The new function `resourceNameToString` glues together resource name parts to a single string. Before doing that it checks if the parts are valid. Valid resource names are: empty string, prefix, type and identifier combination and just identifier.

