### PR TITLE
INTDEV-634 Rename in new project crashes

### DIFF
--- a/tools/data-handler/src/calculate.ts
+++ b/tools/data-handler/src/calculate.ts
@@ -180,6 +180,9 @@ export class Calculate {
 
   // Once card specific files have been done, write the the imports
   private async generateImports(folder: string, destinationFile: string) {
+    if (!pathExists(folder)) {
+      return;
+    }
     const files: string[] = getFilesSync(folder);
 
     const builder = new ClingoProgramBuilder().addComment(folder);


### PR DESCRIPTION
Renaming project forces calculations to be updated. Unfortunately, one of the sub-calculation functions does not check that the folder actually exists. Fixed by adding a check that if folder does not exist, skip the calculation part.