### PR TITLE
Change image max-height to 75vh to make tall graphs render better

### DIFF
--- a/tools/app/app/globals.css
+++ b/tools/app/app/globals.css
@@ -473,7 +473,7 @@
 .doc .imageblock object,
 .doc .imageblock svg {
   display: inline-block;
-  height: auto;
+  max-height: 75vh;
   max-width: 100%;
   vertical-align: middle;
 }


### PR DESCRIPTION
Tall graphs look bad with the dataflow module. This change would limit their height to 75% of the viewport height, which seems to yield acceptable results with graph macro but also with other image attachments. 