### PR TITLE
INTDEV-421 Add support for custom themes

### DIFF
--- a/resources/ui-bundle/partials/footer-content.hbs
+++ b/resources/ui-bundle/partials/footer-content.hbs
@@ -1,3 +1,10 @@
 <footer class="footer">
-  <p>Built with <a href="https://cyberismo.com">Cyberismo</a>, the open source solution for Security-As-Code.</p>
+  <p>Built with <a href="https://cyberismo.com/">Cyberismo</a>.</p>
+  <p>Copyright &copy; Cyberismo Ltd and contributors 2024.</p>
+  <p><a href="https://github.com/CyberismoCom/cyberismo-docs/blob/main/LICENSE">Documentation licence</a>
+    &middot;
+    <a href="https://cyberismo.com/trademark-policy/">Trademark policy</a>
+    &middot;
+    <a href="https://github.com/CyberismoCom/cyberismo-docs/blob/main/CONTRIBUTING">Contributing</a>
+  </p>
 </footer>

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -14,8 +14,9 @@
     "preinstall": "npx only-allow pnpm",
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf node_modules",
-    "lint": "eslint .",
-    "test": "mocha --require mocha-suppress-logs --disable-warning=ExperimentalWarning --forbid-only \"./test/**/*.test.ts\""
+    "lint": "pnpm dlx eslint .",
+    "test": "mocha --require mocha-suppress-logs --disable-warning=ExperimentalWarning --forbid-only \"./test/**/*.test.ts\"",
+    "watch": "tsc --watch -p tsconfig.build.json"
   },
   "keywords": [],
   "author": "",

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -335,6 +335,10 @@ program
     'Path to a card. If defined will export only that card and its children instead of whole project.',
   )
   .option('-p, --project-path [path]', `${pathGuideline}`)
+  .option(
+    '-t, --theme-path [path]',
+    `Path to a custom theme / UI bundle (site export only)`,
+  )
   .action(
     async (
       format: string,

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -44,6 +44,8 @@ export interface CardsOptions {
   projectPath?: string;
   repeat?: number;
   showUse?: boolean;
+  silent?: boolean;
+  themePath?: string;
 }
 
 // Commands that this class supports.
@@ -236,7 +238,7 @@ export class Commands {
         await this.commands?.editCmd.editCard(cardKey);
       } else if (command === Cmd.export) {
         const [format, output, cardKey] = args;
-        await this.export(output, format as ExportFormats, cardKey);
+        await this.export(output, format as ExportFormats, cardKey, options);
       } else if (command === Cmd.import) {
         const target = args.splice(0, 1)[0];
         if (target === 'module') {
@@ -399,11 +401,12 @@ export class Commands {
     destination: string = 'output',
     format: ExportFormats,
     parentCardKey?: string,
+    options?: CardsOptions,
   ): Promise<requestStatus> {
     if (!this.commands) {
       return { statusCode: 500 };
     }
-    let message = '';
+    let message;
     if (format === 'adoc') {
       message = await this.commands?.exportCmd.exportToADoc(
         destination,
@@ -415,9 +418,10 @@ export class Commands {
         parentCardKey,
       );
     } else if (format === 'site') {
-      message = await this.commands?.exportSiteCmd.exportToSite(
+      return this.commands?.exportSiteCmd.exportToSite(
         destination,
         parentCardKey,
+        options,
       );
     }
     return { statusCode: 200, message: message };

--- a/tools/data-handler/test/export.test.ts
+++ b/tools/data-handler/test/export.test.ts
@@ -30,6 +30,7 @@ describe('export-site', () => {
     rmSync(testDir, { recursive: true, force: true });
     rmSync(testDirForExport, { recursive: true, force: true });
   });
+
   it('export site (success)', async () => {
     const exportSite = new ExportSite(
       commands.project,
@@ -40,6 +41,24 @@ describe('export-site', () => {
       silent: true,
     });
     expect(true).to.equal(true);
+  }).timeout(20000);
+
+  it('export site (invalid theme path)', async () => {
+    const exportSite = new ExportSite(
+      commands.project,
+      commands.calculateCmd,
+      commands.showCmd,
+    );
+    try {
+      await exportSite.exportToSite('/tmp/foo', undefined, {
+        themePath: '/tmp/i-do-not-exist',
+      });
+      // If we get here, the test failed
+      expect(true).to.equal(false);
+    } catch (err) {
+      // Check that the error is what we expect
+      expect(err).to.be.an.instanceof(Error);
+    }
   }).timeout(20000);
 });
 


### PR DESCRIPTION
Usage:

    $ cyberismo export site /tmp/site -t <path-to-ui-bundle>

This is equivalent to running the export without the `-t` option:

    $ cyberismo export site /tmp/site -t ../cyberismo/resources/ui-bundle
