### PR TITLE
INTDEV-637: Validate macros

### DIFF
--- a/tools/cli/bin/run
+++ b/tools/cli/bin/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --no-warnings=ExperimentalWarning
 
 import program from '@cyberismocom/cli';
 

--- a/tools/data-handler/src/interfaces/macros.ts
+++ b/tools/data-handler/src/interfaces/macros.ts
@@ -12,7 +12,7 @@
 
 import { macroMetadata } from '../macros/common.js';
 
-type Mode = 'static' | 'inject';
+type Mode = 'validate' | 'static' | 'inject';
 
 export interface MacroGenerationContext {
   projectPath: string;

--- a/tools/data-handler/src/macros/createCards/index.ts
+++ b/tools/data-handler/src/macros/createCards/index.ts
@@ -27,22 +27,28 @@ class CreateCardsMacro extends BaseMacro {
   constructor() {
     super(macroMetadata);
   }
+
+  handleValidate = (data: string) => {
+    this.validate(data);
+  };
+
   async handleStatic() {
     // Buttons aren't supported in static mode
     return '';
   }
 
   handleInject = async (_: MacroGenerationContext, data: string) => {
+    const options = this.validate(data);
+    return createHtmlPlaceholder(this.metadata, options);
+  };
+
+  private validate(data: string): CreateCardsOptions {
     if (!data || typeof data !== 'string') {
       throw new Error('createCards macro requires a JSON object as data');
     }
-    const options = validateMacroContent<CreateCardsOptions>(
-      this.metadata,
-      data,
-    );
 
-    return createHtmlPlaceholder(this.metadata, options);
-  };
+    return validateMacroContent<CreateCardsOptions>(this.metadata, data);
+  }
 }
 
 export default CreateCardsMacro;

--- a/tools/data-handler/src/macros/report/index.ts
+++ b/tools/data-handler/src/macros/report/index.ts
@@ -32,15 +32,17 @@ class ReportMacro extends BaseMacro {
   constructor() {
     super(macroMetadata);
   }
+
+  handleValidate = (data: string) => {
+    this.validate(data);
+  };
+
   handleStatic = async (context: MacroGenerationContext, data: string) => {
     return this.handleInject(context, data);
   };
 
   handleInject = async (context: MacroGenerationContext, data: string) => {
-    if (!data || typeof data !== 'string') {
-      throw new Error('report macro requires a JSON object as data');
-    }
-    const options = validateMacroContent<ReportOptions>(this.metadata, data);
+    const options = this.validate(data);
 
     const project = new Project(context.projectPath);
     const report = await project.report(options.name);
@@ -79,6 +81,14 @@ class ReportMacro extends BaseMacro {
       ...result,
     });
   };
+
+  private validate(data: string): ReportOptions {
+    if (!data || typeof data !== 'string') {
+      throw new Error('report macro requires a JSON object as data');
+    }
+
+    return validateMacroContent<ReportOptions>(this.metadata, data);
+  }
 }
 
 export default ReportMacro;

--- a/tools/data-handler/src/macros/scoreCard/index.ts
+++ b/tools/data-handler/src/macros/scoreCard/index.ts
@@ -29,23 +29,27 @@ class ScoreCardMacro extends BaseMacro {
     super(macroMetadata);
   }
 
-  handleStatic = async (context: MacroGenerationContext, data: string) => {
-    if (!data || typeof data !== 'string') {
-      throw new Error('scoreCard macro requires a JSON object as data');
-    }
-    const options = validateMacroContent<ScoreCardOptions>(this.metadata, data);
+  handleValidate = (data: string) => {
+    this.validate(data);
+  };
 
+  handleStatic = async (context: MacroGenerationContext, data: string) => {
+    const options = this.validate(data);
     return this.createAsciidocElement(options);
   };
 
   handleInject = async (_: MacroGenerationContext, data: string) => {
+    const options = this.validate(data);
+    return createHtmlPlaceholder(this.metadata, options);
+  };
+
+  private validate(data: string): ScoreCardOptions {
     if (!data || typeof data !== 'string') {
       throw new Error('scoreCard macro requires a JSON object as data');
     }
-    const options = validateMacroContent<ScoreCardOptions>(this.metadata, data);
 
-    return createHtmlPlaceholder(this.metadata, options);
-  };
+    return validateMacroContent<ScoreCardOptions>(this.metadata, data);
+  }
 
   private createAsciidocElement(options: ScoreCardOptions) {
     return `\n----\n${options.title}: ${options.value} ${options.unit ?? ''} ${options.legend ?? ''}\n----\n`;

--- a/tools/data-handler/src/validate.ts
+++ b/tools/data-handler/src/validate.ts
@@ -47,6 +47,7 @@ const invalidNames = new RegExp(
 );
 
 import * as EmailValidator from 'email-validator';
+import { evaluateMacros } from './macros/index.js';
 
 const baseDir = dirname(fileURLToPath(import.meta.url));
 const subFoldersToValidate = ['.cards', 'cardRoot', '.calc'];
@@ -513,6 +514,15 @@ export class Validate {
           );
           if (validCustomFields.length !== 0) {
             errorMsg.push(validCustomFields);
+          }
+
+          // Validate macros in content
+          if (card.content) {
+            await evaluateMacros(card.content, {
+              mode: 'validate',
+              projectPath,
+              cardKey: card.key,
+            });
           }
         }
         if (errorMsg.length) {

--- a/tools/data-handler/test/macros/index.test.ts
+++ b/tools/data-handler/test/macros/index.test.ts
@@ -9,7 +9,6 @@ import {
   evaluateMacros,
   registerMacros,
   validateMacroContent,
-  validateMacros,
 } from '../../src/macros/index.js';
 import { Validator } from 'jsonschema';
 import Handlebars from 'handlebars';
@@ -24,6 +23,10 @@ class TestMacro extends BaseMacro {
       schema,
     });
   }
+
+  handleValidate = async (data: string) => {
+    return 'test-static: ' + data;
+  };
 
   handleStatic = async (_: MacroGenerationContext, data: string) => {
     return 'test-static: ' + data;
@@ -132,14 +135,28 @@ describe('macros', () => {
       });
     });
   });
-  describe('validateMacros', () => {
-    it('validateMacros (success)', () => {
-      const result = validateMacros(validAdoc);
-      expect(result).to.equal(null);
-    });
-    it('try validateMacros', () => {
-      const result = validateMacros(invalidAdoc);
+  describe('validate macros', () => {
+    it('validate macros (success)', async () => {
+      // this should not throw an error
+      const result = await evaluateMacros(validAdoc, {
+        mode: 'validate',
+        projectPath: '',
+        cardKey: '',
+      });
       expect(result).to.not.equal(null);
+    });
+    it('validate macros - failure', async () => {
+      try {
+        // this should throw an error
+        await evaluateMacros(invalidAdoc, {
+          mode: 'validate',
+          projectPath: '',
+          cardKey: '',
+        });
+        expect(true).to.equal(false);
+      } catch (error) {
+        expect(error).to.not.equal(null);
+      }
     });
   });
   describe('registerMacros', () => {


### PR DESCRIPTION
- Introduce a new mode for macro evaluation: validate, which only runs validation for macro content and produces no output.
- Validation mode checks that necessary parameter are available in correct format and throws errors if not. Other modes (inject & static) produce Asciidoc error output in case of errors.
- Use this mode during `cyberismo validate `command to validate macros inside project card contents
- Update macro tests to use validation mode and remove old validateMacros function, which was only used by tests

There is a remaining issue where the following warning is printed to CLI output:
`ExperimentalWarning: Importing JSON modules is an experimental feature and might change at any time`
This is probably because of macro JSON schemas that are being loaded with import in code. I do not have a fix for this issue yet.
 