### PR TITLE
INTDEV-681 Fetch workflow data once per instantiated template card

### DIFF
--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -188,8 +188,8 @@ export class Template extends CardContainer {
           throw new Error(`Workflow '${cardType.workflow}' cannot be found`);
         }
 
-        const initialWorkflowState = await this.project.workflowInitialState(
-          cardType.workflow,
+        const initialWorkflowState = workflow.transitions.find(
+          (item) => item.fromState.includes('') || item.fromState.length === 0,
         );
         if (!initialWorkflowState) {
           throw new Error(
@@ -198,7 +198,7 @@ export class Template extends CardContainer {
         }
         if (card.metadata) {
           const cardWithRank = parentCards.find((c) => c.key === card.key);
-          card.metadata.workflowState = initialWorkflowState;
+          card.metadata.workflowState = initialWorkflowState.toState;
           card.metadata.cardType = cardType.name;
           card.metadata.rank =
             cardWithRank?.metadata?.rank || card.metadata.rank || EMPTY_RANK;


### PR DESCRIPTION
When cards from template are instantiated, workflow's initial state is fetched to card's metadata. 
Unfortunately, the operation fetches the workflow information twice: 
- first, for general access of workflow
- second time, to find initial state of the workflow

Remove the latter, as the code itself can deduce the initial state.