### PR TITLE
Revert nextjs config change

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,12 @@ importers:
       codemirror-asciidoc:
         specifier: ^2.0.1
         version: 2.0.1
+      handlebars:
+        specifier: ^4.7.8
+        version: 4.7.8
+      handlebars-loader:
+        specifier: ^1.7.3
+        version: 1.7.3(handlebars@4.7.8)
       html-react-parser:
         specifier: ^5.1.12
         version: 5.1.18(@types/react@18.3.12)(react@18.3.1)
@@ -1900,6 +1906,9 @@ packages:
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
+  big.js@5.2.2:
+    resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -2453,6 +2462,10 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  emojis-list@3.0.0:
+    resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
+    engines: {node: '>= 4'}
+
   end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
 
@@ -2725,6 +2738,9 @@ packages:
   fast-uri@3.0.3:
     resolution: {integrity: sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==}
 
+  fastparse@1.1.2:
+    resolution: {integrity: sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==}
+
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
@@ -2919,6 +2935,11 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  handlebars-loader@1.7.3:
+    resolution: {integrity: sha512-dDb+8D51vE3OTSE2wuGPWRAegtsEuw8Mk8hCjtRu/pNcBfN5q+M8ZG3kVJxBuOeBrVElpFStipGmaxSBTRR1mQ==}
+    peerDependencies:
+      handlebars: '>= 1.3.0 < 5'
 
   handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
@@ -3545,6 +3566,10 @@ packages:
     peerDependenciesMeta:
       enquirer:
         optional: true
+
+  loader-utils@1.4.2:
+    resolution: {integrity: sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==}
+    engines: {node: '>=4.0.0'}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -7177,6 +7202,8 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
+  big.js@5.2.2: {}
+
   binary-extensions@2.3.0: {}
 
   bl@4.1.0:
@@ -7761,6 +7788,8 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  emojis-list@3.0.0: {}
+
   end-of-stream@1.4.4:
     dependencies:
       once: 1.4.0
@@ -8193,6 +8222,8 @@ snapshots:
 
   fast-uri@3.0.3: {}
 
+  fastparse@1.1.2: {}
+
   fastq@1.17.1:
     dependencies:
       reusify: 1.0.4
@@ -8401,6 +8432,14 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
+
+  handlebars-loader@1.7.3(handlebars@4.7.8):
+    dependencies:
+      async: 3.2.6
+      fastparse: 1.1.2
+      handlebars: 4.7.8
+      loader-utils: 1.4.2
+      object-assign: 4.1.1
 
   handlebars@4.7.8:
     dependencies:
@@ -9239,6 +9278,12 @@ snapshots:
       wrap-ansi: 7.0.0
     optionalDependencies:
       enquirer: 2.4.1
+
+  loader-utils@1.4.2:
+    dependencies:
+      big.js: 5.2.2
+      emojis-list: 3.0.0
+      json5: 1.0.2
 
   locate-path@5.0.0:
     dependencies:

--- a/tools/app/next.config.mjs
+++ b/tools/app/next.config.mjs
@@ -3,6 +3,9 @@ import path from 'path';
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   webpack: (config) => {
+    config.resolve.alias.handlebars = path.resolve(
+      './node_modules/handlebars/dist/handlebars.js',
+    );
     config.externals.push({
       'thread-stream': 'commonjs thread-stream',
       pino: 'commonjs pino',

--- a/tools/app/package.json
+++ b/tools/app/package.json
@@ -32,6 +32,8 @@
     "@reduxjs/toolkit": "^2.2.5",
     "@uiw/react-codemirror": "^4.23.5",
     "codemirror-asciidoc": "^2.0.1",
+    "handlebars": "^4.7.8",
+    "handlebars-loader": "^1.7.3",
     "html-react-parser": "^5.1.12",
     "i18next": "^23.11.5",
     "moment": "^2.30.1",


### PR DESCRIPTION
Reverts CyberismoCom/cyberismo#367

We can't remove the nextjs config, because DH still uses handlebars and then nextJS fails to resolve it.

