### PR TITLE
INTDEV-620 Rename isEditable to isCalculated

### DIFF
--- a/calculations/queries/card.lp
+++ b/calculations/queries/card.lp
@@ -72,7 +72,24 @@ field(Field, "value", Value) :-
 
 
 % select only non-custom fields
-selectAll.
+select(1, "cardType").
+select(1, "title").
+select(1, "key").
+select(1, "lastUpdated").
+select(1, "workflowState").
+select(1, "notifications").
+select(1, "policyChecks").
+select(1, "links").
+select(1, "deniedOperations").
+select(1, "labels").
+
+select(2, "visibility").
+select(2, "index").
+select(2, "fieldDisplayName").
+select(2, "fieldDescription").
+select(2, "dataType").
+select(2, "isCalculated").
+select(2, "value").
 
 childResult({{cardKey}}, Field, "fields") :-
     alwaysVisibleField(CardType, Field),
@@ -82,7 +99,11 @@ childResult({{cardKey}}, Field, "fields") :-
     optionallyVisibleField(CardType, Field),
     field({{cardKey}}, "cardType", CardType).
 
-
+% for enum fields, add enum values as child results:
+select(3, "index").
+select(3, "enumDisplayValue").
+select(3, "enumDescription").
+select(3, "enumValue").
 
 childResult(Field, (Field, EnumValue), "enumValues") :-
     enumValue(Field, EnumValue).

--- a/calculations/queries/card.lp
+++ b/calculations/queries/card.lp
@@ -45,19 +45,18 @@ dataType(Field, "isCalculated", "boolean") :-
     childResult(_, Field, "fields"),
     field(Field, "isCalculated", _).
 
-field(Field, "isCalculated", isCalculated) :-
+field(Field, "isCalculated", true) :-
     field({{cardKey}}, "cardType", CardType),
-    field((CardType, Field), "isCalculated", isCalculated).
+    calculatedField(CardType, Field).
 
-field(Field, "isCalculated", "false") :-
-   field({{cardKey}}, "cardType", CardType),
-   alwaysVisibleField(CardType, Field),
-   not field((CardType, Field), "isCalculated", _).
+field(Field, "isCalculated", false) :-
 
-field(Field, "isCalculated", "false") :-
-   field({{cardKey}}, "cardType", CardType),
-   optionallyVisibleField(CardType, Field),
-   not field((CardType, Field), "isCalculated", _).
+    childResult(_, Field, "fields"),
+    field({{cardKey}}, "cardType", CardType),
+    not calculatedField(CardType, Field).
+
+
+
 
 % add value
 dataType(Field, "value", DataType) :-
@@ -73,24 +72,7 @@ field(Field, "value", Value) :-
 
 
 % select only non-custom fields
-select(1, "cardType").
-select(1, "title").
-select(1, "key").
-select(1, "lastUpdated").
-select(1, "workflowState").
-select(1, "notifications").
-select(1, "policyChecks").
-select(1, "links").
-select(1, "deniedOperations").
-select(1, "labels").
-
-select(2, "visibility").
-select(2, "index").
-select(2, "fieldDisplayName").
-select(2, "fieldDescription").
-select(2, "dataType").
-select(2, "isCalculated").
-select(2, "value").
+selectAll.
 
 childResult({{cardKey}}, Field, "fields") :-
     alwaysVisibleField(CardType, Field),
@@ -100,11 +82,7 @@ childResult({{cardKey}}, Field, "fields") :-
     optionallyVisibleField(CardType, Field),
     field({{cardKey}}, "cardType", CardType).
 
-% for enum fields, add enum values as child results:
-select(3, "index").
-select(3, "enumDisplayValue").
-select(3, "enumDescription").
-select(3, "enumValue").
+
 
 childResult(Field, (Field, EnumValue), "enumValues") :-
     enumValue(Field, EnumValue).

--- a/calculations/queries/card.lp
+++ b/calculations/queries/card.lp
@@ -41,23 +41,23 @@ field(Field, "fieldDisplayName", DisplayName) :-
     childResult(_, Field, "fields"),
     displayName({{cardKey}}, Field, DisplayName).
 
-dataType(Field, "isEditable", "boolean") :-
+dataType(Field, "isCalculated", "boolean") :-
     childResult(_, Field, "fields"),
-    field(Field, "isEditable", _).
+    field(Field, "isCalculated", _).
 
-field(Field, "isEditable", IsEditable) :-
+field(Field, "isCalculated", isCalculated) :-
     field({{cardKey}}, "cardType", CardType),
-    field((CardType, Field), "isEditable", IsEditable).
+    field((CardType, Field), "isCalculated", isCalculated).
 
-field(Field, "isEditable", "true") :-
+field(Field, "isCalculated", "false") :-
    field({{cardKey}}, "cardType", CardType),
    alwaysVisibleField(CardType, Field),
-   not field((CardType, Field), "isEditable", _).
+   not field((CardType, Field), "isCalculated", _).
 
-field(Field, "isEditable", "true") :-
+field(Field, "isCalculated", "false") :-
    field({{cardKey}}, "cardType", CardType),
    optionallyVisibleField(CardType, Field),
-   not field((CardType, Field), "isEditable", _).
+   not field((CardType, Field), "isCalculated", _).
 
 % add value
 dataType(Field, "value", DataType) :-
@@ -89,7 +89,7 @@ select(2, "index").
 select(2, "fieldDisplayName").
 select(2, "fieldDescription").
 select(2, "dataType").
-select(2, "isEditable").
+select(2, "isCalculated").
 select(2, "value").
 
 childResult({{cardKey}}, Field, "fields") :-

--- a/tools/app/app/cards/[key]/edit/page.tsx
+++ b/tools/app/app/cards/[key]/edit/page.tsx
@@ -454,10 +454,8 @@ export default function Page(props: { params: Promise<{ key: string }> }) {
       };
 
       for (const key of Object.keys(metadata)) {
-        if (
-          metadata[key] !==
-          card?.fields?.find((field) => field.key === key)?.value
-        ) {
+        const field = card?.fields?.find((field) => field.key === key);
+        if (field && metadata[key] !== field.value && !field.isCalculated) {
           update.metadata[key] = metadata[key];
         }
       }

--- a/tools/app/app/components/MetadataView.tsx
+++ b/tools/app/app/components/MetadataView.tsx
@@ -188,7 +188,7 @@ function MetadataView({
             fieldDisplayName,
             fieldDescription,
             visibility,
-            isEditable,
+            isCalculated,
             value,
           }) => (
             <FieldItem
@@ -205,7 +205,7 @@ function MetadataView({
               editableFieldProps={{
                 dataType,
                 label: fieldDisplayName || key,
-                edit: (editMode && isEditable) ?? false,
+                edit: (editMode && !isCalculated) ?? false,
                 enumValues,
               }}
             />

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -375,7 +375,7 @@ export class Project extends CardContainer {
       for (const item of content.customFields) {
         // DEPRECATED BACKWARDS COMPABILITY: REMOVE
         if (item.isEditable !== undefined) {
-          item.isCalculated = item.isEditable;
+          item.isCalculated = !item.isEditable;
         }
         // Set "isCalculated" if it is missing; default = false
         if (item.isCalculated === undefined && !skipSettingDefaultValues) {

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -373,9 +373,13 @@ export class Project extends CardContainer {
     }
     if (content && content.customFields) {
       for (const item of content.customFields) {
-        // Set "isEditable" if it is missing; default = true
-        if (item.isEditable === undefined && !skipSettingDefaultValues) {
-          item.isEditable = true;
+        // DEPRECATED BACKWARDS COMPABILITY: REMOVE
+        if (item.isEditable !== undefined) {
+          item.isCalculated = item.isEditable;
+        }
+        // Set "isCalculated" if it is missing; default = false
+        if (item.isCalculated === undefined && !skipSettingDefaultValues) {
+          item.isCalculated = false;
         }
         // Fetch displayName from field type
         if (item.name) {

--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -203,6 +203,7 @@ export class Template extends CardContainer {
           card.metadata.rank =
             cardWithRank?.metadata?.rank || card.metadata.rank || EMPTY_RANK;
           for (const customField of cardType.customFields) {
+            if (customField.isCalculated) continue;
             const defaultValue = null;
             card.metadata = {
               ...card.metadata,

--- a/tools/data-handler/src/interfaces/resource-interfaces.ts
+++ b/tools/data-handler/src/interfaces/resource-interfaces.ts
@@ -34,7 +34,12 @@ export interface CustomField {
   name: string;
   description?: string;
   displayName?: string;
+
+  /**
+   * @deprecated
+   */
   isEditable: boolean;
+  isCalculated: boolean;
 }
 
 // Supported data types.

--- a/tools/data-handler/src/types/queries.ts
+++ b/tools/data-handler/src/types/queries.ts
@@ -116,7 +116,7 @@ interface CardQueryField extends BaseResult {
   fieldDisplayName: string;
   fieldDescription: string;
   dataType: DataType;
-  isEditable: boolean;
+  isCalculated: boolean;
   value: string | number | boolean | null | EnumValue | ListValueItem[];
   enumValues: EnumDefinition[];
 }

--- a/tools/data-handler/src/utils/clingo-facts.ts
+++ b/tools/data-handler/src/utils/clingo-facts.ts
@@ -308,7 +308,7 @@ export const createCardTypeFacts = (cardType: CardType) => {
     builder.addCustomFact(Facts.Common.FIELD, (b) =>
       b
         .addArgument(keyTuple)
-        .addArguments('isEditable', customField.isEditable),
+        .addArguments('isCalculated', customField.isCalculated),
     );
 
     let visible = false;

--- a/tools/data-handler/src/utils/clingo-facts.ts
+++ b/tools/data-handler/src/utils/clingo-facts.ts
@@ -32,14 +32,14 @@ export namespace Facts {
     WORKFLOW_TRANSITION = 'workflowTransition',
   }
   export enum Card {
-    LINK = 'link',
     LABEL = 'label',
+    LINK = 'link',
     PARENT = 'parent',
   }
 
   export enum FieldType {
-    FIELD_TYPE = 'fieldType',
     ENUM_VALUE = 'enumValue',
+    FIELD_TYPE = 'fieldType',
   }
 
   export enum Common {
@@ -47,17 +47,17 @@ export namespace Facts {
   }
 
   export enum CardType {
+    ALWAYS_VISIBLE_FIELD = 'alwaysVisibleField',
+    CALCULATED_FIELD = 'calculatedField',
     CARD_TYPE = 'cardType',
     CUSTOM_FIELD = 'customField',
-    ALWAYS_VISIBLE_FIELD = 'alwaysVisibleField',
     OPTIONALLY_VISIBLE_FIELD = 'optionallyVisibleField',
-    CALCULATED_FIELD = 'calculatedField',
   }
 
   export enum LinkType {
-    LINK_TYPE = 'linkType',
-    LINK_SOURCE_CARD_TYPE = 'linkSourceCardType',
     LINK_DESTINATION_CARD_TYPE = 'linkDestinationCardType',
+    LINK_SOURCE_CARD_TYPE = 'linkSourceCardType',
+    LINK_TYPE = 'linkType',
   }
 }
 

--- a/tools/data-handler/src/utils/clingo-facts.ts
+++ b/tools/data-handler/src/utils/clingo-facts.ts
@@ -51,6 +51,7 @@ export namespace Facts {
     CUSTOM_FIELD = 'customField',
     ALWAYS_VISIBLE_FIELD = 'alwaysVisibleField',
     OPTIONALLY_VISIBLE_FIELD = 'optionallyVisibleField',
+    CALCULATED_FIELD = 'calculatedField',
   }
 
   export enum LinkType {
@@ -304,12 +305,13 @@ export const createCardTypeFacts = (cardType: CardType) => {
         ),
       );
     }
-
-    builder.addCustomFact(Facts.Common.FIELD, (b) =>
-      b
-        .addArgument(keyTuple)
-        .addArguments('isCalculated', customField.isCalculated),
-    );
+    if (customField.isCalculated) {
+      builder.addFact(
+        Facts.CardType.CALCULATED_FIELD,
+        cardType.name,
+        customField.name,
+      );
+    }
 
     let visible = false;
     if (cardType.alwaysVisibleFields.includes(customField.name)) {

--- a/tools/data-handler/src/validate.ts
+++ b/tools/data-handler/src/validate.ts
@@ -712,7 +712,16 @@ export class Validate {
             `Custom field '${field.name}' from card type '${cardType.name}' not found from project`,
           );
         }
-        if (card.metadata[field.name] === undefined) {
+        if (field.isCalculated) {
+          // change to in COMPAT-PR: card.metadata[field.name] !== undefined
+          if (card.metadata[field.name] != undefined) {
+            validationErrors.push(
+              `Card '${card.key}' not allowed to have a value in a calculated field '${field.name}'`,
+            );
+          }
+          continue;
+        }
+        if (!field.isCalculated && card.metadata[field.name] === undefined) {
           validationErrors.push(
             `Card '${card.key}' is missing custom field '${field.name}'`,
           );

--- a/tools/data-handler/src/validate.ts
+++ b/tools/data-handler/src/validate.ts
@@ -713,12 +713,13 @@ export class Validate {
           );
         }
         if (field.isCalculated) {
-          // change to in COMPAT-PR: card.metadata[field.name] !== undefined
-          if (card.metadata[field.name] != undefined) {
+          /* uncomment in COMPAT-PR: card.metadata[field.name] !== undefined
+          
+          if (card.metadata[field.name] !== undefined) {
             validationErrors.push(
               `Card '${card.key}' not allowed to have a value in a calculated field '${field.name}'`,
             );
-          }
+          }*/
           continue;
         }
         if (!field.isCalculated && card.metadata[field.name] === undefined) {

--- a/tools/schema/cardTypeSchema.json
+++ b/tools/schema/cardTypeSchema.json
@@ -32,7 +32,12 @@
             "type": "string"
           },
           "isEditable": {
-            "description": "Defines if field value can be modified.",
+            "description": "DEPRECATED: Defines if field value can be modified.",
+            "type": "boolean",
+            "default": true
+          },
+          "isCalculated": {
+            "description": "Defines if field value is a calculated field.",
             "type": "boolean",
             "default": true
           }


### PR DESCRIPTION
This will rename isEditable to isCalculated and prevent saving those. This will still work with repos that use `isEditable`, but I'll make another PR that will remove the backwards compatibility.