### PR TITLE
INTDEV-632 - Add template search for create new card popup

### DIFF
--- a/tools/app/app/locales/en/translation.json
+++ b/tools/app/app/locales/en/translation.json
@@ -29,7 +29,9 @@
     "success": "Card created successfully"
   },
   "newCardDialog": {
-    "title": "New card from template"
+    "title": "New card from template",
+    "searchTemplates": "Search templates...",
+    "noTemplatesFoundMessage": "No templates available"
   },
   "saveCard": {
     "success": "Card saved successfully"


### PR DESCRIPTION
Small adjustment to current NewCardModal to show only filtered/searched results. 
Default view is currently:
![image](https://github.com/user-attachments/assets/7769701b-2f84-4a0b-b591-f6e4d39a2df2)

The search box is using autofocus to make the usage a bit more easier. The autofocus returning after it has been cleared did not work automatically, not even when I added inputRefs, most likely since the content is generated after the filter has been cleared. 

Search results are always parsed with .toLowerCase(), like:
![image](https://github.com/user-attachments/assets/4ff7550a-50df-4753-8b87-3c1d1d1d1563)

This will parse the template names and categories