### PR TITLE
INTDEV-644, INTDEV-648 Improve custom field validation

### DIFF
--- a/tools/data-handler/src/validate.ts
+++ b/tools/data-handler/src/validate.ts
@@ -702,10 +702,17 @@ export class Validate {
 
     if (cardType) {
       for (const field of cardType.customFields) {
+        const found = await project.resourceExists('fieldType', field.name);
+        if (!found) {
+          validationErrors.push(
+            `Custom field '${field.name}' from card type '${cardType.name}' not found from project`,
+          );
+        }
         if (card.metadata[field.name] === undefined) {
           validationErrors.push(
-            `Card '${card.key}' is missing custom field 'name' from '${field.name}'`,
+            `Card '${card.key}' is missing custom field '${field.name}'`,
           );
+          continue;
         }
         const fieldType = await project.fieldType(field.name);
         if (


### PR DESCRIPTION
Two fixes: 

1) **INTDEV-644** Validation now checks that card's card type's custom fields exist. Thus, if there is a typo in the card type metadata, validation fails.
2) **INTDEV-648** Validation error when card is missing a custom field value is now clearer. Also, if custom field is missing from card, no other errors are shown (previously it would also complain about `undefined` being of wrong type for the field).

Earlier (if we assume that `base/fieldTypes/owner` is missing from card `docs_30`): 
```
Card 'docs_30' is missing custom field 'name' from 'base/fieldTypes/owner'
In card 'docs_30' field 'base/fieldTypes/owner' is defined as 'person', but it is 'undefined' with value of undefined
```

Now: 
```
Card 'docs_30' is missing custom field 'base/fieldTypes/owner'
```