### PR TITLE
INTDEV-673 - Performance: Make card creation faster

### DIFF
--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -95,10 +95,11 @@ export class Template extends CardContainer {
     const tempDestination = this.project.paths.tempCardFolder;
 
     // First, create a mapping table.
+    const cardIds = await this.project.listCardIds();
     for (const card of cards) {
       templateIDMap.push({
         from: card.key,
-        to: await this.project.newCardKey(),
+        to: await this.project.newCardKey(cardIds),
       });
     }
 
@@ -383,7 +384,8 @@ export class Template extends CardContainer {
         );
       }
 
-      newCardKey = await this.project.newCardKey();
+      const cardIds = await this.project.listCardIds();
+      newCardKey = await this.project.newCardKey(cardIds);
       const templateCardToCreate = parentCard
         ? join(destinationCardPath, newCardKey)
         : join(this.templateCardsPath, newCardKey);

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -47,6 +47,13 @@ export interface PredefinedCardMetadata {
   lastUpdated?: string;
 }
 
+// todo: do we need in the future separation between module-template-cards and local template-cards
+export enum CardLocation {
+  all = 'all',
+  projectOnly = 'project',
+  templatesOnly = 'local',
+}
+
 // Card's index.json file content.
 export interface CardMetadata extends PredefinedCardMetadata {
   labels?: string[];

--- a/tools/data-handler/src/show.ts
+++ b/tools/data-handler/src/show.ts
@@ -214,8 +214,7 @@ export class Show {
    * @returns cards list array
    */
   public async showCards(): Promise<CardListContainer[]> {
-    const projectCards = await this.project.listAllCards(true);
-    return projectCards;
+    return this.project.listCards();
   }
 
   /**

--- a/tools/data-handler/test/project.test.ts
+++ b/tools/data-handler/test/project.test.ts
@@ -7,7 +7,10 @@ import { mkdirSync, rmSync } from 'node:fs';
 import { basename, dirname, join, resolve, sep } from 'node:path';
 
 import { copyDir } from '../src/utils/file-utils.js';
-import { FileContentType } from '../src/interfaces/project-interfaces.js';
+import {
+  CardLocation,
+  FileContentType,
+} from '../src/interfaces/project-interfaces.js';
 import { fileURLToPath } from 'node:url';
 import { Project } from '../src/containers/project.js';
 import { ProjectConfiguration } from '../src/project-settings.js';
@@ -550,13 +553,13 @@ describe('project', () => {
     expect(Project.isCreated('idontexist')).to.equal(false);
     expect(Project.isCreated('')).to.equal(false);
   });
-  it('list all project cards (success)', async () => {
+  it('list project cards (success)', async () => {
     const decisionRecordsPath = join(testDir, 'valid/decision-records');
     const project = new Project(decisionRecordsPath);
     expect(project).to.not.equal(undefined);
 
-    const allProjectCards = await project.listAllCards(false);
-    const allCards = await project.listAllCards(true);
+    const allProjectCards = await project.listCards(CardLocation.projectOnly);
+    const allCards = await project.listCards();
     expect(allProjectCards).to.not.equal(undefined);
     expect(allCards).to.not.equal(undefined);
     expect(allProjectCards.length).to.be.lessThan(allCards.length);
@@ -564,6 +567,19 @@ describe('project', () => {
     expect(allCards[0].cards.length).to.equal(2);
     expect(allCards[1].type).to.equal('template');
     expect(allCards[1].cards.length).to.equal(1);
+  });
+  it('list project cards IDs (success)', async () => {
+    const decisionRecordsPath = join(testDir, 'valid/decision-records');
+    const project = new Project(decisionRecordsPath);
+    expect(project).to.not.equal(undefined);
+
+    const allTemplateCards = await project.listCardIds(
+      CardLocation.templatesOnly,
+    );
+    const allCards = await project.listCardIds();
+    expect(allTemplateCards).to.not.equal(undefined);
+    expect(allCards).to.not.equal(undefined);
+    expect(allTemplateCards.size).to.be.lessThan(allCards.size);
   });
   it('check all attachments', async () => {
     const decisionRecordsPath = join(testDir, `valid${sep}decision-records`);


### PR DESCRIPTION
Remove 'find' when checking if a created card ID is used. Instead before creating cards, fetch all cards in the project and check if the created cardID is included or not. 

This makes huge difference once there are more than 1000 cards in the project.

Add new API for this that only fetches cardIDs. While at it, rename existing `listAllCards` to `listCards` and replace boolean parameter with an enum. This way we can control where to look for cards. 