### PR TITLE
INTDEV-635 Change ResourceFolderType to use plural resource names

### DIFF
--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -151,20 +151,11 @@ export class Project extends CardContainer {
   }
 
   // Returns (local or all) resources of a given type.
-  // todo: if ResourceFolderType would be plural; this whole function could just be: "return this.resources(type. from);"
   private async resourcesOfType(
     type: ResourceFolderType,
     from: ResourcesFrom = ResourcesFrom.localOnly,
   ): Promise<Resource[]> {
-    if (type === 'calculation') return this.calculations(from);
-    if (type === 'cardType') return this.cardTypes(from);
-    if (type === 'fieldType') return this.fieldTypes(from);
-    if (type === 'linkType') return this.linkTypes(from);
-    if (type === 'module') return this.modules();
-    if (type === 'report') return this.reports(from);
-    if (type === 'template') return this.templates(from);
-    if (type === 'workflow') return this.workflows(from);
-    return [];
+    return this.resources.resources(type, from);
   }
 
   /**
@@ -460,7 +451,7 @@ export class Project extends CardContainer {
       return undefined;
     }
     template.name = resourceNameToString(resourceName(template.name));
-    if (!(await this.resourceExists('template', template.name))) {
+    if (!(await this.resourceExists('templates', template.name))) {
       return undefined;
     }
 

--- a/tools/data-handler/src/containers/project/project-paths.ts
+++ b/tools/data-handler/src/containers/project/project-paths.ts
@@ -13,7 +13,6 @@
 import { join } from 'node:path';
 
 import { ResourceFolderType } from '../../interfaces/project-interfaces.js';
-import { resourceName } from '../../utils/resource-utils.js';
 
 /**
  * Handles paths for a project.
@@ -26,14 +25,14 @@ export class ProjectPaths {
     private prefix: string,
   ) {
     this.pathMap = new Map([
-      ['calculation', this.calculationProjectFolder],
-      ['cardType', this.cardTypesFolder],
-      ['fieldType', this.fieldTypesFolder],
-      ['linkType', this.linkTypesFolder],
-      ['module', this.modulesFolder],
-      ['report', this.reportsFolder],
-      ['template', this.templatesFolder],
-      ['workflow', this.workflowsFolder],
+      ['calculations', this.calculationProjectFolder],
+      ['cardTypes', this.cardTypesFolder],
+      ['fieldTypes', this.fieldTypesFolder],
+      ['linkTypes', this.linkTypesFolder],
+      ['modules', this.modulesFolder],
+      ['reports', this.reportsFolder],
+      ['templates', this.templatesFolder],
+      ['workflows', this.workflowsFolder],
     ]);
   }
 
@@ -98,22 +97,6 @@ export class ProjectPaths {
 
   public get workflowsFolder(): string {
     return join(this.resourcesFolder, 'workflows');
-  }
-
-  /**
-   * Returns valid name of a resource.
-   * @param resourceType Type of resource
-   * @param name Resource name
-   * @returns name of a resource (prefix/type/name)
-   */
-  public resourceFullName(
-    resourceType: ResourceFolderType,
-    name: string,
-  ): string {
-    const { identifier, prefix, type } = resourceName(name);
-    const actualPrefix = prefix ? prefix : this.prefix;
-    const actualType = type ? type : `${resourceType}s`;
-    return `${actualPrefix}/${actualType}s/${identifier}`;
   }
 
   /**

--- a/tools/data-handler/src/containers/project/resource-collector.ts
+++ b/tools/data-handler/src/containers/project/resource-collector.ts
@@ -57,7 +57,7 @@ export class ResourceCollector {
   // Add resources of a given type to an array.
   private async addResources(
     resources: Dirent[],
-    requestedType: string, // todo: should be a ResourceFolderType, but that needs to be converted to use plural values.
+    requestedType: ResourceFolderType,
   ): Promise<Resource[]> {
     const collectedResources: Resource[] = [];
     for (const resource of resources) {
@@ -92,7 +92,9 @@ export class ResourceCollector {
   }
 
   // Adds a resource type from all modules.
-  private async addResourcesFromModules(type: string): Promise<Resource[]> {
+  private async addResourcesFromModules(
+    type: ResourceFolderType,
+  ): Promise<Resource[]> {
     if (!pathExists(this.paths.modulesFolder)) {
       return [];
     }
@@ -121,8 +123,7 @@ export class ResourceCollector {
   }
 
   // Returns local resources of a given type.
-  // todo: parameter should be a ResourceFolderType, but that needs to be converted to use plural values.
-  private localResources(type: string) {
+  private localResources(type: ResourceFolderType) {
     if (type === 'calculations') {
       return this.localCalculations;
     } else if (type === 'cardTypes') {
@@ -165,7 +166,7 @@ export class ResourceCollector {
             entry.name = stripExtension(entry.name);
           }
           return {
-            name: `${this.project.projectPrefix}/${type}s/${entry.name}`,
+            name: `${this.project.projectPrefix}/${type}/${entry.name}`,
             path: entry.parentPath,
           };
         }),
@@ -178,13 +179,13 @@ export class ResourceCollector {
    * Collects all local resources.
    */
   public collectLocalResources() {
-    this.localCalculations = this.resourcesSync('calculation');
-    this.localCardTypes = this.resourcesSync('cardType');
-    this.localFieldTypes = this.resourcesSync('fieldType');
-    this.localLinkTypes = this.resourcesSync('linkType');
-    this.localReports = this.resourcesSync('report');
-    this.localTemplates = this.resourcesSync('template');
-    this.localWorkflows = this.resourcesSync('workflow');
+    this.localCalculations = this.resourcesSync('calculations');
+    this.localCardTypes = this.resourcesSync('cardTypes');
+    this.localFieldTypes = this.resourcesSync('fieldTypes');
+    this.localLinkTypes = this.resourcesSync('linkTypes');
+    this.localReports = this.resourcesSync('reports');
+    this.localTemplates = this.resourcesSync('templates');
+    this.localWorkflows = this.resourcesSync('workflows');
   }
 
   /**
@@ -192,7 +193,7 @@ export class ResourceCollector {
    * @param type Type of resource (e.g. 'templates').
    * @returns array of collected items.
    */
-  public async collectResourcesFromModules(type: string) {
+  public async collectResourcesFromModules(type: ResourceFolderType) {
     return (await this.addResourcesFromModules(type)).map((item) =>
       stripExtension(item.name),
     );
@@ -303,7 +304,10 @@ export class ResourceCollector {
    * @param name Name of the resource.
    * @returns true, if resource exits, false otherwise.
    */
-  public async resourceExists(type: string, name: string): Promise<boolean> {
+  public async resourceExists(
+    type: ResourceFolderType,
+    name: string,
+  ): Promise<boolean> {
     if (!name) {
       return false;
     }
@@ -317,7 +321,7 @@ export class ResourceCollector {
    * @returns Array of resources.
    */
   public async resources(
-    type: string, // todo: should be a ResourceFolderType, but that needs to be converted to use plural values.
+    type: ResourceFolderType,
     from: ResourcesFrom = ResourcesFrom.all,
   ): Promise<Resource[]> {
     const moduleResources =

--- a/tools/data-handler/src/create.ts
+++ b/tools/data-handler/src/create.ts
@@ -588,7 +588,7 @@ export class Create extends EventEmitter {
       throw new Error(`Invalid template JSON: ${validJson}`);
     }
 
-    if (await this.project.resourceExists('template', templateName)) {
+    if (await this.project.resourceExists('templates', templateName)) {
       throw new Error(
         `Template '${templateName}' already exists in the project`,
       );

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -147,14 +147,14 @@ export interface Resource {
 
 // Resources that have own folders.
 export type ResourceFolderType =
-  | 'calculation'
-  | 'cardType'
-  | 'fieldType'
-  | 'linkType'
-  | 'module'
-  | 'report'
-  | 'template'
-  | 'workflow';
+  | 'calculations'
+  | 'cardTypes'
+  | 'fieldTypes'
+  | 'linkTypes'
+  | 'modules'
+  | 'reports'
+  | 'templates'
+  | 'workflows';
 
 // All resource types; both singular and plural.
 export type ResourceTypes =

--- a/tools/data-handler/src/resources/file-resource.ts
+++ b/tools/data-handler/src/resources/file-resource.ts
@@ -39,8 +39,7 @@ import {
   resourceNameToString,
   resourceObjectToResource,
 } from '../utils/resource-utils.js';
-import { ResourceTypes } from '../interfaces/project-interfaces.js';
-import { singularType } from '../utils/common-utils.js';
+import { ResourceFolderType } from '../interfaces/project-interfaces.js';
 import { Validate } from '../validate.js';
 
 export { type Operation, type ChangeOperation };
@@ -56,14 +55,14 @@ export class FileResource extends ResourceObject {
   constructor(
     project: Project,
     resourceName: ResourceName,
-    protected type: string,
+    protected type: ResourceFolderType,
   ) {
     super(project, resourceName);
   }
 
   // Type of resource.
-  private resourceType(): ResourceTypes {
-    return this.type as ResourceTypes;
+  private resourceType(): ResourceFolderType {
+    return this.type as ResourceFolderType;
   }
 
   // Initialize the resource.
@@ -75,9 +74,7 @@ export class FileResource extends ResourceObject {
       this.resourceName.prefix = this.project.projectPrefix;
     }
     if (this.type) {
-      this.resourceFolder = this.project.paths.resourcePath(
-        singularType(this.type),
-      );
+      this.resourceFolder = this.project.paths.resourcePath(this.type);
       this.fileName = resourceNameToPath(this.project, this.resourceName);
       this.moduleResource =
         this.resourceName.prefix !== this.project.projectPrefix;
@@ -100,7 +97,7 @@ export class FileResource extends ResourceObject {
         `${this.project.projectPrefix}/${this.type}/${this.resourceName.identifier}`,
       );
       this.resourceFolder = this.project.paths.resourcePath(
-        singularType(this.resourceName.type),
+        this.resourceName.type as ResourceFolderType,
       );
     }
 
@@ -219,7 +216,7 @@ export class FileResource extends ResourceObject {
       await this.project.projectPrefixes(),
     );
     const newFilename = join(
-      this.project.paths.resourcePath(singularType(newName.type)),
+      this.project.paths.resourcePath(newName.type as ResourceFolderType),
       newName.identifier + '.json',
     );
     if (pathExists(newFilename)) {

--- a/tools/data-handler/src/resources/resource-object.ts
+++ b/tools/data-handler/src/resources/resource-object.ts
@@ -22,6 +22,7 @@ import {
   ResourceContent,
 } from '../interfaces/resource-interfaces.js';
 import { Project, ResourcesFrom } from '../containers/project.js';
+import { ResourceFolderType } from '../interfaces/project-interfaces.js';
 import { ResourceName } from '../utils/resource-utils.js';
 
 // Possible operations to perform when doing "update"
@@ -87,7 +88,7 @@ export class ResourceObject extends AbstractResource {
   protected moduleResource: boolean;
   protected contentSchema: JSON = {} as JSON;
   protected contentSchemaId: string = '';
-  protected type: string = '';
+  protected type: ResourceFolderType = '' as ResourceFolderType;
   protected resourceFolder: string = '';
   constructor(
     protected project: Project,

--- a/tools/data-handler/src/utils/common-utils.ts
+++ b/tools/data-handler/src/utils/common-utils.ts
@@ -10,8 +10,6 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { ResourceFolderType } from '../interfaces/project-interfaces.js';
-
 /**
  * Makes deep comparison between two objects.
  * @param arg1 First object to compare.
@@ -40,14 +38,4 @@ export function deepCompare(arg1: object, arg2: object): boolean {
     return arg1 === arg2;
   }
   return false;
-}
-
-/**
- * Converts plural type name to singular
- * @type Type name to change.
- * @returns singular format of type name
- */
-export function singularType(type: string): ResourceFolderType {
-  // note that this only works with certain nouns
-  return type.substring(0, type.length - 1) as ResourceFolderType;
 }

--- a/tools/data-handler/src/validate.ts
+++ b/tools/data-handler/src/validate.ts
@@ -706,7 +706,7 @@ export class Validate {
 
     if (cardType) {
       for (const field of cardType.customFields) {
-        const found = await project.resourceExists('fieldType', field.name);
+        const found = await project.resourceExists('fieldTypes', field.name);
         if (!found) {
           validationErrors.push(
             `Custom field '${field.name}' from card type '${cardType.name}' not found from project`,

--- a/tools/data-handler/test/project.test.ts
+++ b/tools/data-handler/test/project.test.ts
@@ -72,13 +72,13 @@ describe('project', () => {
     if (templates) {
       for (const template of templates) {
         expect(
-          await project.resourceExists('template', template.name),
+          await project.resourceExists('templates', template.name),
         ).to.equal(true);
         const fetchTemplate = await project.template(template.name);
         expect(fetchTemplate).to.equal(template);
       }
     }
-    expect(await project.resourceExists('template', 'idontexist')).to.equal(
+    expect(await project.resourceExists('templates', 'idontexist')).to.equal(
       false,
     );
 

--- a/tools/data-handler/test/resources.test.ts
+++ b/tools/data-handler/test/resources.test.ts
@@ -17,7 +17,10 @@ import { Validate } from '../src/validate.js';
 import { Project } from '../src/containers/project.js';
 import { ResourceCollector } from '../src/containers/project/resource-collector.js';
 import { resourceName } from '../src/utils/resource-utils.js';
-import { RemovableResourceTypes } from '../src/interfaces/project-interfaces.js';
+import {
+  RemovableResourceTypes,
+  ResourceFolderType,
+} from '../src/interfaces/project-interfaces.js';
 
 import { WorkflowResource } from '../src/resources/workflow-resource.js';
 import { CardTypeResource } from '../src/resources/card-type-resource.js';
@@ -238,7 +241,7 @@ describe('resources', () => {
       const collector = new ResourceCollector(project);
 
       async function checkResource(type: string) {
-        const resourceType = type;
+        const resourceType = type as ResourceFolderType;
         const removeType = resourceType.substring(0, resourceType.length - 1);
         const resourceCount = (await collector.resources(resourceType)).length;
         const nameForResource = `${project.projectPrefix}/${resourceType}/newOne`;
@@ -282,7 +285,7 @@ describe('resources', () => {
       collector.collectLocalResources();
 
       async function checkResource(type: string) {
-        const resourceType = type;
+        const resourceType = type as ResourceFolderType;
         const removeType = resourceType.substring(0, resourceType.length - 1);
         const resourceCount = (await collector.resources(resourceType)).length;
         const nameForResource = `${project.projectPrefix}/${resourceType}/newOne`;

--- a/tools/data-handler/test/utils/common-utils.test.ts
+++ b/tools/data-handler/test/utils/common-utils.test.ts
@@ -1,20 +1,9 @@
 // testing
 import { expect } from 'chai';
 
-import { deepCompare, singularType } from '../../src/utils/common-utils.js';
+import { deepCompare } from '../../src/utils/common-utils.js';
 
 describe('common utils', () => {
-  it('change plural type name to singular', async () => {
-    const types = ['cardtypes', 'fieldtypes', 'linktypes', 'workflows'];
-    const expectedTypes = ['cardtype', 'fieldtype', 'linktype', 'workflow'];
-    let index = 0;
-    for (const type of types) {
-      const singular = singularType(type);
-      expect(expectedTypes[index]).to.equal(singular);
-      ++index;
-    }
-  });
-
   describe('deep compare', () => {
     it('different objects', () => {
       const obj1 = { key: 'value' };


### PR DESCRIPTION
Optimize & simplify current implementation.

By making the `ResourceFolderType` use plural names of resources, we can skip some mapping and naive pluralisation in the code.

Additionally, remove functions that become unnecessary: `resourceFullName` and `singularType`.

Edit. Note that this is intentionally targeting a feature branch. Once INTDEV-636 has been merged, content repos need to be updated. Then this can be merged.
