### PR TITLE
INTDEV-582, INTDEV-583 Change resources

### DIFF
--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -686,6 +686,30 @@ program
     },
   );
 
+// Update command
+program
+  .command('update')
+  .description('Update resource details')
+  .argument('<resourceName>', 'Resource name')
+  .argument('<key>', 'Detail to be changed')
+  .argument('<value>', 'New value for a detail')
+  .option('-p, --project-path [path]', `${pathGuideline}`)
+  .action(
+    async (
+      resourceName: string,
+      key: string,
+      value: string,
+      options: CardsOptions,
+    ) => {
+      const result = await commandHandler.command(
+        Cmd.update,
+        [resourceName, key, value],
+        options,
+      );
+      handleResponse(result);
+    },
+  );
+
 // Validate command
 program
   .command('validate')

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -67,6 +67,7 @@ export enum Cmd {
   show = 'show',
   start = 'start',
   transition = 'transition',
+  update = 'update',
   validate = 'validate',
 }
 
@@ -299,6 +300,9 @@ export class Commands {
         await this.commands?.transitionCmd.cardTransition(cardKey, {
           name: state,
         });
+      } else if (command === Cmd.update) {
+        const [resource, key, value] = args;
+        await this.commands?.updateCmd.updateValue(resource, key, value);
       } else if (command === Cmd.validate) {
         return this.validate();
       } else {

--- a/tools/data-handler/src/command-manager.ts
+++ b/tools/data-handler/src/command-manager.ts
@@ -22,6 +22,7 @@ import { Remove } from './remove.js';
 import { Rename } from './rename.js';
 import { Show } from './show.js';
 import { Transition } from './transition.js';
+import { Update } from './update.js';
 import { Validate } from './validate.js';
 
 // Handles commands and ensures that no extra instances are created.
@@ -40,6 +41,7 @@ export class CommandManager {
   public renameCmd: Rename;
   public showCmd: Show;
   public transitionCmd: Transition;
+  public updateCmd: Update;
   public validateCmd: Validate;
 
   constructor(path: string) {
@@ -70,6 +72,7 @@ export class CommandManager {
       this.calculateCmd,
       this.editCmd,
     );
+    this.updateCmd = new Update(this.project);
   }
 
   /**

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -1008,6 +1008,7 @@ export class Project extends CardContainer {
    * @param resourceType Type of resource as a string.
    * @param name Valid name of resource.
    * @returns boolean, true if resource exists; false otherwise.
+   * @todo: could directly use resourceCollector?
    */
   public async resourceExists(
     resourceType: ResourceFolderType,
@@ -1187,7 +1188,7 @@ export class Project extends CardContainer {
    */
   public async updateResource(
     resourceName: string,
-    content: Workflow | CardType,
+    content: CardType | FieldType | LinkType | Workflow,
     newResourceFileName?: string,
   ) {
     return this.resources.saveResource(

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -1180,6 +1180,24 @@ export class Project extends CardContainer {
   }
 
   /**
+   * Updates any resource.
+   * @param resourceName Name of resource
+   * @param content New content.
+   * @param newResourceFileName Optional. A new name for the resource content file.
+   */
+  public async updateResource(
+    resourceName: string,
+    content: Workflow | CardType,
+    newResourceFileName?: string,
+  ) {
+    return this.resources.saveResource(
+      resourceName,
+      content as unknown as JSON,
+      newResourceFileName,
+    );
+  }
+
+  /**
    * Validates that card's data is valid.
    * @param card Card to validate.
    */

--- a/tools/data-handler/src/create.ts
+++ b/tools/data-handler/src/create.ts
@@ -124,7 +124,12 @@ export class Create extends EventEmitter {
     resourceContent: ResourceMetadataType,
   ) {
     const resourceFolder = this.project.paths.resourcePath(resourceType);
-    const resource = { name: resourceContent.name, path: resourceFolder };
+    const resource = {
+      name: resourceContent.name.endsWith('.json')
+        ? resourceContent.name
+        : resourceContent.name + '.json',
+      path: resourceFolder,
+    };
     const contentSchema: DotSchemaContent | undefined =
       this.contentSchemaMap.get(resourceType);
 

--- a/tools/data-handler/src/update.ts
+++ b/tools/data-handler/src/update.ts
@@ -1,0 +1,117 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Project, ResourcesFrom } from './containers/project.js';
+import { Validate } from './validate.js';
+import {
+  resourceNameParts,
+  resourceNameToString,
+  ResourceName,
+} from './utils/resource-utils.js';
+import { CardType, Workflow } from './interfaces/resource-interfaces.js';
+
+/**
+ * Class that handles 'update' commands.
+ */
+export class Update {
+  constructor(private project: Project) {}
+
+  // Does the actual change to a value.
+  private async doUpdateResource(
+    resourceName: ResourceName,
+    key: string,
+    value: unknown,
+  ) {
+    const resource = await this.resource(resourceName);
+    if (resource && resource.name) {
+      if (key === 'name') {
+        resource.name = value as string;
+      } else if (key === 'workflow') {
+        (resource as CardType).workflow = value as string;
+      } else {
+        throw new Error(
+          `Changing property '${key}' to value '${value}' is not supported `,
+        );
+      }
+      await this.project.updateResource(
+        `${resourceName.prefix}/${resourceName.type}/${resourceName.identifier}`,
+        resource,
+        key === 'name' ? resource.name : undefined,
+      );
+    }
+  }
+
+  // Fetches a resource object that matches the name.
+  private async resource(
+    resourceName: ResourceName,
+  ): Promise<Workflow | CardType | undefined> {
+    let resource;
+    if (resourceName.type === 'workflows') {
+      resource = await this.project.workflow(
+        resourceNameToString(resourceName),
+      );
+    }
+    if (resourceName.type === 'cardTypes') {
+      resource = await this.project.cardType(
+        resourceNameToString(resourceName),
+      );
+    }
+    return resource;
+  }
+
+  // Updates all card types to use renamed workflow.
+  private async updateCardTypes(
+    oldWorkflowName: string,
+    newWorkflowName: string,
+  ) {
+    const cardTypes = await this.project.cardTypes(ResourcesFrom.localOnly);
+    for (const cardType of cardTypes) {
+      const cardTypeObject = await this.project.cardType(cardType.name);
+      if (cardTypeObject && cardTypeObject.workflow === oldWorkflowName) {
+        await this.doUpdateResource(
+          resourceNameParts(cardType.name),
+          'workflow',
+          newWorkflowName,
+        );
+      }
+    }
+  }
+
+  /**
+   * Updates single resource property.
+   * @param resourceName Name of the resource
+   * @param key Property to change in resource JSON
+   * @param value New value for 'key'
+   */
+  public async updateValue(resourceName: string, key: string, value: unknown) {
+    const name = resourceNameParts(resourceName);
+
+    if (key === 'name') {
+      const newName = resourceNameParts(value as string);
+      if (!Validate.isValidResourceName(newName.identifier)) {
+        throw new Error(`Cannot change the name of the resource to '${value}'`);
+      }
+      if (name.type !== newName.type) {
+        throw new Error(`Resource name must contain type '${name.type}'`);
+      }
+    }
+
+    await this.doUpdateResource(name, key, value);
+
+    // If workflow was renamed, update all cardTypes that use that workflow
+    if (name.type === 'workflows' && key === 'name') {
+      await this.updateCardTypes(resourceName, value as string);
+    }
+
+    this.project.collectLocalResources();
+  }
+}

--- a/tools/data-handler/src/update.ts
+++ b/tools/data-handler/src/update.ts
@@ -17,7 +17,12 @@ import {
   resourceNameToString,
   ResourceName,
 } from './utils/resource-utils.js';
-import { CardType, Workflow } from './interfaces/resource-interfaces.js';
+import {
+  CardType,
+  FieldType,
+  LinkType,
+  Workflow,
+} from './interfaces/resource-interfaces.js';
 
 /**
  * Class that handles 'update' commands.
@@ -53,7 +58,7 @@ export class Update {
   // Fetches a resource object that matches the name.
   private async resource(
     resourceName: ResourceName,
-  ): Promise<Workflow | CardType | undefined> {
+  ): Promise<CardType | FieldType | LinkType | Workflow | undefined> {
     let resource;
     if (resourceName.type === 'workflows') {
       resource = await this.project.workflow(
@@ -62,6 +67,16 @@ export class Update {
     }
     if (resourceName.type === 'cardTypes') {
       resource = await this.project.cardType(
+        resourceNameToString(resourceName),
+      );
+    }
+    if (resourceName.type === 'fieldTypes') {
+      resource = await this.project.fieldType(
+        resourceNameToString(resourceName),
+      );
+    }
+    if (resourceName.type === 'linkTypes') {
+      resource = await this.project.linkType(
         resourceNameToString(resourceName),
       );
     }

--- a/tools/data-handler/test/resources.test.ts
+++ b/tools/data-handler/test/resources.test.ts
@@ -1,0 +1,363 @@
+// testing
+import { expect } from 'chai';
+
+// node
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { mkdirSync, rmSync } from 'node:fs';
+
+import { copyDir } from '../src/utils/file-utils.js';
+
+import { Calculate } from '../src/calculate.js';
+import { Create } from '../src/create.js';
+import { Import } from '../src/import.js';
+import { Remove } from '../src/remove.js';
+import { Update } from '../src/update.js';
+import { Validate } from '../src/validate.js';
+
+import { Project } from '../src/containers/project.js';
+import {
+  ResourceCollector,
+  ResourcesFrom,
+} from '../src/containers/project/resource-collector.js';
+
+import { RemovableResourceTypes } from '../src/interfaces/project-interfaces.js';
+import { Workflow } from '../src/interfaces/resource-interfaces.js';
+
+describe('resource-collector', () => {
+  const baseDir = dirname(fileURLToPath(import.meta.url));
+  const testDir = join(baseDir, 'tmp-resource-tests');
+  const decisionRecordsPath = join(testDir, 'valid/decision-records');
+  const minimalPath = join(testDir, 'valid/minimal');
+  let project: Project;
+
+  // Some of the commands are used in testing.
+  const validateCmd = Validate.getInstance();
+  let calculateCmd: Calculate;
+  let createCmd: Create;
+  let importCmd: Import;
+  let removeCmd: Remove;
+  let updateCmd: Update;
+
+  before(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir('test/test-data/', testDir);
+    project = new Project(decisionRecordsPath);
+    calculateCmd = new Calculate(project);
+    createCmd = new Create(
+      project,
+      calculateCmd,
+      validateCmd,
+      await project.projectPrefixes(),
+    );
+    importCmd = new Import(project, createCmd);
+    removeCmd = new Remove(project, calculateCmd);
+    updateCmd = new Update(project);
+  });
+
+  after(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('collect resources', async () => {
+    const collector = new ResourceCollector(
+      project.projectPrefix,
+      project.paths,
+    );
+
+    // Before collecting the resources, there shouldn't be anything.
+    expect((await collector.resources('calculations')).length).to.equal(0);
+    expect((await collector.resources('cardTypes')).length).to.equal(0);
+    expect((await collector.resources('fieldTypes')).length).to.equal(0);
+    expect((await collector.resources('linkTypes')).length).to.equal(0);
+    expect((await collector.resources('reports')).length).to.equal(0);
+    expect((await collector.resources('templates')).length).to.equal(0);
+    expect((await collector.resources('workflows')).length).to.equal(0);
+    collector.collectLocalResources();
+
+    // After collecting the resources, arrays are populated.
+    const calcCount = (await collector.resources('calculations')).length;
+    const cardTypesCount = (await collector.resources('cardTypes')).length;
+    const fieldTypesCount = (await collector.resources('fieldTypes')).length;
+    const linkTypesCount = (await collector.resources('linkTypes')).length;
+    const reportsCount = (await collector.resources('reports')).length;
+    const templatesCount = (await collector.resources('templates')).length;
+    const workflowsCount = (await collector.resources('workflows')).length;
+
+    expect(calcCount).not.to.equal(0);
+    expect(cardTypesCount).not.to.equal(0);
+    expect(fieldTypesCount).not.to.equal(0);
+    expect(linkTypesCount).not.to.equal(0);
+    expect(reportsCount).not.to.equal(0);
+    expect(templatesCount).not.to.equal(0);
+    expect(workflowsCount).not.to.equal(0);
+
+    // Calling collect again does not affect the arrays
+    collector.collectLocalResources();
+
+    const calcCountAgain = (await collector.resources('calculations')).length;
+    const cardTypesCountAgain = (await collector.resources('cardTypes')).length;
+    const fieldTypesCountAgain = (await collector.resources('fieldTypes'))
+      .length;
+    const linkTypesCountAgain = (await collector.resources('linkTypes')).length;
+    const reportsCountAgain = (await collector.resources('reports')).length;
+    const templatesCountAgain = (await collector.resources('templates')).length;
+    const workflowsCountAgain = (await collector.resources('workflows')).length;
+
+    expect(calcCount).to.equal(calcCountAgain);
+    expect(cardTypesCount).to.equal(cardTypesCountAgain);
+    expect(fieldTypesCount).to.equal(fieldTypesCountAgain);
+    expect(linkTypesCount).to.equal(linkTypesCountAgain);
+    expect(reportsCount).to.equal(reportsCountAgain);
+    expect(templatesCount).to.equal(templatesCountAgain);
+    expect(workflowsCount).to.equal(workflowsCountAgain);
+
+    // Since there are no modules imported, collecting module resources does not affect
+    // resource arrays.
+    const moduleCalcs =
+      await collector.collectResourcesFromModules('calculations');
+    const moduleCardTypes =
+      await collector.collectResourcesFromModules('cardTypes');
+    const moduleFieldTypes =
+      await collector.collectResourcesFromModules('fieldTypes');
+    const moduleLinkTypes =
+      await collector.collectResourcesFromModules('linkTypes');
+    const moduleReports =
+      await collector.collectResourcesFromModules('reports');
+    const moduleTemplates =
+      await collector.collectResourcesFromModules('templates');
+    const moduleWorkflows =
+      await collector.collectResourcesFromModules('workflows');
+    collector.collectLocalResources();
+
+    expect(moduleCalcs.length).to.equal(0);
+    expect(moduleCardTypes.length).to.equal(0);
+    expect(moduleFieldTypes.length).to.equal(0);
+    expect(moduleLinkTypes.length).to.equal(0);
+    expect(moduleReports.length).to.equal(0);
+    expect(moduleTemplates.length).to.equal(0);
+    expect(moduleWorkflows.length).to.equal(0);
+
+    expect((await collector.resources('calculations')).length).to.equal(
+      calcCount,
+    );
+    expect((await collector.resources('cardTypes')).length).to.equal(
+      cardTypesCount,
+    );
+    expect((await collector.resources('fieldTypes')).length).to.equal(
+      fieldTypesCount,
+    );
+    expect((await collector.resources('linkTypes')).length).to.equal(
+      linkTypesCount,
+    );
+    expect((await collector.resources('reports')).length).to.equal(
+      reportsCount,
+    );
+    expect((await collector.resources('templates')).length).to.equal(
+      templatesCount,
+    );
+    expect((await collector.resources('workflows')).length).to.equal(
+      workflowsCount,
+    );
+  });
+
+  it('collect resources with module', async () => {
+    const collector = new ResourceCollector(
+      project.projectPrefix,
+      project.paths,
+    );
+
+    // Store the resource counts before import.
+    // Note that minimal project does not have fieldTypes, linkTypes or reports
+    collector.collectLocalResources();
+    const calcCount = (await collector.resources('calculations')).length;
+    const cardTypesCount = (await collector.resources('cardTypes')).length;
+    const templatesCount = (await collector.resources('templates')).length;
+    const workflowsCount = (await collector.resources('workflows')).length;
+
+    await importCmd.importProject(minimalPath, project.basePath);
+    await collector.moduleImported();
+
+    const calcCountAgain = (await collector.resources('calculations')).length;
+    const cardTypesCountAgain = (await collector.resources('cardTypes')).length;
+    const templatesCountAgain = (await collector.resources('templates')).length;
+    const workflowsCountAgain = (await collector.resources('workflows')).length;
+
+    expect(calcCount).to.be.lessThan(calcCountAgain);
+    expect(cardTypesCount).to.be.lessThan(cardTypesCountAgain);
+    expect(templatesCount).to.be.lessThan(templatesCountAgain);
+    expect(workflowsCount).to.be.lessThan(workflowsCountAgain);
+  });
+
+  it('add and remove workflow', async () => {
+    const collector = new ResourceCollector(
+      project.projectPrefix,
+      project.paths,
+    );
+    collector.collectLocalResources();
+
+    const workflowsCount = (await collector.resources('workflows')).length;
+    const nameForWorkflow = `${project.projectPrefix}/workflows/newOne`;
+    const fileName = nameForWorkflow + '.json';
+
+    // Creating new resources automatically updates collector arrays, but only for
+    // instance that is owned by the Project. The tested 'collector' instance needs
+    // to be updated by calling 'collectLocalResources()'.
+    await createCmd.createWorkflow(fileName, '');
+    collector.collectLocalResources();
+    let exists = await collector.resourceExists('workflows', fileName);
+    expect(exists).to.equal(true);
+    const workflowsCountAgain = (await collector.resources('workflows')).length;
+    expect(workflowsCount + 1).to.equal(workflowsCountAgain);
+
+    // Removing resources automatically updates collector arrays, but only for
+    // instance that is owned by the Project (and it is not public).
+    // The tested 'collector' instance needs to be updated by calling 'collectLocalResources()'.
+    await removeCmd.remove('workflow', nameForWorkflow);
+    collector.collectLocalResources();
+    exists = await collector.resourceExists('workflows', fileName);
+    expect(exists).to.equal(false);
+  });
+
+  it('add and remove file based resources', async () => {
+    const collector = new ResourceCollector(
+      project.projectPrefix,
+      project.paths,
+    );
+
+    async function checkResource(type: string) {
+      const resourceType = type;
+      const removeType = resourceType.substring(0, resourceType.length - 1);
+      const resourceCount = (await collector.resources(resourceType)).length;
+      const nameForResource = `${project.projectPrefix}/${resourceType}/newOne`;
+      const fileName = nameForResource + '.json';
+
+      if (type === 'cardTypes') {
+        await createCmd.createCardType(fileName, 'decision/workflows/decision');
+      } else if (type === 'fieldTypes') {
+        await createCmd.createFieldType(fileName, 'shortText');
+      } else if (type === 'linkTypes') {
+        await createCmd.createLinkType(fileName);
+      } else {
+        console.error('unhandled type: ' + type);
+        expect(false).to.equal(true);
+      }
+      collector.collectLocalResources();
+      let exists = await collector.resourceExists(resourceType, fileName);
+      expect(exists).to.equal(true);
+      const resourceCountLater = (await collector.resources(resourceType))
+        .length;
+      expect(resourceCount + 1).to.equal(resourceCountLater);
+
+      await removeCmd.remove(removeType as RemovableResourceTypes, fileName);
+      collector.collectLocalResources();
+      exists = await collector.resourceExists(resourceType, fileName);
+      expect(exists).to.equal(false);
+    }
+
+    collector.collectLocalResources();
+
+    await checkResource('cardTypes');
+    await checkResource('linkTypes');
+    await checkResource('fieldTypes');
+  });
+
+  it('add and remove folder based resources', async () => {
+    const collector = new ResourceCollector(
+      project.projectPrefix,
+      project.paths,
+    );
+    collector.collectLocalResources();
+
+    async function checkResource(type: string) {
+      const resourceType = type;
+      const removeType = resourceType.substring(0, resourceType.length - 1);
+      const resourceCount = (await collector.resources(resourceType)).length;
+      const nameForResource = `${project.projectPrefix}/${resourceType}/newOne`;
+
+      if (type === 'templates') {
+        await createCmd.createTemplate(nameForResource, '');
+      } else if (type === 'reports') {
+        await createCmd.createReport(nameForResource);
+      } else {
+        console.error('unhandled type: ' + type);
+        expect(false).to.equal(true);
+      }
+      collector.collectLocalResources();
+      let exists = await collector.resourceExists(
+        resourceType,
+        nameForResource,
+      );
+      expect(exists).to.equal(true);
+      const resourceCountLater = (await collector.resources(resourceType))
+        .length;
+      expect(resourceCount + 1).to.equal(resourceCountLater);
+
+      await removeCmd.remove(
+        removeType as RemovableResourceTypes,
+        nameForResource,
+      );
+      collector.collectLocalResources();
+      exists = await collector.resourceExists(resourceType, nameForResource);
+      expect(exists).to.equal(false);
+    }
+
+    checkResource('templates');
+    checkResource('reports');
+  });
+
+  it('UpdateCmd: update folder file resource', async () => {
+    // only 'name' is supported for now.
+    const collector = new ResourceCollector(
+      project.projectPrefix,
+      project.paths,
+    );
+    collector.collectLocalResources();
+    const resourceName = `${project.projectPrefix}/workflows/decision`;
+    const fileName = `${resourceName}.json`;
+    const exists = await collector.resourceExists('workflows', fileName);
+    expect(exists).to.equal(true);
+
+    const wf = (await collector.resource(
+      'workflows',
+      fileName,
+      ResourcesFrom.localOnly,
+    )) as Workflow;
+
+    const newName = `${project.projectPrefix}/workflows/newName`;
+    await updateCmd.updateValue(resourceName, 'name', newName);
+    collector.changed();
+    const updatedWf = (await collector.resource(
+      'workflows',
+      newName,
+      ResourcesFrom.localOnly,
+    )) as Workflow;
+    expect(wf.name).to.not.equal(updatedWf.name);
+    expect(updatedWf.name).to.equal(newName);
+  });
+
+  it('UpdateCmd: try to update folder file resource with invalid data', async () => {
+    // only 'name' is supported for now.
+    const collector = new ResourceCollector(
+      project.projectPrefix,
+      project.paths,
+    );
+    collector.collectLocalResources();
+    const resourceName = `${project.projectPrefix}/workflows/simple`;
+    const fileName = `${resourceName}.json`;
+    const exists = await collector.resourceExists('workflows', fileName);
+    expect(exists).to.equal(true);
+
+    const invalidName = `${project.projectPrefix}/workflows/newName111`;
+    await updateCmd
+      .updateValue(resourceName, 'name', invalidName)
+      .then(() => {
+        expect(false).to.equal(true);
+      })
+      .catch((error) => {
+        expect(error.message).to.equal(
+          "Cannot change the name of the resource to 'decision/workflows/newName111'",
+        );
+      });
+  });
+});


### PR DESCRIPTION
First version on how to update resources. This can be used to play around with the functionality in CLI.

This now only supports changing the `name` of a file-based resource (INTDEV-582) or changing `workflow` of a card type.
If workflow's name changes, it can automatically update all the referring cardTypes (but not calculations, macros or other referring elements). I am not going to implement the missing renames for now.

This is how it now looks:
<img width="929" alt="Screenshot 2024-12-10 at 14 31 52" src="https://github.com/user-attachments/assets/9ff1237b-8970-442a-995a-c95f86dc00ba">

In the near future I will replace this implementation with one that uses "resource classes". 
The CLI api and tests probably remain as-is. Why you might ask. 
Reason is that handling all intricacies of a specific resource in one "update command" class becomes nightmarish to update. It is a lot easier if we introduce a class per resource type and that class then handles its own exceptions, if any.