### PR TITLE
INTDEV-642 fix preview

### DIFF
--- a/tools/app/app/cards/[key]/edit/page.tsx
+++ b/tools/app/app/cards/[key]/edit/page.tsx
@@ -316,8 +316,8 @@ export default function Page(props: { params: Promise<{ key: string }> }) {
         ...card,
         ...metadata,
         title: __title__ ?? card.title,
-        content: getContent() ?? card.rawContent,
-        parsed,
+        rawContent: getContent() ?? card.rawContent,
+        parsedContent: parsed,
       }
     : null;
 
@@ -663,7 +663,9 @@ export default function Page(props: { params: Promise<{ key: string }> }) {
                 }}
               >
                 <Box height="100%">
-                  <LoadingGate values={[linkTypes, previewCard.parsed || null]}>
+                  <LoadingGate
+                    values={[linkTypes, previewCard.parsedContent || null]}
+                  >
                     <ContentArea
                       card={previewCard}
                       linkTypes={expandedLinkTypes}


### PR DESCRIPTION
Preview was not visible, because we changed the type of card, but used it still the old way. It was not captured by typescript for some reason.