### PR TITLE
INTDEV-647 ensure deep copy returns undefined/null if input is undefi…

### DIFF
--- a/tools/app/__tests__/utils.test.ts
+++ b/tools/app/__tests__/utils.test.ts
@@ -1,6 +1,7 @@
-import { CardDetails, Project } from '@/app/lib/definitions';
+import { Project } from '@/app/lib/definitions';
 import {
   countChildren,
+  deepCopy,
   findCard,
   findParentCard,
   findPathTo,
@@ -102,6 +103,24 @@ test('getDefaultValue returns a null for null', () => {
     const result = getDefaultValue(value);
     expect(result).toBe(value);
   });
+});
+
+test('Deep copy returns a different object', () => {
+  const obj = { a: 1 };
+  const result = deepCopy(obj);
+
+  expect(result).toEqual(obj);
+  expect(result).not.toBe(obj);
+});
+
+test('deepCopy returns undefined when input is undefined', () => {
+  const result = deepCopy(undefined);
+  expect(result).toBeUndefined();
+});
+
+test('deepCopy returns null when input is null', () => {
+  const result = deepCopy(null);
+  expect(result).toBeNull();
 });
 
 const testProject: Project = {

--- a/tools/app/app/lib/utils.ts
+++ b/tools/app/app/lib/utils.ts
@@ -291,7 +291,10 @@ export function countChildren(treeRoot: QueryResult<'tree'>): number {
  * @param obj: object to copy
  * @returns deep copy of the object
  */
-export function deepCopy<T>(obj: T): T {
+export function deepCopy<T>(obj: T): T | null {
+  if (obj == null) {
+    return obj;
+  }
   return JSON.parse(JSON.stringify(obj));
 }
 


### PR DESCRIPTION
All pages, which did have any customFields, crashed the site in edit mode, because deepCopy tried to do `JSON.parse` on an undefined object. Previously, having no fields resulted in an empty array, but logic program changes changed that behaviour.

Added a couple of tests for deepCopy.