### PR TITLE
Use 'groups' to categorize dependency PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,4 +21,21 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+      groups:
+        chai-dependencies: # Update all Chai dependencies in one PR
+          patterns:
+            - "@types/chai"
+            - "@types/chai-as-promised"
+            - "chai"
+            - "chai-as-promised"
+        eslint-dependencies: # Update all ESLint dependencies in one PR
+          patterns:
+            - "eslint"
+            - "eslint-config-prettier"
+            - "typescript-eslint"
+        mocha-dependencies: # Update all Mocha dependencies in one PR
+          patterns:
+            - "@types/mocha"
+            - "mocha"
+            - "mocha-suppress-logs"
 


### PR DESCRIPTION
Use 'groups' feature from Github's DependaBot to categorise dependency PRs together.
The documentation is here: 
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#prioritizing-meaningful-updates

These three groups ensure that the dependencies named within them will be part of the same PR.

The currently defined groups are:
* Chai dependencies
* ESLint dependencies
* Mocha dependencies

The benefit is that the "onslaught" of new PRs from DependaBot is optimised to fewer PRs. Less manual actions needed.