### PR TITLE
INTDEV-671 Disable card specific logic program generation

### DIFF
--- a/tools/data-handler/src/calculate.ts
+++ b/tools/data-handler/src/calculate.ts
@@ -228,11 +228,7 @@ export class Calculate {
   }
 
   // Collects all logic calculation files from project (local and imported modules)
-  private async generateModules(parentCard: Card | undefined) {
-    // When generating calculations for a specific module, do not generate common calculations.
-    if (parentCard) {
-      return;
-    }
+  private async generateModules() {
     const destinationFile = join(
       this.project.paths.calculationFolder,
       Calculate.modulesFileName,
@@ -333,7 +329,7 @@ export class Calculate {
         this.generateCardTreeContent(card).then(
           this.generateCardTree.bind(this),
         ),
-        this.generateModules(card),
+        this.generateModules(),
         this.generateWorkFlows(),
         this.generateCardTypes(),
         this.generateFieldTypes(),

--- a/tools/data-handler/src/transition.ts
+++ b/tools/data-handler/src/transition.ts
@@ -113,13 +113,12 @@ export class Transition extends EventEmitter {
     const actionGuard = new ActionGuard(this.calculateCmd);
     await actionGuard.checkPermission('transition', cardKey, transition.name);
 
-    // Write new state and re-calculate.
+    // Write new state
     await this.setCardState(details, found.toState);
     await this.editCmd.editCardMetadata(
       details.key,
       'lastTransitioned',
       new Date().toISOString(),
     );
-    this.emit('transitioned', details);
   }
 }


### PR DESCRIPTION
App depends on generating all logic programs again anyway(since everything is not updated) so removing generation of logic programs after a transition actually also improves performance. However, if you do a transition via CLI and run a logic program using the CLI, you'll need to generate the files before doing so.

The original issue was that the modules.lp was not being generated although we delete the whole folder before doing calculations. Also for some reason, after removing that issue, the emit still caused another issue: Clingraph run successfully, but produced an empty image. For now, it's simpler to simply rely on generating all logic programs before calculations. We should be able to get rid of that once the calculations are moved to the resource classes.