### PR TITLE
INTDEV-628 Ensure that project path help is shown in all help topics

### DIFF
--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -73,7 +73,8 @@ const pathGuideline =
 program
   .name('cyberismo')
   .description(packageDef.description)
-  .version(packageDef.version);
+  .version(packageDef.version)
+  .option('-p, --project-path [path]', `${pathGuideline}`);
 
 // Add card to a template
 program
@@ -88,7 +89,6 @@ program
     'Card type to use for the new card. \nYou can list the card types in a project with "show cardTypes" command.',
   )
   .argument('[cardKey]', "Parent card's card key")
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .option('-r, --repeat <quantity>', 'Add multiple cards to a template')
   .action(
     async (
@@ -106,6 +106,17 @@ program
     },
   );
 
+// Start app command
+program
+  .command('app')
+  .description(
+    'Starts the cyberismo app, accessible with a web browser at http://localhost:3000',
+  )
+  .action(async (options: CardsOptions) => {
+    const result = await commandHandler.command(Cmd.start, [], options);
+    handleResponse(result);
+  });
+
 const calculate = program
   .command('calc')
   .description('Used for running logic programs');
@@ -114,7 +125,6 @@ calculate
   .command('generate')
   .description('Generate a logic program')
   .argument('[cardKey]', 'If given, calculates on the subtree of the card')
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (filePath: string, options: CardsOptions) => {
     const result = await commandHandler.command(
       Cmd.calc,
@@ -128,7 +138,6 @@ calculate
   .command('run')
   .description('Run a logic program')
   .argument('<filePath>', 'Path to the logic program')
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (filePath: string, options: CardsOptions) => {
     const result = await commandHandler.command(
       Cmd.calc,
@@ -147,7 +156,6 @@ create
   .description('Create an attachment to a card')
   .argument('<cardKey>', 'Card key of card')
   .argument('<attachment>', 'Full path to an attachment')
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(
     async (cardKey: string, attachment: string, options: CardsOptions) => {
       const result = await commandHandler.command(
@@ -171,7 +179,6 @@ create
     '[cardKey]',
     "Parent card's card key. If defined, new card will be created as a child card to that card.",
   )
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (template: string, cardKey: string, options: CardsOptions) => {
     const result = await commandHandler.command(
       Cmd.create,
@@ -190,7 +197,6 @@ create
     '<workflow>',
     'Workflow for the card type. \nYou can list workflows in a project with "show workflows" command.',
   )
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (name, workflow, options: CardsOptions) => {
     const result = await commandHandler.command(
       Cmd.create,
@@ -209,7 +215,6 @@ create
     '<datatype>',
     'Type of field. \nYou can list field types in a project with "show fieldTypes" command.',
   )
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (name, datatype, options: CardsOptions) => {
     const result = await commandHandler.command(
       Cmd.create,
@@ -224,7 +229,6 @@ create
   .description('Create a label')
   .argument('<cardKey>', 'Key of the card that the label will be added to')
   .argument('<label>', `Name of the created label. ${nameGuideline}`)
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (cardKey: string, label: string, options: CardsOptions) => {
     const result = await commandHandler.command(
       Cmd.create,
@@ -243,7 +247,6 @@ create
     'Link type. \nYou can list link types in a project with "show linkTypes" command.',
   )
   .argument('[description]', 'Description of the link')
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(
     async (
       source: string,
@@ -266,7 +269,6 @@ create
   .command('linkType')
   .description('Create a link type')
   .argument('<name>', `Name for link type. ${nameGuideline}`)
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (name, options: CardsOptions) => {
     const result = await commandHandler.command(
       Cmd.create,
@@ -298,6 +300,20 @@ create
     handleResponse(result);
   });
 
+// Create report
+create
+  .command('report')
+  .description('Create a report')
+  .argument('<name>', `Name for the report. ${nameGuideline}`)
+  .action(async (name: string, options: CardsOptions) => {
+    const result = await commandHandler.command(
+      Cmd.create,
+      ['report', name],
+      options,
+    );
+    handleResponse(result);
+  });
+
 // Create template
 create
   .command('template')
@@ -307,7 +323,6 @@ create
     '[content]',
     'If empty, template is created with default values. \nTemplate content must conform to schema "templateSchema.json"',
   )
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (name: string, content: string, options: CardsOptions) => {
     const result = await commandHandler.command(
       Cmd.create,
@@ -326,25 +341,10 @@ create
     '[content]',
     'If empty, workflow is created with default values. \nWorkflow content must conform to schema "workflowSchema.json"',
   )
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (name: string, content: string, options: CardsOptions) => {
     const result = await commandHandler.command(
       Cmd.create,
       ['workflow', name, content],
-      options,
-    );
-    handleResponse(result);
-  });
-
-create
-  .command('report')
-  .description('Create a report')
-  .argument('<name>', `Name for the report. ${nameGuideline}`)
-  .option('-p, --project-path [path]', pathGuideline)
-  .action(async (name: string, options: CardsOptions) => {
-    const result = await commandHandler.command(
-      Cmd.create,
-      ['report', name],
       options,
     );
     handleResponse(result);
@@ -355,7 +355,6 @@ program
   .command('edit')
   .description('Edit a card')
   .argument('<cardKey>', 'Card key of card')
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (cardKey: string, options: CardsOptions) => {
     const result = await commandHandler.command(Cmd.edit, [cardKey], options);
     handleResponse(result);
@@ -375,7 +374,6 @@ program
     '[cardKey]',
     'Path to a card. If defined will export only that card and its children instead of whole project.',
   )
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(
     async (
       format: string,
@@ -399,7 +397,6 @@ importCmd
   .command('module')
   .description('Imports another project to this project as a module.')
   .argument('<source>', 'Path to import from')
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (source: string, options: CardsOptions) => {
     const result = await commandHandler.command(
       Cmd.import,
@@ -418,7 +415,6 @@ importCmd
     '[cardKey]',
     'Card key of the parent. If defined, cards are created as children of this card',
   )
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (csvFile: string, cardKey: string, options: CardsOptions) => {
     const result = await commandHandler.command(
       Cmd.import,
@@ -439,7 +435,6 @@ program
     '[destination]',
     'Destination Card key where "source" is moved to. If moving to root, use "root"',
   )
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(
     async (source: string, destination: string, options: CardsOptions) => {
       const result = await commandHandler.command(
@@ -463,7 +458,6 @@ rank
     '<afterCardKey>',
     'Card key of the card that the card should be after. Use "first" to rank the card first.',
   )
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(
     async (cardKey: string, afterCardKey: string, options: CardsOptions) => {
       const result = await commandHandler.command(
@@ -484,7 +478,6 @@ rank
     '[parentCardKey]',
     'if null, rebalance the whole project, otherwise rebalance only the direct children of the card key',
   )
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (cardKey: string, options: CardsOptions) => {
     const result = await commandHandler.command(
       Cmd.rank,
@@ -500,7 +493,6 @@ remove
   .command('attachment')
   .argument('<cardKey>', 'Card key of the owning card')
   .argument('<filename>', 'attachment filename')
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (cardKey: string, filename: string, options: CardsOptions) => {
     const result = await commandHandler.command(
       Cmd.remove,
@@ -513,7 +505,6 @@ remove
 remove
   .command('card')
   .argument('<cardKey>', 'Card key of card to remove')
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (cardKey: string, options: CardsOptions) => {
     const result = await commandHandler.command(
       Cmd.remove,
@@ -526,7 +517,6 @@ remove
 remove
   .command('cardType')
   .argument('<name>', 'Name of the card type to remove')
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (name: string, options: CardsOptions) => {
     const result = await commandHandler.command(
       Cmd.remove,
@@ -539,7 +529,6 @@ remove
 remove
   .command('fieldType')
   .argument('<name>', 'Name of the field type to remove')
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (name: string, options: CardsOptions) => {
     const result = await commandHandler.command(
       Cmd.remove,
@@ -553,7 +542,6 @@ remove
   .command('label')
   .argument('<cardKey>', 'Source card key of the link')
   .argument('[label]', 'Label being removed')
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (cardKey: string, label: string, options: CardsOptions) => {
     const result = await commandHandler.command(
       Cmd.remove,
@@ -568,7 +556,6 @@ remove
   .argument('<source>', 'Source card key of the link')
   .argument('<destination>', 'Destination card key of the link')
   .argument('<linkType>', 'Link type')
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(
     async (
       source: string,
@@ -588,7 +575,6 @@ remove
 remove
   .command('linkType')
   .argument('<name>', 'Name of the link type to remove')
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (name: string, options: CardsOptions) => {
     const result = await commandHandler.command(
       Cmd.remove,
@@ -601,7 +587,6 @@ remove
 remove
   .command('module')
   .argument('<name>', 'Name of the module to remove')
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (name: string, options: CardsOptions) => {
     const result = await commandHandler.command(
       Cmd.remove,
@@ -614,7 +599,6 @@ remove
 remove
   .command('report')
   .argument('<name>', 'Name of the report to remove')
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (name: string, options: CardsOptions) => {
     const result = await commandHandler.command(
       Cmd.remove,
@@ -627,7 +611,6 @@ remove
 remove
   .command('template')
   .argument('<name>', 'Name of the template to remove')
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (name: string, options: CardsOptions) => {
     const result = await commandHandler.command(
       Cmd.remove,
@@ -640,7 +623,6 @@ remove
 remove
   .command('workflow')
   .argument('<name>', 'Name of the workflow to remove')
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (name: string, options: CardsOptions) => {
     const result = await commandHandler.command(
       Cmd.remove,
@@ -657,7 +639,6 @@ program
     'Change project prefix and rename all the content with the new prefix',
   )
   .argument('<to>', 'New project prefix')
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (to: string, options: CardsOptions) => {
     const result = await commandHandler.command(Cmd.rename, [to], options);
     handleResponse(result);
@@ -681,7 +662,6 @@ program
     '-d --details',
     'Certain resources (such as cards) can have additional details',
   )
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (type: string, typeDetail, options: CardsOptions) => {
     if (type !== '') {
       const result = await commandHandler.command(
@@ -702,7 +682,6 @@ program
     '<transition>',
     'Workflow state transition that is done.\nYou can list the workflows in a project with "show workflows" command.\nYou can see the available transitions with "show workflow <name>" command.',
   )
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(
     async (cardKey: string, transition: string, options: CardsOptions) => {
       const result = await commandHandler.command(
@@ -718,22 +697,19 @@ program
 program
   .command('validate')
   .description('Validate project structure')
-  .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (options: CardsOptions) => {
     const result = await commandHandler.command(Cmd.validate, [], options);
     handleResponse(result);
   });
 
-// Start app command
-program
-  .command('app')
-  .description(
-    'Starts the cyberismo app, accessible with a web browser at http://localhost:3000',
-  )
-  .option('-p, --project-path [path]', `${pathGuideline}`)
-  .action(async (options: CardsOptions) => {
-    const result = await commandHandler.command(Cmd.start, [], options);
-    handleResponse(result);
-  });
+// Add the project path option to 'program' commands.
+program.commands.forEach((cmd) => {
+  if (cmd.commands) {
+    cmd.commands.forEach((innerCmd) => {
+      innerCmd.option('-p, --project-path [path]', `${pathGuideline}`);
+    });
+  }
+  cmd.option('-p, --project-path [path]', `${pathGuideline}`);
+});
 
 export default program;


### PR DESCRIPTION
Ensure that "project path" help is shown in all levels of CLI help.

<img width="1445" alt="Screenshot 2025-01-08 at 13 36 05" src="https://github.com/user-attachments/assets/5c962806-f2a6-4a5a-88a7-9ddbc7a0f7b2" />
<img width="1212" alt="Screenshot 2025-01-08 at 13 36 17" src="https://github.com/user-attachments/assets/009aa33b-51e0-4dad-9008-8501f62718d6" />
<img width="1194" alt="Screenshot 2025-01-08 at 13 36 31" src="https://github.com/user-attachments/assets/c08835ed-39d8-4fa3-912c-e1311eed003a" />


Additionally, order the commands (and subcommands) alphabetically, as CLI shows them in that order.