### PR TITLE
Improve Python function daysSince and implement Python function today

### DIFF
--- a/calculations/common/pythonFunctions.lp
+++ b/calculations/common/pythonFunctions.lp
@@ -2,7 +2,7 @@
 
 #script (python)
 from clingo import Number, String, SymbolType
-from datetime import date
+from datetime import date, datetime, timezone
 
 class Functions:
     def concatenate(self, *args):
@@ -23,11 +23,20 @@ class Functions:
 
     def daysSince(self, isodate):
         try:
-            userdate = date.fromisoformat(isodate.string)
-            today = date.today()
+            userdate = datetime.fromisoformat(isodate.string)
+            # add UTC timezone in case the isodate was just a date without time
+            # datetimes are stored in UTC format in Cyberismo, so for them there is no effect
+            userdate = userdate.replace(tzinfo=timezone.utc)
+            today = datetime.now(timezone.utc)
             return Number((today-userdate).days)
         except:
             return Number(0)
+
+    def today(self):
+        try:
+            return String(date.today().isoformat())
+        except:
+            return String("")
 
 def main(prg):
     prg.ground([("base", [])], context=Functions())

--- a/calculations/common/pythonFunctions.lp
+++ b/calculations/common/pythonFunctions.lp
@@ -33,10 +33,7 @@ class Functions:
             return Number(0)
 
     def today(self):
-        try:
-            return String(date.today().isoformat())
-        except:
-            return String("")
+        return String(date.today().isoformat())
 
 def main(prg):
     prg.ground([("base", [])], context=Functions())

--- a/tools/data-handler/test/calculate.test.ts
+++ b/tools/data-handler/test/calculate.test.ts
@@ -124,6 +124,12 @@ describe('calculate', () => {
       });
       expect(Number(res.results[0].key)).greaterThan(365);
     });
+    it('calculate daysSince "2022-01-15T17:08:50.716Z"', async () => {
+      const res = await calculate.runLogicProgram({
+        query: 'result(@daysSince("2022-01-01T17:08:50.716Z")).',
+      });
+      expect(Number(res.results[0].key)).greaterThan(1000);
+    });
     it('daysSince of an invalid date should be zero', async () => {
       const res = await calculate.runLogicProgram({
         query: 'result(@daysSince("23232323")).',
@@ -135,6 +141,12 @@ describe('calculate', () => {
         query: 'result(@daysSince(1)).',
       });
       expect(Number(res.results[0].key)).to.equal(0);
+    });
+    it('the length of today() should be 10', async () => {
+      const res = await calculate.runLogicProgram({
+        query: 'result(@today()).',
+      });
+      expect(res.results[0].key.length).to.equal(10);
     });
   });
 });


### PR DESCRIPTION
Previously, daysSince did not work for datetimes. We also need a function to get today's date for checking whether a due date has passed.