### PR TITLE
Change dependabot frequency to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,17 +8,17 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/tools/data-handler" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/tools/cli" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/tools/app" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"
 


### PR DESCRIPTION
To avoid too frequent (and costly) Pull Requests from dependabot - let's move from weekly to monthly updates.
Security notifications are still immediately available when Github Alerts database is updated (and are visible in the "Security" tab).