### PR TITLE
Resource based implementation

### DIFF
--- a/tools/app/app/api/cardTypes/route.tsx
+++ b/tools/app/app/api/cardTypes/route.tsx
@@ -48,7 +48,7 @@ export async function GET(request: NextRequest) {
   }
 
   const commands = await CommandManager.getInstance(projectPath);
-  const detailsResponse = await commands.showCmd.showCardTypeDetails(cardType);
+  const detailsResponse = await commands.showCmd.showResource(cardType);
 
   if (detailsResponse) {
     return NextResponse.json(detailsResponse);

--- a/tools/app/app/api/fieldTypes/route.tsx
+++ b/tools/app/app/api/fieldTypes/route.tsx
@@ -50,7 +50,7 @@ export async function GET() {
   if (response) {
     const fieldTypes = await Promise.all(
       response.map((fieldType: string) =>
-        commands.showCmd.showFieldType(fieldType),
+        commands.showCmd.showResource(fieldType),
       ),
     );
 

--- a/tools/app/app/api/linkTypes/route.tsx
+++ b/tools/app/app/api/linkTypes/route.tsx
@@ -50,7 +50,7 @@ export async function GET() {
   if (response) {
     const linkTypes = await Promise.all(
       response.map((linkType: string) =>
-        commands.showCmd.showLinkType(linkType),
+        commands.showCmd.showResource(linkType),
       ),
     );
 

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -19,6 +19,7 @@ import {
   ExportFormats,
   requestStatus,
   ShowTypes,
+  UpdateOperations,
 } from '@cyberismocom/data-handler';
 
 // To avoid duplication, fetch description and version from package.json file.
@@ -708,6 +709,37 @@ program
       const result = await commandHandler.command(
         Cmd.transition,
         [cardKey, transition],
+        options,
+      );
+      handleResponse(result);
+    },
+  );
+
+// Update command
+program
+  .command('update')
+  .description('Update resource details')
+  .argument('<resourceName>', 'Resource name')
+  .argument(
+    '<operation>',
+    'Type of change, either "add", "change", "rank" or "remove" ',
+  )
+  .argument('<key>', 'Detail to be changed')
+  .argument('<value>', 'Value for a detail')
+  .argument('[newValue]', 'When using "change" define new value for detail')
+  .option('-p, --project-path [path]', `${pathGuideline}`)
+  .action(
+    async (
+      resourceName: string,
+      key: string,
+      operation: UpdateOperations,
+      value: string,
+      newValue: string,
+      options: CardsOptions,
+    ) => {
+      const result = await commandHandler.command(
+        Cmd.update,
+        [resourceName, key, operation, value, newValue],
         options,
       );
       handleResponse(result);

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -36,6 +36,7 @@ import { requestStatus } from './interfaces/request-status-interfaces.js';
 
 import { Create } from './create.js';
 import { CommandManager } from './command-manager.js';
+import { UpdateOperations } from './resources/resource-object.js';
 import { Project } from './containers/project.js';
 import { Validate } from './validate.js';
 
@@ -67,6 +68,7 @@ export enum Cmd {
   show = 'show',
   start = 'start',
   transition = 'transition',
+  update = 'update',
   validate = 'validate',
 }
 
@@ -307,6 +309,23 @@ export class Commands {
         await this.commands?.transitionCmd.cardTransition(cardKey, {
           name: state,
         });
+      } else if (command === Cmd.update) {
+        const [resource, operation, key, value, newValue] = args;
+        let parsedValue = '';
+        try {
+          parsedValue = JSON.parse(value);
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        } catch (error) {
+          parsedValue = value;
+        }
+
+        await this.commands?.updateCmd.updateValue(
+          resource,
+          operation as UpdateOperations,
+          key,
+          parsedValue,
+          newValue ? JSON.parse(newValue) : undefined,
+        );
       } else if (command === Cmd.validate) {
         return this.validate();
       } else {
@@ -599,22 +618,19 @@ export class Commands {
         promise = this.commands!.showCmd.showCards();
         break;
       case 'cardType':
-        promise = this.commands!.showCmd.showCardTypeDetails(detail);
+      case 'fieldType':
+      case 'linkType':
+      case 'workflow':
+        promise = this.commands!.showCmd.showResource(detail);
         break;
       case 'cardTypes':
         promise = this.commands!.showCmd.showCardTypes();
-        break;
-      case 'fieldType':
-        promise = this.commands!.showCmd.showFieldType(detail);
         break;
       case 'fieldTypes':
         promise = this.commands!.showCmd.showFieldTypes();
         break;
       case 'labels':
         promise = this.commands!.showCmd.showLabels();
-        break;
-      case 'linkType':
-        promise = this.commands!.showCmd.showLinkType(detail);
         break;
       case 'linkTypes':
         promise = this.commands!.showCmd.showLinkTypes();
@@ -633,9 +649,6 @@ export class Commands {
         break;
       case 'templates':
         promise = this.commands!.showCmd.showTemplates();
-        break;
-      case 'workflow':
-        promise = this.commands!.showCmd.showWorkflow(detail);
         break;
       case 'workflows':
         promise = this.commands!.showCmd.showWorkflows();

--- a/tools/data-handler/src/command-manager.ts
+++ b/tools/data-handler/src/command-manager.ts
@@ -22,6 +22,7 @@ import { Remove } from './remove.js';
 import { Rename } from './rename.js';
 import { Show } from './show.js';
 import { Transition } from './transition.js';
+import { Update } from './update.js';
 import { Validate } from './validate.js';
 
 // Handles commands and ensures that no extra instances are created.
@@ -40,6 +41,7 @@ export class CommandManager {
   public renameCmd: Rename;
   public showCmd: Show;
   public transitionCmd: Transition;
+  public updateCmd: Update;
   public validateCmd: Validate;
 
   constructor(path: string) {
@@ -70,6 +72,7 @@ export class CommandManager {
       this.calculateCmd,
       this.editCmd,
     );
+    this.updateCmd = new Update(this.project);
   }
 
   /**

--- a/tools/data-handler/src/containers/project/project-paths.ts
+++ b/tools/data-handler/src/containers/project/project-paths.ts
@@ -13,7 +13,7 @@
 import { join } from 'node:path';
 
 import { ResourceFolderType } from '../../interfaces/project-interfaces.js';
-import { resourceNameParts } from '../../utils/resource-utils.js';
+import { resourceName } from '../../utils/resource-utils.js';
 
 /**
  * Handles paths for a project.
@@ -103,14 +103,14 @@ export class ProjectPaths {
   /**
    * Returns valid name of a resource.
    * @param resourceType Type of resource
-   * @param resourceName Resource name
+   * @param name Resource name
    * @returns name of a resource (prefix/type/name)
    */
   public resourceFullName(
     resourceType: ResourceFolderType,
-    resourceName: string,
+    name: string,
   ): string {
-    const { identifier, prefix, type } = resourceNameParts(resourceName);
+    const { identifier, prefix, type } = resourceName(name);
     const actualPrefix = prefix ? prefix : this.prefix;
     const actualType = type ? type : `${resourceType}s`;
     return `${actualPrefix}/${actualType}s/${identifier}`;

--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -39,7 +39,7 @@ import {
   sortItems,
 } from '../utils/lexorank.js';
 import { logger } from '../utils/log-utils.js';
-import { resourceNameParts } from '../utils/resource-utils.js';
+import { resourceName } from '../utils/resource-utils.js';
 
 // Simple mapping table for card instantiation
 interface mappingValue {
@@ -164,7 +164,6 @@ export class Template extends CardContainer {
       await mkdir(tempDestination, { recursive: true });
 
       // Create cards to the temp-folder.
-      // @todo: new function - fetch the workflow of a card
       for (const card of cards) {
         // A bit of a hack to prevent duplicated '/c' in the path for child cards.
         if (card.path.includes(`${sep}c${sep}`) && !parentCard) {
@@ -175,7 +174,6 @@ export class Template extends CardContainer {
         } else {
           card.path = card.path.replace(templatesFolder, tempDestination);
         }
-        // @todo: could just fetch initial state based on card
         const cardType = await this.project.cardType(
           card.metadata?.cardType || '',
         );
@@ -329,7 +327,7 @@ export class Template extends CardContainer {
 
   // Set path to template location.
   private setTemplatePath(templateName: string): string {
-    const { prefix, identifier } = resourceNameParts(templateName);
+    const { prefix, identifier } = resourceName(templateName);
     const localTemplate = join(this.project.paths.templatesFolder, identifier);
 
     // Template can either be local ...

--- a/tools/data-handler/src/create-defaults.ts
+++ b/tools/data-handler/src/create-defaults.ts
@@ -46,10 +46,14 @@ export abstract class DefaultContent {
    * @returns Default content for field type.
    */
   static fieldType(fieldTypeName: string, dataType: DataType): FieldType {
-    return {
+    const value = {
       name: fieldTypeName,
       dataType: dataType,
-    };
+    } as FieldType;
+    if (dataType === 'enum') {
+      value.enumValues = [{ enumValue: 'value1' }, { enumValue: 'value2' }];
+    }
+    return value;
   }
 
   /**

--- a/tools/data-handler/src/export.ts
+++ b/tools/data-handler/src/export.ts
@@ -216,7 +216,6 @@ export class Export {
     if (cardKey) {
       const card = await this.project.findSpecificCard(cardKey);
       if (!card) {
-        console.log('should be here?');
         throw new Error(
           `Input validation error: cannot find card '${cardKey}'`,
         );

--- a/tools/data-handler/src/index.ts
+++ b/tools/data-handler/src/index.ts
@@ -19,6 +19,7 @@ import {
   ShowTypes,
 } from './command-handler.js';
 import { requestStatus } from './interfaces/request-status-interfaces.js';
+import { UpdateOperations } from './resources/resource-object.js';
 
 export {
   CardsOptions,
@@ -28,4 +29,5 @@ export {
   ExportFormats,
   requestStatus,
   ShowTypes,
+  UpdateOperations,
 };

--- a/tools/data-handler/src/interfaces/resource-interfaces.ts
+++ b/tools/data-handler/src/interfaces/resource-interfaces.ts
@@ -54,17 +54,20 @@ export type DataType =
 // Custom field enum value
 export interface EnumDefinition {
   enumValue: string;
-  enumDisplayValue: string;
-  enumDescription: string;
+  enumDisplayValue?: string;
+  enumDescription?: string;
 }
 
-// FieldType content.
+// Field type content.
 export interface FieldType extends ResourceBaseMetadata {
   displayName?: string;
   fieldDescription?: string;
   dataType: DataType;
   enumValues?: Array<EnumDefinition>;
 }
+
+// File-based resources metadata content.
+export type ResourceContent = CardType | FieldType | LinkType | Workflow;
 
 // Link content.
 export interface Link {
@@ -98,7 +101,7 @@ export interface ReportMetadata {
 }
 
 // Base interface for all resources.
-interface ResourceBaseMetadata {
+export interface ResourceBaseMetadata {
   name: string;
 }
 

--- a/tools/data-handler/src/macros/graph/index.ts
+++ b/tools/data-handler/src/macros/graph/index.ts
@@ -21,7 +21,7 @@ import macroMetadata from './metadata.js';
 import { pathExists } from '../../utils/file-utils.js';
 import { Project } from '../../containers/project.js';
 import { readFile } from 'node:fs/promises';
-import { resourceNameParts } from '../../utils/resource-utils.js';
+import { resourceName } from '../../utils/resource-utils.js';
 import { Schema } from 'jsonschema';
 import { validateJson } from '../../utils/validate.js';
 
@@ -48,7 +48,7 @@ class ReportMacro extends BaseMacro {
     const calculate = new Calculate(project);
 
     const resourceNameToPath = (name: string, fileName: string) => {
-      const { identifier, prefix, type } = resourceNameParts(name);
+      const { identifier, prefix, type } = resourceName(name);
       if (prefix === project.projectPrefix) {
         return join(project.paths.resourcesFolder, type, identifier, fileName);
       }

--- a/tools/data-handler/src/resources/array-handler.ts
+++ b/tools/data-handler/src/resources/array-handler.ts
@@ -1,0 +1,140 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { deepCompare } from '../utils/common-utils.js';
+
+import {
+  AddOperation,
+  ChangeOperation,
+  Operation,
+  RankOperation,
+  RemoveOperation,
+} from './resource-object.js';
+
+export class ArrayHandler<T> {
+  private isValidIndex(index: number, array: T[]): boolean {
+    return index >= 0 && index < array.length;
+  }
+
+  private tryParseJSON<U>(value: U): U {
+    if (typeof value !== 'string') return value;
+    try {
+      const trimmed = value.trim();
+      if (trimmed.startsWith('[') || trimmed.startsWith('{')) {
+        return JSON.parse(trimmed) as U;
+      }
+    } catch {
+      // Ignore parse errors
+    }
+    return value;
+  }
+
+  private findItemIndex(item: T, array: T[]): number {
+    if (!array) return -1;
+    let index = array.findIndex((element) => {
+      return deepCompare(element as object, item as object);
+    });
+
+    // Special case 1: change was provided with object that has 'name' only (not full object)
+    if (index === -1) {
+      index = array.findIndex((element) => {
+        const nameOnlyElement = { name: element['name' as keyof T] };
+        return deepCompare(nameOnlyElement as object, item as object);
+      });
+    }
+
+    // Special case 2: change was provided with string (name) only. Try to find with string as 'name'.
+    if (index === -1) {
+      for (const element of array) {
+        if (element['name' as keyof T] === item) {
+          index = array.indexOf(element);
+          break;
+        }
+      }
+    }
+    return index;
+  }
+
+  private handleAdd(operation: AddOperation<T>, array: T[]): T[] {
+    const parsedItem = this.tryParseJSON(operation.target);
+    const index = this.findItemIndex(parsedItem, array);
+
+    if (index !== -1) {
+      throw new Error(`Item '${JSON.stringify(parsedItem)}' already exists`);
+    }
+
+    return [...array, parsedItem];
+  }
+
+  private handleChange(operation: ChangeOperation<T>, array: T[]): T[] {
+    const { target, to } = operation;
+    const parsedTarget = this.tryParseJSON(operation.target);
+    const targetIndex = this.findItemIndex(parsedTarget, array);
+    if (targetIndex === -1) {
+      throw new Error(`Item '${JSON.stringify(target)}' not found`);
+    }
+    const parsedTo = this.tryParseJSON(to);
+
+    if (typeof to === 'string' && (to.startsWith('[') || to.startsWith('{'))) {
+      return parsedTo as T[];
+    }
+
+    return array.map((item) =>
+      deepCompare(item as object, target as object) ? parsedTo : item,
+    );
+  }
+
+  private handleRank(operation: RankOperation<T>, array: T[]): T[] {
+    const { target, newIndex } = operation;
+    const fromIndex = this.findItemIndex(target, array);
+    if (fromIndex === -1) {
+      throw new Error(`Item '${JSON.stringify(target)}' not found`);
+    }
+
+    if (!this.isValidIndex(newIndex, array)) {
+      throw new Error(`Invalid target index: ${newIndex}`);
+    }
+
+    const result = [...array];
+    const [removed] = result.splice(fromIndex, 1);
+    result.splice(newIndex, 0, removed);
+    return result;
+  }
+
+  private handleRemove(operation: RemoveOperation<T>, array: T[]): T[] {
+    const index = this.findItemIndex(operation.target, array);
+
+    if (index === -1) {
+      throw new Error(`Item '${JSON.stringify(operation.target)}' not found`);
+    }
+
+    return array.filter((_, i) => i !== index);
+  }
+
+  /**
+   * Handles operation to an array.
+   * @param operation Operation to perform on array.
+   * @param array Array to operate on.
+   * @returns Changed array after the operation.
+   */
+  public handleArray(operation: Operation<T>, array: T[]): T[] {
+    const handlers = {
+      add: (op: AddOperation<T>) => this.handleAdd(op, array),
+      change: (op: ChangeOperation<T>) => this.handleChange(op, array),
+      rank: (op: RankOperation<T>) => this.handleRank(op, array),
+      remove: (op: RemoveOperation<T>) => this.handleRemove(op, array),
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return handlers[operation.name](operation as any);
+  }
+}

--- a/tools/data-handler/src/resources/card-type-resource.ts
+++ b/tools/data-handler/src/resources/card-type-resource.ts
@@ -1,0 +1,304 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+import { Card } from '../interfaces/project-interfaces.js';
+import {
+  CardType,
+  CustomField,
+  LinkType,
+} from '../interfaces/resource-interfaces.js';
+import { DefaultContent } from '../create-defaults.js';
+import { FileResource, Operation } from './file-resource.js';
+import { LinkTypeResource } from './link-type-resource.js';
+import { Project, ResourcesFrom } from '../containers/project.js';
+import {
+  ResourceName,
+  resourceName,
+  resourceNameToString,
+} from '../utils/resource-utils.js';
+import { Template } from '../containers/template.js';
+import { Validate } from '../validate.js';
+import { AddOperation, ChangeOperation } from './resource-object.js';
+
+/**
+ * Card type resource class.
+ */
+export class CardTypeResource extends FileResource {
+  constructor(project: Project, name: ResourceName) {
+    super(project, name, 'cardTypes');
+
+    this.contentSchemaId = 'cardTypeSchema';
+    this.contentSchema = super.contentSchemaContent(this.contentSchemaId);
+
+    this.initialize();
+  }
+
+  // Collects affected cards.
+  private async collectCards(cardContent: object) {
+    async function filteredCards(
+      cardSource: Promise<Card[]>,
+      cardTypeName: string,
+    ): Promise<Card[]> {
+      const cards = await cardSource;
+      return cards.filter((card) => card.metadata?.cardType === cardTypeName);
+    }
+
+    // Collect both project cards ...
+    const projectCardsPromise = filteredCards(
+      this.project.cards(this.project.paths.cardRootFolder, cardContent),
+      this.content.name,
+    );
+    // ... and cards from each template that would be affected.
+    const templates = await this.project.templates(ResourcesFrom.localOnly);
+    const templateCardsPromises = templates.map((template) => {
+      const templateObject = new Template(this.project, template);
+      return filteredCards(
+        templateObject.cards('', cardContent),
+        this.content.name,
+      );
+    });
+    // Return all affected cards
+    const cards = (
+      await Promise.all([projectCardsPromise, ...templateCardsPromises])
+    ).reduce((accumulator, value) => accumulator.concat(value), []);
+    return cards;
+  }
+
+  // If custom fields change, cards need to be updated.
+  // Rename change changes key names in cards.
+  private async handleCustomFieldsChange<Type>(op: Operation<Type>) {
+    const cardContent = {
+      metadata: true,
+      content: true,
+    };
+
+    if (op && op.name === 'change') {
+      const from = (op as ChangeOperation<string>).target;
+      const to = (op as ChangeOperation<string>).to;
+
+      // Collect both project cards and template cards.
+      const cards = await this.collectCards(cardContent);
+      // Then update them all parallel.
+      const promises: Promise<void>[] = [];
+      for (const card of cards) {
+        promises.push(this.updateCardMetadata(card, from, to));
+      }
+      await Promise.all(promises);
+    }
+    if (op && (op.name === 'add' || op.name === 'remove')) {
+      const item = (op as AddOperation<Type>).target as CustomField;
+      const cards = await this.collectCards(cardContent);
+      if (op.name === 'add') {
+        await this.handleAddNewField(cards, item);
+      } else {
+        await this.handleRemoveField(cards, item);
+      }
+    }
+  }
+
+  // When new field is added, add it all affected cards with 'null' value.
+  private async handleAddNewField(cards: Card[], item: CustomField) {
+    for (const card of cards) {
+      if (card.metadata) {
+        card.metadata[item.name] = null;
+        await this.project.updateCardMetadata(card, card.metadata, true);
+      }
+    }
+  }
+
+  // When resource name changes.
+  private async handleNameChange(existingName: string) {
+    await Promise.all([
+      this.updateLinkTypes(existingName),
+      super.updateHandleBars(existingName, this.content.name),
+      super.updateCalculations(existingName, this.content.name),
+    ]);
+  }
+
+  // When new field is removed, add it all affected cards with 'null' value.
+  private async handleRemoveField(cards: Card[], item: CustomField) {
+    for (const card of cards) {
+      if (card.metadata) {
+        delete card.metadata[item.name];
+        await this.project.updateCardMetadata(card, card.metadata, true);
+      }
+    }
+  }
+
+  // Updates dependent link types.
+  private async updateLinkTypes(oldName: string): Promise<void> {
+    const linkTypes = await this.project.linkTypes(ResourcesFrom.localOnly);
+
+    const updatePromises = linkTypes.map(async (linkType) => {
+      const object = new LinkTypeResource(
+        this.project,
+        resourceName(linkType.name),
+      );
+
+      const data = object.data as LinkType;
+      const updates: Promise<void>[] = [];
+
+      const cardTypeFields: Array<
+        keyof Pick<LinkType, 'destinationCardTypes' | 'sourceCardTypes'>
+      > = ['destinationCardTypes', 'sourceCardTypes'];
+
+      for (const field of cardTypeFields) {
+        if (data[field].includes(oldName)) {
+          const op: ChangeOperation<string> = {
+            name: 'change',
+            target: oldName,
+            to: this.content.name,
+          } as ChangeOperation<string>;
+          updates.push(object.update(field, op));
+        }
+      }
+
+      if (updates.length > 0) {
+        await Promise.all(updates);
+      }
+    });
+    await Promise.all(updatePromises);
+  }
+
+  // Update changed custom fields to cards
+  private async updateCardMetadata(card: Card, from: string, to: string) {
+    if (card.metadata?.cardType && card.metadata?.cardType.length > 0) {
+      if (card.metadata && Object.keys(card.metadata).includes(from)) {
+        delete Object.assign(card.metadata, {
+          [to]: card.metadata[from],
+        })[from];
+
+        const skipValidation = true;
+        await this.project.updateCardMetadata(
+          card,
+          card.metadata,
+          skipValidation,
+        );
+      }
+    }
+  }
+
+  /**
+   * Creates a new card type object. Base class writes the object to disk automatically.
+   * @param workflowName Workflow name that this card type uses.
+   */
+  public async createCardType(workflowName: string) {
+    const validWorkflowName = await Validate.getInstance().validResourceName(
+      'workflows',
+      resourceNameToString(resourceName(workflowName)),
+      await this.project.projectPrefixes(),
+    );
+    if (!(await this.project.workflow(workflowName))) {
+      throw new Error(
+        `Workflow '${workflowName}' does not exist in the project`,
+      );
+    }
+    const content = DefaultContent.cardType(
+      resourceNameToString(this.resourceName),
+      validWorkflowName + '.json',
+    );
+    return super.create(content);
+  }
+
+  /**
+   * Deletes file(s) from disk and clears out the memory resident object.
+   */
+  public async delete() {
+    return super.delete();
+  }
+
+  /**
+   * Renames resource metadata file and renames memory resident object 'name'.
+   * @param newName New name for the resource.
+   */
+  public async rename(newName: ResourceName) {
+    const existingName = this.content.name;
+    await super.rename(newName);
+    return this.handleNameChange(existingName);
+  }
+
+  /**
+   * Shows metadata of the resource.
+   * @returns card type metadata.
+   */
+  public async show(): Promise<CardType> {
+    return super.show() as Promise<CardType>;
+  }
+
+  /**
+   * Updates card type resource.
+   * @param key Key to modify
+   * @param op Operation to perform on 'key'
+   */
+  public async update<Type>(key: string, op: Operation<Type>) {
+    const nameChange = key === 'name';
+    const customFieldsChange = key === 'customFields';
+    const existingName = this.content.name;
+    await super.update(key, op);
+
+    const content = this.content as CardType;
+    if (key === 'name') {
+      content.name = super.handleScalar(op) as string;
+    } else if (key === 'alwaysVisibleFields') {
+      content.alwaysVisibleFields = super.handleArray(
+        op,
+        key,
+        content.alwaysVisibleFields as Type[],
+      ) as string[];
+    } else if (key === 'optionallyVisibleFields') {
+      content.optionallyVisibleFields = super.handleArray(
+        op,
+        key,
+        content.optionallyVisibleFields as Type[],
+      ) as string[];
+    } else if (key === 'workflow') {
+      content.workflow = super.handleScalar(op) as string;
+    } else if (key === 'customFields') {
+      content.customFields = super.handleArray(
+        op,
+        key,
+        content.customFields as Type[],
+      ) as CustomField[];
+
+      // Once the actual key has been changed, check if anything else needs to be updated.
+      if (op.name === 'change') {
+        const from = (op as ChangeOperation<string>).target;
+        const to = (op as ChangeOperation<string>).to;
+
+        // Changed item can be in two other arrays.
+        content.optionallyVisibleFields = content.optionallyVisibleFields?.map(
+          (item) => (item === from ? to : item),
+        );
+        content.alwaysVisibleFields = content.alwaysVisibleFields?.map(
+          (item) => (item === from ? to : item),
+        );
+      }
+    } else {
+      throw new Error(`Unknown property '${key}' for CardType`);
+    }
+
+    await super.postUpdate(content, key, op);
+
+    // Renaming this card type causes that references to its name must be updated.
+    if (nameChange) {
+      return this.handleNameChange(existingName);
+    } else if (customFieldsChange) {
+      return this.handleCustomFieldsChange(op as ChangeOperation<string>);
+    }
+  }
+
+  /**
+   * Validates the resource. If object is invalid, throws.
+   */
+  public async validate(content?: object) {
+    return super.validate(content);
+  }
+}

--- a/tools/data-handler/src/resources/field-type-resource.ts
+++ b/tools/data-handler/src/resources/field-type-resource.ts
@@ -1,0 +1,210 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import {
+  CardType,
+  DataType,
+  EnumDefinition,
+  FieldType,
+} from '../interfaces/resource-interfaces.js';
+import { CardTypeResource } from './card-type-resource.js';
+import { DefaultContent } from '../create-defaults.js';
+import { ChangeOperation, FileResource, Operation } from './file-resource.js';
+import { Project, ResourcesFrom } from '../containers/project.js';
+import {
+  ResourceName,
+  resourceName,
+  resourceNameToString,
+} from '../utils/resource-utils.js';
+
+/**
+ * Field type resource class.
+ *
+ */
+export class FieldTypeResource extends FileResource {
+  constructor(project: Project, name: ResourceName) {
+    super(project, name, 'fieldTypes');
+
+    this.contentSchemaId = 'fieldTypeSchema';
+    this.contentSchema = super.contentSchemaContent(this.contentSchemaId);
+
+    this.initialize();
+  }
+
+  // When resource name changes.
+  private async handleNameChange(existingName: string) {
+    await Promise.all([
+      this.updateCardTypes(existingName),
+      super.updateHandleBars(existingName, this.content.name),
+      super.updateCalculations(existingName, this.content.name),
+    ]);
+  }
+
+  // Update dependant card types
+  private async updateCardTypes(oldName: string) {
+    const cardTypes = await this.project.cardTypes(ResourcesFrom.localOnly);
+    const op = {
+      name: 'change',
+      target: oldName,
+      to: this.content.name,
+    } as ChangeOperation<string>;
+    for (const cardType of cardTypes) {
+      const object = new CardTypeResource(
+        this.project,
+        resourceName(cardType.name),
+      );
+      const data = object.data as CardType;
+      if (data) {
+        const found = data.customFields
+          ? data.customFields.find((item) => item.name === oldName)
+          : undefined;
+        if (found) {
+          await object.update('customFields', op);
+        }
+      }
+    }
+  }
+
+  /**
+   * Returns all possible field types.
+   * @returns all possible field types.
+   */
+  public static fieldTypes(): string[] {
+    return [
+      'shortText',
+      'longText',
+      'number',
+      'integer',
+      'boolean',
+      'enum',
+      'list',
+      'date',
+      'dateTime',
+      'person',
+    ];
+  }
+
+  /**
+   * Creates a new field type object. Base class writes the object to disk automatically.
+   * @param dataType Type for the new field type.
+   */
+  public async createFieldType(dataType: string) {
+    if (!FieldTypeResource.fieldTypes().includes(dataType)) {
+      throw new Error(
+        `Field type '${dataType}' not supported. Supported types ${FieldTypeResource.fieldTypes().join(', ')}`,
+      );
+    }
+
+    const useDataType = dataType as DataType;
+    const content = DefaultContent.fieldType(
+      resourceNameToString(this.resourceName),
+      useDataType,
+    );
+    return super.create(content);
+  }
+
+  /**
+   * Deletes file(s) from disk and clears out the memory resident object.
+   */
+  public async delete() {
+    return super.delete();
+  }
+
+  /**
+   * Renames resource metadata file and renames memory resident object 'name'.
+   * @param newName New name for the resource.
+   */
+  public async rename(newName: ResourceName) {
+    const existingName = this.content.name;
+    await super.rename(newName);
+    return this.handleNameChange(existingName);
+  }
+
+  /**
+   * Shows metadata of the resource.
+   * @returns field type metadata.
+   */
+  public async show(): Promise<FieldType> {
+    return super.show() as Promise<FieldType>;
+  }
+
+  /**
+   * Updates field type resource.
+   * @param key Key to modify
+   * @param op Operation to perform on 'key'
+   */
+  public async update<Type>(key: string, op: Operation<Type>) {
+    const nameChange = key === 'name';
+    const typeChange = key === 'dataType';
+    const existingName = this.content.name;
+    const existingType = (this.content as FieldType).dataType;
+
+    await super.update(key, op);
+
+    const content = this.content as FieldType;
+    if (key === 'name') {
+      content.name = super.handleScalar(op) as string;
+    } else if (key === 'dataType') {
+      const toType = op as ChangeOperation<string>;
+      if (!FieldTypeResource.fieldTypes().includes(toType.to)) {
+        throw new Error(
+          `Cannot change '${key}' to unknown type '${toType.to}'`,
+        );
+      }
+      if (existingType === content.dataType) {
+        throw new Error(`'${key}' is already '${toType.to}'`);
+      }
+      // @todo: handle supported datatype changes:
+      // shortText/longText --> person (if valid email)
+      // shortText/longText --> integer/number (if can be parseNumber/parseInt'd)
+      // shortText/longText --> list, if text can be split with comma (we could potentially bring the separator character as additional detail)
+      // shortText/longText --> date / datetime (if it can be parsed as date)
+      // shortText/longText --> boolean ?  if string is "false" or "true"
+      // number --> integer (drop fractions)
+      // integer --> number
+      // any --> shortText (unless too long)
+      // any --> longText
+      // other cases are verboten
+
+      content.dataType = super.handleScalar(op) as DataType;
+    } else if (key === 'displayName') {
+      content.displayName = super.handleScalar(op) as string;
+    } else if (key === 'enumValues') {
+      content.enumValues = super.handleArray(
+        op,
+        key,
+        content.enumValues as Type[],
+      ) as EnumDefinition[];
+    } else if (key === 'fieldDescription') {
+      content.fieldDescription = super.handleScalar(op) as string;
+    } else {
+      throw new Error(`Unknown property '${key}' for FieldType`);
+    }
+
+    await super.postUpdate(content, key, op);
+
+    // Renaming this field type causes that references to its name must be updated.
+    if (nameChange) {
+      await this.handleNameChange(existingName);
+    } else if (typeChange) {
+      // @todo: fetch all cardTypes that use this FT, then fetch all cards that use those CTs and update ALL the values.
+      console.error('all affected card types cards should be updated');
+    }
+  }
+
+  /**
+   * Validates the resource. If object is invalid, throws.
+   */
+  public async validate(content?: object) {
+    return super.validate(content);
+  }
+}

--- a/tools/data-handler/src/resources/file-resource.ts
+++ b/tools/data-handler/src/resources/file-resource.ts
@@ -1,0 +1,304 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+// node
+import { basename, join } from 'node:path';
+import { mkdir, rename } from 'node:fs/promises';
+
+import { deleteFile, pathExists } from '../utils/file-utils.js';
+import {
+  ChangeOperation,
+  Operation,
+  ResourceObject,
+} from './resource-object.js';
+import { Project } from '../containers/project.js';
+import {
+  readJsonFile,
+  readJsonFileSync,
+  writeJsonFile,
+} from '../utils/json.js';
+import {
+  ResourceBaseMetadata,
+  ResourceContent,
+} from '../interfaces/resource-interfaces.js';
+import {
+  ResourceName,
+  resourceName,
+  resourceNameToPath,
+  resourceNameToString,
+  resourceObjectToResource,
+} from '../utils/resource-utils.js';
+import { ResourceTypes } from '../interfaces/project-interfaces.js';
+import { singularType } from '../utils/common-utils.js';
+import { Validate } from '../validate.js';
+
+export { type Operation, type ChangeOperation };
+
+/**
+ * Base class for file based resources (card types, field types, link types, workflows, ...)
+ */
+export class FileResource extends ResourceObject {
+  public fileName: string = '';
+
+  protected content: ResourceBaseMetadata = { name: '' };
+
+  constructor(
+    project: Project,
+    resourceName: ResourceName,
+    protected type: string,
+  ) {
+    super(project, resourceName);
+  }
+
+  // Type of resource.
+  private resourceType(): ResourceTypes {
+    return this.type as ResourceTypes;
+  }
+
+  // Initialize the resource.
+  protected initialize() {
+    if (this.resourceName.type === '') {
+      this.resourceName.type = this.type;
+    }
+    if (this.resourceName.prefix === '') {
+      this.resourceName.prefix = this.project.projectPrefix;
+    }
+    if (this.type) {
+      this.resourceFolder = this.project.paths.resourcePath(
+        singularType(this.type),
+      );
+      this.fileName = resourceNameToPath(this.project, this.resourceName);
+      this.moduleResource =
+        this.resourceName.prefix !== this.project.projectPrefix;
+    }
+    if (pathExists(this.fileName)) {
+      this.content = readJsonFileSync(this.fileName);
+    }
+  }
+
+  // Creates resource.
+  protected async create(newContent?: ResourceContent) {
+    if (pathExists(this.fileName)) {
+      throw new Error(
+        `Resource '${this.resourceName.identifier}' already exists in the project`,
+      );
+    }
+
+    if (this.resourceFolder === '') {
+      this.resourceName = resourceName(
+        `${this.project.projectPrefix}/${this.type}/${this.resourceName.identifier}`,
+      );
+      this.resourceFolder = this.project.paths.resourcePath(
+        singularType(this.resourceName.type),
+      );
+    }
+
+    const validName = await Validate.getInstance().validResourceName(
+      this.resourceType(),
+      resourceNameToString(this.resourceName),
+      await this.project.projectPrefixes(),
+    );
+
+    let validContent = {} as ResourceContent;
+    if (newContent) {
+      validContent = newContent as unknown as ResourceContent;
+      validContent.name = validName.endsWith('.json')
+        ? validName
+        : validName + '.json';
+    }
+
+    this.content = validContent;
+    await this.write();
+
+    // Notify project & collector
+    this.project.addResource(resourceObjectToResource(this));
+  }
+
+  // Returns memory resident data as JSON.
+  // This is basically same as 'show' but doesn't do any checks; just returns the current content.
+  public get data() {
+    return this.content.name !== '' ? this.content : undefined;
+  }
+
+  // Deletes resource.
+  protected async delete() {
+    if (this.moduleResource) {
+      throw new Error(`Cannot delete module resources`);
+    }
+    if (!pathExists(this.fileName)) {
+      throw new Error(
+        `Resource '${this.resourceName.identifier}' does not exist in the project`,
+      );
+    }
+    await deleteFile(this.fileName);
+    this.project.removeResource(resourceObjectToResource(this));
+    this.fileName = '';
+  }
+
+  protected async isValidName(newName: ResourceName) {
+    await Validate.getInstance().validResourceName(
+      this.resourceType(),
+      resourceNameToString(newName),
+      await this.project.projectPrefixes(),
+    );
+  }
+
+  // Called after inherited class has finished 'update' operation.
+  protected async postUpdate<Type>(
+    content: ResourceContent,
+    key: string,
+    op: Operation<Type>,
+  ) {
+    function toValue(op: Operation<Type>) {
+      if (op.name === 'rank') return op.newIndex;
+      if (op.name === 'add') return op.target;
+      if (op.name === 'remove') return op.target;
+      if (op.name === 'change') return op.to;
+    }
+
+    // Check that new name is valid.
+    if (op.name === 'change' && key === 'name') {
+      const newName = resourceName(
+        (op as ChangeOperation<string>).to as string,
+      );
+      await this.isValidName(newName);
+    }
+
+    // Once changes have been made; validate the content.
+    try {
+      await this.validate(content);
+    } catch (error) {
+      if (error instanceof Error) {
+        const errorValue = typeof op === 'object' ? toValue(op) : op;
+        throw new Error(`Cannot ${op.name} '${key}' --> '${errorValue}'`);
+      }
+    }
+
+    this.content = content;
+    await this.write();
+  }
+
+  // Reads content from file to memory.
+  protected async read() {
+    if (pathExists(this.fileName)) {
+      this.content = await readJsonFile(this.fileName);
+    }
+  }
+
+  // Renames resource.
+  protected async rename(newName: ResourceName) {
+    if (this.moduleResource) {
+      throw new Error(`Cannot rename module resources`);
+    }
+    if (!pathExists(this.fileName)) {
+      throw new Error(
+        `Resource '${this.resourceName.identifier}' does not exist`,
+      );
+    }
+    if (newName.prefix !== this.project.projectPrefix) {
+      throw new Error('Can only rename project resources');
+    }
+    if (newName.type !== this.resourceName.type) {
+      throw new Error('Cannot change resource type');
+    }
+    await Validate.getInstance().validResourceName(
+      this.resourceType(),
+      resourceNameToString(newName),
+      await this.project.projectPrefixes(),
+    );
+    const newFilename = join(
+      this.project.paths.resourcePath(singularType(newName.type)),
+      newName.identifier + '.json',
+    );
+    if (pathExists(newFilename)) {
+      throw new Error(`Resource '${newFilename}' already exists`);
+    }
+    await rename(this.fileName, newFilename);
+
+    this.fileName = newFilename;
+    const content = await readJsonFile(newFilename);
+    content.name = newName.identifier;
+    this.write();
+  }
+
+  // Show resource data as JSON.
+  protected async show(): Promise<ResourceContent> {
+    if (!pathExists(this.fileName)) {
+      const resourceType = `${this.type[0].toUpperCase()}${this.type.slice(1, this.type.length - 1)}`;
+      const name = resourceNameToString(this.resourceName);
+      throw new Error(
+        `${resourceType} '${name}' does not exist in the project`,
+      );
+    }
+    return this.content as ResourceContent;
+  }
+
+  // Update resource; the base class makes some checks only.
+  protected async update<Type>(
+    key: string,
+    _op: Operation<Type>,
+  ): Promise<void> {
+    const content = this.data;
+    if (!content) {
+      throw new Error(`Resource '${this.fileName}' does not exist`);
+    }
+    if (this.moduleResource) {
+      throw new Error(`Cannot update module resources`);
+    }
+    if (key === '' || key === undefined) {
+      throw new Error(`Cannot update empty key`);
+    }
+  }
+
+  // Write the content from memory to disk.
+  protected async write() {
+    if (this.moduleResource) {
+      throw new Error(`Cannot change module resources`);
+    }
+
+    // Create folder for resources and add correct .schema file.
+    if (!pathExists(this.resourceFolder)) {
+      await mkdir(this.resourceFolder);
+      await writeJsonFile(
+        join(this.resourceFolder, '.schema'),
+        this.contentSchema,
+        {
+          flag: 'wx',
+        },
+      );
+    }
+
+    // Check if "name" has changed. Changing "name" means renaming the file.
+    const nameInContent = resourceName(this.content.name).identifier + '.json';
+    const currentFileName = basename(this.fileName);
+
+    if (nameInContent !== currentFileName) {
+      const newFileName = join(this.resourceFolder, nameInContent);
+      await rename(this.fileName, newFileName);
+      this.fileName = newFileName;
+    }
+    await writeJsonFile(this.fileName, this.content);
+  }
+
+  // Validate that current memory-based 'content' is valid.
+  protected async validate(content?: object) {
+    const invalidJson = Validate.getInstance().validateJson(
+      content ? content : this.content,
+      this.contentSchemaId,
+    );
+    if (invalidJson.length) {
+      throw new Error(`Invalid content JSON: ${invalidJson}`);
+    }
+  }
+}

--- a/tools/data-handler/src/resources/link-type-resource.ts
+++ b/tools/data-handler/src/resources/link-type-resource.ts
@@ -1,0 +1,131 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { DefaultContent } from '../create-defaults.js';
+import { FileResource, Operation } from './file-resource.js';
+import { LinkType } from '../interfaces/resource-interfaces.js';
+import { Project } from '../containers/project.js';
+import { ResourceName, resourceNameToString } from '../utils/resource-utils.js';
+
+/**
+ * Link Type resource class.
+ */
+export class LinkTypeResource extends FileResource {
+  constructor(project: Project, name: ResourceName) {
+    super(project, name, 'linkTypes');
+
+    this.contentSchemaId = 'linkTypeSchema';
+    this.contentSchema = super.contentSchemaContent(this.contentSchemaId);
+
+    this.initialize();
+  }
+
+  // When resource name changes.
+  private async handleNameChange(existingName: string) {
+    await Promise.all([
+      super.updateHandleBars(existingName, this.content.name),
+      super.updateCalculations(existingName, this.content.name),
+    ]);
+  }
+
+  /**
+   * Creates a new link type object. Base class writes the object to disk automatically.
+   * @param newContent Content for the link type.
+   */
+  public async create(newContent?: LinkType) {
+    if (!newContent) {
+      newContent = DefaultContent.linkTypeContent(
+        resourceNameToString(this.resourceName),
+      );
+    } else {
+      await this.validate(newContent);
+    }
+    return super.create(newContent);
+  }
+
+  /**
+   * Deletes file(s) from disk and clears out the memory resident object.
+   */
+  public async delete() {
+    return super.delete();
+  }
+
+  /**
+   * Renames resource metadata file and renames memory resident object 'name'.
+   * @param newName New name for the resource.
+   */
+  public async rename(newName: ResourceName) {
+    const existingName = this.content.name;
+    await super.rename(newName);
+    await this.handleNameChange(existingName);
+  }
+
+  /**
+   * Shows metadata of the resource.
+   * @returns link type metadata.
+   */
+  public async show(): Promise<LinkType> {
+    return super.show() as Promise<LinkType>;
+  }
+
+  /**
+   * Updates link type resource.
+   * @param key Key to modify
+   * @param op Operation to perform on 'key'
+   */
+  public async update<Type>(key: string, op: Operation<Type>) {
+    const nameChange = key === 'name';
+    const existingName = this.content.name;
+
+    await super.update(key, op);
+
+    const content = this.content as LinkType;
+
+    if (key === 'name') {
+      content.name = super.handleScalar(op) as string;
+    } else if (key === 'destinationCardTypes') {
+      content.destinationCardTypes = super.handleArray(
+        op,
+        key,
+        content.destinationCardTypes as Type[],
+      ) as string[];
+    } else if (key === 'enableLinkDescription') {
+      content.enableLinkDescription = super.handleScalar(op) as boolean;
+    } else if (key === 'inboundDisplayName') {
+      content.inboundDisplayName = super.handleScalar(op) as string;
+    } else if (key === 'outboundDisplayName') {
+      content.outboundDisplayName = super.handleScalar(op) as string;
+    } else if (key === 'sourceCardTypes') {
+      content.sourceCardTypes = super.handleArray(
+        op,
+        key,
+        content.sourceCardTypes as Type[],
+      ) as string[];
+    } else {
+      throw new Error(`Unknown property '${key}' for FieldType`);
+    }
+
+    await super.postUpdate(content, key, op);
+
+    // Renaming this card type causes that references to its name must be updated.
+    if (nameChange) {
+      await this.handleNameChange(existingName);
+    }
+  }
+
+  /**
+   * Validates the resource. If object is invalid, throws.
+   */
+  public async validate(content?: object) {
+    return super.validate(content);
+  }
+}

--- a/tools/data-handler/src/resources/resource-object.ts
+++ b/tools/data-handler/src/resources/resource-object.ts
@@ -1,0 +1,237 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+// node
+import { readFile, writeFile } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+
+import { ArrayHandler } from './array-handler.js';
+import {
+  DataType,
+  ResourceContent,
+} from '../interfaces/resource-interfaces.js';
+import { Project, ResourcesFrom } from '../containers/project.js';
+import { ResourceName } from '../utils/resource-utils.js';
+
+// Possible operations to perform when doing "update"
+export type UpdateOperations = 'add' | 'change' | 'rank' | 'remove';
+//| 'elementTypeChange';
+
+// Base class for update operations.
+type BaseOperation<T> = {
+  name: 'add' | 'change' | 'rank' | 'remove';
+  target: T;
+};
+
+// Add item to an array.
+export type AddOperation<T> = BaseOperation<T> & {
+  name: 'add';
+};
+
+// Change item in an array or property in an object or rename a scalar.
+export type ChangeOperation<T> = BaseOperation<T> & {
+  name: 'change';
+  to: T;
+};
+
+// Move item in an array to new position.
+export type RankOperation<T> = BaseOperation<T> & {
+  name: 'rank';
+  newIndex: number;
+};
+
+// Remove item from an array.
+export type RemoveOperation<T> = BaseOperation<T> & {
+  name: 'remove';
+};
+
+export type Operation<T> =
+  | AddOperation<T>
+  | ChangeOperation<T>
+  | RankOperation<T>
+  | RemoveOperation<T>;
+
+/**
+ * Abstract class for resources.
+ */
+export abstract class AbstractResource {
+  protected abstract calculate(): Promise<void>; // update resource specific calculations
+  protected abstract create(content?: ResourceContent): Promise<void>; // create a new with the content (memory)
+  protected abstract delete(): Promise<void>; // delete from disk
+  protected abstract read(): Promise<void>; // read content from disk (replaces existing content, if any)
+  protected abstract rename(newName: ResourceName): Promise<void>; // change name of the resource and filename; same as update('name', ...)
+  protected abstract show(): Promise<ResourceContent>; // return the content as JSON
+  protected abstract update<Type>(
+    key: string,
+    operation: Operation<Type>,
+  ): Promise<void>; // change one key of resource
+  protected abstract validate(content?: object): Promise<void>; // validate the content
+  protected abstract write(): Promise<void>; // write content to disk
+}
+
+/**
+ * Base class for all resources.
+ */
+export class ResourceObject extends AbstractResource {
+  protected moduleResource: boolean;
+  protected contentSchema: JSON = {} as JSON;
+  protected contentSchemaId: string = '';
+  protected type: string = '';
+  protected resourceFolder: string = '';
+  constructor(
+    protected project: Project,
+    protected resourceName: ResourceName,
+  ) {
+    super();
+    this.moduleResource =
+      this.resourceName.prefix !== this.project.projectPrefix;
+  }
+
+  protected async calculate() {}
+  protected async create(_content?: ResourceContent) {}
+  protected async delete() {}
+  protected async read() {}
+  protected async rename(_name: ResourceName) {}
+  protected async show(): Promise<ResourceContent> {
+    return {} as ResourceContent;
+  }
+  protected async update<Type>(_key: string, _op: Operation<Type>) {}
+  protected async validate(_content?: object) {}
+  protected async write() {}
+
+  /**
+   * Returns .schema content file.
+   * @param schemaId schema id
+   * @returns .schema content.
+   */
+  protected contentSchemaContent(schemaId: string): JSON {
+    return [
+      {
+        id: schemaId,
+        version: 1,
+      },
+    ] as unknown as JSON;
+  }
+
+  /**
+   * Handles operation to an array.
+   * @param operation Operation to perform on array.
+   * @param arrayName Name of the array, for error messages.
+   * @param array Array to be updated.
+   * @returns Changed array after the operation.
+   */
+  protected handleArray<Type>(
+    operation: Operation<Type>,
+    arrayName: string,
+    array: Type[],
+  ): Type[] {
+    const handler = new ArrayHandler<Type>();
+    let result: Type[] = [];
+    try {
+      result = handler.handleArray(operation, array);
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(
+          `Cannot perform operation on '${arrayName}'. ${error.message}`,
+        );
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Updates scalar value. The only accepted operation is 'change'
+   * @param operation Operation to perform on scalar.
+   * @returns What the scalar should be changed to.
+   */
+  protected handleScalar<Type>(operation: Operation<Type>): Type {
+    if (
+      operation.name === 'add' ||
+      operation.name === 'rank' ||
+      operation.name === 'remove'
+    ) {
+      throw new Error(`Cannot do operation ${operation.name} on scalar value`);
+    }
+    return (operation as ChangeOperation<Type>).to;
+  }
+
+  /**
+   * Update calculation files.
+   * @param from Resource name to update
+   * @param to New name for resource
+   */
+  protected async updateCalculations(from: string, to: string) {
+    if (!from.trim() || !to.trim()) {
+      throw new Error(
+        'updateCalculations: "from" and "to" parameters must not be empty',
+      );
+    }
+
+    const calculations = await this.project.calculations(
+      ResourcesFrom.localOnly,
+    );
+
+    await Promise.all(
+      calculations.map(async (calculation) => {
+        if (!calculation.path) {
+          throw new Error(
+            `Calculation file's '${calculation.name}' path is not defined`,
+          );
+        }
+
+        const filename = join(calculation.path, basename(calculation.name));
+        try {
+          const content = await readFile(filename, 'utf-8');
+          const updatedContent = content.replaceAll(from, to);
+          await writeFile(filename, updatedContent);
+        } catch (error) {
+          throw new Error(
+            `Failed to process file ${filename}: ${(error as Error).message}`,
+          );
+        }
+      }),
+    );
+  }
+
+  /**
+   * Update references in handlebars.
+   * @param from Resource name to update
+   * @param to New name for resource
+   * @todo: this is 95% same as in 'rename.ts'. Combine and share?
+   */
+  protected async updateHandleBars(from: string, to: string) {
+    if (!from.trim() || !to.trim()) {
+      throw new Error(
+        'updateHandleBars: "from" and "to" parameters must not be empty',
+      );
+    }
+
+    const handleBarFiles = await this.project.reportHandlerBarFiles(
+      ResourcesFrom.localOnly,
+    );
+
+    // Create a safe regex by escaping special characters
+    const escapedFrom = from.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const fromRe = new RegExp(escapedFrom, 'g');
+
+    // Process all files in parallel with proper error handling
+    await Promise.all(
+      handleBarFiles.map(async (handleBarFile) => {
+        const content = await readFile(handleBarFile);
+        const updatedContent = content.toString().replace(fromRe, to);
+        await writeFile(handleBarFile, Buffer.from(updatedContent));
+      }),
+    );
+  }
+}

--- a/tools/data-handler/src/resources/workflow-resource.ts
+++ b/tools/data-handler/src/resources/workflow-resource.ts
@@ -1,0 +1,159 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import {
+  CardType,
+  Workflow,
+  WorkflowState,
+  WorkflowTransition,
+} from '../interfaces/resource-interfaces.js';
+import { CardTypeResource } from './card-type-resource.js';
+import { DefaultContent } from '../create-defaults.js';
+import { ChangeOperation, FileResource, Operation } from './file-resource.js';
+import { Project, ResourcesFrom } from '../containers/project.js';
+import {
+  ResourceName,
+  resourceName,
+  resourceNameToString,
+} from '../utils/resource-utils.js';
+
+/**
+ * Workflow resource class.
+ */
+export class WorkflowResource extends FileResource {
+  constructor(project: Project, name: ResourceName) {
+    super(project, name, 'workflows');
+
+    this.contentSchemaId = 'workflowSchema';
+    this.contentSchema = super.contentSchemaContent(this.contentSchemaId);
+
+    this.initialize();
+  }
+
+  // When resource name changes.
+  private async handleNameChange(existingName: string) {
+    await Promise.all([
+      this.updateCardTypes(existingName),
+      super.updateHandleBars(existingName, this.content.name),
+      super.updateCalculations(existingName, this.content.name),
+    ]);
+  }
+
+  // Update dependant card types.
+  private async updateCardTypes(oldName: string) {
+    const cardTypes = await this.project.cardTypes(ResourcesFrom.localOnly);
+    const op = {
+      name: 'change',
+      target: oldName,
+      to: this.content.name,
+    } as ChangeOperation<string>;
+    for (const cardType of cardTypes) {
+      const object = new CardTypeResource(
+        this.project,
+        resourceName(cardType.name),
+      );
+      if (object.data && (object.data as CardType).workflow === oldName) {
+        await object.update('workflow', op);
+      }
+    }
+  }
+
+  /**
+   * Sets new metadata into the workflow object.
+   * @param newContent metadata content for the workflow.
+   * @throws if 'newContent' is not valid.
+   */
+  public async create(newContent?: Workflow) {
+    if (!newContent) {
+      newContent = DefaultContent.workflowContent(
+        resourceNameToString(this.resourceName),
+      );
+    } else {
+      await this.validate(newContent);
+    }
+    return super.create(newContent);
+  }
+
+  /**
+   * Deletes file that this object is based on.
+   * If there are card types that depended on this workflow, they are now invalid.
+   */
+  public async delete() {
+    return super.delete();
+  }
+
+  /**
+   * Renames the object and the file.
+   * @param newName New name for the resource.
+   */
+  public async rename(newName: ResourceName) {
+    const existingName = this.content.name;
+    await super.rename(newName);
+    return this.handleNameChange(existingName);
+  }
+
+  /**
+   * Shows metadata of the resource.
+   * @returns workflow metadata.
+   */
+  public async show(): Promise<Workflow> {
+    return super.show() as Promise<Workflow>;
+  }
+
+  /**
+   * Updates workflow resource.
+   * @param key Key to modify
+   * @param op Operation to perform on 'key'
+   * @throws if key is unknown.
+   */
+  public async update<Type>(key: string, op: Operation<Type>) {
+    const nameChange = key === 'name';
+    const existingName = this.content.name;
+
+    await super.update(key, op);
+
+    const content = { ...(this.content as Workflow) };
+
+    if (key === 'name') {
+      content.name = super.handleScalar(op) as string;
+    } else if (key === 'states') {
+      content.states = super.handleArray(
+        op,
+        key,
+        content.states as Type[],
+      ) as WorkflowState[];
+    } else if (key === 'transitions') {
+      content.transitions = super.handleArray(
+        op,
+        key,
+        content.transitions as WorkflowTransition[] as Type[],
+      ) as WorkflowTransition[];
+    } else {
+      throw new Error(`Unknown property '${key}' for Workflow`);
+    }
+
+    await super.postUpdate(content, key, op);
+
+    // Renaming this workflow causes that references to its name must be updated.
+    if (nameChange) {
+      await this.handleNameChange(existingName);
+    }
+  }
+
+  /**
+   * Validates workflow.
+   * @throws when there are validation errors.
+   */
+  public validate(content?: object): Promise<void> {
+    return super.validate(content);
+  }
+}

--- a/tools/data-handler/src/show.ts
+++ b/tools/data-handler/src/show.ts
@@ -18,7 +18,6 @@ import { spawn } from 'node:child_process';
 
 import mime from 'mime-types';
 
-// cyberismo
 import { attachmentPayload } from './interfaces/request-status-interfaces.js';
 import {
   CardAttachment,
@@ -35,10 +34,14 @@ import {
   LinkType,
   Workflow,
 } from './interfaces/resource-interfaces.js';
-import { stripExtension } from './utils/file-utils.js';
 import { Project } from './containers/project.js';
+import { resourceName } from './utils/resource-utils.js';
+import { stripExtension } from './utils/file-utils.js';
 import { UserPreferences } from './utils/user-preferences.js';
 
+/**
+ * Show command.
+ */
 export class Show {
   constructor(private project: Project) {}
 
@@ -226,24 +229,6 @@ export class Show {
   }
 
   /**
-   * Shows details of a particular card type.
-   * @param cardTypeName card type name
-   * @returns card type details
-   */
-  public async showCardTypeDetails(cardTypeName: string): Promise<CardType> {
-    if (cardTypeName === '') {
-      throw new Error(`Must define card type name to query its details.`);
-    }
-    const cardTypeDetails = await this.project.cardType(cardTypeName);
-    if (cardTypeDetails === undefined) {
-      throw new Error(
-        `Card type '${cardTypeName}' not found from the project.`,
-      );
-    }
-    return cardTypeDetails;
-  }
-
-  /**
    * Shows all card types in a project.
    * @returns sorted array of card types
    */
@@ -309,23 +294,6 @@ export class Show {
   }
 
   /**
-   * Shows details of a link type.
-   * @param linkTypeName name of a link type
-   * @returns details of a link type.
-   */
-  public async showLinkType(
-    linkTypeName: string,
-  ): Promise<LinkType | undefined> {
-    const linkTypeDetails = await this.project.linkType(linkTypeName);
-    if (linkTypeDetails === undefined) {
-      throw new Error(
-        `Link type '${linkTypeName}' not found from the project.`,
-      );
-    }
-    return linkTypeDetails;
-  }
-
-  /**
    * Shows all available field types.
    * @returns sorted array of field types
    */
@@ -333,23 +301,6 @@ export class Show {
     return (await this.project.fieldTypes())
       .map((item) => stripExtension(item.name))
       .sort();
-  }
-
-  /**
-   * Shows details of a field type.
-   * @param fieldTypeName name of a field type
-   * @returns details of a field type.
-   */
-  public async showFieldType(
-    fieldTypeName: string,
-  ): Promise<FieldType | undefined> {
-    const fieldTypeDetails = await this.project.fieldType(fieldTypeName);
-    if (fieldTypeDetails === undefined) {
-      throw new Error(
-        `Field type '${fieldTypeName}' not found from the project.`,
-      );
-    }
-    return fieldTypeDetails;
   }
 
   /**
@@ -405,6 +356,18 @@ export class Show {
   }
 
   /**
+   * Shows details of certain resource.
+   * @param name Name of resource.
+   * @returns resource metadata as JSON.
+   */
+  public async showResource(
+    name: string,
+  ): Promise<CardType | Workflow | LinkType | FieldType | undefined> {
+    const resource = Project.resourceObject(this.project, resourceName(name));
+    return resource?.show();
+  }
+
+  /**
    * Shows details of a particular template.
    * @param templateName template name
    * @returns template details
@@ -442,23 +405,6 @@ export class Show {
     );
     const result = await Promise.all(promiseContainer);
     return result.filter(Boolean) as TemplateConfiguration[];
-  }
-
-  /**
-   * Shows details of a particular workflow.
-   * @param workflowName name of workflow
-   * @returns workflow details
-   */
-  public async showWorkflow(workflowName: string): Promise<Workflow> {
-    if (workflowName === '') {
-      throw new Error(`Must define workflow name to query its details.`);
-    }
-
-    const workflowContent = await this.project.workflow(workflowName);
-    if (workflowContent === undefined) {
-      throw new Error(`Workflow '${workflowName}' not found from the project.`);
-    }
-    return workflowContent;
   }
 
   /**

--- a/tools/data-handler/src/update.ts
+++ b/tools/data-handler/src/update.ts
@@ -1,0 +1,73 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import {
+  AddOperation,
+  ChangeOperation,
+  Operation,
+  RankOperation,
+  RemoveOperation,
+  UpdateOperations,
+} from './resources/resource-object.js';
+import { Project } from './containers/project.js';
+import { resourceName } from './utils/resource-utils.js';
+
+/**
+ * Class that handles 'update' commands.
+ */
+export class Update {
+  constructor(private project: Project) {}
+
+  /**
+   * Updates single resource property.
+   * @param name Name of the resource to operate on.
+   * @param operation Operation to perform ('add', 'remove', 'change', 'rank')
+   * @param key Property to change in resource JSON
+   * @param value Value for 'key'
+   * @param optionalDetail Additional detail needed for some operations. For example, 'update' needs a new value.
+   */
+  public async updateValue<Type>(
+    name: string,
+    operation: UpdateOperations,
+    key: string,
+    value: Type,
+    optionalDetail?: Type, // todo: for 'rank' it might be reasonable to accept also 'number'
+  ) {
+    const resource = Project.resourceObject(this.project, resourceName(name));
+    const op: Operation<Type> = {
+      name: operation,
+      target: '' as Type,
+      to: '' as Type,
+      newIndex: 0 as number,
+    };
+
+    // Set operation specific properties.
+    if (operation === 'add') {
+      (op as AddOperation<Type>).target = value;
+    } else if (operation === 'change') {
+      (op as ChangeOperation<Type>).target = optionalDetail
+        ? value
+        : (optionalDetail as Type);
+      (op as ChangeOperation<Type>).to = optionalDetail
+        ? optionalDetail
+        : (value as Type);
+    } else if (operation === 'rank') {
+      (op as RankOperation<Type>).newIndex = optionalDetail as number;
+      (op as RankOperation<Type>).target = value;
+    } else if (operation === 'remove') {
+      (op as RemoveOperation<Type>).target = value;
+    }
+
+    await resource?.update(key, op);
+    this.project.collectLocalResources();
+  }
+}

--- a/tools/data-handler/src/utils/clingo-facts.ts
+++ b/tools/data-handler/src/utils/clingo-facts.ts
@@ -237,14 +237,14 @@ export const createFieldTypeFacts = (fieldType: FieldType) => {
         builder.addCustomFact(Facts.Common.FIELD, (b) =>
           b
             .addArgument(keyTuple)
-            .addArguments('enumDisplayValue', enumValue.enumDisplayValue),
+            .addArguments('enumDisplayValue', enumValue.enumDisplayValue!),
         );
 
       if (enumValue.enumDescription)
         builder.addCustomFact(Facts.Common.FIELD, (b) =>
           b
             .addArgument(keyTuple)
-            .addArguments('enumDescription', enumValue.enumDescription),
+            .addArguments('enumDescription', enumValue.enumDescription!),
         );
     }
   }

--- a/tools/data-handler/src/utils/common-utils.ts
+++ b/tools/data-handler/src/utils/common-utils.ts
@@ -1,0 +1,53 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { ResourceFolderType } from '../interfaces/project-interfaces.js';
+
+/**
+ * Makes deep comparison between two objects.
+ * @param arg1 First object to compare.
+ * @param arg2 Second object to compare.
+ * @returns true, if objects are the same, false otherwise.
+ */
+export function deepCompare(arg1: object, arg2: object): boolean {
+  if (
+    Object.prototype.toString.call(arg1) ===
+    Object.prototype.toString.call(arg2)
+  ) {
+    if (
+      Object.prototype.toString.call(arg1) === '[object Object]' ||
+      Object.prototype.toString.call(arg1) === '[object Array]'
+    ) {
+      if (Object.keys(arg1).length !== Object.keys(arg2).length) {
+        return false;
+      }
+      return Object.keys(arg1).every(function (key) {
+        return deepCompare(
+          arg1[key as keyof typeof arg1],
+          arg2[key as keyof typeof arg2],
+        );
+      });
+    }
+    return arg1 === arg2;
+  }
+  return false;
+}
+
+/**
+ * Converts plural type name to singular
+ * @type Type name to change.
+ * @returns singular format of type name
+ */
+export function singularType(type: string): ResourceFolderType {
+  // note that this only works with certain nouns
+  return type.substring(0, type.length - 1) as ResourceFolderType;
+}

--- a/tools/data-handler/src/utils/resource-utils.ts
+++ b/tools/data-handler/src/utils/resource-utils.ts
@@ -7,7 +7,13 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { parse } from 'node:path';
+// node
+import { join, parse, sep } from 'node:path';
+
+import { FileResource } from '../resources/file-resource.js';
+import { Project } from '../containers/project.js';
+import { Resource } from '../interfaces/project-interfaces.js';
+import { stripExtension } from './file-utils.js';
 
 // Resource name parts are:
 // - prefix; name of the project this resource is part of
@@ -26,6 +32,12 @@ const IDENTIFIER_INDEX = 2;
 // Valid resource name has three parts
 const RESOURCE_NAME_PARTS = 3;
 
+const EMPTY_NAME = {
+  prefix: '',
+  type: '',
+  identifier: '',
+};
+
 // Checks if name is valid (3 parts, separated by '/').
 export function isResourceName(name: string): boolean {
   const partsCount = name.split('/').length;
@@ -38,7 +50,7 @@ export function isResourceName(name: string): boolean {
  * @throws if 'resourceName' is not valid resource name.
  * @returns resource name parts: project or module prefix, resource type (plural) and actual name of the resource.
  */
-export function resourceNameParts(resourceName: string): ResourceName {
+export function resourceName(resourceName: string): ResourceName {
   const parts = resourceName.split('/');
   // just resource identifier - type and prefix are unknown
   if (parts.length === 1 && parts.at(0) !== '') {
@@ -57,12 +69,87 @@ export function resourceNameParts(resourceName: string): ResourceName {
     };
   }
   // other formats are not accepted
+  if (resourceName === '') {
+    throw new Error('Must define resource name to query its details');
+  }
   throw new Error(`Name '${resourceName}' is not valid resource name`);
 }
 
 /**
+ * Converts resource name to path.
+ * @param project Project
+ * @param resourceName Name of the resource (e.g. <prefix>/<type>/<name>)
+ * @returns path to resource metadata file
+ */
+export function resourceNameToPath(
+  project: Project,
+  resourceName: ResourceName,
+): string {
+  if (project.projectPrefix === resourceName.prefix) {
+    return join(
+      project.paths.resourcesFolder,
+      resourceName.type,
+      resourceName.identifier + '.json',
+    );
+  } else if (resourceName.prefix !== '') {
+    return join(
+      project.paths.modulesFolder,
+      resourceName.prefix,
+      resourceName.type,
+      resourceName.identifier + '.json',
+    );
+  }
+  throw new Error('resourceName does not contain prefix');
+}
+
+/**
+ * Resource metadata file path to resource name (e.g. <prefix>/<type>/<name>)
+ * @param project Project where resource is in
+ * @param path Path to resource metadata file
+ * @returns Resource name (<prefix>/<type>/<name>)
+ */
+export function pathToResourceName(
+  project: Project,
+  path: string,
+): ResourceName {
+  const parts = path.split(sep);
+  const modulesIndex = parts.lastIndexOf('modules');
+  const localIndex = parts.lastIndexOf('local');
+  // Check that either 'local' or 'modules' is included in path (but not both).
+  // And after that there is required amount of parts.
+  if (
+    (modulesIndex === -1 && localIndex === -1) ||
+    (modulesIndex !== -1 && localIndex !== -1) ||
+    (modulesIndex !== -1 &&
+      localIndex === 1 &&
+      parts.length === modulesIndex + 3) ||
+    (modulesIndex === -1 &&
+      localIndex !== -1 &&
+      parts.length === localIndex + 2)
+  ) {
+    throw new Error(`invalid path: ${path}`);
+  }
+  // Finally check that all relevant parts are defined.
+  const prefix =
+    modulesIndex !== -1 ? parts.at(modulesIndex + 1) : project.projectPrefix;
+  const typeIndex = modulesIndex !== -1 ? modulesIndex + 2 : localIndex + 1;
+  const identifierIndex =
+    modulesIndex !== -1 ? modulesIndex + 3 : localIndex + 2;
+  const type = parts.at(typeIndex);
+  const identifier = stripExtension(parts.at(identifierIndex)!);
+  if (!identifier || !type || !prefix) {
+    throw new Error(`invalid path: ${path}`);
+  }
+  return {
+    prefix: prefix,
+    type: type,
+    identifier: identifier,
+  };
+}
+
+/**
  * Returns ResourceName as a single string.
- * @param resourceName ResourceName to convert.
+ * @param resourceName Resource name to convert.
  * @returns resource name as a single string.
  * @note that valid resource names are: empty string, identifier alone and prefix/type/identifier combination.
  */
@@ -90,4 +177,27 @@ export function resourceNameToString(resourceName: ResourceName): string {
   return resourceName.prefix && resourceName.type && resourceName.prefix
     ? `${resourceName.prefix}/${resourceName.type}/${resourceName.identifier}`
     : `${resourceName.identifier}`;
+}
+
+/**
+ * Converts resource object to Resource. Resource is basically path + file for certain name.
+ * @param object Resource object of any type.
+ * @returns Resource information (file name and path)
+ */
+export function resourceObjectToResource(object: FileResource): Resource {
+  return {
+    name: object.data ? object.data.name : '',
+    path: object.fileName.substring(0, object.fileName.lastIndexOf(sep)),
+  };
+}
+
+/**
+ * Converts resource object to ResourceName.
+ * @param object Resource object of any type.
+ * @returns ResourceName information (prefix, type and identifier).
+ */
+export function resourceObjectToResourceName(
+  object: FileResource,
+): ResourceName {
+  return object.data ? resourceName(object.data.name) : EMPTY_NAME;
 }

--- a/tools/data-handler/test/command-handler-create.test.ts
+++ b/tools/data-handler/test/command-handler-create.test.ts
@@ -11,10 +11,10 @@ import { fileURLToPath } from 'node:url';
 // cyberismo
 import { CardsOptions, Cmd, Commands } from '../src/command-handler.js';
 import { copyDir, deleteDir, resolveTilde } from '../src/utils/file-utils.js';
-import { Create } from '../src/create.js';
 import { Calculate } from '../src/calculate.js';
 import { DefaultContent } from '../src/create-defaults.js';
 import { CardListContainer } from '../src/interfaces/project-interfaces.js';
+import { FieldTypeResource } from '../src/resources/field-type-resource.js';
 
 // Create test artifacts in a temp folder.
 const baseDir = dirname(fileURLToPath(import.meta.url));
@@ -324,7 +324,7 @@ describe('create command', () => {
       ['fieldTypes'],
       optionsMini,
     );
-    const fieldTypes = Create.supportedFieldTypes();
+    const fieldTypes = FieldTypeResource.fieldTypes();
     for (const fieldType of fieldTypes) {
       const name = `ft_${fieldType}`;
       const result = await commandHandler.command(

--- a/tools/data-handler/test/command-handler-remove.test.ts
+++ b/tools/data-handler/test/command-handler-remove.test.ts
@@ -175,7 +175,6 @@ describe('remove command', () => {
       expect(found?.length).to.equal(0);
     });
 
-    // todo: for some reason, the project is not updated between removals --> this must be run after 'link removal' tests
     it('remove linkType', async () => {
       const name = 'test';
       await createLinkType(commandHandler, name);

--- a/tools/data-handler/test/command-handler-update.test.ts
+++ b/tools/data-handler/test/command-handler-update.test.ts
@@ -1,0 +1,140 @@
+// testing
+import { expect } from 'chai';
+
+// node
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { mkdirSync, rmSync } from 'node:fs';
+
+import { copyDir } from '../src/utils/file-utils.js';
+import { Project } from '../src/containers/project.js';
+import { ResourceCollector } from '../src/containers/project/resource-collector.js';
+
+import { Show } from '../src/show.js';
+import { Update } from '../src/update.js';
+import { CardType } from '../src/interfaces/resource-interfaces.js';
+
+describe('Update command tests', async () => {
+  const baseDir = dirname(fileURLToPath(import.meta.url));
+  const testDir = join(baseDir, 'tmp-update-tests');
+  const decisionRecordsPath = join(testDir, 'valid/decision-records');
+  mkdirSync(testDir, { recursive: true });
+  await copyDir('test/test-data/', testDir);
+
+  const project = new Project(decisionRecordsPath);
+  const update = new Update(project);
+  const show = new Show(project);
+  const collector = new ResourceCollector(project);
+  collector.collectLocalResources();
+
+  after(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('update folder file resource', async () => {
+    const name = `${project.projectPrefix}/workflows/decision`;
+    const fileName = `${name}.json`;
+    const exists = await collector.resourceExists('workflows', fileName);
+    expect(exists).to.equal(true);
+
+    const newName = `${project.projectPrefix}/workflows/newName`;
+
+    await update.updateValue(fileName, 'change', 'name', newName);
+    collector.changed();
+    const workflows = await project.workflows();
+    let found = false;
+    for (const wf of workflows) {
+      if (wf.name === newName + '.json') {
+        found = true;
+      }
+    }
+    expect(found).to.equal(true);
+  });
+
+  it('update resource - rank item using string value (name)', async () => {
+    const name = `${project.projectPrefix}/cardTypes/decision`;
+    const fileName = `${name}.json`;
+    const moveToIndex = 0;
+
+    let indexBefore = -1;
+    let indexAfter = -1;
+    const before = await show.showResource(name);
+    let found = (before as CardType).customFields.find((item) => {
+      return item.name === 'decision/fieldTypes/finished';
+    });
+    if (found) {
+      indexBefore = (before as CardType).customFields.indexOf(found);
+    }
+
+    await update.updateValue(
+      fileName,
+      'rank',
+      'customFields',
+      'decision/fieldTypes/finished',
+      moveToIndex as unknown as string,
+    );
+
+    const after = await show.showResource(name);
+    found = (after as CardType).customFields.find((item) => {
+      return item.name === 'decision/fieldTypes/finished';
+    });
+    if (found) {
+      indexAfter = (after as CardType).customFields.indexOf(found);
+    }
+    expect(indexBefore).not.to.equal(indexAfter);
+    expect(indexAfter).to.equal(moveToIndex);
+  });
+  it('update resource - rank item using partial object value', async () => {
+    const name = `${project.projectPrefix}/cardTypes/decision`;
+    const fileName = `${name}.json`;
+    const moveToIndex = 4;
+
+    let indexBefore = -1;
+    let indexAfter = -1;
+    const before = (await show.showResource(name)) as CardType;
+    let found = before.customFields.find((item) => {
+      return item.name === 'decision/fieldTypes/finished';
+    });
+    if (found) {
+      indexBefore = before.customFields.indexOf(found);
+      console.error(indexBefore);
+    }
+
+    await update.updateValue(
+      fileName,
+      'rank',
+      'customFields',
+      { name: 'decision/fieldTypes/finished' } as CardType,
+      moveToIndex as unknown as object,
+    );
+
+    const after = (await show.showResource(name)) as CardType;
+    found = after.customFields.find((item) => {
+      return item.name === 'decision/fieldTypes/finished';
+    });
+    if (found) {
+      indexAfter = after.customFields.indexOf(found);
+    }
+    expect(indexBefore).not.to.equal(indexAfter);
+    expect(indexAfter).to.equal(moveToIndex);
+  });
+
+  it('try to update folder file resource with invalid data', async () => {
+    const name = `${project.projectPrefix}/workflows/simple`;
+    const fileName = `${name}.json`;
+    const exists = await collector.resourceExists('workflows', fileName);
+    expect(exists).to.equal(true);
+
+    const invalidName = `${project.projectPrefix}/workflows/newName111`;
+    await update
+      .updateValue(fileName, 'change', 'name', invalidName)
+      .then(() => {
+        expect(false).to.equal(true);
+      })
+      .catch((error) => {
+        expect(error.message).to.equal(
+          "Resource identifier must follow naming rules. Identifier 'newName111' is invalid",
+        );
+      });
+  });
+});

--- a/tools/data-handler/test/project.test.ts
+++ b/tools/data-handler/test/project.test.ts
@@ -7,10 +7,16 @@ import { mkdirSync, rmSync } from 'node:fs';
 import { basename, dirname, join, resolve, sep } from 'node:path';
 
 import { copyDir } from '../src/utils/file-utils.js';
+import { FileContentType } from '../src/interfaces/project-interfaces.js';
+import { fileURLToPath } from 'node:url';
 import { Project } from '../src/containers/project.js';
 import { ProjectConfiguration } from '../src/project-settings.js';
-import { fileURLToPath } from 'node:url';
-import { FileContentType } from '../src/interfaces/project-interfaces.js';
+import { resourceName } from '../src/utils/resource-utils.js';
+
+import { WorkflowResource } from '../src/resources/workflow-resource.js';
+import { CardTypeResource } from '../src/resources/card-type-resource.js';
+import { FieldTypeResource } from '../src/resources/field-type-resource.js';
+import { LinkTypeResource } from '../src/resources/link-type-resource.js';
 
 describe('project', () => {
   // Create test artifacts in a temp folder.
@@ -680,7 +686,47 @@ describe('project', () => {
     expect(files.length).to.equal(0);
   });
 
+  it('create card type resource through resourceObject static API', () => {
+    const decisionRecordsPath = join(testDir, `valid${sep}decision-records`);
+    const project = new Project(decisionRecordsPath);
+    const ct = Project.resourceObject(
+      project,
+      resourceName('decision/cardTypes/decision'),
+    );
+    expect((ct as CardTypeResource).data).not.to.equal(undefined);
+  });
+
+  it('create field type resource through resourceObject static API', () => {
+    const decisionRecordsPath = join(testDir, `valid${sep}decision-records`);
+    const project = new Project(decisionRecordsPath);
+    const ft = Project.resourceObject(
+      project,
+      resourceName('decision/fieldTypes/finished'),
+    );
+    expect((ft as FieldTypeResource).data).not.to.equal(undefined);
+  });
+
+  it('create link type resource through resourceObject static API', () => {
+    const decisionRecordsPath = join(testDir, `valid${sep}decision-records`);
+    const project = new Project(decisionRecordsPath);
+    const lt = Project.resourceObject(
+      project,
+      resourceName('decision/linkTypes/test'),
+    );
+    expect((lt as LinkTypeResource).data).not.to.equal(undefined);
+  });
+
+  it('create workflow resource through resourceObject static API', () => {
+    const decisionRecordsPath = join(testDir, `valid${sep}decision-records`);
+    const project = new Project(decisionRecordsPath);
+    const wf = Project.resourceObject(
+      project,
+      resourceName('decision/workflows/decision'),
+    );
+    expect((wf as WorkflowResource).data).not.to.equal(undefined);
+  });
+
   // @todo: tests needed:
   // it('cardAttachments()', async () => { }); - requires test data in which project cards have attachments
-  // modules in project: moduleNames, prefixes, ...
+  // modules in project: prefixes, ...
 });

--- a/tools/data-handler/test/resources.test.ts
+++ b/tools/data-handler/test/resources.test.ts
@@ -1,0 +1,1634 @@
+// testing
+import { expect } from 'chai';
+
+// node
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { mkdirSync, rmSync } from 'node:fs';
+
+import { copyDir } from '../src/utils/file-utils.js';
+
+import { Calculate } from '../src/calculate.js';
+import { Create } from '../src/create.js';
+import { Import } from '../src/import.js';
+import { Remove } from '../src/remove.js';
+import { Validate } from '../src/validate.js';
+
+import { Project } from '../src/containers/project.js';
+import { ResourceCollector } from '../src/containers/project/resource-collector.js';
+import { resourceName } from '../src/utils/resource-utils.js';
+import { RemovableResourceTypes } from '../src/interfaces/project-interfaces.js';
+
+import { WorkflowResource } from '../src/resources/workflow-resource.js';
+import { CardTypeResource } from '../src/resources/card-type-resource.js';
+import { FieldTypeResource } from '../src/resources/field-type-resource.js';
+import { LinkTypeResource } from '../src/resources/link-type-resource.js';
+
+import {
+  CardType,
+  CustomField,
+  EnumDefinition,
+  FieldType,
+  LinkType,
+  Workflow,
+  WorkflowState,
+  WorkflowTransition,
+} from '../src/interfaces/resource-interfaces.js';
+
+import {
+  AddOperation,
+  ChangeOperation,
+  RemoveOperation,
+} from '../src/resources/resource-object.js';
+
+describe('resources', () => {
+  const baseDir = dirname(fileURLToPath(import.meta.url));
+  const testDir = join(baseDir, 'tmp-resource-tests');
+  const decisionRecordsPath = join(testDir, 'valid/decision-records');
+  const minimalPath = join(testDir, 'valid/minimal');
+  let project: Project;
+
+  // Some of the commands are used in testing.
+  const validateCmd = Validate.getInstance();
+  let calculateCmd: Calculate;
+  let createCmd: Create;
+  let importCmd: Import;
+  let removeCmd: Remove;
+
+  before(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir('test/test-data/', testDir);
+    project = new Project(decisionRecordsPath);
+    calculateCmd = new Calculate(project);
+    createCmd = new Create(
+      project,
+      calculateCmd,
+      validateCmd,
+      await project.projectPrefixes(),
+    );
+    importCmd = new Import(project, createCmd);
+    removeCmd = new Remove(project, calculateCmd);
+  });
+
+  after(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  describe('resource-collector', () => {
+    it('collect resources locally', async () => {
+      const collector = new ResourceCollector(project);
+
+      // Before collecting the resources, there shouldn't be anything.
+      expect((await collector.resources('calculations')).length).to.equal(0);
+      expect((await collector.resources('cardTypes')).length).to.equal(0);
+      expect((await collector.resources('fieldTypes')).length).to.equal(0);
+      expect((await collector.resources('linkTypes')).length).to.equal(0);
+      expect((await collector.resources('reports')).length).to.equal(0);
+      expect((await collector.resources('templates')).length).to.equal(0);
+      expect((await collector.resources('workflows')).length).to.equal(0);
+      collector.collectLocalResources();
+
+      // After collecting the resources, arrays are populated.
+      const calcCount = (await collector.resources('calculations')).length;
+      const cardTypesCount = (await collector.resources('cardTypes')).length;
+      const fieldTypesCount = (await collector.resources('fieldTypes')).length;
+      const linkTypesCount = (await collector.resources('linkTypes')).length;
+      const reportsCount = (await collector.resources('reports')).length;
+      const templatesCount = (await collector.resources('templates')).length;
+      const workflowsCount = (await collector.resources('workflows')).length;
+
+      expect(calcCount).not.to.equal(0);
+      expect(cardTypesCount).not.to.equal(0);
+      expect(fieldTypesCount).not.to.equal(0);
+      expect(linkTypesCount).not.to.equal(0);
+      expect(reportsCount).not.to.equal(0);
+      expect(templatesCount).not.to.equal(0);
+      expect(workflowsCount).not.to.equal(0);
+
+      // Calling collect again does not affect the arrays
+      collector.collectLocalResources();
+
+      const calcCountAgain = (await collector.resources('calculations')).length;
+      const cardTypesCountAgain = (await collector.resources('cardTypes'))
+        .length;
+      const fieldTypesCountAgain = (await collector.resources('fieldTypes'))
+        .length;
+      const linkTypesCountAgain = (await collector.resources('linkTypes'))
+        .length;
+      const reportsCountAgain = (await collector.resources('reports')).length;
+      const templatesCountAgain = (await collector.resources('templates'))
+        .length;
+      const workflowsCountAgain = (await collector.resources('workflows'))
+        .length;
+
+      expect(calcCount).to.equal(calcCountAgain);
+      expect(cardTypesCount).to.equal(cardTypesCountAgain);
+      expect(fieldTypesCount).to.equal(fieldTypesCountAgain);
+      expect(linkTypesCount).to.equal(linkTypesCountAgain);
+      expect(reportsCount).to.equal(reportsCountAgain);
+      expect(templatesCount).to.equal(templatesCountAgain);
+      expect(workflowsCount).to.equal(workflowsCountAgain);
+
+      // Since there are no modules imported, collecting module resources does not affect
+      // resource arrays.
+      const moduleCalcs =
+        await collector.collectResourcesFromModules('calculations');
+      const moduleCardTypes =
+        await collector.collectResourcesFromModules('cardTypes');
+      const moduleFieldTypes =
+        await collector.collectResourcesFromModules('fieldTypes');
+      const moduleLinkTypes =
+        await collector.collectResourcesFromModules('linkTypes');
+      const moduleReports =
+        await collector.collectResourcesFromModules('reports');
+      const moduleTemplates =
+        await collector.collectResourcesFromModules('templates');
+      const moduleWorkflows =
+        await collector.collectResourcesFromModules('workflows');
+      collector.collectLocalResources();
+
+      expect(moduleCalcs.length).to.equal(0);
+      expect(moduleCardTypes.length).to.equal(0);
+      expect(moduleFieldTypes.length).to.equal(0);
+      expect(moduleLinkTypes.length).to.equal(0);
+      expect(moduleReports.length).to.equal(0);
+      expect(moduleTemplates.length).to.equal(0);
+      expect(moduleWorkflows.length).to.equal(0);
+
+      expect((await collector.resources('calculations')).length).to.equal(
+        calcCount,
+      );
+      expect((await collector.resources('cardTypes')).length).to.equal(
+        cardTypesCount,
+      );
+      expect((await collector.resources('fieldTypes')).length).to.equal(
+        fieldTypesCount,
+      );
+      expect((await collector.resources('linkTypes')).length).to.equal(
+        linkTypesCount,
+      );
+      expect((await collector.resources('reports')).length).to.equal(
+        reportsCount,
+      );
+      expect((await collector.resources('templates')).length).to.equal(
+        templatesCount,
+      );
+      expect((await collector.resources('workflows')).length).to.equal(
+        workflowsCount,
+      );
+    });
+
+    it('collect resources locally and from module', async () => {
+      const collector = new ResourceCollector(project);
+
+      // Store the resource counts before import.
+      // Note that minimal project does not have fieldTypes, linkTypes or reports
+      collector.collectLocalResources();
+      const calcCount = (await collector.resources('calculations')).length;
+      const cardTypesCount = (await collector.resources('cardTypes')).length;
+      const templatesCount = (await collector.resources('templates')).length;
+      const workflowsCount = (await collector.resources('workflows')).length;
+
+      await importCmd.importProject(minimalPath, project.basePath);
+      await collector.moduleImported();
+
+      const calcCountAgain = (await collector.resources('calculations')).length;
+      const cardTypesCountAgain = (await collector.resources('cardTypes'))
+        .length;
+      const templatesCountAgain = (await collector.resources('templates'))
+        .length;
+      const workflowsCountAgain = (await collector.resources('workflows'))
+        .length;
+
+      expect(calcCount).to.be.lessThan(calcCountAgain);
+      expect(cardTypesCount).to.be.lessThan(cardTypesCountAgain);
+      expect(templatesCount).to.be.lessThan(templatesCountAgain);
+      expect(workflowsCount).to.be.lessThan(workflowsCountAgain);
+    });
+
+    it('add and remove workflow', async () => {
+      const collector = new ResourceCollector(project);
+      collector.collectLocalResources();
+
+      const workflowsCount = (await collector.resources('workflows')).length;
+      const nameForWorkflow = `${project.projectPrefix}/workflows/newOne`;
+      const fileName = nameForWorkflow + '.json';
+
+      // Creating new resources automatically updates collector arrays, but only for
+      // instance that is owned by the Project. The tested 'collector' instance needs
+      // to be updated by calling 'collectLocalResources()'.
+      await createCmd.createWorkflow(fileName, '');
+      collector.collectLocalResources();
+      let exists = await collector.resourceExists('workflows', fileName);
+      expect(exists).to.equal(true);
+      const workflowsCountAgain = (await collector.resources('workflows'))
+        .length;
+      expect(workflowsCount + 1).to.equal(workflowsCountAgain);
+
+      // Removing resources automatically updates collector arrays, but only for
+      // instance that is owned by the Project (and it is not public).
+      // The tested 'collector' instance needs to be updated by calling 'collectLocalResources()'.
+      await removeCmd.remove('workflow', nameForWorkflow);
+      collector.collectLocalResources();
+      exists = await collector.resourceExists('workflows', fileName);
+      expect(exists).to.equal(false);
+    });
+
+    it('add and remove other file based resources', async () => {
+      const collector = new ResourceCollector(project);
+
+      async function checkResource(type: string) {
+        const resourceType = type;
+        const removeType = resourceType.substring(0, resourceType.length - 1);
+        const resourceCount = (await collector.resources(resourceType)).length;
+        const nameForResource = `${project.projectPrefix}/${resourceType}/newOne`;
+        const fileName = nameForResource + '.json';
+
+        if (type === 'cardTypes') {
+          await createCmd.createCardType(
+            fileName,
+            'decision/workflows/decision',
+          );
+        } else if (type === 'fieldTypes') {
+          await createCmd.createFieldType(fileName, 'shortText');
+        } else if (type === 'linkTypes') {
+          await createCmd.createLinkType(fileName);
+        } else {
+          expect(false).to.equal(true);
+          return;
+        }
+        collector.collectLocalResources();
+        let exists = await collector.resourceExists(resourceType, fileName);
+        expect(exists).to.equal(true);
+        const resourceCountLater = (await collector.resources(resourceType))
+          .length;
+        expect(resourceCount + 1).to.equal(resourceCountLater);
+
+        await removeCmd.remove(removeType as RemovableResourceTypes, fileName);
+        collector.collectLocalResources();
+        exists = await collector.resourceExists(resourceType, fileName);
+        expect(exists).to.equal(false);
+      }
+
+      collector.collectLocalResources();
+
+      await checkResource('cardTypes');
+      await checkResource('linkTypes');
+      await checkResource('fieldTypes');
+    });
+
+    it('add and remove folder based resources', async () => {
+      const collector = new ResourceCollector(project);
+      collector.collectLocalResources();
+
+      async function checkResource(type: string) {
+        const resourceType = type;
+        const removeType = resourceType.substring(0, resourceType.length - 1);
+        const resourceCount = (await collector.resources(resourceType)).length;
+        const nameForResource = `${project.projectPrefix}/${resourceType}/newOne`;
+
+        if (type === 'templates') {
+          await createCmd.createTemplate(nameForResource, '');
+        } else if (type === 'reports') {
+          await createCmd.createReport(nameForResource);
+        } else {
+          expect(false).to.equal(true);
+        }
+        collector.collectLocalResources();
+        let exists = await collector.resourceExists(
+          resourceType,
+          nameForResource,
+        );
+        expect(exists).to.equal(true);
+        const resourceCountLater = (await collector.resources(resourceType))
+          .length;
+        expect(resourceCount + 1).to.equal(resourceCountLater);
+
+        await removeCmd.remove(
+          removeType as RemovableResourceTypes,
+          nameForResource,
+        );
+        exists = await collector.resourceExists(resourceType, nameForResource);
+        expect(exists).to.equal(false);
+      }
+
+      checkResource('templates');
+      checkResource('reports');
+    });
+  });
+
+  describe('resource basic operations', () => {
+    const baseDir = dirname(fileURLToPath(import.meta.url));
+    const testDir = join(baseDir, 'tmp-resource-classes-tests');
+    const decisionRecordsPath = join(testDir, 'valid/decision-records');
+    let project: Project;
+
+    before(async () => {
+      mkdirSync(testDir, { recursive: true });
+      await copyDir('test/test-data/', testDir);
+      project = new Project(decisionRecordsPath);
+    });
+
+    after(() => {
+      rmSync(testDir, { recursive: true, force: true });
+    });
+
+    it('create card type', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/cardTypes/newWF.json'),
+      );
+      const before = await project.cardTypes();
+      let found = before.find(
+        (item) => item.name === 'decision/cardTypes/newWF.json',
+      );
+      expect(found).to.equal(undefined);
+      await res.createCardType('decision/workflows/decision');
+      const after = await project.cardTypes();
+      found = after.find(
+        (item) => item.name === 'decision/cardTypes/newWF.json',
+      );
+      expect(found).to.not.equal(undefined);
+    });
+    it('create field type', async () => {
+      const res = new FieldTypeResource(
+        project,
+        resourceName('decision/fieldTypes/newWF.json'),
+      );
+      const before = await project.fieldTypes();
+      let found = before.find(
+        (item) => item.name === 'decision/fieldTypes/newWF.json',
+      );
+      expect(found).to.equal(undefined);
+      await res.createFieldType('shortText');
+      const after = await project.fieldTypes();
+      found = after.find(
+        (item) => item.name === 'decision/fieldTypes/newWF.json',
+      );
+      expect(found).to.not.equal(undefined);
+    });
+    it('create link type', async () => {
+      const res = new LinkTypeResource(
+        project,
+        resourceName('decision/linkTypes/newWF.json'),
+      );
+      const before = await project.linkTypes();
+      let found = before.find(
+        (item) => item.name === 'decision/linkTypes/newWF.json',
+      );
+      expect(found).to.equal(undefined);
+      await res.create();
+      const after = await project.linkTypes();
+      found = after.find(
+        (item) => item.name === 'decision/linkTypes/newWF.json',
+      );
+      expect(found).to.not.equal(undefined);
+    });
+    it('create link type with provided content', async () => {
+      const name = 'decision/linkTypes/newLTWithContent.json';
+      const res = new LinkTypeResource(project, resourceName(name));
+      const before = await project.linkTypes();
+      let found = before.find((item) => item.name === name);
+      expect(found).to.equal(undefined);
+      const linkTypeData = {
+        name: name,
+        inboundDisplayName: 'in',
+        outboundDisplayName: 'out',
+        destinationCardTypes: ['decision/cardTypes/decision'],
+        sourceCardTypes: ['decision/cardTypes/decision'],
+        enableLinkDescription: false,
+      } as LinkType;
+      await res.create(linkTypeData);
+      const after = await project.linkTypes();
+      found = after.find((item) => item.name === name);
+      expect(found).to.not.equal(undefined);
+    });
+    it('try to create link type with invalid provided content', async () => {
+      const name = 'decision/linkTypes/invalidLTWithContent.json';
+      const res = new LinkTypeResource(project, resourceName(name));
+      const before = await project.linkTypes();
+      const found = before.find((item) => item.name === name);
+      expect(found).to.equal(undefined);
+      const linkTypeData = {
+        // missing mandatory value 'enableLinkDescription'
+        // note that interface should be such that property is mandatory.
+        name: name,
+        inboundDisplayName: 'in',
+        outboundDisplayName: 'out',
+        destinationCardTypes: ['decision/cardTypes/decision'],
+        sourceCardTypes: ['decision/cardTypes/decision'],
+      } as LinkType;
+      await res
+        .create(linkTypeData)
+        .then(() => {
+          expect(false).to.equal(true);
+        })
+        .catch((error) => {
+          // note that there is sometimes extra whitespace at the end of error messages.
+          expect(error.message.trim()).to.equal(
+            `Invalid content JSON: Schema 'linkTypeSchema' validation Error: requires property "enableLinkDescription"`,
+          );
+        });
+    });
+    it('create workflow', async () => {
+      const res = new WorkflowResource(
+        project,
+        resourceName('decision/workflows/newWF.json'),
+      );
+      const before = await project.workflows();
+      let found = before.find(
+        (item) => item.name === 'decision/workflows/newWF.json',
+      );
+      expect(found).to.equal(undefined);
+      await res.create();
+      const after = await project.workflows();
+      found = after.find(
+        (item) => item.name === 'decision/workflows/newWF.json',
+      );
+      expect(found).to.not.equal(undefined);
+    });
+    it('create workflow with provided content', async () => {
+      const name = 'decision/workflows/newWFWithContent.json';
+      const res = new WorkflowResource(project, resourceName(name));
+      const before = await project.workflows();
+      let found = before.find((item) => item.name === name);
+      expect(found).to.equal(undefined);
+      const workflowData = {
+        name: name,
+        states: [],
+        transitions: [],
+      } as Workflow;
+      await res.create(workflowData);
+      const after = await project.workflows();
+      found = after.find((item) => item.name === name);
+      expect(found).to.not.equal(undefined);
+    });
+    it('try to create card type with invalid name', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/cardTypes/new111.json'), // names cannot have digits
+      );
+      await res
+        .createCardType('decision/workflows/decision')
+        .then(() => expect(false).to.equal(true))
+        .catch((err) => {
+          if (err instanceof Error) {
+            expect(err.message).to.equal(
+              "Resource identifier must follow naming rules. Identifier 'new111' is invalid",
+            );
+          }
+        });
+    });
+    it('try to create field type with invalid name', async () => {
+      const res = new FieldTypeResource(
+        project,
+        resourceName('decision/fieldTypes/new111.json'), // names cannot have digits
+      );
+      await res
+        .createFieldType('shortText')
+        .then(() => expect(false).to.equal(true))
+        .catch((err) => {
+          if (err instanceof Error) {
+            expect(err.message).to.equal(
+              "Resource identifier must follow naming rules. Identifier 'new111' is invalid",
+            );
+          }
+        });
+    });
+    it('try to create link type with invalid name', async () => {
+      const res = new LinkTypeResource(
+        project,
+        resourceName('decision/linkTypes/new111.json'), // names cannot have digits
+      );
+      await res
+        .create()
+        .then(() => expect(false).to.equal(true))
+        .catch((err) => {
+          if (err instanceof Error) {
+            expect(err.message).to.equal(
+              "Resource identifier must follow naming rules. Identifier 'new111' is invalid",
+            );
+          }
+        });
+    });
+    it('try to create workflow with invalid name', async () => {
+      const res = new WorkflowResource(
+        project,
+        resourceName('decision/workflows/new111.json'), // names cannot have digits
+      );
+      await res
+        .create()
+        .then(() => expect(false).to.equal(true))
+        .catch((err) => {
+          if (err instanceof Error) {
+            expect(err.message).to.equal(
+              "Resource identifier must follow naming rules. Identifier 'new111' is invalid",
+            );
+          }
+        });
+    });
+    it('try to create card type with invalid type', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/workflows/new-one'), // cannot create from workflows
+      );
+      await res
+        .createCardType('decision/workflows/decision')
+        .then(() => expect(false).to.equal(true))
+        .catch((err) => {
+          if (err instanceof Error) {
+            expect(err.message).to.equal(
+              "Resource name must match the resource type. Type 'workflows' does not match 'cardTypes'",
+            );
+          }
+        });
+    });
+    it('try to create field type with invalid type', async () => {
+      const res = new FieldTypeResource(
+        project,
+        resourceName('decision/workflows/new-one'), // cannot create from workflows
+      );
+      await res
+        .createFieldType('shortText')
+        .then(() => expect(false).to.equal(true))
+        .catch((err) => {
+          if (err instanceof Error) {
+            expect(err.message).to.equal(
+              "Resource name must match the resource type. Type 'workflows' does not match 'fieldTypes'",
+            );
+          }
+        });
+    });
+    it('try to create link type with invalid type', async () => {
+      const res = new LinkTypeResource(
+        project,
+        resourceName('decision/workflows/new-one'), // cannot create from workflows
+      );
+      await res
+        .create()
+        .then(() => expect(false).to.equal(true))
+        .catch((err) => {
+          if (err instanceof Error) {
+            expect(err.message).to.equal(
+              "Resource name must match the resource type. Type 'workflows' does not match 'linkTypes'",
+            );
+          }
+        });
+    });
+    it('try to create workflow with invalid type', async () => {
+      const res = new WorkflowResource(
+        project,
+        resourceName('decision/linkTypes/new-one.json'), // cannot create from link types
+      );
+      await res
+        .create()
+        .then(() => expect(false).to.equal(true))
+        .catch((err) => {
+          if (err instanceof Error) {
+            expect(err.message).to.equal(
+              "Resource name must match the resource type. Type 'linkTypes' does not match 'workflows'",
+            );
+          }
+        });
+    });
+    it('try to create card type with invalid project prefix', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('diipadaapa/cardTypes/new-one'), // cannot create from unknown prefix
+      );
+      await res
+        .createCardType('decision/workflows/decision')
+        .then(() => expect(false).to.equal(true))
+        .catch((err) => {
+          if (err instanceof Error) {
+            expect(err.message).to.equal(
+              "Resource name can only refer to project that it is part of. Prefix 'diipadaapa' is not included in '[decision]'",
+            );
+          }
+        });
+    });
+    it('try to create field type with invalid project prefix', async () => {
+      const res = new FieldTypeResource(
+        project,
+        resourceName('diipadaapa/fieldTypes/new-one'), // cannot create from unknown prefix
+      );
+      await res
+        .createFieldType('shortText')
+        .then(() => expect(false).to.equal(true))
+        .catch((err) => {
+          if (err instanceof Error) {
+            expect(err.message).to.equal(
+              "Resource name can only refer to project that it is part of. Prefix 'diipadaapa' is not included in '[decision]'",
+            );
+          }
+        });
+    });
+    it('try to create link type with invalid project prefix', async () => {
+      const res = new LinkTypeResource(
+        project,
+        resourceName('diipadaapa/linkTypes/new-one'), // cannot create from unknown prefix
+      );
+      await res
+        .create()
+        .then(() => expect(false).to.equal(true))
+        .catch((err) => {
+          if (err instanceof Error) {
+            expect(err.message).to.equal(
+              "Resource name can only refer to project that it is part of. Prefix 'diipadaapa' is not included in '[decision]'",
+            );
+          }
+        });
+    });
+    it('try to create workflow with invalid project prefix', async () => {
+      const res = new WorkflowResource(
+        project,
+        resourceName('diipadaapa/workflows/new-one.json'), // cannot create from unknown prefix
+      );
+      await res
+        .create()
+        .then(() => expect(false).to.equal(true))
+        .catch((err) => {
+          if (err instanceof Error) {
+            expect(err.message).to.equal(
+              "Resource name can only refer to project that it is part of. Prefix 'diipadaapa' is not included in '[decision]'",
+            );
+          }
+        });
+    });
+    it('try to create card type with invalid content', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/cardTypes/new-one'),
+      );
+      await res
+        .createCardType('decision/workflows/does-not-exist') // invalid workflow
+        .then(() => expect(false).to.equal(true))
+        .catch((err) => {
+          if (err instanceof Error) {
+            expect(err.message).to.equal(
+              "Workflow 'decision/workflows/does-not-exist' does not exist in the project",
+            );
+          }
+        });
+    });
+    it('try to create field type with invalid content', async () => {
+      const res = new FieldTypeResource(
+        project,
+        resourceName('decision/cardTypes/new-one'),
+      );
+      await res
+        .createFieldType('data-type-that-does-not-exist') // invalid data type
+        .then(() => expect(false).to.equal(true))
+        .catch((err) => {
+          if (err instanceof Error) {
+            expect(err.message).to.equal(
+              "Field type 'data-type-that-does-not-exist' not supported. Supported types shortText, longText, number, integer, boolean, enum, list, date, dateTime, person",
+            );
+          }
+        });
+    });
+    it('data of card type', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/cardTypes/newWF.json'),
+      );
+      expect(JSON.stringify(res.data)).to.equal(
+        JSON.stringify({
+          name: 'decision/cardTypes/newWF.json',
+          workflow: 'decision/workflows/decision.json',
+          customFields: [],
+          alwaysVisibleFields: [],
+          optionallyVisibleFields: [],
+        }),
+      );
+    });
+    it('data of field type', async () => {
+      const res = new FieldTypeResource(
+        project,
+        resourceName('decision/fieldTypes/newWF.json'),
+      );
+      expect(JSON.stringify(res.data)).to.equal(
+        JSON.stringify({
+          name: 'decision/fieldTypes/newWF.json',
+          dataType: 'shortText',
+        }),
+      );
+    });
+    it('data of link type', async () => {
+      const res = new LinkTypeResource(
+        project,
+        resourceName('decision/linkTypes/newWF.json'),
+      );
+      expect(JSON.stringify(res.data)).to.equal(
+        JSON.stringify({
+          name: 'decision/linkTypes/newWF.json',
+          outboundDisplayName: 'decision/linkTypes/newWF',
+          inboundDisplayName: 'decision/linkTypes/newWF',
+          sourceCardTypes: [],
+          destinationCardTypes: [],
+          enableLinkDescription: false,
+        }),
+      );
+    });
+    it('data of workflow', async () => {
+      const res = new WorkflowResource(
+        project,
+        resourceName('decision/workflows/newWF.json'),
+      );
+      expect(JSON.stringify(res.data)).to.equal(
+        JSON.stringify({
+          name: 'decision/workflows/newWF.json',
+          states: [
+            { name: 'Draft', category: 'initial' },
+            { name: 'Approved', category: 'closed' },
+            { name: 'Deprecated', category: 'closed' },
+          ],
+          transitions: [
+            { name: 'Create', fromState: [''], toState: 'Draft' },
+            { name: 'Approve', fromState: ['Draft'], toState: 'Approved' },
+            { name: 'Archive', fromState: ['*'], toState: 'Deprecated' },
+          ],
+        }),
+      );
+    });
+    // Show is basically same as '.data' - it just has extra validation.
+    it('show card type', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/cardTypes/newWF.json'),
+      );
+      const data = await res.show();
+      expect(JSON.stringify(data)).to.equal(
+        JSON.stringify({
+          name: 'decision/cardTypes/newWF.json',
+          workflow: 'decision/workflows/decision.json',
+          customFields: [],
+          alwaysVisibleFields: [],
+          optionallyVisibleFields: [],
+        }),
+      );
+    });
+    it('show field type', async () => {
+      const res = new FieldTypeResource(
+        project,
+        resourceName('decision/fieldTypes/newWF.json'),
+      );
+      const data = await res.show();
+      expect(JSON.stringify(data)).to.equal(
+        JSON.stringify({
+          name: 'decision/fieldTypes/newWF.json',
+          dataType: 'shortText',
+        }),
+      );
+    });
+    it('show link type', async () => {
+      const res = new LinkTypeResource(
+        project,
+        resourceName('decision/linkTypes/newWF.json'),
+      );
+      const data = await res.show();
+      expect(JSON.stringify(data)).to.equal(
+        JSON.stringify({
+          name: 'decision/linkTypes/newWF.json',
+          outboundDisplayName: 'decision/linkTypes/newWF',
+          inboundDisplayName: 'decision/linkTypes/newWF',
+          sourceCardTypes: [],
+          destinationCardTypes: [],
+          enableLinkDescription: false,
+        }),
+      );
+    });
+    it('show workflow', async () => {
+      const res = new WorkflowResource(
+        project,
+        resourceName('decision/workflows/newWF.json'),
+      );
+      const data = await res.show();
+      expect(JSON.stringify(data)).to.equal(
+        JSON.stringify({
+          name: 'decision/workflows/newWF.json',
+          states: [
+            { name: 'Draft', category: 'initial' },
+            { name: 'Approved', category: 'closed' },
+            { name: 'Deprecated', category: 'closed' },
+          ],
+          transitions: [
+            { name: 'Create', fromState: [''], toState: 'Draft' },
+            { name: 'Approve', fromState: ['Draft'], toState: 'Approved' },
+            { name: 'Archive', fromState: ['*'], toState: 'Deprecated' },
+          ],
+        }),
+      );
+    });
+    it('validate card type', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/cardTypes/newWF.json'),
+      );
+      await res.validate().catch(() => expect(false).to.equal(true));
+    });
+    it('validate field type', async () => {
+      const res = new FieldTypeResource(
+        project,
+        resourceName('decision/fieldTypes/newWF.json'),
+      );
+      await res.validate().catch(() => expect(false).to.equal(true));
+    });
+    it('validate link type', async () => {
+      const res = new LinkTypeResource(
+        project,
+        resourceName('decision/linkTypes/newWF.json'),
+      );
+      await res.validate().catch(() => expect(false).to.equal(true));
+    });
+    it('validate workflow', async () => {
+      const res = new WorkflowResource(
+        project,
+        resourceName('decision/workflows/newWF.json'),
+      );
+      await res.validate().catch(() => expect(false).to.equal(true));
+    });
+    it('try to validate missing card type', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/cardTypes/i-do-not-exist.json'),
+      );
+      await res.validate().catch(() => expect(true).to.equal(true));
+    });
+    it('try to validate missing field type', async () => {
+      const res = new FieldTypeResource(
+        project,
+        resourceName('decision/fieldTypes/i-do-not-exist.json'),
+      );
+      await res.validate().catch(() => expect(true).to.equal(true));
+    });
+    it('try to validate missing link type', async () => {
+      const res = new LinkTypeResource(
+        project,
+        resourceName('decision/linkTypes/i-do-not-exist.json'),
+      );
+      await res.validate().catch(() => expect(true).to.equal(true));
+    });
+    it('try to validate missing workflow', async () => {
+      const res = new WorkflowResource(
+        project,
+        resourceName('decision/workflows/i-do-not-exist.json'),
+      );
+      await res.validate().catch(() => expect(true).to.equal(true));
+    });
+    it('rename card type', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/cardTypes/newResForRename.json'),
+      );
+      await res.createCardType('decision/workflows/decision');
+      await res.rename(resourceName('decision/cardTypes/newname.json'));
+      await res.delete();
+    });
+    it('rename field type', async () => {
+      const res = new FieldTypeResource(
+        project,
+        resourceName('decision/fieldTypes/newResForRename.json'),
+      );
+      await res.createFieldType('shortText');
+      await res.rename(resourceName('decision/fieldTypes/newname.json'));
+      await res.delete();
+    });
+    it('rename link type', async () => {
+      const res = new LinkTypeResource(
+        project,
+        resourceName('decision/linkTypes/newResForRename.json'),
+      );
+      await res.create();
+      await res.rename(resourceName('decision/linkTypes/newname.json'));
+      await res.delete();
+    });
+    it('rename workflow', async () => {
+      const res = new WorkflowResource(
+        project,
+        resourceName('decision/workflows/newResForRename.json'),
+      );
+      await res.create();
+      await res.rename(resourceName('decision/workflows/newname.json'));
+      await res.delete();
+    });
+    it('try to rename workflow - attempt to change prefix', async () => {
+      const res = new WorkflowResource(
+        project,
+        resourceName('decision/workflows/newResForRename.json'),
+      );
+      await res.create();
+      await res
+        .rename(resourceName('newpre/workflows/newname.json'))
+        .then(() => expect(false).to.equal(true))
+        .catch((err) => {
+          if (err instanceof Error) {
+            expect(err.message).to.include('Can only rename project resources');
+          }
+        });
+      await res.delete();
+    });
+    it('try to rename workflow - attempt to change type', async () => {
+      const res = new WorkflowResource(
+        project,
+        resourceName('decision/workflows/newResForRename.json'),
+      );
+      await res.create();
+      await res
+        .rename(resourceName('decision/linkTypes/newname.json'))
+        .then(() => expect(false).to.equal(true))
+        .catch((err) => {
+          if (err instanceof Error) {
+            expect(err.message).to.include('Cannot change resource type');
+          }
+        });
+      await res.delete();
+    });
+    it('try to rename workflow - attempt to use illegal name', async () => {
+      const res = new WorkflowResource(
+        project,
+        resourceName('decision/workflows/newResForRename.json'),
+      );
+      await res.create();
+      await res
+        .rename(resourceName('decision/workflows/newname111.json'))
+        .then(() => expect(false).to.equal(true))
+        .catch((err) => {
+          if (err instanceof Error) {
+            expect(err.message).to.include(
+              'Resource identifier must follow naming',
+            );
+          }
+        });
+      await res.delete();
+    });
+    it('update card type - name', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/cardTypes/forRename.json'),
+      );
+      await res.createCardType('decision/workflows/decision');
+      await res.update('name', {
+        name: 'change',
+        target: '',
+        to: 'decision/cardTypes/afterUpdate',
+      });
+      expect(res.data?.name).to.equal('decision/cardTypes/afterUpdate');
+    });
+    it('update card type - try to "rank" scalar "name"', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/cardTypes/tryForUpdate.json'),
+      );
+      await res.createCardType('decision/workflows/decision');
+      await res
+        .update('name', {
+          name: 'rank',
+          target: '',
+          newIndex: 99,
+        })
+        .then(() => {
+          expect(false).to.equal(true);
+        })
+        .catch((error) => {
+          expect(error.message).to.equal(
+            'Cannot do operation rank on scalar value',
+          );
+        });
+    });
+    it('update card type - try to "add" scalar "name"', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/cardTypes/tryForUpdate.json'),
+      );
+      await res
+        .update('name', {
+          name: 'add',
+          target: '',
+        })
+        .then(() => {
+          expect(false).to.equal(true);
+        })
+        .catch((error) => {
+          expect(error.message).to.equal(
+            'Cannot do operation add on scalar value',
+          );
+        });
+    });
+    it('update card type - try to "remove" scalar "name"', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/cardTypes/tryForUpdate.json'),
+      );
+      await res
+        .update('name', {
+          name: 'remove',
+          target: '',
+        })
+        .then(() => {
+          expect(false).to.equal(true);
+        })
+        .catch((error) => {
+          expect(error.message).to.equal(
+            'Cannot do operation remove on scalar value',
+          );
+        });
+    });
+    it('update card type - add element to alwaysVisibleFields', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/cardTypes/updateAlwaysVisible.json'),
+      );
+      await res.createCardType('decision/workflows/decision');
+      expect((res.data as CardType).alwaysVisibleFields.length).to.equal(0);
+      await res.update('alwaysVisibleFields', {
+        name: 'add',
+        target: 'decision/fieldTypes/newOne',
+      });
+      expect((res.data as CardType).alwaysVisibleFields.length).to.equal(1);
+    });
+    it('update card type - remove element from alwaysVisibleFields', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/cardTypes/updateAlwaysVisible.json'),
+      );
+      expect((res.data as CardType).alwaysVisibleFields.length).to.equal(1);
+      await res.update('alwaysVisibleFields', {
+        name: 'remove',
+        target: 'decision/fieldTypes/newOne',
+      });
+      expect((res.data as CardType).alwaysVisibleFields.length).to.equal(0);
+    });
+    it('update card type - add two elements to alwaysVisibleFields and move the latter to first', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/cardTypes/updateAlwaysVisible.json'),
+      );
+      expect((res.data as CardType).alwaysVisibleFields.length).to.equal(0);
+      await res.update('alwaysVisibleFields', {
+        name: 'add',
+        target: 'decision/fieldTypes/newOne',
+      });
+      await res.update('alwaysVisibleFields', {
+        name: 'add',
+        target: 'decision/fieldTypes/secondNewOne',
+      });
+      expect((res.data as CardType).alwaysVisibleFields.length).to.equal(2);
+      await res.update('alwaysVisibleFields', {
+        name: 'rank',
+        target: 'decision/fieldTypes/secondNewOne',
+        newIndex: 0,
+      });
+      expect((res.data as CardType).alwaysVisibleFields.length).to.equal(2);
+      expect((res.data as CardType).alwaysVisibleFields.at(0)).to.equal(
+        'decision/fieldTypes/secondNewOne',
+      );
+    });
+    it('update card type - add element to optionallyVisibleFields', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/cardTypes/optionallyVisible.json'),
+      );
+      await res.createCardType('decision/workflows/decision');
+      expect((res.data as CardType).optionallyVisibleFields.length).to.equal(0);
+      await res.update('optionallyVisibleFields', {
+        name: 'add',
+        target: 'decision/fieldTypes/newOne',
+      });
+      expect((res.data as CardType).optionallyVisibleFields.length).to.equal(1);
+    });
+    it('update card type - remove element from optionallyVisibleFields', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/cardTypes/optionallyVisible.json'),
+      );
+      expect((res.data as CardType).optionallyVisibleFields.length).to.equal(1);
+      await res.update('optionallyVisibleFields', {
+        name: 'remove',
+        target: 'decision/fieldTypes/newOne',
+      });
+      expect((res.data as CardType).optionallyVisibleFields.length).to.equal(0);
+    });
+    it('update card type - add two elements to optionallyVisibleFields and move the latter to first', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/cardTypes/optionallyVisible.json'),
+      );
+      expect((res.data as CardType).optionallyVisibleFields.length).to.equal(0);
+      await res.update('optionallyVisibleFields', {
+        name: 'add',
+        target: 'decision/fieldTypes/newOne',
+      });
+      await res.update('optionallyVisibleFields', {
+        name: 'add',
+        target: 'decision/fieldTypes/secondNewOne',
+      });
+      expect((res.data as CardType).optionallyVisibleFields.length).to.equal(2);
+      await res.update('optionallyVisibleFields', {
+        name: 'rank',
+        target: 'decision/fieldTypes/secondNewOne',
+        newIndex: 0,
+      });
+      expect((res.data as CardType).optionallyVisibleFields.length).to.equal(2);
+      expect((res.data as CardType).optionallyVisibleFields.at(0)).to.equal(
+        'decision/fieldTypes/secondNewOne',
+      );
+    });
+    it('update card type - workflow', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/cardTypes/updateWorkflow.json'),
+      );
+      await res.createCardType('decision/workflows/decision');
+      await res.update('workflow', {
+        name: 'change',
+        target: '',
+        to: 'decision/cardTypes/afterUpdate',
+      });
+      expect((res.data as CardType).workflow).to.equal(
+        'decision/cardTypes/afterUpdate',
+      );
+    });
+    it('update card type - add element to customFields', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/cardTypes/customFields.json'),
+      );
+      await res.createCardType('decision/workflows/decision');
+      expect((res.data as CardType).customFields.length).to.equal(0);
+      await res.update('customFields', {
+        name: 'add',
+        target: { name: 'decision/fieldTypes/newOne' },
+      });
+      expect((res.data as CardType).customFields.length).to.equal(1);
+    });
+    it('update card type - remove element from customFields', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/cardTypes/customFields.json'),
+      );
+      await res.update('customFields', {
+        name: 'remove',
+        target: { name: 'decision/fieldTypes/newOne' },
+      });
+      expect((res.data as CardType).customFields.length).to.equal(0);
+    });
+    it('update card type - add two elements to customFields, then move last one to first', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/cardTypes/customFields.json'),
+      );
+      expect((res.data as CardType).customFields.length).to.equal(0);
+      await res.update('customFields', {
+        name: 'add',
+        target: { name: 'decision/fieldTypes/newOne' },
+      });
+      await res.update('customFields', {
+        name: 'add',
+        target: { name: 'decision/fieldTypes/newSecondOne' },
+      });
+      await res.update('customFields', {
+        name: 'rank',
+        target: { name: 'decision/fieldTypes/newSecondOne' },
+        newIndex: 0,
+      });
+      expect((res.data as CardType).customFields.length).to.equal(2);
+      const first = (res.data as CardType).customFields.at(0);
+      expect((first as CustomField)?.name).to.equal(
+        'decision/fieldTypes/newSecondOne',
+      );
+    });
+    it('update field type', async () => {
+      const res = new FieldTypeResource(
+        project,
+        resourceName('decision/fieldTypes/dateFieldType.json'),
+      );
+      await res.createFieldType('dateTime');
+      await res.update('name', {
+        name: 'change',
+        target: '',
+        to: 'decision/fieldTypes/afterUpdate',
+      });
+      expect(res.data?.name).to.equal('decision/fieldTypes/afterUpdate');
+    });
+    it('try to update field type with invalid name', async () => {
+      const res = new FieldTypeResource(
+        project,
+        resourceName('decision/fieldTypes/dateFieldType.json'),
+      );
+      await res.createFieldType('dateTime');
+      await res
+        .update('name', {
+          name: 'change',
+          target: '',
+          to: 'decision/fieldTypes/afterUpdate12121212',
+        })
+        .then(() => {
+          expect(false).to.equal(true);
+        })
+        .catch((error) => {
+          expect(error.message).to.include(
+            'Resource identifier must follow naming rules.',
+          );
+        });
+    });
+    // @todo:
+    //it('update field type - change data type', async () => {});
+    it('update field type - change displayName and fieldDescription', async () => {
+      const res = new FieldTypeResource(
+        project,
+        resourceName('decision/fieldTypes/dateFieldType.json'),
+      );
+      await res.update('displayName', {
+        name: 'change',
+        target: '',
+        to: 'Field for dates',
+      });
+      await res.update('fieldDescription', {
+        name: 'change',
+        target: '',
+        to: 'Field description',
+      });
+      expect((res.data as FieldType).displayName).to.equal('Field for dates');
+      expect((res.data as FieldType).fieldDescription).to.equal(
+        'Field description',
+      );
+    });
+    it('update field type - change enumValues', async () => {
+      const res = new FieldTypeResource(
+        project,
+        resourceName('decision/fieldTypes/enumFieldType.json'),
+      );
+      await res.createFieldType('enum');
+      await res.update<EnumDefinition>('enumValues', {
+        name: 'change',
+        to: {
+          enumValue: 'yes',
+          enumDescription: 'Definitely a yes',
+          enumDisplayValue: 'YES',
+        },
+        target: {
+          enumValue: 'value1',
+        },
+      });
+      await res.update<EnumDefinition>('enumValues', {
+        name: 'change',
+        to: {
+          enumValue: 'no',
+          enumDescription: 'Absolutely not',
+          enumDisplayValue: 'NO',
+        },
+        target: {
+          enumValue: 'value2',
+        },
+      });
+      const enums = (res.data as FieldType).enumValues;
+      expect(enums?.length).to.equal(2);
+      expect(enums?.at(0)?.enumValue).to.equal('yes');
+      expect(enums?.at(1)?.enumValue).to.equal('no');
+    });
+    it('update link type scalar values', async () => {
+      const res = new LinkTypeResource(
+        project,
+        resourceName('decision/linkTypes/newLT.json'),
+      );
+      await res.create();
+      await res.update<boolean>('enableLinkDescription', {
+        name: 'change',
+        target: false,
+        to: true,
+      });
+      await res.update('inboundDisplayName', {
+        name: 'change',
+        target: '',
+        to: 'inbound',
+      });
+      await res.update('outboundDisplayName', {
+        name: 'change',
+        target: '',
+        to: 'outbound',
+      });
+      const data = res.data as LinkType;
+      expect(data.inboundDisplayName).to.equal('inbound');
+      expect(data.outboundDisplayName).to.equal('outbound');
+      expect(data.enableLinkDescription).to.equal(true);
+    });
+    it('update link type arrays', async () => {
+      const res = new LinkTypeResource(
+        project,
+        resourceName('decision/linkTypes/newLT.json'),
+      );
+      await res.update('sourceCardTypes', {
+        name: 'add',
+        target: 'CT1',
+      });
+      await res.update('destinationCardTypes', {
+        name: 'add',
+        target: 'CT1',
+      });
+      await res.update('sourceCardTypes', {
+        name: 'change',
+        target: 'CT1',
+        to: 'CT1NEW',
+      });
+      await res.update('destinationCardTypes', {
+        name: 'change',
+        target: 'CT1',
+        to: 'CT1NEW',
+      });
+      const data = res.data as LinkType;
+      expect(data.sourceCardTypes).to.include('CT1NEW');
+      expect(data.destinationCardTypes).to.include('CT1NEW');
+    });
+    it('update workflow - rename state', async () => {
+      const res = new WorkflowResource(
+        project,
+        resourceName('decision/workflows/newWF.json'),
+      );
+      const expectedItem = { name: 'Deprecated', category: 'closed' };
+      const updatedItem = { name: 'ReallyDeprecated', category: 'closed' };
+      let found = (res.data as Workflow).states.find(
+        (item) => item.name === expectedItem.name,
+      );
+      expect(found).not.to.equal(undefined);
+      const op = {
+        name: 'change',
+        target: expectedItem,
+        to: updatedItem,
+      } as ChangeOperation<WorkflowState>;
+      await res.update('states', op);
+      found = (res.data as Workflow).states.find(
+        (item) => item.name === expectedItem.name,
+      );
+      expect(found).to.equal(undefined);
+      found = (res.data as Workflow).states.find(
+        (item) => item.name === updatedItem.name,
+      );
+      expect(found).not.to.equal(undefined);
+    });
+    it('update workflow - rename transition', async () => {
+      const res = new WorkflowResource(
+        project,
+        resourceName('decision/workflows/newWF.json'),
+      );
+      const expectedItem = {
+        name: 'Approve',
+        fromState: ['Draft'],
+        toState: 'Approved',
+      };
+      const updatedItem = {
+        name: 'RemoveDraftStatus',
+        fromState: ['Draft'],
+        toState: 'Approved',
+      };
+      let found = (res.data as Workflow).transitions.find(
+        (item) => item.name === expectedItem.name,
+      );
+      expect(found).not.to.equal(undefined);
+      const op = {
+        name: 'change',
+        target: expectedItem,
+        to: updatedItem,
+      } as ChangeOperation<WorkflowState>;
+      await res.update('transitions', op);
+      found = (res.data as Workflow).transitions.find(
+        (item) => item.name === expectedItem.name,
+      );
+      expect(found).to.equal(undefined);
+      found = (res.data as Workflow).transitions.find(
+        (item) => item.name === updatedItem.name,
+      );
+      expect(found).not.to.equal(undefined);
+    });
+    it('update workflow - add state', async () => {
+      const res = new WorkflowResource(
+        project,
+        resourceName('decision/workflows/newWF.json'),
+      );
+      const newState = { name: 'OrphanState', category: 'closed' };
+      let found = (res.data as Workflow).states.find(
+        (item) => item.name === newState.name,
+      );
+      expect(found).to.equal(undefined);
+      const op = {
+        name: 'add',
+        target: newState,
+      } as AddOperation<WorkflowState>;
+      await res.update('states', op);
+      found = (res.data as Workflow).states.find(
+        (item) => item.name === newState.name,
+      );
+      expect(found).to.not.equal(undefined);
+    });
+    it('update workflow - add transition', async () => {
+      const res = new WorkflowResource(
+        project,
+        resourceName('decision/workflows/newWF.json'),
+      );
+      const newTransition = {
+        name: 'Orphaned',
+        fromState: ['*'],
+        toState: 'OrphanState',
+      };
+      let found = (res.data as Workflow).transitions.find(
+        (item) => item.name === newTransition.name,
+      );
+      expect(found).to.equal(undefined);
+      const op = {
+        name: 'add',
+        target: newTransition,
+      } as AddOperation<WorkflowState>;
+      await res.update('transitions', op);
+      found = (res.data as Workflow).transitions.find(
+        (item) => item.name === newTransition.name,
+      );
+      expect(found).to.not.equal(undefined);
+    });
+    it('update workflow - remove state', async () => {
+      const res = new WorkflowResource(
+        project,
+        resourceName('decision/workflows/newWF.json'),
+      );
+      const expectedItem = { name: 'ReallyDeprecated', category: 'closed' };
+      let found = (res.data as Workflow).states.find(
+        (item) => item.name === expectedItem.name,
+      );
+      expect(found).not.to.equal(undefined);
+      const op = {
+        name: 'remove',
+        target: expectedItem,
+      } as RemoveOperation<WorkflowState>;
+      await res.update('states', op);
+      found = (res.data as Workflow).states.find(
+        (item) => item.name === expectedItem.name,
+      );
+      expect(found).to.equal(undefined);
+    });
+    it('update workflow - remove transition', async () => {
+      const res = new WorkflowResource(
+        project,
+        resourceName('decision/workflows/newWF.json'),
+      );
+      const expectedItem = {
+        name: 'RemoveDraftStatus',
+        fromState: ['Draft'],
+        toState: 'Approved',
+      };
+      let found = (res.data as Workflow).transitions.find(
+        (item) => item.name === expectedItem.name,
+      );
+      expect(found).not.to.equal(undefined);
+      const op = {
+        name: 'remove',
+        target: expectedItem,
+      } as RemoveOperation<WorkflowTransition>;
+      await res.update('transitions', op);
+      found = (res.data as Workflow).transitions.find(
+        (item) => item.name === expectedItem.name,
+      );
+      expect(found).to.equal(undefined);
+    });
+    // Note that the delete operations depend on previously created and updated data.
+    it('delete card type', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/cardTypes/newWF.json'),
+      );
+      const before = await project.cardTypes();
+      let found = before.find(
+        (item) => item.name === 'decision/cardTypes/newWF.json',
+      );
+      expect(found).to.not.equal(undefined);
+      await res.delete();
+      const after = await project.workflows();
+      found = after.find(
+        (item) => item.name === 'decision/cardTypes/newWF.json',
+      );
+    });
+    it('delete field type', async () => {
+      const res = new FieldTypeResource(
+        project,
+        resourceName('decision/fieldTypes/newWF.json'),
+      );
+      const before = await project.fieldTypes();
+      let found = before.find(
+        (item) => item.name === 'decision/fieldTypes/newWF.json',
+      );
+      expect(found).to.not.equal(undefined);
+      await res.delete();
+      const after = await project.fieldTypes();
+      found = after.find(
+        (item) => item.name === 'decision/fieldTypes/newWF.json',
+      );
+    });
+    it('delete link type', async () => {
+      const res = new LinkTypeResource(
+        project,
+        resourceName('decision/linkTypes/newWF.json'),
+      );
+      const before = await project.linkTypes();
+      let found = before.find(
+        (item) => item.name === 'decision/linkTypes/newWF.json',
+      );
+      expect(found).to.not.equal(undefined);
+      await res.delete();
+      const after = await project.linkTypes();
+      found = after.find(
+        (item) => item.name === 'decision/linkTypes/newWF.json',
+      );
+    });
+    it('delete workflow', async () => {
+      const res = new WorkflowResource(
+        project,
+        resourceName('decision/workflows/newWF.json'),
+      );
+      const before = await project.workflows();
+      let found = before.find(
+        (item) => item.name === 'decision/workflows/newWF.json',
+      );
+      expect(found).to.not.equal(undefined);
+      await res.delete();
+      const after = await project.workflows();
+      found = after.find(
+        (item) => item.name === 'decision/workflows/newWF.json',
+      );
+      expect(found).to.equal(undefined);
+    });
+    it('try to delete card type that does not exist', async () => {
+      const res = new CardTypeResource(
+        project,
+        resourceName('decision/cardTypes/nonExistingCT.json'),
+      );
+      const before = await project.cardTypes();
+      const found = before.find(
+        (item) => item.name === 'decision/cardTypes/nonExistingCT.json',
+      );
+      expect(found).to.equal(undefined);
+      await res
+        .delete()
+        .then(() => expect(false).to.equal(true))
+        .catch((error) =>
+          expect(error.message).to.equal(
+            `Resource 'nonExistingCT' does not exist in the project`,
+          ),
+        );
+    });
+    it('try to delete field type that does not exist', async () => {
+      const res = new FieldTypeResource(
+        project,
+        resourceName('decision/fieldTypes/nonExistingFT.json'),
+      );
+      const before = await project.fieldTypes();
+      const found = before.find(
+        (item) => item.name === 'decision/fieldTypes/nonExistingFT.json',
+      );
+      expect(found).to.equal(undefined);
+      await res
+        .delete()
+        .then(() => expect(false).to.equal(true))
+        .catch((error) =>
+          expect(error.message).to.equal(
+            `Resource 'nonExistingFT' does not exist in the project`,
+          ),
+        );
+    });
+    it('try to delete link type that does not exist', async () => {
+      const res = new LinkTypeResource(
+        project,
+        resourceName('decision/linkTypes/nonExistingLT.json'),
+      );
+      const before = await project.cardTypes();
+      const found = before.find(
+        (item) => item.name === 'decision/linkTypes/nonExistingLT.json',
+      );
+      expect(found).to.equal(undefined);
+      await res
+        .delete()
+        .then(() => expect(false).to.equal(true))
+        .catch((error) =>
+          expect(error.message).to.equal(
+            `Resource 'nonExistingLT' does not exist in the project`,
+          ),
+        );
+    });
+    it('try to delete workflow that does not exist', async () => {
+      const res = new WorkflowResource(
+        project,
+        resourceName('decision/workflows/nonExistingWF.json'),
+      );
+      const before = await project.cardTypes();
+      const found = before.find(
+        (item) => item.name === 'decision/workflows/nonExistingWF.json',
+      );
+      expect(found).to.equal(undefined);
+      await res
+        .delete()
+        .then(() => expect(false).to.equal(true))
+        .catch((error) =>
+          expect(error.message).to.equal(
+            `Resource 'nonExistingWF' does not exist in the project`,
+          ),
+        );
+    });
+  });
+});

--- a/tools/data-handler/test/resources/array-handler.test.ts
+++ b/tools/data-handler/test/resources/array-handler.test.ts
@@ -1,0 +1,301 @@
+// testing
+import { expect } from 'chai';
+
+import { ArrayHandler } from '../../src/resources/array-handler.js';
+
+const testObject1 = {
+  first: 'value1',
+  second: 'value1',
+};
+const testObject2 = {
+  first: 'value2',
+  second: 'value2',
+};
+
+const testStringArray = ['first', 'second'];
+const testNumberArray = [0, 1];
+const testObjectArray = [testObject1, testObject2];
+
+describe('array handler', () => {
+  const numberArrayHandler = new ArrayHandler<number>();
+  const stringArrayHandler = new ArrayHandler<string>();
+  const objectArrayHandler = new ArrayHandler<typeof testObject1>();
+
+  describe('handle add', () => {
+    it('string array', () => {
+      const changedArray = stringArrayHandler.handleArray(
+        { name: 'add', target: 'three' },
+        testStringArray,
+      );
+      expect(changedArray.at(2)).to.equal('three');
+    });
+    it('number array', () => {
+      const changedArray = numberArrayHandler.handleArray(
+        { name: 'add', target: 3 },
+        testNumberArray,
+      );
+      expect(changedArray.at(2)).to.equal(3);
+    });
+    it('object array', () => {
+      const changedArray = objectArrayHandler.handleArray(
+        {
+          name: 'add',
+          target: { first: 'value3', second: 'value3' },
+        },
+        testObjectArray,
+      );
+      const newElement = changedArray.at(2);
+      expect(newElement?.first).to.equal('value3');
+      expect(newElement?.second).to.equal('value3');
+    });
+    it('try to add duplicate string', () => {
+      try {
+        stringArrayHandler.handleArray(
+          { name: 'add', target: 'second' },
+          testStringArray,
+        );
+        expect(false).to.equal(true);
+      } catch (e) {
+        if (e instanceof Error) {
+          expect(e.message).to.equal(`Item '"second"' already exists`);
+        }
+      }
+    });
+    it('try to add duplicate object', () => {
+      try {
+        objectArrayHandler.handleArray(
+          { name: 'add', target: testObject2 },
+          testObjectArray,
+        );
+        expect(false).to.equal(true);
+      } catch (e) {
+        if (e instanceof Error) {
+          expect(e.message).to.equal(
+            `Item '{"first":"value2","second":"value2"}' already exists`,
+          );
+        }
+      }
+    });
+    it('try to add duplicate number', () => {
+      try {
+        numberArrayHandler.handleArray(
+          { name: 'add', target: 1 },
+          testNumberArray,
+        );
+        expect(false).to.equal(true);
+      } catch (e) {
+        if (e instanceof Error) {
+          expect(e.message).to.equal(`Item '1' already exists`);
+        }
+      }
+    });
+  });
+
+  describe('handle change', () => {
+    it('string array', () => {
+      const changedArray = stringArrayHandler.handleArray(
+        { name: 'change', target: 'second', to: 'newSecond' },
+        testStringArray,
+      );
+      expect(changedArray.at(1)).to.equal('newSecond');
+    });
+    it('number array', () => {
+      const changedArray = numberArrayHandler.handleArray(
+        { name: 'change', target: 0, to: 99 },
+        testNumberArray,
+      );
+      expect(changedArray.at(0)).to.equal(99);
+    });
+    it('object array', () => {
+      const changedArray = objectArrayHandler.handleArray(
+        { name: 'change', target: testObject1, to: { first: '', second: '' } },
+        testObjectArray,
+      );
+      const changedElement = changedArray.at(0);
+      expect(changedElement?.first).to.equal('');
+      expect(changedElement?.second).to.equal('');
+    });
+    it('object element not in array', () => {
+      try {
+        objectArrayHandler.handleArray(
+          {
+            name: 'change',
+            target: { first: '', second: '' },
+            to: { first: '', second: '' },
+          },
+          testObjectArray,
+        );
+        expect(false).to.equal(true);
+      } catch (e) {
+        if (e instanceof Error) {
+          expect(e.message).to.equal(
+            `Item '{"first":"","second":""}' not found`,
+          );
+        }
+      }
+    });
+  });
+
+  describe('handle remove', () => {
+    it('string array', () => {
+      const changedArray = stringArrayHandler.handleArray(
+        { name: 'remove', target: 'second' },
+        testStringArray,
+      );
+      expect(changedArray.length).to.equal(1);
+    });
+    it('number array', () => {
+      const changedArray = numberArrayHandler.handleArray(
+        { name: 'remove', target: 1 },
+        testNumberArray,
+      );
+      expect(changedArray.length).to.equal(1);
+    });
+    it('object array', () => {
+      const changedArray = objectArrayHandler.handleArray(
+        { name: 'remove', target: testObject2 },
+        testObjectArray,
+      );
+      expect(changedArray.length).to.equal(1);
+    });
+    it('string element not in array', () => {
+      try {
+        stringArrayHandler.handleArray(
+          { name: 'remove', target: 'wrongOne' },
+          testStringArray,
+        );
+        expect(false).to.equal(true);
+      } catch (e) {
+        if (e instanceof Error) {
+          expect(e.message).to.equal(`Item '"wrongOne"' not found`);
+        }
+      }
+    });
+    it('object element not in array', () => {
+      try {
+        objectArrayHandler.handleArray(
+          { name: 'remove', target: { first: 'wrong', second: 'wrong' } },
+          testObjectArray,
+        );
+        expect(false).to.equal(true);
+      } catch (e) {
+        if (e instanceof Error) {
+          expect(e.message).to.equal(
+            `Item '{"first":"wrong","second":"wrong"}' not found`,
+          );
+        }
+      }
+    });
+    it('number element not in array', () => {
+      try {
+        numberArrayHandler.handleArray(
+          { name: 'remove', target: 99 },
+          testNumberArray,
+        );
+        expect(false).to.equal(true);
+      } catch (e) {
+        if (e instanceof Error) {
+          expect(e.message).to.equal(`Item '99' not found`);
+        }
+      }
+    });
+  });
+
+  describe('handle rank', () => {
+    it('string array', () => {
+      const changedArray = stringArrayHandler.handleArray(
+        { name: 'rank', target: 'second', newIndex: 0 },
+        testStringArray,
+      );
+      expect(changedArray).to.not.be.equal(testStringArray);
+      expect(changedArray.at(0)).to.equal('second');
+      expect(changedArray.at(1)).to.equal('first');
+    });
+    it('number array', () => {
+      const changedArray = numberArrayHandler.handleArray(
+        { name: 'rank', target: 1, newIndex: 0 },
+        testNumberArray,
+      );
+      expect(changedArray).to.not.be.equal(testNumberArray);
+      expect(changedArray.at(0)).to.equal(1);
+      expect(changedArray.at(1)).to.equal(0);
+    });
+    it('object array', () => {
+      const changedArray = objectArrayHandler.handleArray(
+        {
+          name: 'rank',
+          target: testObject1,
+          newIndex: 1,
+        },
+        testObjectArray,
+      );
+      expect(changedArray).to.not.be.equal(testNumberArray);
+      expect(changedArray.at(0)).to.equal(testObject2);
+      expect(changedArray.at(1)).to.equal(testObject1);
+    });
+    it('element not in string array', () => {
+      try {
+        stringArrayHandler.handleArray(
+          { name: 'rank', target: 'three', newIndex: 0 },
+          testStringArray,
+        );
+        expect(false).to.equal(true);
+      } catch (e) {
+        if (e instanceof Error) {
+          expect(e.message).to.equal(`Item '"three"' not found`);
+        }
+      }
+    });
+    it('element not in number array', () => {
+      try {
+        numberArrayHandler.handleArray(
+          { name: 'rank', target: 3, newIndex: 0 },
+          testNumberArray,
+        );
+        expect(false).to.equal(true);
+      } catch (e) {
+        if (e instanceof Error) {
+          expect(e.message).to.equal(`Item '3' not found`);
+        }
+      }
+    });
+    it('element not in object array', () => {
+      try {
+        objectArrayHandler.handleArray(
+          {
+            name: 'rank',
+            target: {
+              first: 'value3',
+              second: 'value3',
+            },
+            newIndex: 0,
+          },
+          testObjectArray,
+        );
+        expect(false).to.equal(true);
+      } catch (e) {
+        if (e instanceof Error) {
+          expect(e.message).to.equal(
+            `Item '{"first":"value3","second":"value3"}' not found`,
+          );
+        }
+      }
+    });
+    it('incorrect new index', () => {
+      try {
+        objectArrayHandler.handleArray(
+          {
+            name: 'rank',
+            target: testObject1,
+            newIndex: 99,
+          },
+          testObjectArray,
+        );
+      } catch (e) {
+        if (e instanceof Error) {
+          expect(e.message).to.equal('Invalid target index: 99');
+        }
+      }
+    });
+  });
+});

--- a/tools/data-handler/test/show.test.ts
+++ b/tools/data-handler/test/show.test.ts
@@ -160,28 +160,28 @@ describe('show', () => {
     const results = await showCmd.showProjectCards();
     expect(results).to.not.equal(undefined);
   });
-  it('showCardTypeDetails (success)', async () => {
+  it('showResource - card type (success)', async () => {
     const cardType = 'decision/cardTypes/decision';
-    const results = await showCmd.showCardTypeDetails(cardType);
+    const results = await showCmd.showResource(cardType);
     expect(results).to.not.equal(undefined);
   });
-  it('showCardTypeDetails - no cardType', async () => {
+  it('showResource - empty cardType', async () => {
     const cardType = '';
     await showCmd
-      .showCardTypeDetails(cardType)
+      .showResource(cardType)
       .catch((error) =>
         expect(errorFunction(error)).to.equal(
-          `Must define card type name to query its details.`,
+          `Must define resource name to query its details`,
         ),
       );
   });
-  it('showCardTypeDetails - card type does not exist in project', async () => {
-    const cardType = 'my-card-type';
+  it('showResource - card type does not exist in project', async () => {
+    const cardType = 'decision/cardTypes/my-card-type';
     await showCmd
-      .showCardTypeDetails(cardType)
+      .showResource(cardType)
       .catch((error) =>
         expect(errorFunction(error)).to.equal(
-          `Card type 'my-card-type' not found from the project.`,
+          `CardType '${cardType}' does not exist in the project`,
         ),
       );
   });
@@ -197,18 +197,18 @@ describe('show', () => {
     const results = await showCmd.showFieldTypes();
     expect(results).to.not.equal(undefined);
   });
-  it('showFieldType (success)', async () => {
+  it('showResource - field type (success)', async () => {
     const fieldTypeName = 'decision/fieldTypes/obsoletedBy';
-    const results = await showCmd.showFieldType(fieldTypeName);
+    const results = await showCmd.showResource(fieldTypeName);
     expect(results).to.not.equal(undefined);
   });
-  it('showFieldType (success)', async () => {
-    const fieldTypeName = 'i-do-not-exist';
+  it('showResource - field type does not exist', async () => {
+    const fieldTypeName = 'decision/fieldTypes/i-do-not-exist';
     await showCmd
-      .showFieldType(fieldTypeName)
+      .showResource(fieldTypeName)
       .catch((error) =>
         expect(errorFunction(error)).to.equal(
-          `Field type 'i-do-not-exist' not found from the project.`,
+          `FieldType '${fieldTypeName}' does not exist in the project`,
         ),
       );
   });
@@ -216,18 +216,18 @@ describe('show', () => {
     const results = await showCmd.showLinkTypes();
     expect(results).to.not.equal(undefined);
   });
-  it('showLinkType (success)', async () => {
+  it('showResource - link type (success)', async () => {
     const fieldTypeName = 'decision/linkTypes/test';
-    const results = await showCmd.showLinkType(fieldTypeName);
+    const results = await showCmd.showResource(fieldTypeName);
     expect(results).to.not.equal(undefined);
   });
-  it('try showLinkType', async () => {
-    const linkTypeName = 'i-do-not-exist';
+  it('try showResource - link type does not exist', async () => {
+    const linkTypeName = 'decision/linkTypes/i-do-not-exist';
     await showCmd
-      .showLinkType(linkTypeName)
+      .showResource(linkTypeName)
       .catch((error) =>
         expect(errorFunction(error)).to.equal(
-          `Link type 'i-do-not-exist' not found from the project.`,
+          `LinkType '${linkTypeName}' does not exist in the project`,
         ),
       );
   });
@@ -286,28 +286,28 @@ describe('show', () => {
     const results = await showCmd.showTemplatesWithDetails();
     expect(results).to.not.equal(undefined);
   });
-  it('showWorkflow (success)', async () => {
+  it('showResource - workflow (success)', async () => {
     const workflowName = 'decision/workflows/decision';
-    const results = await showCmd.showWorkflow(workflowName);
+    const results = await showCmd.showResource(workflowName);
     expect(results).to.not.equal(undefined);
   });
-  it('showWorkflow - empty workflow name', async () => {
+  it('showResource - empty workflow name', async () => {
     const workflowName = '';
     await showCmd
-      .showWorkflow(workflowName)
+      .showResource(workflowName)
       .catch((error) =>
         expect(errorFunction(error)).to.equal(
-          `Must define workflow name to query its details.`,
+          `Must define resource name to query its details`,
         ),
       );
   });
-  it('showWorkflow - workflow does not exist in project', async () => {
-    const workflowName = 'i-do-not-exist';
+  it('showResource - workflow does not exist in project', async () => {
+    const workflowName = 'decision/workflows/i-do-not-exist';
     await showCmd
-      .showWorkflow(workflowName)
+      .showResource(workflowName)
       .catch((error) =>
         expect(errorFunction(error)).to.equal(
-          `Workflow 'i-do-not-exist' not found from the project.`,
+          `Workflow '${workflowName}' does not exist in the project`,
         ),
       );
   });

--- a/tools/data-handler/test/template.test.ts
+++ b/tools/data-handler/test/template.test.ts
@@ -35,7 +35,9 @@ describe('template', () => {
       new Template(project, { name: '', path: '' });
     } catch (error) {
       if (error instanceof Error) {
-        expect(error.message).to.contain("Name '' is not valid resource name");
+        expect(error.message).to.contain(
+          `Must define resource name to query its details`,
+        );
       }
     }
   });

--- a/tools/data-handler/test/utils/common-utils.test.ts
+++ b/tools/data-handler/test/utils/common-utils.test.ts
@@ -1,0 +1,60 @@
+// testing
+import { expect } from 'chai';
+
+import { deepCompare, singularType } from '../../src/utils/common-utils.js';
+
+describe('common utils', () => {
+  it('change plural type name to singular', async () => {
+    const types = ['cardtypes', 'fieldtypes', 'linktypes', 'workflows'];
+    const expectedTypes = ['cardtype', 'fieldtype', 'linktype', 'workflow'];
+    let index = 0;
+    for (const type of types) {
+      const singular = singularType(type);
+      expect(expectedTypes[index]).to.equal(singular);
+      ++index;
+    }
+  });
+
+  describe('deep compare', () => {
+    it('different objects', () => {
+      const obj1 = { key: 'value' };
+      const obj2 = { anotherKey: 'value' };
+      const result = deepCompare(obj1, obj2);
+      expect(result).to.equal(false);
+    });
+    it('same objects, but different values', () => {
+      const obj1 = { key: 'value' };
+      const obj2 = { key: 'value2' };
+      const result = deepCompare(obj1, obj2);
+      expect(result).to.equal(false);
+    });
+    it('same objects', () => {
+      const obj1 = { key: 'value' };
+      const obj2 = { key: 'value' };
+      const result = deepCompare(obj1, obj2);
+      expect(result).to.equal(true);
+    });
+    it('object and array', () => {
+      const obj1 = { key: 'value' };
+      const arr = [{ key: 'value' }];
+      const result = deepCompare(obj1, arr);
+      expect(result).to.equal(false);
+    });
+    it('same arrays', () => {
+      const arr1 = [{ key: 'value' }];
+      const arr2 = [{ key: 'value' }];
+      const result = deepCompare(arr1, arr2);
+      expect(result).to.equal(true);
+    });
+    it('different arrays', () => {
+      const arr1 = [{ key: 'value' }];
+      const arr2 = [{ key: 'anotherValue' }];
+      const result = deepCompare(arr1, arr2);
+      expect(result).to.equal(false);
+    });
+    it('empty objects', () => {
+      const result = deepCompare({}, {});
+      expect(result).to.equal(true);
+    });
+  });
+});

--- a/tools/data-handler/test/utils/resource-utils.test.ts
+++ b/tools/data-handler/test/utils/resource-utils.test.ts
@@ -2,33 +2,44 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
+// node
+import { dirname, join, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import {
+  pathToResourceName,
   ResourceName,
-  resourceNameParts,
+  resourceNameToPath,
+  resourceName,
   resourceNameToString,
+  resourceObjectToResource,
+  resourceObjectToResourceName,
 } from '../../src/utils/resource-utils.js';
 
+import { Project } from '../../src/containers/project.js';
+import { WorkflowResource } from '../../src/resources/workflow-resource.js';
+
 describe('resource utils', () => {
-  it('resourceNameParts with valid resource name (success)', () => {
-    const resourceName = 'test/test/test';
+  it('resourceName with valid resource name (success)', () => {
+    const name = 'test/test/test';
     // note that resource name util does not handle incorrect prefixes, or types
-    const { identifier, prefix, type } = resourceNameParts(resourceName);
+    const { identifier, prefix, type } = resourceName(name);
     expect(prefix).to.equal('test');
     expect(type).to.equal('test');
     expect(identifier).to.equal('test');
   });
-  it('resourceNameParts with valid identifier (success)', () => {
-    const resourceName = 'test';
-    const { identifier, prefix, type } = resourceNameParts(resourceName);
+  it('resourceName with valid identifier (success)', () => {
+    const name = 'test';
+    const { identifier, prefix, type } = resourceName(name);
     expect(prefix).to.equal('');
     expect(type).to.equal('');
     expect(identifier).to.equal('test');
   });
-  it('resourceNameParts with invalid names', () => {
+  it('resourceName with invalid names', () => {
     const invalidResourceNames = ['', 'test/test', 'test/test/test/test'];
     for (const invalidName of invalidResourceNames) {
       expect(() => {
-        resourceNameParts(invalidName);
+        resourceName(invalidName);
       }).to.throw();
     }
   });
@@ -67,10 +78,155 @@ describe('resource utils', () => {
       { prefix: '', type: 'a', identifier: 'a' },
     ];
     for (const invalidName of invalidResourceNames) {
-      console.error(invalidName);
       expect(() => {
         resourceNameToString(invalidName);
       }).to.throw();
     }
+  });
+});
+
+describe('resource utils with Project instance', () => {
+  let project: Project;
+  before(() => {
+    const baseDir = dirname(fileURLToPath(import.meta.url));
+    const decisionRecordsPath = join(
+      baseDir,
+      '../test-data/valid/decision-records',
+    );
+    // uses the actual test data (not a copy); do not change it in tests.
+    project = new Project(decisionRecordsPath);
+  });
+  it('resourceNameToPath with valid values', () => {
+    const validNames: Map<ResourceName, string> = new Map([
+      [
+        {
+          prefix: project.projectPrefix,
+          type: 'cardTypes',
+          identifier: 'test',
+        },
+        `${project.paths.resourcesFolder}${sep}cardTypes${sep}test.json`,
+      ],
+      [
+        {
+          prefix: project.projectPrefix,
+          type: 'workflows',
+          identifier: 'decision',
+        },
+        `${project.paths.resourcesFolder}${sep}workflows${sep}decision.json`,
+      ],
+    ]);
+
+    for (const name of validNames) {
+      const resultPath = resourceNameToPath(project, name[0]);
+      expect(resultPath).to.equal(name[1]);
+    }
+  });
+  it('resourceNameToPath with empty prefix throws', () => {
+    try {
+      resourceNameToPath(project, {
+        prefix: '',
+        type: '',
+        identifier: '',
+      });
+    } catch (e) {
+      if (e instanceof Error)
+        expect(e.message).to.equal('resourceName does not contain prefix');
+    }
+  });
+
+  it('pathToResourceName with valid values', () => {
+    const validNames: Map<string, ResourceName> = new Map([
+      [
+        `${project.paths.resourcesFolder}${sep}cardTypes${sep}test.json`,
+        {
+          prefix: project.projectPrefix,
+          type: 'cardTypes',
+          identifier: 'test',
+        },
+      ],
+      [
+        `${project.paths.resourcesFolder}${sep}workflows${sep}decision.json`,
+        {
+          prefix: project.projectPrefix,
+          type: 'workflows',
+          identifier: 'decision',
+        },
+      ],
+      [
+        `${project.paths.modulesFolder}${sep}base${sep}workflows${sep}decision.json`,
+        {
+          prefix: 'base',
+          type: 'workflows',
+          identifier: 'decision',
+        },
+      ],
+    ]);
+    for (const name of validNames) {
+      const resourceName = pathToResourceName(project, name[0]);
+      expect(resourceName.prefix).to.equal(name[1].prefix);
+      expect(resourceName.type).to.equal(name[1].type);
+      expect(resourceName.identifier).to.equal(name[1].identifier);
+    }
+  });
+  it('pathToResourceName with invalid values', () => {
+    const validNames: Map<string, ResourceName> = new Map([
+      [
+        `${project.paths.resourcesFolder}${sep}cardTypes${sep}`,
+        {
+          prefix: project.projectPrefix,
+          type: 'cardTypes',
+          identifier: 'test',
+        },
+      ],
+      [
+        `${sep}path${sep}to${sep}somewhere${sep}that${sep}is${sep}not${sep}a${sep}project${sep}path`,
+        {
+          prefix: project.projectPrefix,
+          type: 'workflows',
+          identifier: 'decision',
+        },
+      ],
+      [
+        `${project.paths.resourcesFolder}${sep}base${sep}workflows${sep}decision.json`,
+        {
+          prefix: 'base',
+          type: 'workflows',
+          identifier: 'decision',
+        },
+      ],
+    ]);
+    for (const name of validNames) {
+      try {
+        pathToResourceName(project, name[0]);
+      } catch (e) {
+        if (e instanceof Error) {
+          expect(e.message).to.contain(`invalid path`);
+          expect(e.message).to.contain(`${name[0]}`);
+        }
+      }
+    }
+  });
+  it('resourceObjectToResource with valid values', () => {
+    const resourceFullName = 'decision/workflows/decision';
+    const workflow = new WorkflowResource(
+      project,
+      resourceName(resourceFullName),
+    );
+    const resource = resourceObjectToResource(workflow);
+    expect(resource.name).to.equal(resourceFullName);
+    expect(resource.path).to.equal(
+      `${project.paths.resourcesFolder}${sep}workflows`,
+    );
+  });
+  it('resourceObjectToResourceName with valid values', () => {
+    const resourceFullName = 'decision/workflows/decision';
+    const workflow = new WorkflowResource(
+      project,
+      resourceName(resourceFullName),
+    );
+    const name = resourceObjectToResourceName(workflow);
+    expect(name.prefix).to.equal('decision');
+    expect(name.type).to.equal('workflows');
+    expect(name.identifier).to.equal('decision');
   });
 });

--- a/tools/schema/cardTypeSchema.json
+++ b/tools/schema/cardTypeSchema.json
@@ -9,7 +9,7 @@
       "description": "The name of the card type",
       "type": "string",
       "minLength": 1,
-      "pattern": "^[A-Za-z]*/?[A-Za-z]*/?[A-Za-z-_]+$"
+      "pattern": "^[A-Za-z]*/?[A-Za-z]*/?[A-Za-z-_]+[.json]*$"
     },
     "workflow": {
       "description": "The name of the workflow",


### PR DESCRIPTION
New way to handle resources and update command for these.

This is still lacking "folder based" resources - reports and templates.
But I'd like to make these resources "similar" to other resources first (INTDEV-636) and then implement later the support for those resources.  Thus, templates and reports are excluded from this PR.

Also missing from this implementation is data type change handling (related to changing data type in field type).
This will be implemented later, in other PR. 

Some minute details are needed for certain other updates as well (e.g. change the workflow state machine; how to update card states INTDEV-582; or removal of state INTDEV-579). Basically these operations already work, but they don't propogate the changes to affected cards automatically, since it would need to provide a mapping table for state changes. These details will be polished when the aforementioned tickets are handled.

Other than that, the implementation is complete.

******************
**Resources**:
******************

A type of resource is now its own class that implements the various commands it can handle. These include: create, delete, show, rename and update. Adding new commands is straight forward; implement new function to base classes and to the actual resource classes. Adding new resource type is also similarly easy; inherit new class from base class and implement the commands - majority of these just call the base class.

To make working with resources easier, there are now new utility functions that can change `path` to `resourceName` and vice versa. Also way to change `Resource` (this is an existing interface that is `path` and `filename`) to `ResourceObject` (the new type of `Resource` from this PR)).

******************
**Update command**:
******************

It is now possible to update resources from CLI (or programmatically). There are four different types of updates: 
`change` - resource property value is changed;
`add` - a new element is added to a resource property array;
`remove` - an element is removed from a resource property array;
`rank` - an element is moved to a new location within a resource array;
Only the first works on scalar values. To change a sub-key of a property, you need to provide the whole changed property as a parameter (including the sub-key)

Some example operations from CLI:

`cyberismo update cisms/fieldTypes/riskEvaluationNeeded add enumValues "{ \"enumValue\": \"maybe\" }"`
--> Adds new enumValue 'maybe' to the field type
`cyberismo update cisms/fieldTypes/riskEvaluationNeeded remove enumValues "{ \"enumValue\": \"maybe\" }"`
--> Removes enumValue 'maybe' from the field type. Note that cards currently using `maybe` are not updated.
`cyberismo update cisms/cardTypes/task rank customFields cisms/fieldTypes/reviewPeriod 0`
--> Moves item `cisms/fieldTypes/reviewPeriod` to be the first of customFields
`cyberismo update cisms/fieldTypes/owner name change cisms/fieldTypes/ownernew`
--> Rename field type `cisms/fieldTypes/owner` to `cisms/fieldTypes/ownernew`. Note that the change is also done to all resources using the field type, and to all cards having the custom field.

Note that many of the operations automatically propagate the change further. 
For example, changing the name of the resource, automatically updates all references to that resource.


Added unit tests to all new public interfaces; close to 130 new unit tests, which is roughly half of the changes in this PR.