### PR TITLE
INTDEV-639 Improve error message when 'cardRoot' is missing

### DIFF
--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -157,11 +157,14 @@ export class Commands {
   // Handles initializing the project so that it can be used in the class.
   private async doSetProject(path: string) {
     this.projectPath = resolveTilde(await this.setProjectPath(path));
-
     if (!Validate.validateFolder(this.projectPath)) {
-      throw new Error(
-        `Input validation error: folder name '${path}' is invalid`,
-      );
+      let errorMessage = '';
+      if (path === '' || path === undefined) {
+        errorMessage = `No 'cardRoot' in the current folder`;
+      } else {
+        errorMessage = `Input validation error: folder name '${path}' is invalid`;
+      }
+      throw new Error(errorMessage);
     }
 
     if (!pathExists(this.projectPath)) {


### PR DESCRIPTION
Instead of showing error message: 

`Input validation error: folder name '' is invalid`

show:

`No 'cardRoot' in the current folder`