### PR TITLE
INTDEV-682 Resource name update: expand identifier-only correctly

### DIFF
--- a/tools/data-handler/src/resources/file-resource.ts
+++ b/tools/data-handler/src/resources/file-resource.ts
@@ -144,12 +144,13 @@ export class FileResource extends ResourceObject {
     this.fileName = '';
   }
 
-  protected async isValidName(newName: ResourceName) {
-    await Validate.getInstance().validResourceName(
+  protected async validName(newName: ResourceName) {
+    const validName = await Validate.getInstance().validResourceName(
       this.resourceType(),
       resourceNameToString(newName),
       await this.project.projectPrefixes(),
     );
+    return validName;
   }
 
   // Called after inherited class has finished 'update' operation.
@@ -170,7 +171,7 @@ export class FileResource extends ResourceObject {
       const newName = resourceName(
         (op as ChangeOperation<string>).to as string,
       );
-      await this.isValidName(newName);
+      content.name = await this.validName(newName);
     }
 
     // Once changes have been made; validate the content.

--- a/tools/data-handler/test/command-handler-update.test.ts
+++ b/tools/data-handler/test/command-handler-update.test.ts
@@ -48,6 +48,23 @@ describe('Update command tests', async () => {
     }
     expect(found).to.equal(true);
   });
+  it('update file resource name using just identifier', async () => {
+    const name = `${project.projectPrefix}/workflows/newName`;
+    const exists = await collector.resourceExists('workflows', name);
+    const newName = `decision`;
+    expect(exists).to.equal(true);
+
+    await update.updateValue(name, 'change', 'name', newName);
+    collector.changed();
+    const workflows = await project.workflows();
+    let found = false;
+    for (const wf of workflows) {
+      if (wf.name === `${project.projectPrefix}/workflows/${newName}`) {
+        found = true;
+      }
+    }
+    expect(found).to.equal(true);
+  });
 
   it('update resource - rank item using string value (name)', async () => {
     const name = `${project.projectPrefix}/cardTypes/decision`;


### PR DESCRIPTION
Expand identifier-only resource name correctly in resource implementation.

When user did `cyberismo update <resource> change name <identifier-only-name>` the 
`<identifier-only-name>` was stored to resource metadata file. 

The implementation did correctly validate and expand the name, but didn't set it to resource `name`. Thus only `identifier` was stored to metadata file. Which led to resource being impossible to find.