### PR TITLE
INTDEV-610 Use 'es2023' as 'lib' value

### DIFF
--- a/tools/cli/tsconfig.json
+++ b/tools/cli/tsconfig.json
@@ -13,8 +13,8 @@
 
     "outDir": "./dist",
 
-    "target": "es2022",
-    "lib": ["es2020"],
+    "target": "es2023",
+    "lib": ["es2023"],
     "types": ["node", "mocha"]
   },
   "include": ["src/**/*", "test/**/*.ts"],

--- a/tools/data-handler/tsconfig.json
+++ b/tools/data-handler/tsconfig.json
@@ -8,8 +8,8 @@
     "moduleResolution": "NodeNext",
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "target": "es2022",
-    "lib": ["es2020"],
+    "target": "es2023",
+    "lib": ["es2023"],
     "types": ["node", "mocha"]
   },
   "include": ["src/**/*", "test/**/*.ts"]


### PR DESCRIPTION
Since we already:
*  have TS 5.2.+ (we are using 5.6.3 at the moment)
* we have nodeJS 20+
* even ESLint supports `es2023` since 8.44; we are using 9.x+

--> We can move to "eslint2023". 

This gets us some convenience APIs that were not available earlier.

Haven't spotted any regression, as of yet.