### PR TITLE
INTDEV-607 implement new query language features

### DIFF
--- a/calculations/common/base.lp
+++ b/calculations/common/base.lp
@@ -9,21 +9,10 @@ ancestor(A, C) :- parent(A, B), ancestor (B, C), card(A), card(B), card(C).
 % if the card type is given, then it's a card
 card(C) :- field(C, "cardType", _).
 
-% data types for the default card fields
-dataType(Card, "cardType", "shortText") :-
-    field(Card, "cardType", _).
-
-dataType(Card, "title", "shortText") :-
-    field(Card, "title", _).
+% data types for non-shortText default values
 
 dataType(Card, "lastUpdated", "dateTime") :-
     field(Card, "lastUpdated", _).
-
-dataType(Card, "workflowState", "shortText") :-
-    field(Card, "workflowState", _).
-
-dataType(Card, "rank", "shortText") :-
-    field(Card, "rank", _).
 
 % add workflow state category as a calculated field for Cards
 field(Card, "workflowStateCategory", Category) :-
@@ -33,8 +22,6 @@ field(Card, "workflowStateCategory", Category) :-
     field(CardType, "workflow", Workflow),
     workflowState(Workflow, State, Category).
 
-dataType(Card, "workflowStateCategory", "shortText") :-
-    field(Card, "workflowStateCategory", _).
 
 % data types of fields
 dataType(Key, Field, DataType) :-

--- a/calculations/common/base.lp
+++ b/calculations/common/base.lp
@@ -1,4 +1,3 @@
-
 %
 % Common definitions for all Cards projects
 %
@@ -10,4 +9,55 @@ ancestor(A, C) :- parent(A, B), ancestor (B, C), card(A), card(B), card(C).
 % if the card type is given, then it's a card
 card(C) :- field(C, "cardType", _).
 
+% data types for the default card fields
+dataType(Card, "cardType", "shortText") :-
+    field(Card, "cardType", _).
 
+dataType(Card, "title", "shortText") :-
+    field(Card, "title", _).
+
+dataType(Card, "lastUpdated", "dateTime") :-
+    field(Card, "lastUpdated", _).
+
+dataType(Card, "workflowState", "shortText") :-
+    field(Card, "workflowState", _).
+
+dataType(Card, "rank", "shortText") :-
+    field(Card, "rank", _).
+
+% add workflow state category as a calculated field for Cards
+field(Card, "workflowStateCategory", Category) :-
+    card(Card),
+    field(Card, "workflowState", State),
+    field(Card, "cardType", CardType),
+    field(CardType, "workflow", Workflow),
+    workflowState(Workflow, State, Category).
+
+dataType(Card, "workflowStateCategory", "shortText") :-
+    field(Card, "workflowStateCategory", _).
+
+% data types of fields
+dataType(Key, Field, DataType) :-
+    field(Key, Field, _),
+    fieldType(Field),
+    field(Field, "dataType", DataType).
+
+% data types for enum values
+
+dataType((FieldType, EnumValue), "index", "integer") :-
+    enumValue(FieldType, EnumValue).
+
+dataType((FieldType, EnumValue), "enumDisplayValue", "shortText") :-
+    enumValue(FieldType, EnumValue).
+
+dataType((FieldType, EnumValue), "enumDescription", "longText") :-
+    enumValue(FieldType, EnumValue).
+
+dataType((FieldType, EnumValue), "enumValue", "longText") :-
+    enumValue(FieldType, EnumValue).
+
+% descendants of hidden cards are hidden
+
+hiddenInTreeView(Card) :-
+    ancestor(Card, Ancestor),
+    hiddenInTreeView(Ancestor).

--- a/calculations/common/queryLanguage.lp
+++ b/calculations/common/queryLanguage.lp
@@ -275,12 +275,12 @@ showField(Key, Field) :-
 % orderBy is syntactic sugar for order, as you can order by 1..3 fields with one term when using the default collection "results"
 
 % orderBy with an even numer of parameters refers to results on all levels of hierarchy.
-order(N, "results", 1, Field, Direction) :- orderBy(Field, Direction), resultLevel(_, N).
-order(N, "results", 1, Field1, Direction1) :- orderBy(Field1, Direction1, _, _), resultLevel(_, N).
-order(N, "results", 2, Field2, Direction2) :- orderBy(_, _, Field2, Direction2), resultLevel(_, N).
-order(N, "results", 1, Field1, Direction1) :- orderBy(Field1, Direction1, _, _, _, _), resultLevel(_, N).
-order(N, "results", 2, Field2, Direction2) :- orderBy(_, _, Field2, Direction2, _, _), resultLevel(_, N).
-order(N, "results", 3, Field3, Direction3) :- orderBy(_, _, _, _, Field3, Direction3), resultLevel(_, N).
+order(N, "results", 1, Field, Direction) :- orderBy(Field, Direction), resultLevel(_, N, "results").
+order(N, "results", 1, Field1, Direction1) :- orderBy(Field1, Direction1, _, _), resultLevel(_, N, "results").
+order(N, "results", 2, Field2, Direction2) :- orderBy(_, _, Field2, Direction2), resultLevel(_, N, "results").
+order(N, "results", 1, Field1, Direction1) :- orderBy(Field1, Direction1, _, _, _, _), resultLevel(_, N, "results").
+order(N, "results", 2, Field2, Direction2) :- orderBy(_, _, Field2, Direction2, _, _), resultLevel(_, N, "results").
+order(N, "results", 3, Field3, Direction3) :- orderBy(_, _, _, _, Field3, Direction3), resultLevel(_, N, "results").
 
 % orderBy with an odd numer of parameters has the result level as the first parameter
 order(Level, "results", 1, Field, Direction) :- orderBy(Level, Field, Direction).

--- a/calculations/common/queryLanguage.lp
+++ b/calculations/common/queryLanguage.lp
@@ -1,52 +1,134 @@
 % Cyberismo query language
 
-% select(n, field): on result level n, "field" should be returned
-% selectAll(n): on result level n, all fields should be returned
-% select(field): "field" should be returned on all levels of hierarchy
-% selectAll: all fields should be returned on all levels of hierarchy
+% select(n, collection, field): on result level n and for "collection", "field" should be returned
+% selectCollectionField(collection, field): on all result levels for "collection", "field" should be returned
+% selectAll(n): on result level n, all fields should be returned for all collections
+% select(field): "field" should be returned on all levels of hierarchy for all collections
+% selectAll: all fields should be returned on all levels of hierarchy for all collections
 
 % select works similarly for "labels", "links", "notifications", "policyChecks" and "deniedOperations" as it works for fields
 
-select(N, Field) :- select(Field), resultLevel(_, N).
-selectAll(N) :- selectAll, resultLevel(_, N).
+select(N, Collection, Field) :- select(Field), resultLevel(_, N, Collection).
 
-% resultLevel(key, n): result "key" is on result level n
-resultLevel(Key, 1) :- result(Key).
-resultLevel(Child, N+1) :- childResult(Key, Child), resultLevel(Key, N).
+selectAll(N) :- selectAll, resultLevel(_, N, _).
+
+select(N, Collection, Field) :-
+    selectCollectionField(Collection, Field),
+    resultLevel(_, N, Collection).
+
+% the default child result collection is "results"
+childResult(Key, Child, "results") :- childResult(Key, Child).
+
+% resultLevel(key, n, collection): result "key" is on result level n in "collection"
+resultLevel(Key, 1, "results") :- result(Key).
+resultLevel(Child, N+1, Collection) :- childResult(Key, Child, Collection), resultLevel(Key, N, _).
 
 % result(key): key is a result of the query
 #show result(Key) : result(Key), not queryError.
 
 % childResult(key, child key): child key is a child result of key
-#show childResult(Key, Child) : childResult(Key, Child), not queryError.
+#show childResult(Key, Child, Collection) : childResult(Key, Child, Collection), not queryError.
 
 % helpers for simplifying some of the #show statements
 
 % resultOrChildResult(key): key is included in the results as a result or a child result
 resultOrChildResult(Key) :- result(Key).
-resultOrChildResult(Key) :- childResult(_, Key).
+resultOrChildResult(Key) :- childResult(_, Key, _).
 
 % showAll(key): whether all fields or field-like things of a key should be included in the results
 showAll(Key) :-
     resultOrChildResult(Key),
-    resultLevel(Key, Level),
+    resultLevel(Key, Level, _),
     selectAll(Level),
     not queryError.
 
 % showField: whether a certain field or field-like thing of a key should be included in the results
 showField(Key, Field) :-
     resultOrChildResult(Key),
-    resultLevel(Key, Level),
+    resultLevel(Key, Level, _),
     select(Level, Field),
     not queryError.
 
-% field(key, field, value): "field" of result/child result "key" has value "value"
-#show field(Key, Field, Value) :
+% Fields
+%
+% field(key, field, value, data type):
+% "field" of result/child result "key" has value "value",
+% data type of the field is included
+% a field term like this is returned for all other fields except enum and list
+%
+% enumField(key, field, value, index, enum display value):
+% listField(key, field, value, index, enum display value):
+% otherwise the same as field, but for enum and list fields,
+% we also need the enum value index and enum display value
+
+#show field(Key, Field, Value, "shortText") :
     field(Key, Field, Value),
+    dataType(Key, Field, DataType),
+%    DataType != "enum",
+%    DataType != "list",
     showField(Key, Field).
 
-#show field(Key, Field, Value) :
+#show field(Key, Field, Value, DataType) :
     field(Key, Field, Value),
+    dataType(Key, Field, DataType),
+%    DataType != "enum",
+%    DataType != "list",
+    showAll(Key).
+
+#show enumField(Key, Field, Value, Index, DisplayValue) :
+    field(Key, Field, Value),
+    dataType(Key, Field, "enum"),
+    field((Field, Value), "index", Index),
+    field((Field, Value), "enumDisplayValue", DisplayValue),
+    showField(Key, Field).
+
+#show enumField(Key, Field, Value, Index, Value) :
+    field(Key, Field, Value),
+    dataType(Key, Field, "enum"),
+    field((Field, Value), "index", Index),
+    not field((Field, Value), "enumDisplayValue", _),
+    showField(Key, Field).
+
+#show enumField(Key, Field, Value, Index, DisplayValue) :
+    field(Key, Field, Value),
+    dataType(Key, Field, "enum"),
+    field((Field, Value), "index", Index),
+    field((Field, Value), "enumDisplayValue", DisplayValue),
+    showAll(Key).
+
+#show enumField(Key, Field, Value, Index, Value) :
+    field(Key, Field, Value),
+    dataType(Key, Field, "enum"),
+    field((Field, Value), "index", Index),
+    not field((Field, Value), "enumDisplayValue", _),
+    showAll(Key).
+
+#show listField(Key, Field, Value, Index, DisplayValue) :
+    field(Key, Field, Value),
+    dataType(Key, Field, "list"),
+    field((Field, Value), "index", Index),
+    field((Field, Value), "enumDisplayValue", DisplayValue),
+    showField(Key, Field).
+
+#show listField(Key, Field, Value, Index, Value) :
+    field(Key, Field, Value),
+    dataType(Key, Field, "list"),
+    field((Field, Value), "index", Index),
+    not field((Field, Value), "enumDisplayValue", _),
+    showField(Key, Field).
+
+#show listField(Key, Field, Value, Index, DisplayValue) :
+    field(Key, Field, Value),
+    dataType(Key, Field, "list"),
+    field((Field, Value), "index", Index),
+    field((Field, Value), "enumDisplayValue", DisplayValue),
+    showAll(Key).
+
+#show listField(Key, Field, Value, Index, Value) :
+    field(Key, Field, Value),
+    dataType(Key, Field, "list"),
+    field((Field, Value), "index", Index),
+    not field((Field, Value), "enumDisplayValue", _),
     showAll(Key).
 
 % label(key, label): key is tagged with "label"
@@ -179,58 +261,53 @@ showField(Key, Field) :-
     editingContentDenied(Key, ErrorMessage),
     showAll(Key).
 
-% order(n, 1, field, direction): the results on level n should be first ordered by "field" in "direction"
-% order(n, 2, field, direction): the results on level n should be secondly ordered by "field" in "direction"
+% order(n, collection, 1, field, direction): the results in the collection on level n should be first ordered by "field" in "direction"
+% order(n, collection, 2, field, direction): the results in the collection on level n should be secondly ordered by "field" in "direction"
 % etc.
 % direction must be "ASC" or "DESC".
 
-% orderBy is syntactic sugar for order, as you can order by 1..3 fields with one predicate
+% orderBy is syntactic sugar for order, as you can order by 1..3 fields with one term when using the default collection "results"
 
 % orderBy with an even numer of parameters refers to results on all levels of hierarchy.
-order(N, 1, Field, Direction) :- orderBy(Field, Direction), resultLevel(_, N).
-order(N, 1, Field1, Direction1) :- orderBy(Field1, Direction1, _, _), resultLevel(_, N).
-order(N, 2, Field2, Direction2) :- orderBy(_, _, Field2, Direction2), resultLevel(_, N).
-order(N, 1, Field1, Direction1) :- orderBy(Field1, Direction1, _, _, _, _), resultLevel(_, N).
-order(N, 2, Field2, Direction2) :- orderBy(_, _, Field2, Direction2, _, _), resultLevel(_, N).
-order(N, 3, Field3, Direction3) :- orderBy(_, _, _, _, Field3, Direction3), resultLevel(_, N).
+order(N, "results", 1, Field, Direction) :- orderBy(Field, Direction), resultLevel(_, N).
+order(N, "results", 1, Field1, Direction1) :- orderBy(Field1, Direction1, _, _), resultLevel(_, N).
+order(N, "results", 2, Field2, Direction2) :- orderBy(_, _, Field2, Direction2), resultLevel(_, N).
+order(N, "results", 1, Field1, Direction1) :- orderBy(Field1, Direction1, _, _, _, _), resultLevel(_, N).
+order(N, "results", 2, Field2, Direction2) :- orderBy(_, _, Field2, Direction2, _, _), resultLevel(_, N).
+order(N, "results", 3, Field3, Direction3) :- orderBy(_, _, _, _, Field3, Direction3), resultLevel(_, N).
 
 % orderBy with an odd numer of parameters has the result level as the first parameter
-order(Level, 1, Field, Direction) :- orderBy(Level, Field, Direction).
-order(Level, 1, Field1, Direction1) :- orderBy(Level, Field1, Direction1, _, _).
-order(Level, 2, Field2, Direction2) :- orderBy(Level, _, _, Field2, Direction2).
-order(Level, 1, Field1, Direction1) :- orderBy(Level, Field1, Direction1, _, _, _, _).
-order(Level, 2, Field2, Direction2) :- orderBy(Level, _, _, Field2, Direction2, _, _).
-order(Level, 3, Field3, Direction3) :- orderBy(Level, _, _, _, _, Field3, Direction3).
+order(Level, "results", 1, Field, Direction) :- orderBy(Level, Field, Direction).
+order(Level, "results", 1, Field1, Direction1) :- orderBy(Level, Field1, Direction1, _, _).
+order(Level, "results", 2, Field2, Direction2) :- orderBy(Level, _, _, Field2, Direction2).
+order(Level, "results", 1, Field1, Direction1) :- orderBy(Level, Field1, Direction1, _, _, _, _).
+order(Level, "results", 2, Field2, Direction2) :- orderBy(Level, _, _, Field2, Direction2, _, _).
+order(Level, "results", 3, Field3, Direction3) :- orderBy(Level, _, _, _, _, Field3, Direction3).
 
-queryError("Invalid direction in ordering:", Level, Index, Field, Direction) :-
-    order(Level, Index, Field, Direction),
+% select the fields that are needed for sorting automatically
+select(Level, Collection, Field) :- order(Level, Collection, _, Field, _).
+
+queryError("Invalid direction in ordering:", (Level, Collection, Index, Field, Direction)) :-
+    order(Level, Collection, Index, Field, Direction),
     Direction != "ASC",
     Direction != "DESC".
 
-queryError("Ordering direction missing:", Field) :- orderBy(Field).
+queryError("Ordering direction missing:", (Field)) :- orderBy(Field).
 
-queryError("Conflicting ordering for fields: ", Field1, Field2) :-
-    order(Level, Index, Field1, _),
-    order(Level, Index, Field2, _),
+queryError("Conflicting ordering for fields: ", (Field1, Field2)) :-
+    order(Level, Collection, Index, Field1, _),
+    order(Level, Collection, Index, Field2, _),
     Field1 != Field2.
 
-queryError("Conflicting ordering direction", Field, Direction1, Direction2) :-
-    order(Level, Index, Field, Direction1),
-    order(Level, Index, Field, Direction2),
+queryError("Conflicting ordering direction", (Field, Collection, Direction1, Direction2)) :-
+    order(Level, Collection, Index, Field, Direction1),
+    order(Level, Collection, Index, Field, Direction2),
     Direction1 != Direction2.
 
-queryError :- queryError(_).
 queryError :- queryError(_, _).
-queryError :- queryError(_, _, _).
-queryError :- queryError(_, _, _, _).
-queryError :- queryError(_, _, _, _, _).
 
-#show order(Level, Index, Field, Direction) :
-    order(Level, Index, Field, Direction),
+#show order(Level, Collection, Index, Field, Direction) :
+    order(Level, Collection, Index, Field, Direction),
     not queryError.
 
-#show queryError/1.
 #show queryError/2.
-#show queryError/3.
-#show queryError/4.
-#show queryError/5.

--- a/calculations/common/queryLanguage.lp
+++ b/calculations/common/queryLanguage.lp
@@ -49,6 +49,12 @@ showField(Key, Field) :-
     select(Level, Field),
     not queryError.
 
+showField(Key, Field) :-
+    resultOrChildResult(Key),
+    resultLevel(Key, Level, Collection),
+    select(Level, Collection, Field),
+    not queryError.
+
 % Fields
 %
 % field(key, field, value, data type):
@@ -64,15 +70,15 @@ showField(Key, Field) :-
 #show field(Key, Field, Value, "shortText") :
     field(Key, Field, Value),
     dataType(Key, Field, DataType),
-%    DataType != "enum",
-%    DataType != "list",
+    DataType != "enum",
+    DataType != "list",
     showField(Key, Field).
 
 #show field(Key, Field, Value, DataType) :
     field(Key, Field, Value),
     dataType(Key, Field, DataType),
-%    DataType != "enum",
-%    DataType != "list",
+    DataType != "enum",
+    DataType != "list",
     showAll(Key).
 
 #show enumField(Key, Field, Value, Index, DisplayValue) :
@@ -311,3 +317,8 @@ queryError :- queryError(_, _).
     not queryError.
 
 #show queryError/2.
+
+% helper terms
+
+level(Level) :-
+    resultLevel(_, Level, _).

--- a/calculations/common/queryLanguage.lp
+++ b/calculations/common/queryLanguage.lp
@@ -59,7 +59,7 @@ showField(Key, Field) :-
 %
 % field(key, field, value, data type):
 % "field" of result/child result "key" has value "value",
-% data type of the field is included
+% data type of the field is included, if not specified, it is shortText
 % a field term like this is returned for all other fields except enum and list
 %
 % enumField(key, field, value, index, enum display value):
@@ -67,7 +67,7 @@ showField(Key, Field) :-
 % otherwise the same as field, but for enum and list fields,
 % we also need the enum value index and enum display value
 
-#show field(Key, Field, Value, "shortText") :
+#show field(Key, Field, Value, DataType) :
     field(Key, Field, Value),
     dataType(Key, Field, DataType),
     DataType != "enum",
@@ -79,6 +79,16 @@ showField(Key, Field) :-
     dataType(Key, Field, DataType),
     DataType != "enum",
     DataType != "list",
+    showAll(Key).
+
+#show field(Key, Field, Value, "shortText") :
+    field(Key, Field, Value),
+    not dataType(Key, Field, _),
+    showField(Key, Field).
+
+#show field(Key, Field, Value, "shortText") :
+    field(Key, Field, Value),
+    not dataType(Key, Field, _),
     showAll(Key).
 
 #show enumField(Key, Field, Value, Index, DisplayValue) :

--- a/calculations/queries/card.lp
+++ b/calculations/queries/card.lp
@@ -69,8 +69,22 @@ field(Field, "isEditable", "true") :-
 % add value
 dataType(Field, "value", DataType) :-
     childResult(_, Field, "fields"),
+    DataType != "enum",
+    DataType != "list",
     field({{cardKey}}, Field, Value),
     dataType({{cardKey}}, Field, DataType).
+
+% use short text for enums
+dataType(Field, "value", "shortText") :-
+    childResult(_, Field, "fields"),
+    field({{cardKey}}, Field, Value),
+    dataType({{cardKey}}, Field, "enum").
+
+% use short text for lists
+dataType(Field, "value", "shortText") :-
+    childResult(_, Field, "fields"),
+    field({{cardKey}}, Field, Value),
+    dataType({{cardKey}}, Field, "list").
 
 
 % add value
@@ -93,6 +107,7 @@ select(1, "policyChecks").
 select(1, "links").
 select(1, "deniedOperations").
 select(1, "labels").
+selectAll.
 
 select(2, "visibility").
 select(2, "index").

--- a/calculations/queries/card.lp
+++ b/calculations/queries/card.lp
@@ -107,7 +107,6 @@ select(1, "policyChecks").
 select(1, "links").
 select(1, "deniedOperations").
 select(1, "labels").
-selectAll.
 
 select(2, "visibility").
 select(2, "index").

--- a/calculations/queries/card.lp
+++ b/calculations/queries/card.lp
@@ -1,7 +1,22 @@
-
 result({{cardKey}}).
 
+% a helper term for display names
+
+displayName(Card, Field, DisplayName) :-
+    field(Card, Field, _),
+    fieldType(Field),
+    field(Field, "displayName", DisplayName),
+    field(Card, "cardType", CardType),
+    not field((CardType, Field), "displayName", _).
+
+displayName(Card, Field, DisplayName) :-
+    field(Card, "cardType", CardType),
+    field((CardType, Field), "displayName", DisplayName).
+
 % the second level includes metadata for the always visible and optionally visible fields
+
+dataType(Field, "visibility", "shortText") :-
+    field(Field, "visibility", _).
 
 field(Field, "visibility", "always") :-
     alwaysVisibleField(CardType, Field),
@@ -11,6 +26,10 @@ field(Field, "visibility", "optional") :-
     optionallyVisibleField(CardType, Field),
     field({{cardKey}}, "cardType", CardType).
 
+dataType(Field, "index", "integer") :-
+    childResult(_, Field, "fields"),
+    field(Field, "index", _).
+
 field(Field, "index", Index) :-
     alwaysVisibleField(CardType, Field),
     field((CardType, Field), "index", Index),
@@ -21,24 +40,49 @@ field(Field, "index", Index) :-
     field((CardType, Field), "index", Index),
     field({{cardKey}}, "cardType", CardType).
 
-field(Field, "fieldDisplayName", Name) :-
-    field({{cardKey}}, "cardType", CardType),
-    field((CardType, Field), "displayName", Name).
+dataType(Field, "fieldDisplayName", "shortText") :-
+    childResult(_, Field, "fields"),
+    field(Field, "fieldDisplayName", _).
 
-field(Field, "fieldDisplayName", Name) :-
-    field(Field, "displayName", Name),
-    field({{cardKey}}, "cardType", CardType),
-    not field((CardType, Field), "displayName", _).
+field(Field, "fieldDisplayName", DisplayName) :-
+    childResult(_, Field, "fields"),
+    displayName({{cardKey}}, Field, DisplayName).
+
+dataType(Field, "isEditable", "boolean") :-
+    childResult(_, Field, "fields"),
+    field(Field, "isEditable", _).
 
 field(Field, "isEditable", IsEditable) :-
     field({{cardKey}}, "cardType", CardType),
     field((CardType, Field), "isEditable", IsEditable).
 
-% Add value
+field(Field, "isEditable", "true") :-
+   field({{cardKey}}, "cardType", CardType),
+   alwaysVisibleField(CardType, Field),
+   not field((CardType, Field), "isEditable", _).
+
+field(Field, "isEditable", "true") :-
+   field({{cardKey}}, "cardType", CardType),
+   optionallyVisibleField(CardType, Field),
+   not field((CardType, Field), "isEditable", _).
+
+% add value
+dataType(Field, "value", DataType) :-
+    childResult(_, Field, "fields"),
+    field({{cardKey}}, Field, Value),
+    dataType({{cardKey}}, Field, DataType).
+
+
+% add value
 field(Field, "value", Value) :-
+    childResult({{cardKey}}, Field, "fields"),
     field({{cardKey}}, Field, Value).
 
-% Add only non-custom fields
+dataType(Field, "dataType", "shortText") :-
+    childResult(_, Field, "fields").
+
+
+% select only non-custom fields
 select(1, "cardType").
 select(1, "title").
 select(1, "key").
@@ -58,29 +102,26 @@ select(2, "dataType").
 select(2, "isEditable").
 select(2, "value").
 
-childResult({{cardKey}}, Field) :-
+childResult({{cardKey}}, Field, "fields") :-
     alwaysVisibleField(CardType, Field),
     field({{cardKey}}, "cardType", CardType).
 
-childResult({{cardKey}}, Field) :-
+childResult({{cardKey}}, Field, "fields") :-
     optionallyVisibleField(CardType, Field),
     field({{cardKey}}, "cardType", CardType).
 
-
-
-% For enum fields, add enum values as child results:
-
+% for enum fields, add enum values as child results:
 select(3, "index").
 select(3, "enumDisplayValue").
 select(3, "enumDescription").
 select(3, "enumValue").
 
-childResult(Field, (Field, EnumValue)) :-
+childResult(Field, (Field, EnumValue), "enumValues") :-
     enumValue(Field, EnumValue).
 
 field((Field, EnumValue), "enumValue", EnumValue) :-
     enumValue(Field, EnumValue).
 
-order(2, 1, "visibility", "ASC").
-order(2, 2, "index", "ASC").
-order(3, 1, "index", "ASC").
+order(2, "fields", 1, "visibility", "ASC").
+order(2, "fields", 2, "index", "ASC").
+order(3, "enumValues", 1, "index", "ASC").

--- a/calculations/queries/card.lp
+++ b/calculations/queries/card.lp
@@ -15,9 +15,6 @@ displayName(Card, Field, DisplayName) :-
 
 % the second level includes metadata for the always visible and optionally visible fields
 
-dataType(Field, "visibility", "shortText") :-
-    field(Field, "visibility", _).
-
 field(Field, "visibility", "always") :-
     alwaysVisibleField(CardType, Field),
     field({{cardKey}}, "cardType", CardType).
@@ -25,10 +22,6 @@ field(Field, "visibility", "always") :-
 field(Field, "visibility", "optional") :-
     optionallyVisibleField(CardType, Field),
     field({{cardKey}}, "cardType", CardType).
-
-dataType(Field, "index", "integer") :-
-    childResult(_, Field, "fields"),
-    field(Field, "index", _).
 
 field(Field, "index", Index) :-
     alwaysVisibleField(CardType, Field),
@@ -74,26 +67,11 @@ dataType(Field, "value", DataType) :-
     field({{cardKey}}, Field, Value),
     dataType({{cardKey}}, Field, DataType).
 
-% use short text for enums
-dataType(Field, "value", "shortText") :-
-    childResult(_, Field, "fields"),
-    field({{cardKey}}, Field, Value),
-    dataType({{cardKey}}, Field, "enum").
-
-% use short text for lists
-dataType(Field, "value", "shortText") :-
-    childResult(_, Field, "fields"),
-    field({{cardKey}}, Field, Value),
-    dataType({{cardKey}}, Field, "list").
-
 
 % add value
 field(Field, "value", Value) :-
     childResult({{cardKey}}, Field, "fields"),
     field({{cardKey}}, Field, Value).
-
-dataType(Field, "dataType", "shortText") :-
-    childResult(_, Field, "fields").
 
 
 % select only non-custom fields

--- a/calculations/queries/tree.lp
+++ b/calculations/queries/tree.lp
@@ -1,10 +1,5 @@
-field(Card, "workflowStateCategory", Category) :-
-    field(Card, "workflowState", State),
-    field(Card, "cardType", CardType),
-    field(CardType, "workflow", Workflow),
-    workflowState(Workflow, State, Category).
-
-select("title";"workflowStateCategory";"base/fieldTypes/progress";"rank";"cardType").
+%select("title";"workflowStateCategory";"base/fieldTypes/progress";"rank";"cardType").
+selectAll.
 result(Card) :- card(Card), not parent(Card, _), not hiddenInTreeView(Card).
-childResult(Parent, Card) :- card(Card), parent(Card, Parent), not hiddenInTreeView(Card).
+childResult(Parent, Card, "children") :- card(Card), parent(Card, Parent), not hiddenInTreeView(Card).
 orderBy("rank", "ASC").

--- a/calculations/queries/tree.lp
+++ b/calculations/queries/tree.lp
@@ -1,5 +1,6 @@
-%select("title";"workflowStateCategory";"base/fieldTypes/progress";"rank";"cardType").
-selectAll.
+select("title";"workflowStateCategory";"base/fieldTypes/progress";"rank";"cardType").
 result(Card) :- card(Card), not parent(Card, _), not hiddenInTreeView(Card).
 childResult(Parent, Card, "children") :- card(Card), parent(Card, Parent), not hiddenInTreeView(Card).
-orderBy("rank", "ASC").
+order(Level, "children", 1, "rank", "ASC") :-
+    level(Level).
+

--- a/tools/app/__tests__/api.test.ts
+++ b/tools/app/__tests__/api.test.ts
@@ -141,10 +141,10 @@ test('tree endpoint returns proper data', async () => {
   expect(result[0].title).toBe('Decision Records');
   expect(result[0].rank).toBe('0|a');
   expect(result[0].workflowStateCategory).toBe('initial');
-  expect(result[0].results[0].key).toBe('decision_6');
-  expect(result[0].results[0].title).toBe(
+  expect(result[0].children?.at(0)?.key).toBe('decision_6');
+  expect(result[0].children?.at(0)?.title).toBe(
     'Document Decisions with Decision Records',
   );
-  expect(result[0].results[0].rank).toBe('0|a');
-  expect(result[0].results[0].workflowStateCategory).toBe('closed');
+  expect(result[0].children?.at(0)?.rank).toBe('0|a');
+  expect(result[0].children?.at(0)?.workflowStateCategory).toBe('closed');
 });

--- a/tools/app/__tests__/components.test.tsx
+++ b/tools/app/__tests__/components.test.tsx
@@ -248,7 +248,7 @@ const treeQueryResult: QueryResult<'tree'>[] = [
     rank: '0|i',
     title: 'SDL Decision',
     cardType: 'test/cardTypes/decision',
-    results: [
+    children: [
       {
         key: 'usdl_44',
         labels: [],
@@ -268,7 +268,7 @@ const treeQueryResult: QueryResult<'tree'>[] = [
         rank: '0|i',
         title: 'SDL Project',
         cardType: 'test/cardTypes/simplePage',
-        results: [
+        children: [
           {
             key: 'usdl_45',
             labels: [],
@@ -288,7 +288,6 @@ const treeQueryResult: QueryResult<'tree'>[] = [
             rank: '0|a',
             title: 'Untitled',
             cardType: 'test/cardTypes/controlledDocument',
-            results: [],
           },
           {
             key: 'usdl_46',
@@ -309,7 +308,6 @@ const treeQueryResult: QueryResult<'tree'>[] = [
             rank: '0|b',
             title: 'Demand phase',
             cardType: 'test/cardTypes/simplePage',
-            results: [],
           },
           {
             key: 'usdl_47',
@@ -330,7 +328,7 @@ const treeQueryResult: QueryResult<'tree'>[] = [
             rank: '0|d',
             title: 'Design phase',
             cardType: 'test/cardTypes/simplePage',
-            results: [
+            children: [
               {
                 key: 'usdl_53',
                 labels: [],
@@ -350,7 +348,6 @@ const treeQueryResult: QueryResult<'tree'>[] = [
                 rank: '0|c',
                 title: 'Threat model',
                 cardType: 'test/cardTypes/controlledDocument',
-                results: [],
               },
             ],
           },
@@ -373,7 +370,6 @@ const treeQueryResult: QueryResult<'tree'>[] = [
             rank: '0|e',
             title: 'Implementation phase',
             cardType: 'test/cardTypes/simplePage',
-            results: [],
           },
           {
             key: 'usdl_49',
@@ -394,7 +390,6 @@ const treeQueryResult: QueryResult<'tree'>[] = [
             rank: '',
             title: '',
             cardType: '',
-            results: [],
           },
           {
             key: 'usdl_50',
@@ -415,7 +410,6 @@ const treeQueryResult: QueryResult<'tree'>[] = [
             rank: '0|f',
             title: 'Release phase',
             cardType: 'test/cardTypes/simplePage',
-            results: [],
           },
           {
             key: 'usdl_51',
@@ -436,7 +430,6 @@ const treeQueryResult: QueryResult<'tree'>[] = [
             rank: '0|g',
             title: 'Operations phase',
             cardType: 'test/cardTypes/simplePage',
-            results: [],
           },
           {
             key: 'usdl_52',
@@ -457,7 +450,6 @@ const treeQueryResult: QueryResult<'tree'>[] = [
             rank: '0|h',
             title: 'Meetings',
             cardType: 'test/cardTypes/simplePage',
-            results: [],
           },
         ],
       },

--- a/tools/app/__tests__/utils.test.ts
+++ b/tools/app/__tests__/utils.test.ts
@@ -230,7 +230,7 @@ const treeQueryResult: QueryResult<'tree'>[] = [
     rank: '0|i',
     title: 'SDL Decision',
     cardType: 'test/cardTypes/decision',
-    results: [
+    children: [
       {
         key: 'usdl_44',
         labels: [],
@@ -250,7 +250,7 @@ const treeQueryResult: QueryResult<'tree'>[] = [
         rank: '0|i',
         title: 'SDL Project',
         cardType: 'test/cardTypes/simplePage',
-        results: [
+        children: [
           {
             key: 'usdl_45',
             labels: [],
@@ -270,7 +270,6 @@ const treeQueryResult: QueryResult<'tree'>[] = [
             rank: '0|a',
             title: 'Untitled',
             cardType: 'test/cardTypes/controlledDocument',
-            results: [],
           },
           {
             key: 'usdl_46',
@@ -291,7 +290,6 @@ const treeQueryResult: QueryResult<'tree'>[] = [
             rank: '0|b',
             title: 'Demand phase',
             cardType: 'test/cardTypes/simplePage',
-            results: [],
           },
           {
             key: 'usdl_47',
@@ -312,7 +310,7 @@ const treeQueryResult: QueryResult<'tree'>[] = [
             rank: '0|d',
             title: 'Design phase',
             cardType: 'test/cardTypes/simplePage',
-            results: [
+            children: [
               {
                 key: 'usdl_53',
                 labels: [],
@@ -332,7 +330,6 @@ const treeQueryResult: QueryResult<'tree'>[] = [
                 rank: '0|c',
                 title: 'Threat model',
                 cardType: 'test/cardTypes/controlledDocument',
-                results: [],
               },
             ],
           },
@@ -355,7 +352,6 @@ const treeQueryResult: QueryResult<'tree'>[] = [
             rank: '0|e',
             title: 'Implementation phase',
             cardType: 'test/cardTypes/simplePage',
-            results: [],
           },
           {
             key: 'usdl_49',
@@ -376,7 +372,6 @@ const treeQueryResult: QueryResult<'tree'>[] = [
             rank: '',
             title: '',
             cardType: '',
-            results: [],
           },
           {
             key: 'usdl_50',
@@ -397,7 +392,6 @@ const treeQueryResult: QueryResult<'tree'>[] = [
             rank: '0|f',
             title: 'Release phase',
             cardType: 'test/cardTypes/simplePage',
-            results: [],
           },
           {
             key: 'usdl_51',
@@ -418,7 +412,6 @@ const treeQueryResult: QueryResult<'tree'>[] = [
             rank: '0|g',
             title: 'Operations phase',
             cardType: 'test/cardTypes/simplePage',
-            results: [],
           },
           {
             key: 'usdl_52',
@@ -439,7 +432,6 @@ const treeQueryResult: QueryResult<'tree'>[] = [
             rank: '0|h',
             title: 'Meetings',
             cardType: 'test/cardTypes/simplePage',
-            results: [],
           },
         ],
       },

--- a/tools/app/app/cards/[key]/page.tsx
+++ b/tools/app/app/cards/[key]/page.tsx
@@ -51,7 +51,7 @@ export default function Page(props: { params: Promise<{ key: string }> }) {
       dispatch(
         cardViewed({
           key: listCard.key,
-          children: listCard?.results?.map((c) => c.key) ?? [],
+          children: listCard?.children?.map((c) => c.key) ?? [],
           timestamp: new Date().toISOString(),
         }),
       );

--- a/tools/app/app/components/FieldEditor.tsx
+++ b/tools/app/app/components/FieldEditor.tsx
@@ -60,7 +60,9 @@ export default function FieldEditor({
           onChange={(e, value) => onChange?.(value)}
           color="primary"
         >
-          <Option value="">{t('none')}</Option>
+          <Option value="" key="none">
+            {t('none')}
+          </Option>
           {enumValues?.map((enumDef) => (
             <Option key={enumDef.enumValue} value={enumDef.enumValue}>
               {enumDef.enumDisplayValue}

--- a/tools/app/app/components/MetadataView.tsx
+++ b/tools/app/app/components/MetadataView.tsx
@@ -163,11 +163,11 @@ function MetadataView({
             edit: false,
           }}
         />
-        {card.results.map(
+        {(card.fields ?? []).map(
           ({
             key,
             dataType,
-            results,
+            enumValues,
             fieldDisplayName,
             visibility,
             isEditable,
@@ -184,15 +184,16 @@ function MetadataView({
                 dataType,
                 label: fieldDisplayName || key,
                 edit: (editMode && isEditable) ?? false,
-                enumValues: results,
+                enumValues,
               }}
             />
           ),
         )}
       </Stack>
-      {card.results.filter((field) => field.visibility === 'always').length !==
-        card.results.length &&
-        card.results.length !== 0 && (
+      {card.fields &&
+        card.fields.filter((field) => field.visibility === 'always').length !==
+          card.fields.length &&
+        card.fields.length !== 0 && (
           <Box alignContent="flex-end" flexShrink={0} paddingLeft={1}>
             <Link
               variant="soft"

--- a/tools/app/app/components/TreeMenu.tsx
+++ b/tools/app/app/components/TreeMenu.tsx
@@ -164,7 +164,7 @@ export const TreeMenu: React.FC<TreeMenuProps> = ({
           data={tree}
           openByDefault={false}
           idAccessor={(node) => node.key}
-          childrenAccessor="results"
+          childrenAccessor="children"
           indent={16}
           width={(width || 0) - 1}
           height={height}

--- a/tools/data-handler/src/calculate.ts
+++ b/tools/data-handler/src/calculate.ts
@@ -298,7 +298,7 @@ export class Calculate {
         error: null,
       };
     }
-    const parser = new ClingoParser(this.project);
+    const parser = new ClingoParser();
     return parser.parseInput(actual_result);
   }
 

--- a/tools/data-handler/src/export.ts
+++ b/tools/data-handler/src/export.ts
@@ -191,7 +191,7 @@ export class Export {
     card.content = asciiDocContent;
     card.attachments = cardDetailsResponse.attachments;
 
-    for (const result of treeQueryResult.results) {
+    for (const result of treeQueryResult.children ?? []) {
       card.children!.push(await this.treeQueryResultToCard(result));
     }
 

--- a/tools/data-handler/src/types/queries.ts
+++ b/tools/data-handler/src/types/queries.ts
@@ -56,7 +56,6 @@ export interface BaseResult extends Record<string, unknown> {
   notifications: Notification[];
   policyChecks: PolicyCheckCollection;
   deniedOperations: DeniedOperationCollection;
-  results: BaseResult[]; // Nested results
 }
 
 export interface ParseResult<T extends BaseResult> {
@@ -87,7 +86,7 @@ interface TreeQueryResult extends BaseResult {
   title: string;
   cardType: string;
   workflowStateCategory?: WorkflowCategory;
-  results: TreeQueryResult[];
+  children?: TreeQueryResult[];
 }
 
 interface CardQueryResult extends BaseResult {
@@ -97,7 +96,7 @@ interface CardQueryResult extends BaseResult {
   cardType: string;
   workflowState: string;
   lastUpdated: string;
-  results: CardQueryField[];
+  fields?: CardQueryField[];
 }
 
 interface CardQueryField extends BaseResult {
@@ -108,7 +107,7 @@ interface CardQueryField extends BaseResult {
   dataType: DataType;
   isEditable: boolean;
   value: MetadataContent;
-  results: EnumDefinition[];
+  enumValues: EnumDefinition[];
 }
 
 export interface EnumDefinition extends BaseResult {

--- a/tools/data-handler/src/utils/clingo-parser.ts
+++ b/tools/data-handler/src/utils/clingo-parser.ts
@@ -96,10 +96,20 @@ class ClingoParser {
       this.childResultQueue.push({ parentKey, childKey, collection });
       this.collections.add(collection);
     },
-    enumField: async (key: string, fieldName: string, fieldValue: string) => {
+    enumField: async (
+      key: string,
+      fieldName: string,
+      fieldValue: string,
+      index: number,
+      displayName: string,
+    ) => {
       const res = this.getOrInitResult(key);
       const decoded = decodeClingoValue(fieldValue);
-      res[fieldName] = decoded;
+      res[fieldName] = {
+        value: decoded,
+        index,
+        displayName,
+      };
     },
     field: async (
       key: string,

--- a/tools/data-handler/src/utils/clingo-parser.ts
+++ b/tools/data-handler/src/utils/clingo-parser.ts
@@ -100,14 +100,15 @@ class ClingoParser {
       key: string,
       fieldName: string,
       fieldValue: string,
-      index: number,
+      index: string,
       displayValue: string,
     ) => {
       const res = this.getOrInitResult(key);
       const decoded = decodeClingoValue(fieldValue);
+      const parsedIndex = parseInt(index, 10);
       res[fieldName] = {
         value: decoded,
-        index,
+        index: parsedIndex,
         displayValue,
       };
     },

--- a/tools/data-handler/src/utils/clingo-parser.ts
+++ b/tools/data-handler/src/utils/clingo-parser.ts
@@ -96,13 +96,7 @@ class ClingoParser {
       this.childResultQueue.push({ parentKey, childKey, collection });
       this.collections.add(collection);
     },
-    enumField: async (
-      key: string,
-      fieldName: string,
-      fieldValue: string,
-      index: string,
-      displayName: string,
-    ) => {
+    enumField: async (key: string, fieldName: string, fieldValue: string) => {
       const res = this.getOrInitResult(key);
       const decoded = decodeClingoValue(fieldValue);
       res[fieldName] = decoded;

--- a/tools/data-handler/test/calculate.test.ts
+++ b/tools/data-handler/test/calculate.test.ts
@@ -20,13 +20,12 @@ const expectedTree: QueryResult<'tree'>[] = [
     links: [],
     rank: '0|a',
     workflowStateCategory: WorkflowCategory.initial,
-    results: [
+    children: [
       {
         key: 'decision_6',
         cardType: 'decision/cardTypes/decision',
         labels: [],
         links: [],
-        results: [],
         rank: '0|a',
         notifications: [],
         policyChecks: { successes: [], failures: [] },
@@ -77,6 +76,12 @@ describe('calculate', () => {
     const query = 'tree';
 
     const res = await calculate.runQuery(query);
+
+    // remove once select is fixed
+    delete res[0].workflowState;
+    delete res[0].children?.[0].workflowState;
+    delete res[0].lastUpdated;
+    delete res[0].children?.[0].lastUpdated;
 
     expect(res).to.deep.equal(expectedTree);
   });

--- a/tools/data-handler/test/utils/clingo-parser.test.ts
+++ b/tools/data-handler/test/utils/clingo-parser.test.ts
@@ -84,6 +84,15 @@ describe('ClingoParser', () => {
     expect(result.results[0].results2).to.have.lengthOf(1);
     expect(result.results[0].results2[0].key).to.equal('childKey');
   });
+  it('should parse enumField correctly', async () => {
+    const input = `result("key1")\nenumField("key1", "fieldName", "${encodeClingoValue('fieldValue')}", "1", "displayName")`;
+    const result = await parser.parseInput(input);
+    expect(result.results[0].fieldName).to.deep.equal({
+      value: 'fieldValue',
+      index: 1,
+      displayValue: 'displayName',
+    });
+  });
 
   it('should parse field correctly', async () => {
     const input = `result("key1")\nfield("key1", "fieldName", "${encodeClingoValue('fieldValue')}", "shortText")`;

--- a/tools/data-handler/test/utils/clingo-parser.test.ts
+++ b/tools/data-handler/test/utils/clingo-parser.test.ts
@@ -3,7 +3,6 @@ import ClingoParser, {
   decodeClingoValue,
 } from '../../src/utils/clingo-parser.js';
 import { encodeClingoValue } from '../../src/utils/clingo-fact-builder.js';
-import { Project } from '../../src/containers/project.js';
 
 const encodingTests = [
   ['\n', '\\n'],
@@ -25,18 +24,10 @@ const fieldTypeTests = [
   ['list', 'test,test2,test3', ['test', 'test2', 'test3']],
 ] as const;
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 describe('ClingoParser', () => {
-  let parser: ClingoParser;
-  let project: Project;
-  beforeEach(() => {
-    project = {
-      fieldType: () =>
-        Promise.resolve({
-          dataType: 'longText',
-        }),
-    } as unknown as Project;
-    parser = new ClingoParser(project);
-  });
+  const parser = new ClingoParser();
 
   encodingTests.forEach(([input, expected]) => {
     it(`should encode special value ${input} to ${expected}`, () => {
@@ -75,16 +66,27 @@ describe('ClingoParser', () => {
   });
 
   it('should parse childResult correctly', async () => {
-    const input = 'result("parentKey")\nchildResult("parentKey", "childKey")';
-    const result = await parser.parseInput(input);
+    const input =
+      'result("parentKey")\nchildResult("parentKey", "childKey", "results")';
+    const result: any = await parser.parseInput(input);
     expect(result.results).to.have.lengthOf(1);
     expect(result.results[0].key).to.equal('parentKey');
     expect(result.results[0].results).to.have.lengthOf(1);
     expect(result.results[0].results[0].key).to.equal('childKey');
   });
 
+  it('should parse childResult correctly with different collection', async () => {
+    const input =
+      'result("parentKey")\nchildResult("parentKey", "childKey", "results2")';
+    const result: any = await parser.parseInput(input);
+    expect(result.results).to.have.lengthOf(1);
+    expect(result.results[0].key).to.equal('parentKey');
+    expect(result.results[0].results2).to.have.lengthOf(1);
+    expect(result.results[0].results2[0].key).to.equal('childKey');
+  });
+
   it('should parse field correctly', async () => {
-    const input = `result("key1")\nfield("key1", "fieldName", "${encodeClingoValue('fieldValue')}")`;
+    const input = `result("key1")\nfield("key1", "fieldName", "${encodeClingoValue('fieldValue')}", "shortText")`;
     const result = await parser.parseInput(input);
     expect(result.results[0].fieldName).to.equal('fieldValue');
   });
@@ -92,27 +94,22 @@ describe('ClingoParser', () => {
   fieldTypeTests.forEach((test) => {
     const [type, value, expected] = test;
     it(`should parse field with type ${type} correctly`, async () => {
-      project.fieldType = () =>
-        Promise.resolve({
-          name: '',
-          dataType: type,
-        });
       const fieldValue = encodeClingoValue(value.toString());
-      const input = `result("key1")\nfield("key1", "fieldName", "${fieldValue}")`;
+      const input = `result("key1")\nfield("key1", "fieldName", "${fieldValue}", "${type}")`;
       const result = await parser.parseInput(input);
       expect(result.results[0].fieldName).to.deep.equal(expected);
     });
   });
   it('should parse field correctly which has special characters', async () => {
     const fieldValue = 'fieldValueä)"()="()()()=\n';
-    const input = `result("key1")\nfield("key1", "fieldName", "${encodeClingoValue(fieldValue)}")`;
+    const input = `result("key1")\nfield("key1", "fieldName", "${encodeClingoValue(fieldValue)}", "shortText")`;
     const result = await parser.parseInput(input);
     expect(result.results[0].fieldName).to.equal(fieldValue);
   });
 
   it('should parse field correctly when last argument is an empty string', async () => {
     const fieldValue = '';
-    const input = `result("key1")\nfield("key1", "fieldName", "${encodeClingoValue(fieldValue)}")`;
+    const input = `result("key1")\nfield("key1", "fieldName", "${encodeClingoValue(fieldValue)}", "shortText")`;
     const result = await parser.parseInput(input);
     expect(result.results[0].fieldName).to.equal(fieldValue);
   });
@@ -229,7 +226,7 @@ describe('ClingoParser', () => {
   });
 
   it('should parse order correctly', async () => {
-    const input = 'result("key1")\norder("1", "0", "field", "ASC")';
+    const input = 'result("key1")\norder("1", "results", "0", "field", "ASC")';
     const result = await parser.parseInput(input);
     expect(result.results).to.have.lengthOf(1);
   });
@@ -238,9 +235,9 @@ describe('ClingoParser', () => {
     const input = `
             result("key1")
             result("key2")
-            field("key1", "field", "${encodeClingoValue('b')}")
-            field("key2", "field", "${encodeClingoValue('a')}")
-            order("1", "0", "field", "ASC")`;
+            field("key1", "field", "${encodeClingoValue('b')}", "shortText")
+            field("key2", "field", "${encodeClingoValue('a')}", "shortText")
+            order("1", "results", "0", "field", "ASC")`;
     const result = await parser.parseInput(input);
 
     expect(result.results).to.have.lengthOf(2);
@@ -252,9 +249,9 @@ describe('ClingoParser', () => {
     const input = `
             result("key1")
             result("key2")
-            field("key1", "field", "${encodeClingoValue('a')}")
-            field("key2", "field", "${encodeClingoValue('b')}")
-            order("1", "0", "field", "DESC")`;
+            field("key1", "field", "${encodeClingoValue('a')}", "shortText")
+            field("key2", "field", "${encodeClingoValue('b')}", "shortText")
+            order("1", "results", "0", "field", "DESC")`;
     const result = await parser.parseInput(input);
 
     expect(result.results).to.have.lengthOf(2);
@@ -265,16 +262,16 @@ describe('ClingoParser', () => {
   it('should handle order on multiple levels correctly', async () => {
     const input = `
         result("key1")
-        childResult("key1", "key2")
-        field("key2", "field", "${encodeClingoValue('b')}")
-        childResult("key1", "key3")
-        field("key3", "field", "${encodeClingoValue('a')}")
-        childResult("key1", "key4")
-        field("key4", "field", "${encodeClingoValue('c')}")
-        order(2, 1, "field", "ASC")
+        childResult("key1", "key2", "results")
+        field("key2", "field", "${encodeClingoValue('b')}", "shortText")
+        childResult("key1", "key3", "results")
+        field("key3", "field", "${encodeClingoValue('a')}", "shortText")
+        childResult("key1", "key4", "results")
+        field("key4", "field", "${encodeClingoValue('c')}", "shortText")
+        order(2, "results", 1, "field", "ASC")
     `;
 
-    const result = await parser.parseInput(input);
+    const result: any = await parser.parseInput(input);
     expect(result.results).to.have.lengthOf(1);
     expect(result.results[0].results).to.have.lengthOf(3);
     expect(result.results[0].results[0].field).to.equal('a');
@@ -284,16 +281,16 @@ describe('ClingoParser', () => {
   it('should handle order on multiple levels correctly in reverse', async () => {
     const input = `
         result("key1")
-        childResult("key1", "key2")
-        field("key2", "field", "${encodeClingoValue('b')}")
-        childResult("key1", "key3")
-        field("key3", "field", "${encodeClingoValue('a')}")
-        childResult("key1", "key4")
-        field("key4", "field", "${encodeClingoValue('c')}")
-        order(2, 1, "field", "DESC")
+        childResult("key1", "key2", "results")
+        field("key2", "field", "${encodeClingoValue('b')}", "shortText")
+        childResult("key1", "key3", "results")
+        field("key3", "field", "${encodeClingoValue('a')}", "shortText")
+        childResult("key1", "key4", "results")
+        field("key4", "field", "${encodeClingoValue('c')}", "shortText")
+        order(2, "results", 1, "field", "DESC")
     `;
 
-    const result = await parser.parseInput(input);
+    const result: any = await parser.parseInput(input);
     expect(result.results).to.have.lengthOf(1);
     expect(result.results[0].results).to.have.lengthOf(3);
     expect(result.results[0].results[0].field).to.equal('c');
@@ -304,18 +301,18 @@ describe('ClingoParser', () => {
   it('should handle oreder on 4th level correctly', async () => {
     const input = `
         result("key1")
-        childResult("key1", "key2")
-        childResult("key2", "key3")
-        childResult("key3", "key4")
-        field("key4", "field", "${encodeClingoValue('b')}")
-        childResult("key3", "key5")
-        field("key5", "field", "${encodeClingoValue('a')}")
-        childResult("key3", "key6")
-        field("key6", "field", "${encodeClingoValue('c')}")
-        order(4, 1, "field", "ASC")
+        childResult("key1", "key2", "results")
+        childResult("key2", "key3", "results")
+        childResult("key3", "key4", "results")
+        field("key4", "field", "${encodeClingoValue('b')}", "shortText")
+        childResult("key3", "key5", "results")
+        field("key5", "field", "${encodeClingoValue('a')}", "shortText")
+        childResult("key3", "key6", "results")
+        field("key6", "field", "${encodeClingoValue('c')}", "shortText")
+        order(4, "results", 1, "field", "ASC")
     `;
 
-    const result = await parser.parseInput(input);
+    const result: any = await parser.parseInput(input);
     expect(result.results).to.have.lengthOf(1);
     expect(result.results[0].results).to.have.lengthOf(1);
     expect(result.results[0].results[0].results).to.have.lengthOf(1);
@@ -334,7 +331,7 @@ describe('ClingoParser', () => {
   it('should handle multiple commands correctly', async () => {
     const input = `
             result("key1")
-            field("key1", "fieldName", "${encodeClingoValue('fieldValue')}")
+            field("key1", "fieldName", "${encodeClingoValue('fieldValue')}", "shortText")
             label("key1", "label1")
             link("key1", "cardKey", "linkType", "linkDescription")
             transitionDenied("key1", "transitionName", "errorMessage")
@@ -344,7 +341,7 @@ describe('ClingoParser', () => {
             editingContentDenied("key1", "errorMessage")
             policyCheckFailure("key1", "category", "title", "errorMessage")
             policyCheckSuccess("key1", "category", "title")
-            order("1", "0", "field", "ASC")
+            order("1", "results", "0", "field", "ASC")
         `;
     const result = await parser.parseInput(input);
     expect(result.results).to.have.lengthOf(1);
@@ -363,8 +360,8 @@ describe('ClingoParser', () => {
   it('should handle multiple parenthesis', async () => {
     const input = `
             result("key1")
-            field("key1", "test", ("test", "testing something"))
-            field("key1", "test2", (("test1", test2), "testing something"))
+            field("key1", "test", ("test", "testing something"), "shortText")
+            field("key1", "test2", (("test1", test2), "testing something"), "shortText")
         `;
     const result = await parser.parseInput(input);
     expect(result.results).to.have.lengthOf(1);


### PR DESCRIPTION
Features:

The child results in the query language are generalised: there could be multiple types of child results, with different collection names, yielding different array objects as children of the result.

The data type of fields should be included in the query results. Query language could produce 4-member field terms that include the data type, and a more complex term for enums and lists. QueryParser does not depend on project anymore.

For enum and list data types, the results should be objects that include the value, display value and index of the enum value

When sorting by an enum field, used the index property of the enum value.

When sorting by an list field, used the smallest index property of the list value.

Also changed results->children in tree query and results->fields  and results->enumValues in cardQuery
