### PR TITLE
INTDEV-706 Add clingo and graphviz binary postinstall & custom path during execution

### DIFF
--- a/.github/workflows/build-clingo-binaries.yml
+++ b/.github/workflows/build-clingo-binaries.yml
@@ -1,0 +1,377 @@
+name: Build and Package Python + Clingo
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version nubmer'
+        required: true
+        default: 0.0.1
+
+jobs:
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create Release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ github.event.inputs.version }}
+        with:
+          tag_name: v${{ env.VERSION }}
+          release_name: clingo-binary
+          body: Cyberismo suitable Clingo binary
+    outputs:
+      upload_url: ${{ steps.create-release.outputs.upload_url }}
+
+  build-windows:
+    name: Build and Package (Windows)
+    runs-on: windows-latest
+    needs: create-release
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Download Embeddable Python
+        run: |
+          curl -LO https://www.python.org/ftp/python/3.11.2/python-3.11.2-embed-amd64.zip
+          mkdir python-embed
+          tar.exe -xf python-3.11.2-embed-amd64.zip -C python-embed
+
+          (Get-Content python-embed/python311._pth) |
+            ForEach-Object { $_ -replace '#import site', 'import site' } |
+            Set-Content python-embed/python311._pth
+
+      - name: Install pip in embeddable Python
+        run: |
+          curl -LO https://bootstrap.pypa.io/get-pip.py
+          python-embed/python.exe get-pip.py --no-warn-script-location
+          python-embed/python.exe -m pip install --no-warn-script-location cffi clingo clingraph          
+
+      - name: Build Clingo with MSVC
+        run: |
+          git clone --recurse-submodules https://github.com/potassco/clingo.git clingo-source
+          cd clingo-source
+          mkdir build
+          cd build
+
+          cmake .. -G "Visual Studio 17 2022" -A x64 -DCLINGO_BUILD_WITH_PYTHON=ON -DCLINGO_BUILD_STATIC=ON -DCLINGO_BUILD_WITH_LUA=OFF -DCMAKE_BUILD_TYPE=Release -DPYCLINGO_INSTALL_DIR="LOCATION" -DPython_ROOT_DIR="${{ github.workspace }}\\python-embed"
+
+          # Build the Release config
+          cmake --build . --config Release
+
+      - name: Package Clingo + Python
+        shell: pwsh
+        run: |
+          mkdir clingo
+
+          Copy-Item clingo-source\build\bin\Release\clingo.exe .\clingo\
+          Copy-Item .\python-embed\* .\clingo\ -Recurse
+
+          Compress-Archive -Path .\clingo -DestinationPath clingo-windows-x64.zip
+
+      - name: Test Clingo
+        run: |
+          Expand-Archive clingo-windows-x64.zip -DestinationPath test_dir
+
+          # Create a test logic program
+          Set-Content -Path test_dir\clingo\test.lp -Value @"
+          #script (python)
+          from clingo.symbol import String
+
+          class Context:
+              def test(self):
+                  return String('Python works great.')
+
+          def main(prg):
+              prg.ground([('base', [])], context=Context())
+              prg.solve()
+          #end.
+
+          test(@test()).
+          "@
+
+          Push-Location test_dir\clingo
+
+          .\clingo test.lp
+          $code = $LASTEXITCODE
+          Write-Host "Clingo returned exit code: $code"
+
+          # If you consider 10 = SAT, 20 = UNSAT, 0 = normal, all success:
+          if ($code -eq 0 -or $code -eq 10 -or $code -eq 20) {
+            exit 0
+          } else {
+            exit $code
+          }
+
+          Pop-Location
+
+      - name: Upload binary
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ./clingo-windows-x64.zip
+          asset_name: clingo-windows-x64.zip
+          asset_content_type: application/zip
+
+  build-ubuntu:
+    name: Build and Package (Ubuntu)
+    runs-on: ubuntu-20.04
+    needs: create-release
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            libffi-dev \
+            libssl-dev \
+            zlib1g-dev \
+            libbz2-dev \
+            libreadline-dev \
+            libsqlite3-dev \
+            libncurses5-dev \
+            libgdbm-dev \
+            liblzma-dev \
+            uuid-dev \
+            tk-dev \
+            libexpat1-dev
+
+      - name: Download and build Python
+        run: |
+          curl -O https://www.python.org/ftp/python/3.11.11/Python-3.11.11.tgz
+          tar -xvzf Python-3.11.11.tgz
+          cd Python-3.11.11
+          CFLAGS="-Os" ./configure \
+            --enable-optimizations \
+            --prefix=$(pwd)/dist \
+            --without-readline \
+            --disable-test-modules \
+            --disable-ipv6
+          make -j$(nproc) 
+          make altinstall
+          ./dist/bin/python3.11 -m pip install cffi clingo clingraph --prefix dist/
+          strip dist/bin/python3.11
+
+      - name: Build Clingo
+        run: |
+          git clone --recurse-submodules https://github.com/potassco/clingo.git
+          cd clingo
+          mkdir build
+          cd build
+          cmake .. \
+            -DCLINGO_BUILD_WITH_PYTHON=ON \
+            -DPYTHON_EXECUTABLE=$(pwd)/../../Python-3.11.11/dist/bin/python3.11 \
+            -DCLINGO_PYTHON_VERSION=3.11 \
+            -DPYTHON_INCLUDE_DIR=$(pwd)/../../Python-3.11.11/dist/include/python3.11 \
+            -DPYTHON_LIBRARY=$(pwd)/../../Python-3.11.11/dist/lib/libpython3.11.a \
+            -DPYCLINGO_INSTALL_DIR=$(pwd)/install/python/site-packages \
+            -DCLINGO_BUILD_STATIC=ON \
+            -DCLINGO_BUILD_WITH_LUA=OFF \
+            -DCMAKE_INSTALL_RPATH='$ORIGIN' \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build . --config Release -j$(nproc)
+
+          strip bin/clingo
+          mv bin/clingo bin/clingo_bin
+
+          echo '#!/bin/bash
+
+          export PYTHONHOME="$(dirname "$0")/clingo_env"
+          export PYTHONPATH="$(dirname "$0")/clingo_env/lib/python3.11"
+
+          "$(dirname "$0")/clingo_bin" "$@"' > bin/clingo
+
+          chmod +x bin/clingo
+
+          # Remove unnecessary binaries
+          rm -f bin/{clasp,gringo,lpconvert,reify}
+          
+          mkdir bin/clingo_env
+
+      - name: Clean Python and Combine with Clingo
+        run: |
+          # Remove unnecessary files
+          rm -f Python-3.11.11/dist/lib/libpython3.11.a
+          rm -rf Python-3.11.11/dist/lib/python3.11/__pycache__
+          rm -rf Python-3.11.11/dist/lib/python3.11/{config-3.11-x86_64-linux-gnu,idlelib,ensurepip,asyncio,tkinter,lib2to3,email,unittest,multiprocessing,xml}
+          rm -rf Python-3.11.11/dist/lib/python3.11/site-packages/{pip,setuptools,pkg_resources,pycparser}
+          find Python-3.11.11/dist/bin -type f ! -name '*python3*' -exec rm -f {} +
+          find Python-3.11.11/dist/bin -type l -exec rm -f {} +
+
+          cp -r Python-3.11.11/dist/* clingo/build/bin/clingo_env/
+
+          cd clingo/build
+          mv bin clingo
+          tar -czvf ../../clingo-linux-x64.tar.gz clingo
+
+      - name: Verify Clingo Functionality
+        run: |
+          mkdir test_dir
+          tar -xzf clingo-linux-x64.tar.gz -C test_dir
+
+          cd test_dir/clingo
+
+          echo "#script (python)
+          from clingo.symbol import String
+
+          class Context:
+              def test(self):
+                  return String('Python works great.')
+
+          def main(prg):
+              prg.ground([('base', [])], context=Context())
+              prg.solve()
+          #end.
+
+          test(@test())." > test.lp
+
+          ./clingo test.lp || [ $? -eq 10 ]
+
+      - name: Upload binary
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ./clingo-linux-x64.tar.gz
+          asset_name: clingo-linux-x64.tar.gz
+          asset_content_type: application/gzip
+
+  build-macos:
+    name: Build and Package (macOS)
+    runs-on: macos-latest
+    if: false
+    needs: create-release
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          brew update
+          brew install openssl xz gdbm
+
+      - name: Download and build Python
+        run: |
+          curl -O https://www.python.org/ftp/python/3.11.11/Python-3.11.11.tgz
+          tar -xvzf Python-3.11.11.tgz
+          cd Python-3.11.11
+          
+          export MACOSX_DEPLOYMENT_TARGET=10.15
+          
+          CFLAGS="-Os" ./configure \
+            --enable-optimizations \
+            --enable-shared \
+            --prefix="$(pwd)/dist" \
+            --disable-test-modules \
+            --disable-ipv6
+          make -j$(sysctl -n hw.logicalcpu)
+          make altinstall
+
+          ./dist/bin/python3.11 -m ensurepip
+          ./dist/bin/python3.11 -m pip install cffi clingo clingraph --prefix dist/
+          
+          strip dist/bin/python3.11 2>/dev/null || true
+
+      - name: Build Clingo
+        run: |
+          git clone --recurse-submodules https://github.com/potassco/clingo.git
+          cd clingo
+          mkdir build
+          cd build
+
+          cmake .. \
+            -DCLINGO_BUILD_WITH_PYTHON=ON \
+            -DPYTHON_EXECUTABLE=$(pwd)/../../Python-3.11.11/dist/bin/python3.11 \
+            -DCLINGO_PYTHON_VERSION=3.11 \
+            -DPYTHON_INCLUDE_DIR=$(pwd)/../../Python-3.11.11/dist/include/python3.11 \
+            -DPYTHON_LIBRARY=$(pwd)/../../Python-3.11.11/dist/lib/libpython3.11.dylib \
+            -DCLINGO_BUILD_STATIC=ON \
+            -DCLINGO_BUILD_WITH_LUA=OFF \
+            -DCMAKE_INSTALL_RPATH="@loader_path" \
+            -DCMAKE_BUILD_TYPE=Release
+
+          cmake --build . --config Release -- -j$(sysctl -n hw.logicalcpu)
+
+          strip bin/clingo 2>/dev/null || true
+          mv bin/clingo bin/clingo_bin
+
+          echo '#!/bin/bash
+
+          export PYTHONHOME="$(dirname "$0")/clingo_env"
+          export PYTHONPATH="$(dirname "$0")/clingo_env/lib/python3.11"
+
+          "$(dirname "$0")/clingo_bin" "$@"' > bin/clingo
+          chmod +x bin/clingo
+
+          rm -f bin/{clasp,gringo,lpconvert,reify}
+          
+          mkdir bin/clingo_env
+
+      - name: Clean Python and Combine with Clingo
+        run: |
+          rm -f Python-3.11.11/dist/lib/libpython3.11.a
+          rm -rf Python-3.11.11/dist/lib/python3.11/__pycache__
+          rm -rf Python-3.11.11/dist/lib/python3.11/{config-3.11-*,idlelib,ensurepip,asyncio,tkinter,lib2to3,email,unittest,multiprocessing,xml}
+          rm -rf Python-3.11.11/dist/lib/python3.11/site-packages/{pip,setuptools,pkg_resources,pycparser}
+          find Python-3.11.11/dist/bin -type f ! -name '*python3*' -exec rm -f {} +
+          find Python-3.11.11/dist/bin -type l -exec rm -f {} +
+
+          cp -r Python-3.11.11/dist/* clingo/build/bin/clingo_env/
+
+          cd clingo/build
+          mv bin clingo
+          tar -czvf ../../clingo-mac-arm64.tar.gz clingo
+
+      - name: Verify Clingo Functionality
+        run: |
+          mkdir test_dir
+          tar -xzf clingo-mac-arm64.tar.gz -C test_dir
+          cd test_dir/clingo
+
+          cat <<EOF > test.lp
+          #script (python)
+          from clingo.symbol import String
+
+          class Context:
+              def test(self):
+                  return String('Python works great.')
+
+          def main(prg):
+              prg.ground([('base', [])], context=Context())
+              prg.solve()
+          #end.
+
+          test(@test()).
+          EOF
+
+          ./clingo test.lp || [ $? -eq 10 ]
+
+      - name: Upload binary
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ./clingo-mac-arm64.tar.gz
+          asset_name: clingo-mac-arm64.tar.gz
+          asset_content_type: application/gzip

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@
 .DS_Store
 *.pem
 
+# Vendor binary location
+vendor
+
 # debug
 npm-debug.log*
 yarn-debug.log*

--- a/LICENSE
+++ b/LICENSE
@@ -659,3 +659,31 @@ specific requirements.
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU AGPL, see
 <https://www.gnu.org/licenses/>.
+
+
+THIRD PARTY LICENSES
+
+The utility distribution for installing third party dependencies includes the Clingo '
+software, licensed MIT:
+
+# The MIT License (MIT)
+
+Copyright 2017 Roland Kaminski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "private": true,
   "scripts": {
     "preinstall": "npx only-allow pnpm",
+    "postinstall": "node scripts/install-clingo.mjs",
     "build": "pnpm -r run build",
     "clean": "rm -rf node_modules && pnpm -r run clean",
     "test": "pnpm test-data-handler && pnpm test-cli && pnpm test-app",

--- a/scripts/install-clingo.mjs
+++ b/scripts/install-clingo.mjs
@@ -1,0 +1,192 @@
+// scripts/install-clingo.js
+
+import os from 'os';
+import fs from 'fs';
+import { pipeline } from 'stream/promises';
+import { execSync } from 'child_process';
+import { dirname, resolve, join } from 'path';
+import { fileURLToPath } from 'url';
+
+// Convert import.meta.url to a file path
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function getPlatformAndExtension() {
+  const platform = os.platform(); // 'darwin', 'win32', 'linux'
+  const arch = os.arch(); // 'x64', 'arm64', etc.
+
+  const platformMap = {
+    darwin: 'mac',
+    win32: 'windows',
+    linux: 'linux',
+  };
+
+  const mappedPlatform = platformMap[platform];
+  if (!mappedPlatform) {
+    throw new Error(`Unsupported platform: ${platform}`);
+  }
+
+  const extension = platform === 'win32' ? 'zip' : 'tar.gz';
+
+  return { platform, arch, mappedPlatform, extension };
+}
+
+function getClingoDownloadUrl() {
+  const { mappedPlatform, arch, extension } = getPlatformAndExtension();
+
+  const baseUrl =
+    'https://github.com/CyberismoCom/cyberismo/releases/download/v0.0.1';
+
+  const filename = `clingo-${mappedPlatform}-${arch}.${extension}`;
+
+  return {
+    url: `${baseUrl}/${filename}`,
+    filename,
+  };
+}
+
+async function downloadFile(url, destPath) {
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      redirect: 'follow',
+      headers: {
+        'User-Agent': 'Node.js',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Download failed: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const fileStream = fs.createWriteStream(destPath);
+
+    await pipeline(response.body, fileStream);
+
+    console.log(`Download completed successfully: ${destPath}`);
+  } catch (error) {
+    fs.unlink(destPath, (err) => {
+      if (err) {
+        console.error(`Failed to delete incomplete file: ${destPath}`, err);
+      }
+    });
+    console.error('Download failed:', error);
+    throw error;
+  }
+}
+
+async function installVendorPackages() {
+  // Feature only enabled for Windows machines!
+  const { mappedPlatform } = getPlatformAndExtension();
+
+  if (mappedPlatform !== 'windows') {
+    console.log(
+      'Postinstall script enabled only for Windows machines! Skipping',
+    );
+    process.exit(0);
+  }
+
+  try {
+    const utilsLocation = resolve(__dirname, '../', 'vendor', 'utils');
+
+    if (!fs.existsSync(utilsLocation)) {
+      fs.mkdirSync(utilsLocation, { recursive: true });
+    }
+
+    /**
+     * =======================
+     * Clingo Installation
+     * =======================
+     */
+
+    const clingoInstallationLocation = join(utilsLocation, 'clingo');
+    const { url, filename } = getClingoDownloadUrl();
+    const clingoArchivePath = join(utilsLocation, filename);
+
+    console.log(`[clingo-install] Checking for existing installation`);
+
+    if (fs.existsSync(clingoInstallationLocation)) {
+      console.log(
+        `[clingo-install] Existing installation detected, removing...`,
+      );
+      fs.rmSync(clingoInstallationLocation, { recursive: true, force: true });
+    }
+
+    console.log(`[clingo-install] Installation location ready`);
+    console.log(`[clingo-install] Downloading from: ${url}`);
+
+    await downloadFile(url, clingoArchivePath);
+
+    console.log('[clingo-install] Download complete.');
+
+    execSync(`tar -xzf "${clingoArchivePath}" -C "${utilsLocation}"`);
+
+    fs.unlinkSync(clingoArchivePath);
+
+    console.log('[clingo-install] Extraction complete.');
+
+    /**
+     * =======================
+     * Graphviz Installation
+     * =======================
+     */
+    const graphvizUrl =
+      'https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/12.2.1/windows_10_cmake_Release_Graphviz-12.2.1-win64.zip';
+
+    const graphvizBaseName = 'graphviz';
+    const graphvizOriginalName = 'Graphviz-12.2.1-win64';
+    const graphvizArchive = graphvizOriginalName + '.zip';
+    const graphvizInstallationLocation = join(utilsLocation, graphvizBaseName);
+    const graphvizOriginalInstallationLocation = join(
+      utilsLocation,
+      graphvizOriginalName,
+    );
+    const graphvizArchivePath = join(utilsLocation, graphvizArchive);
+
+    console.log(`[graphviz-install] Checking for existing installation`);
+
+    if (fs.existsSync(graphvizInstallationLocation)) {
+      console.log(
+        `[graphviz-install] Existing installation detected, removing...`,
+      );
+      fs.rmSync(graphvizInstallationLocation, { recursive: true, force: true });
+    }
+    if (fs.existsSync(graphvizOriginalInstallationLocation)) {
+      console.log(
+        `[graphviz-install] Existing installation attempt detected, removing...`,
+      );
+      fs.rmSync(graphvizOriginalInstallationLocation, {
+        recursive: true,
+        force: true,
+      });
+    }
+
+    console.log(`[graphviz-install] Installation location ready`);
+    console.log(`[graphviz-install] Downloading from: ${graphvizUrl}`);
+
+    await downloadFile(graphvizUrl, graphvizArchivePath);
+
+    console.log('[graphviz-install] Download complete.');
+
+    execSync(`tar -xzf "${graphvizArchivePath}" -C "${utilsLocation}"`);
+
+    fs.rename(
+      join(utilsLocation, graphvizOriginalName),
+      join(utilsLocation, graphvizBaseName),
+      (err) => {
+        if (err) throw err;
+      },
+    );
+
+    fs.unlinkSync(graphvizArchivePath);
+
+    console.log('[graphviz-install] Extraction complete.');
+  } catch (err) {
+    console.error('[install] ERROR:', err);
+    process.exit(1);
+  }
+}
+
+installVendorPackages();

--- a/tools/cli/bin/run
+++ b/tools/cli/bin/run
@@ -2,7 +2,27 @@
 
 import program from '@cyberismocom/cli';
 
-// Don't show any warnings when running CLI.
+import { fileURLToPath } from 'url';
+import { dirname, resolve, delimiter } from 'path';
+
+// Convert import.meta.url to a file path
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const rootDirectory = resolve(__dirname, '../../../');
+
+const clingoDir = resolve(rootDirectory, 'vendor', 'utils', 'clingo');
+const graphvizDir = resolve(
+  rootDirectory,
+  'vendor',
+  'utils',
+  'graphviz',
+  'bin',
+);
+
+process.env.PATH =
+  clingoDir + delimiter + graphvizDir + delimiter + process.env.PATH;
+
 process.removeAllListeners('warning');
 
 program.parseAsync(process.argv).catch((error) => {


### PR DESCRIPTION
Postinstall script that will:
- Download our own built clingo from https://github.com/CyberismoCom/cyberismo-base/tags (not public)
- Extract it under vendor/utils
- Download latest graphviz binary
- Extract it under vendor/utils

Run alteration:
- Added custom path for these two binaries, so that runtime inclusion works properly
