### PR TITLE
INTDEV-559: Scorecard macro

### DIFF
--- a/tools/app/app/components/macros/ScoreCard.tsx
+++ b/tools/app/app/components/macros/ScoreCard.tsx
@@ -1,0 +1,78 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Box, Card, Typography } from '@mui/joy';
+import { MacroContext } from '.';
+import React from 'react';
+
+export type CreateCardsProps = {
+  title?: string;
+  value: number;
+  unit?: string;
+  legend?: string;
+} & MacroContext;
+
+export default function ScoreCard({
+  title,
+  value,
+  unit,
+  legend,
+}: CreateCardsProps) {
+  return (
+    <Card
+      variant="outlined"
+      style={{
+        borderRadius: '12px',
+        boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)',
+        display: 'inline-block',
+        padding: '20px',
+        marginTop: '20px',
+        marginRight: '20px',
+      }}
+    >
+      <Typography style={{ fontSize: '16px' }}>{title}</Typography>
+      <Box
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+        }}
+      >
+        <Typography
+          style={{
+            fontSize: '48px',
+            fontWeight: 'bold',
+            color: '#333333',
+          }}
+        >
+          {value}
+        </Typography>
+        <Typography
+          style={{
+            fontSize: '24px',
+            marginLeft: '4px',
+            color: '#333333',
+          }}
+        >
+          {unit}
+        </Typography>
+      </Box>
+      <Typography
+        style={{
+          fontSize: '14px',
+          color: '#999999',
+        }}
+      >
+        {legend}
+      </Typography>
+    </Card>
+  );
+}

--- a/tools/app/app/components/macros/index.ts
+++ b/tools/app/app/components/macros/index.ts
@@ -12,6 +12,7 @@
 
 import { MacroName } from '@cyberismocom/data-handler/interfaces/macros';
 import CreateCards from './CreateCards';
+import ScoreCard from './ScoreCard';
 import { ReactElement } from 'react';
 
 export interface MacroContext {
@@ -29,4 +30,5 @@ export type UIMacroName = Exclude<MacroName, 'report'>;
 
 export const macros: Record<UIMacroName, (props: any) => ReactElement> = {
   createCards: CreateCards,
+  scoreCard: ScoreCard,
 };

--- a/tools/data-handler/src/macros/report/index.ts
+++ b/tools/data-handler/src/macros/report/index.ts
@@ -10,7 +10,11 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { registerEmptyMacros, validateMacroContent } from '../index.js';
+import {
+  registerEmptyMacros,
+  registerMacroHelpers,
+  validateMacroContent,
+} from '../index.js';
 
 import { MacroGenerationContext } from '../../interfaces/macros.js';
 import macroMetadata from './metadata.js';
@@ -68,6 +72,8 @@ class ReportMacro extends BaseMacro {
       throw new Error(result.error);
     }
     registerEmptyMacros(handlebars);
+    registerMacroHelpers(handlebars);
+
     return handlebars.compile(report.contentTemplate)({
       ...handlebarsContext,
       ...result,

--- a/tools/data-handler/src/macros/scoreCard/index.ts
+++ b/tools/data-handler/src/macros/scoreCard/index.ts
@@ -1,0 +1,55 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { createHtmlPlaceholder, validateMacroContent } from '../index.js';
+
+import { MacroGenerationContext } from '../../interfaces/macros.js';
+import macroMetadata from './metadata.js';
+import BaseMacro from '../BaseMacro.js';
+
+export interface ScoreCardOptions {
+  title?: string;
+  value: number;
+  unit?: string;
+  legend?: string;
+  [key: string]: string | number | undefined;
+}
+
+class ScoreCardMacro extends BaseMacro {
+  constructor() {
+    super(macroMetadata);
+  }
+
+  handleStatic = async (context: MacroGenerationContext, data: string) => {
+    if (!data || typeof data !== 'string') {
+      throw new Error('scoreCard macro requires a JSON object as data');
+    }
+    const options = validateMacroContent<ScoreCardOptions>(this.metadata, data);
+
+    return this.createAsciidocElement(options);
+  };
+
+  handleInject = async (_: MacroGenerationContext, data: string) => {
+    if (!data || typeof data !== 'string') {
+      throw new Error('scoreCard macro requires a JSON object as data');
+    }
+    const options = validateMacroContent<ScoreCardOptions>(this.metadata, data);
+
+    return createHtmlPlaceholder(this.metadata, options);
+  };
+
+  private createAsciidocElement(options: ScoreCardOptions) {
+    return `\n----\n${options.title}: ${options.value} ${options.unit ?? ''} ${options.legend ?? ''}\n----\n`;
+  }
+}
+
+export default ScoreCardMacro;

--- a/tools/data-handler/src/macros/scoreCard/metadata.ts
+++ b/tools/data-handler/src/macros/scoreCard/metadata.ts
@@ -10,13 +10,12 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-// important that this file imports only the metadata
-import createCards from './createCards/metadata.js';
-import scoreCard from './scoreCard/metadata.js';
-import report from './report/metadata.js';
+import { MacroMetadata } from '../../interfaces/macros.js';
 
-export const macroMetadata = {
-  createCards,
-  scoreCard,
-  report,
+const macroMetadata: MacroMetadata = {
+  name: 'scoreCard',
+  tagName: 'score-card',
+  schema: 'scoreCardMacroSchema',
 };
+
+export default macroMetadata;

--- a/tools/data-handler/src/utils/schemas.ts
+++ b/tools/data-handler/src/utils/schemas.ts
@@ -14,6 +14,7 @@ import cardBaseSchema from '../../../schema/cardBaseSchema.json' with { type: 'j
 import cardTypeSchema from '../../../schema/cardTypeSchema.json' with { type: 'json' };
 import cardsConfigSchema from '../../../schema/cardsConfigSchema.json' with { type: 'json' };
 import createCardsMacroSchema from '../../../schema/createCardsMacroSchema.json' with { type: 'json' };
+import scoreCardMacroSchema from '../../../schema/scoreCardMacroSchema.json' with { type: 'json' };
 import csvSchema from '../../../schema/csvSchema.json' with { type: 'json' };
 import dotSchema from '../../../schema/dotSchema.json' with { type: 'json' };
 import fieldTypeSchema from '../../../schema/fieldTypeSchema.json' with { type: 'json' };
@@ -29,6 +30,7 @@ export const schemas = [
   cardTypeSchema,
   cardsConfigSchema,
   createCardsMacroSchema,
+  scoreCardMacroSchema,
   csvSchema,
   dotSchema,
   fieldTypeSchema,

--- a/tools/data-handler/test/macros/index.test.ts
+++ b/tools/data-handler/test/macros/index.test.ts
@@ -110,6 +110,27 @@ describe('macros', () => {
         expect(result).to.not.contain('<create-cards>');
       });
     });
+
+    describe('scoreCard', () => {
+      it('scoreCard inject (success)', async () => {
+        const macro = `{{{ scoreCard '{"title": "Scorecard", "value": 99, "unit": "%", "legend": "complete" }' }}}`;
+        const result = await evaluateMacros(macro, {
+          mode: 'inject',
+          projectPath: '',
+          cardKey: '',
+        });
+        expect(result).to.contain('<score-card');
+      });
+      it('scoreCard static (success)', async () => {
+        const macro = `{{{ scoreCard '{"title": "Open issues", "value": 0 }}}`;
+        const result = await evaluateMacros(macro, {
+          mode: 'static',
+          projectPath: '',
+          cardKey: '',
+        });
+        expect(result).to.contain('----');
+      });
+    });
   });
   describe('validateMacros', () => {
     it('validateMacros (success)', () => {
@@ -130,6 +151,7 @@ describe('macros', () => {
         cardKey: '',
       });
       expect(handlebars.helpers).to.have.property('createCards');
+      expect(handlebars.helpers).to.have.property('scoreCard');
       expect(handlebars.helpers).to.have.property('report');
     });
   });
@@ -139,12 +161,12 @@ describe('macros', () => {
         test: 'test-data',
       });
       expect(result).to.equal(
-        '++++\n<test-tag-name test="test-data"></test-tag-name>\n++++',
+        '\n++++\n<test-tag-name test="test-data"></test-tag-name>\n++++',
       );
     });
     it('createHtmlPlaceholder (success) without data', () => {
       const result = createHtmlPlaceholder(macro.metadata, {});
-      expect(result).to.equal('++++\n<test-tag-name></test-tag-name>\n++++');
+      expect(result).to.equal('\n++++\n<test-tag-name></test-tag-name>\n++++');
     });
     it('createAdmonition (success)', () => {
       const result = createAdmonition('WARNING', 'test-title', 'test-content');

--- a/tools/schema/scoreCardMacroSchema.json
+++ b/tools/schema/scoreCardMacroSchema.json
@@ -1,0 +1,24 @@
+{
+  "type": "object",
+  "$id": "scoreCardMacroSchema",
+  "properties": {
+    "title": {
+      "type": "string",
+      "description": "Title text on top of the card (optional)"
+    },
+    "value": {
+      "type": "number",
+      "description": "Value shown as content of the card"
+    },
+    "unit": {
+      "type": "string",
+      "description": "Unit shown after the value (optional)"
+    },
+    "legend": {
+      "type": "string",
+      "description": "Description text shown below the value (optional)"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["value"]
+}


### PR DESCRIPTION
This is a work-in-progress PR for intermediate review, not ready for merging yet.

Here we introduce a new UI macro: scoreCard, which displays a value with added context.

It can be used in card Asciidoc content as follows:
`{{{ scoreCard '{"title": "SDL control adoption", "value": 30, "unit": "%", "legend": "In progress" }' }}}`

It can also be used inside other macros in project resources, such as the report macro Handlebars template, as follows (.hbs code):
```
{{#each results}}

  {{{scoreCard (scoreCardParams "Internal control adoption" this.[base/fieldTypes/progress] "%" )}}}

  {{{scoreCard (scoreCardParams "Security issues that require attention" this.[usdl/fieldTypes/issueCount] )}}}

{{/each}}
```
scoreCardParams is a Handlebars helper that creates a JSON string out of the given parameters. This was the only way I could come up with supporting macros inside other macros .hbs template 😅

App support for the macro also implemented, app will replace html placeholder with material/joy ui element.

**Open issue: how to support this in exports?**
If we want shared graphical representation as in app, we cannot use material elements at the moment.
Inline html+css would be possible as this is a simple element, but is not very maintainable.
Currently I implemented only a simple Asciidoc representation for export cases.
