### PR TITLE
INTDEV-542 Add labels support to app

### DIFF
--- a/tools/app/app/cards/[key]/edit/page.tsx
+++ b/tools/app/app/cards/[key]/edit/page.tsx
@@ -71,7 +71,6 @@ import AsciiDoctor from '@asciidoctor/core';
 import { deepCopy, expandLinkTypes, useModals } from '@/app/lib/utils';
 import { AddAttachmentModal } from '@/app/components/modals';
 import { parseContent } from '@/app/lib/api/actions/card';
-import { CardResponse } from '@/app/lib/api/types';
 
 const asciiDoctor = AsciiDoctor();
 
@@ -446,7 +445,7 @@ export default function Page(props: { params: Promise<{ key: string }> }) {
 
   const handleSave = async (data: Record<string, MetadataValue>) => {
     try {
-      const { __title__, ...metadata } = data;
+      const { __title__, __labels__, ...metadata } = data;
       const update: {
         content?: string;
         metadata: Record<string, MetadataValue>;
@@ -470,6 +469,10 @@ export default function Page(props: { params: Promise<{ key: string }> }) {
 
       if (content !== card.rawContent) {
         update.content = content;
+      }
+
+      if (JSON.stringify(card.labels) !== JSON.stringify(__labels__)) {
+        update.metadata.labels = __labels__;
       }
 
       await updateCard(update);

--- a/tools/app/app/components/EditableField.tsx
+++ b/tools/app/app/components/EditableField.tsx
@@ -10,18 +10,18 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Stack, Tooltip, Typography } from '@mui/joy';
+import { Box, Chip, Stack, Tooltip, Typography } from '@mui/joy';
 import React from 'react';
 import { DataType, MetadataValue } from '../lib/definitions';
 import FieldEditor from './FieldEditor';
 import { metadataValueToString } from '../lib/utils';
 import { useTranslation } from 'react-i18next';
 import { EnumDefinition } from '@cyberismocom/data-handler/types/queries';
-import { Description, InfoOutlined } from '@mui/icons-material';
+import { InfoOutlined } from '@mui/icons-material';
 
 export type EditableFieldProps = {
   value: MetadataValue;
-  dataType: DataType;
+  dataType: DataType | 'label';
   description?: string;
   label: string;
   onChange?: (value: string | string[] | null) => void;
@@ -66,6 +66,22 @@ const EditableField = ({
           enumValues={enumValues}
           disabled={disabled}
         />
+      ) : dataType === 'label' ? (
+        <Box>
+          {(value as string[] | null)?.map((label) => (
+            <Chip
+              key={label}
+              variant="soft"
+              color="primary"
+              sx={{
+                marginX: 0.2,
+                marginBottom: 0.4,
+              }}
+            >
+              {label}
+            </Chip>
+          ))}
+        </Box>
       ) : (
         <Typography
           level="body-sm"

--- a/tools/app/app/components/FieldEditor.tsx
+++ b/tools/app/app/components/FieldEditor.tsx
@@ -10,14 +10,25 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Select, Option, Input, Textarea } from '@mui/joy';
+import {
+  Select,
+  Option,
+  Input,
+  Textarea,
+  Chip,
+  ChipDelete,
+  Box,
+  Stack,
+  IconButton,
+} from '@mui/joy';
 import { DataType, EnumDefinition, MetadataValue } from '../lib/definitions';
 import { useTranslation } from 'react-i18next';
-import { Person } from '@mui/icons-material';
+import { Add, Person } from '@mui/icons-material';
+import { useState } from 'react';
 
 export interface FieldEditorProps {
   value: MetadataValue;
-  dataType?: DataType;
+  dataType?: DataType | 'label';
   onChange?: (value: string | string[] | null) => void;
   enumValues?: Array<EnumDefinition>;
   disabled?: boolean;
@@ -31,6 +42,7 @@ export default function FieldEditor({
   disabled,
 }: FieldEditorProps) {
   const { t } = useTranslation();
+  const [label, setLabel] = useState('');
   switch (dataType) {
     case 'integer':
     case 'number':
@@ -164,6 +176,65 @@ export default function FieldEditor({
           }}
           placeholder={t('placeholder.longText')}
         />
+      );
+    case 'label':
+      return (
+        <Stack spacing={1} width="100%">
+          <Stack direction="row" spacing={1}>
+            <Input
+              onChange={(e) => setLabel(e.target.value)}
+              disabled={disabled}
+              value={label}
+              color="primary"
+              size="sm"
+              fullWidth
+              placeholder={t('placeholder.label')}
+            />
+            <IconButton
+              size="sm"
+              color="primary"
+              variant="soft"
+              onClick={() => {
+                if (!label) {
+                  return;
+                }
+                const copy = Array.isArray(value)
+                  ? [...value].filter((item) => item !== label)
+                  : [];
+                copy.push(label);
+
+                setLabel('');
+
+                onChange?.(copy as string[]);
+              }}
+            >
+              <Add />
+            </IconButton>
+          </Stack>
+          <Box>
+            {(value as string[] | null)?.map((label) => (
+              <Chip
+                key={label}
+                variant="soft"
+                color="primary"
+                endDecorator={
+                  <ChipDelete
+                    disabled={disabled}
+                    onDelete={() =>
+                      onChange?.(
+                        (value as string[] | null)?.filter(
+                          (l) => label !== l,
+                        ) ?? [],
+                      )
+                    }
+                  />
+                }
+              >
+                {label}
+              </Chip>
+            ))}
+          </Box>
+        </Stack>
       );
     case 'shortText':
     default:

--- a/tools/app/app/components/MetadataView.tsx
+++ b/tools/app/app/components/MetadataView.tsx
@@ -34,7 +34,7 @@ interface FieldItemProps {
   handleChange?: (
     e: any,
     onChange: (arg0: MetadataValue) => void,
-    dataType: DataType,
+    dataType: DataType | 'label',
   ) => void;
   disabled?: boolean;
   description?: string;
@@ -104,7 +104,7 @@ function MetadataView({
     (
       value: string | null,
       onChange: (arg0: MetadataValue) => void,
-      dataType: DataType | undefined,
+      dataType: DataType | 'label',
     ) => {
       switch (dataType) {
         case 'number':
@@ -166,6 +166,18 @@ function MetadataView({
             label: t('cardType'),
             dataType: 'shortText',
             edit: false,
+          }}
+        />
+        <FieldItem
+          name="__labels__"
+          defaultValue={card.labels}
+          control={context.control}
+          handleChange={handleChange}
+          expanded={true}
+          editableFieldProps={{
+            label: t('labels'),
+            dataType: 'label',
+            edit: editMode ?? false,
           }}
         />
         {(card.fields ?? []).map(

--- a/tools/app/app/locales/en/translation.json
+++ b/tools/app/app/locales/en/translation.json
@@ -46,6 +46,7 @@
   "delete": "Delete",
   "cardKey": "Card key",
   "cardType": "Card type",
+  "labels": "Labels",
   "value": "Value",
   "name": "Name",
   "title": "Title",
@@ -120,6 +121,7 @@
     "longText": "Enter text",
     "boolean": "Select",
     "person": "firstname.lastname@example.com",
-    "list": "Select"
+    "list": "Select",
+    "label": "Add label"
   }
 }

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -1192,7 +1192,13 @@ export class Project extends CardContainer {
       this,
       card,
     );
-    if (invalidCustomData.length === 0 && invalidWorkFlow.length === 0) {
+
+    const invalidLabels = await this.validator.validateCardLabels(card);
+    if (
+      invalidCustomData.length === 0 &&
+      invalidWorkFlow.length === 0 &&
+      invalidLabels.length === 0
+    ) {
       return '';
     }
     const errors: string[] = [];
@@ -1201,6 +1207,9 @@ export class Project extends CardContainer {
     }
     if (invalidWorkFlow.length > 0) {
       errors.push(invalidWorkFlow);
+    }
+    if (invalidLabels.length > 0) {
+      errors.push(invalidLabels);
     }
     return errors.join('\n');
   }

--- a/tools/data-handler/src/export.ts
+++ b/tools/data-handler/src/export.ts
@@ -56,6 +56,7 @@ export class Export {
       content += `|Card key|${card.key}\n`;
       content += `|Status|${card.metadata.workflowState}\n`;
       content += `|Card type|${card.metadata.cardType}\n`;
+      content += `|Labels|${card.metadata.labels?.join(', ') || ''}`;
 
       for (const [key, value] of Object.entries(card.metadata)) {
         if (

--- a/tools/data-handler/src/validate.ts
+++ b/tools/data-handler/src/validate.ts
@@ -516,6 +516,11 @@ export class Validate {
             errorMsg.push(validCustomFields);
           }
 
+          const validLabels = await this.validateCardLabels(card);
+          if (validLabels.length > 0) {
+            errorMsg.push(validLabels);
+          }
+
           // Validate macros in content
           if (card.content) {
             await evaluateMacros(card.content, {
@@ -737,6 +742,37 @@ export class Validate {
     }
 
     return validationErrors.join('\n');
+  }
+
+  /**
+   * Validates the labels of a card
+   * @param card card to validate. Card must have metadata.
+   */
+  public async validateCardLabels(card: Card): Promise<string> {
+    const validationErrors: string[] = [];
+    if (!card.metadata) {
+      validationErrors.push(
+        `Card '${card.key}' has no metadata. Card object needs to be instantiated with '{metadata: true}'`,
+      );
+    }
+    // labels are not mandatory
+    if (card.metadata?.labels) {
+      if (!Array.isArray(card.metadata?.labels)) {
+        validationErrors.push(
+          `Expected labels to be an array of strings, but instead got ${card.metadata.labels}`,
+        );
+      } else {
+        for (const label of card.metadata.labels) {
+          // labels follow same name guidance as resource names
+          if (!Validate.isValidResourceName(label)) {
+            validationErrors.push(
+              `Label '${label}' does not follow naming rules`,
+            );
+          }
+        }
+      }
+    }
+    return validationErrors.join('/');
   }
 
   /**

--- a/tools/data-handler/test/command-handler-show.test.ts
+++ b/tools/data-handler/test/command-handler-show.test.ts
@@ -153,7 +153,7 @@ describe('shows command', () => {
       );
       expect(result.payload).to.deep.equal([
         'test',
-        'test2',
+        'test-two',
         'template-test-label',
       ]);
     });

--- a/tools/data-handler/test/test-data/valid/decision-records/cardRoot/decision_5/index.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/cardRoot/decision_5/index.json
@@ -6,6 +6,6 @@
     "lastUpdated": "2024-07-12T11:07:35.247Z",
     "labels": [
         "test",
-        "test2"
+        "test-two"
     ]
 }


### PR DESCRIPTION
App: can now add/remove/view labels.
Site export: Labels are also visible

Labels are now validated by DH's validate function. Currently they use the same convention as resource names, but that can be changed if needed