### PR TITLE
Add Dockerfile to enable container image building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM docker.io/continuumio/miniconda3:24.11.1-0
+
+# Set environment variables
+ENV DEBIAN_FRONTEND=noninteractive
+ENV SHELL=/bin/bash
+ENV PATH /opt/conda/envs/clingo-env/bin:$PATH
+ENV PATH /usr/local/share/pnpm:$PATH
+ENV PNPM_HOME=/usr/local/share/pnpm
+
+# Necessary packages
+RUN apt-get update && apt-get install -y curl git && \
+    curl -fsSL https://deb.nodesource.com/setup_21.x | bash - && \
+    apt-get install -y nodejs && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    conda create -n clingo-env -y python=3.12 && \
+    /bin/bash -c "\
+        source activate clingo-env && \
+        conda install -c conda-forge clingo && \
+        conda install -c potassco clingraph && \
+        conda clean --all --yes \
+    " && \
+    npm install -g pnpm antora && \
+    git clone https://github.com/CyberismoCom/cyberismo.git /cyberismo && \
+    cd /cyberismo && \
+    /bin/bash -c "pnpm setup && pnpm install && pnpm build && pnpm link -g" && \
+    rm -rf /cyberismo/tools/app/.next/cache/ && \
+    pnpm store prune && pnpm prune --prod && \
+    find /cyberismo -path /cyberismo/node_modules -prune -o -exec chmod 777 {} \;
+
+WORKDIR /project
+
+# Set default command
+CMD ["cyberismo"]

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "prettier-check": "prettier --check .",
     "prettier-fix": "prettier --write .",
     "script:schemas": "node scripts/generateSchemaImports && prettier --write tools/data-handler/src/utils/schemas.ts",
-    "dev": "concurrently \"pnpm --filter app dev\" \"pnpm --filter data-handler watch\""
+    "dev": "concurrently \"pnpm --filter app dev\" \"pnpm --filter data-handler watch\"",
+    "build-docker": "docker build -t cyberismo ."
   }
 }


### PR DESCRIPTION
Some notes:
- This Dockerfile is not properly optimized
- Image should be based on some smaller image, like Alpine
- Clingo should be built (with python support) in builder container and installed on the final image
- Current image size is 2.69GB, but could be brought down to 1.5GB

This version is just a enabler for the use of container environments and further optimizations will follow