### PR TITLE
Python functions daysSince and concatenate

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -30,8 +30,9 @@ jobs:
       with:
         python-version: 3.12
         auto-update-conda: true
-    - name: Install Clingo from Potassco channel
-      run: conda create -n potassco -c conda-forge clingo && conda init && conda activate potassco
+        activate-environment: test-env
+        environment-file: environment.yml
+
     - name: Check Clingo Availability
       run: which clingo
     - name: Install pnpm

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -32,9 +32,6 @@ jobs:
         auto-update-conda: true
         activate-environment: test-env
         environment-file: environment.yml
-
-    - name: Check Clingo Availability
-      run: which clingo
     - name: Install pnpm
       uses: pnpm/action-setup@v4
       with:

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -31,7 +31,9 @@ jobs:
         python-version: 3.12
         auto-update-conda: true
     - name: Install Clingo from Potassco channel
-      run: conda install -c potassco clingo
+      run: conda create -n potassco -c conda-forge clingo && conda init && conda activate potassco
+    - name: Check Clingo Availability
+      run: which clingo
     - name: Install pnpm
       uses: pnpm/action-setup@v4
       with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -58,9 +58,6 @@ jobs:
         repository: CyberismoCom/cyberismo-docs
         path: .tmp/cyberismo-docs
         ref: main
-  
-    - name: Check Clingo Availability
-      run: which clingo
     - run: pnpm install
     - run: pnpm --filter=app exec cypress install
     - run: pnpm prettier-check

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,10 +23,18 @@ jobs:
       contents: read
       packages: write
 
+    defaults:
+      run:
+        shell: bash -el {0}  
     steps:
     - uses: actions/checkout@v4
-    - name: Install Clingo
-      run: sudo apt-get update && sudo apt-get install -y gringo
+    - name: Setup Miniconda
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        python-version: 3.12
+        auto-update-conda: true
+        activate-environment: test-env
+        environment-file: environment.yml
     - name: Install pnpm
       uses: pnpm/action-setup@v4
       with:
@@ -50,6 +58,9 @@ jobs:
         repository: CyberismoCom/cyberismo-docs
         path: .tmp/cyberismo-docs
         ref: main
+  
+    - name: Check Clingo Availability
+      run: which clingo
     - run: pnpm install
     - run: pnpm --filter=app exec cypress install
     - run: pnpm prettier-check

--- a/calculations/common/base.lp
+++ b/calculations/common/base.lp
@@ -48,39 +48,3 @@ dataType((FieldType, EnumValue), "enumValue", "longText") :-
 hiddenInTreeView(Card) :-
     ancestor(Card, Ancestor),
     hiddenInTreeView(Ancestor).
-
-% python functions
-
-#script (python)
-from clingo import Number, String, SymbolType
-from datetime import date
-
-class Context:
-    def daysSince(self, isodate):
-        try:
-            userdate = date.fromisoformat(isodate.string)
-            today = date.today()
-            return Number((today-userdate).days)
-        except:
-            return Number(0)
-
-    def concatenate(self, *args):
-        try:
-            result = ""
-            for arg in args:
-                match arg.type:
-                    case SymbolType.String:
-                        result = result + arg.string
-                    case SymbolType.Number:
-                        result = result + str(arg.number)
-                    case SymbolType.Function:
-                        # constants such as card keys are represented as function symbols
-                        result = result + arg.name
-            return String(result)
-        except:
-            return String("")
-
-def main(prg):
-    prg.ground([("base", [])], context=Context())
-    prg.solve()
-#end.

--- a/calculations/common/base.lp
+++ b/calculations/common/base.lp
@@ -48,3 +48,39 @@ dataType((FieldType, EnumValue), "enumValue", "longText") :-
 hiddenInTreeView(Card) :-
     ancestor(Card, Ancestor),
     hiddenInTreeView(Ancestor).
+
+% python functions
+
+#script (python)
+from clingo import Number, String, SymbolType
+from datetime import date
+
+class Context:
+    def daysSince(self, isodate):
+        try:
+            userdate = date.fromisoformat(isodate.string)
+            today = date.today()
+            return Number((today-userdate).days)
+        except:
+            return Number(0)
+
+    def concatenate(self, *args):
+        try:
+            result = ""
+            for arg in args:
+                match arg.type:
+                    case SymbolType.String:
+                        result = result + arg.string
+                    case SymbolType.Number:
+                        result = result + str(arg.number)
+                    case SymbolType.Function:
+                        # constants such as card keys are represented as function symbols
+                        result = result + arg.name
+            return String(result)
+        except:
+            return String("")
+
+def main(prg):
+    prg.ground([("base", [])], context=Context())
+    prg.solve()
+#end.

--- a/calculations/common/main.lp
+++ b/calculations/common/main.lp
@@ -3,3 +3,4 @@
 #include "cardTree.lp".
 #include "resourceImports.lp".
 #include "modules.lp".
+#include "pythonFunctions.lp".

--- a/calculations/common/pythonFunctions.lp
+++ b/calculations/common/pythonFunctions.lp
@@ -1,0 +1,35 @@
+% python functions
+
+#script (python)
+from clingo import Number, String, SymbolType
+from datetime import date
+
+class Functions:
+    def concatenate(self, *args):
+        try:
+            result = ""
+            for arg in args:
+                match arg.type:
+                    case SymbolType.String:
+                        result = result + arg.string
+                    case SymbolType.Number:
+                        result = result + str(arg.number)
+                    case SymbolType.Function:
+                        # constants such as card keys are represented as function symbols
+                        result = result + arg.name
+            return String(result)
+        except:
+            return String("")
+
+    def daysSince(self, isodate):
+        try:
+            userdate = date.fromisoformat(isodate.string)
+            today = date.today()
+            return Number((today-userdate).days)
+        except:
+            return Number(0)
+
+def main(prg):
+    prg.ground([("base", [])], context=Functions())
+    prg.solve()
+#end.

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: test-env
 channels:
-  - potassco
+  - conda-forge
   - defaults
 dependencies:
   - python=3.12

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,7 @@
+name: test-env
+channels:
+  - potassco
+  - defaults
+dependencies:
+  - python=3.12
+  - clingo

--- a/tools/data-handler/test/calculate.test.ts
+++ b/tools/data-handler/test/calculate.test.ts
@@ -85,4 +85,39 @@ describe('calculate', () => {
 
     expect(res).to.deep.equal(expectedTree);
   });
+  it('calculate daysSince 2024-01-01', async () => {
+    const res = await calculate.run({
+      query: 'result(@daysSince("2024-01-01")).'
+    });
+
+    expect(Number(res.results[0].key)).greaterThan(365);
+  });
+  it('concatenate a string, a number and a constant', async () => {
+    const res = await calculate.run({
+      query: 'result(@concatenate("string", 1234, constant)).'
+    });
+
+    expect(res.results[0].key).to.equal("string1234constant");
+  });
+  it('concatenate without parameters', async () => {
+    const res = await calculate.run({
+      query: 'result(@concatenate()).'
+    });
+
+    expect(res.results[0].key).to.equal("");
+  });
+  it('concatenate with 1 parameter', async () => {
+    const res = await calculate.run({
+      query: 'result(@concatenate("parameter")).'
+    });
+
+    expect(res.results[0].key).to.equal("parameter");
+  });
+  it('concatenate with 2 parameters', async () => {
+    const res = await calculate.run({
+      query: 'result(@concatenate("one", "two")).'
+    });
+
+    expect(res.results[0].key).to.equal("onetwo");
+  });
 });

--- a/tools/data-handler/test/calculate.test.ts
+++ b/tools/data-handler/test/calculate.test.ts
@@ -85,46 +85,48 @@ describe('calculate', () => {
 
     expect(res).to.deep.equal(expectedTree);
   });
-  it('concatenate a string, a number and a constant', async () => {
-    const res = await calculate.run({
-      query: 'result(@concatenate("string", 1234, constant)).',
+  describe('python functions', () => {
+    it('concatenate a string, a number and a constant', async () => {
+      const res = await calculate.run({
+        query: 'result(@concatenate("string", 1234, constant)).',
+      });
+      expect(res.results[0].key).to.equal('string1234constant');
     });
-    expect(res.results[0].key).to.equal('string1234constant');
-  });
-  it('concatenate without parameters', async () => {
-    const res = await calculate.run({
-      query: 'result(@concatenate()).',
+    it('concatenate without parameters', async () => {
+      const res = await calculate.run({
+        query: 'result(@concatenate()).',
+      });
+      expect(res.results[0].key).to.equal('');
     });
-    expect(res.results[0].key).to.equal('');
-  });
-  it('concatenate with 1 parameter', async () => {
-    const res = await calculate.run({
-      query: 'result(@concatenate("parameter")).',
+    it('concatenate with 1 parameter', async () => {
+      const res = await calculate.run({
+        query: 'result(@concatenate("parameter")).',
+      });
+      expect(res.results[0].key).to.equal('parameter');
     });
-    expect(res.results[0].key).to.equal('parameter');
-  });
-  it('concatenate with 2 parameters', async () => {
-    const res = await calculate.run({
-      query: 'result(@concatenate("one", "two")).',
+    it('concatenate with 2 parameters', async () => {
+      const res = await calculate.run({
+        query: 'result(@concatenate("one", "two")).',
+      });
+      expect(res.results[0].key).to.equal('onetwo');
     });
-    expect(res.results[0].key).to.equal('onetwo');
-  });
-  it('calculate daysSince 2024-01-01', async () => {
-    const res = await calculate.run({
-      query: 'result(@daysSince("2024-01-01")).',
+    it('calculate daysSince 2024-01-01', async () => {
+      const res = await calculate.run({
+        query: 'result(@daysSince("2024-01-01")).',
+      });
+      expect(Number(res.results[0].key)).greaterThan(365);
     });
-    expect(Number(res.results[0].key)).greaterThan(365);
-  });
-  it('daysSince of an invalid date should be zero', async () => {
-    const res = await calculate.run({
-      query: 'result(@daysSince("23232323")).',
+    it('daysSince of an invalid date should be zero', async () => {
+      const res = await calculate.run({
+        query: 'result(@daysSince("23232323")).',
+      });
+      expect(Number(res.results[0].key)).to.equal(0);
     });
-    expect(Number(res.results[0].key)).to.equal(0);
-  });
-  it('daysSince of a number date should be zero', async () => {
-    const res = await calculate.run({
-      query: 'result(@daysSince(1)).',
+    it('daysSince of a number date should be zero', async () => {
+      const res = await calculate.run({
+        query: 'result(@daysSince(1)).',
+      });
+      expect(Number(res.results[0].key)).to.equal(0);
     });
-    expect(Number(res.results[0].key)).to.equal(0);
   });
 });

--- a/tools/data-handler/test/calculate.test.ts
+++ b/tools/data-handler/test/calculate.test.ts
@@ -85,39 +85,46 @@ describe('calculate', () => {
 
     expect(res).to.deep.equal(expectedTree);
   });
-  it('calculate daysSince 2024-01-01', async () => {
-    const res = await calculate.run({
-      query: 'result(@daysSince("2024-01-01")).'
-    });
-
-    expect(Number(res.results[0].key)).greaterThan(365);
-  });
   it('concatenate a string, a number and a constant', async () => {
     const res = await calculate.run({
-      query: 'result(@concatenate("string", 1234, constant)).'
+      query: 'result(@concatenate("string", 1234, constant)).',
     });
-
-    expect(res.results[0].key).to.equal("string1234constant");
+    expect(res.results[0].key).to.equal('string1234constant');
   });
   it('concatenate without parameters', async () => {
     const res = await calculate.run({
-      query: 'result(@concatenate()).'
+      query: 'result(@concatenate()).',
     });
-
-    expect(res.results[0].key).to.equal("");
+    expect(res.results[0].key).to.equal('');
   });
   it('concatenate with 1 parameter', async () => {
     const res = await calculate.run({
-      query: 'result(@concatenate("parameter")).'
+      query: 'result(@concatenate("parameter")).',
     });
-
-    expect(res.results[0].key).to.equal("parameter");
+    expect(res.results[0].key).to.equal('parameter');
   });
   it('concatenate with 2 parameters', async () => {
     const res = await calculate.run({
-      query: 'result(@concatenate("one", "two")).'
+      query: 'result(@concatenate("one", "two")).',
     });
-
-    expect(res.results[0].key).to.equal("onetwo");
+    expect(res.results[0].key).to.equal('onetwo');
+  });
+  it('calculate daysSince 2024-01-01', async () => {
+    const res = await calculate.run({
+      query: 'result(@daysSince("2024-01-01")).',
+    });
+    expect(Number(res.results[0].key)).greaterThan(365);
+  });
+  it('daysSince of an invalid date should be zero', async () => {
+    const res = await calculate.run({
+      query: 'result(@daysSince("23232323")).',
+    });
+    expect(Number(res.results[0].key)).to.equal(0);
+  });
+  it('daysSince of a number date should be zero', async () => {
+    const res = await calculate.run({
+      query: 'result(@daysSince(1)).',
+    });
+    expect(Number(res.results[0].key)).to.equal(0);
   });
 });


### PR DESCRIPTION
Add two first Python functions for logic programs.

`@daysSince(Date)` returns the number of days since `Date`. If `Date` is not a valid ISO date, then `@daysSince` returns 0. This function is useful, for example, when checking whether a review has expired.

`@concatenate(*args)` takes a variable number of arguments and returns a string that concatenates all arguments. The arguments can be numbers, strings or constants (which are a special case of Clingo functions). This function can be used, for example, to create dynamic strings for notifications and policy check failure error messages.