### PR TITLE
INTDEV-478 CLI: Make create/remove/show/ commands use resource name directly

### DIFF
--- a/tools/cli/src/resource-type-parser.ts
+++ b/tools/cli/src/resource-type-parser.ts
@@ -1,0 +1,219 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+// Resource types that have commands affecting them.
+const Resources = [
+  'cardType',
+  'fieldType',
+  'linkType',
+  'report',
+  'template',
+  'workflow',
+];
+
+// Lookup table for plural forms for command targets that have plural form commands.
+const pluralLookUpForResources = new Map([
+  ['cardType', 'cardTypes'],
+  ['fieldType', 'fieldTypes'],
+  ['linkType', 'linkTypes'],
+  ['report', 'reports'],
+  ['template', 'templates'],
+  ['workflow', 'workflows'],
+]);
+
+// Default 'sort' puts Uppercase before lowercase.
+// Make sorting case-independent.
+// @todo: This could be in some util file.
+function alphabeticalOrder(a: string, b: string) {
+  const aLower = a.toLowerCase();
+  const bLower = b.toLowerCase();
+  if (aLower < bLower) return -1;
+  if (aLower > bLower) return 1;
+  return 0;
+}
+
+/**
+ * Class that helps parsing 'create', 'remove' and 'show' commands.
+ */
+abstract class CreateTypes {
+  private static ResourceTypes = Resources;
+
+  // Command specific additions; these can also be affected with 'create'.
+  private static ResourceLikeTypes = [
+    'attachment',
+    'card',
+    'label',
+    'link',
+    'project',
+  ];
+
+  private static TargetTypes = [
+    ...CreateTypes.ResourceTypes,
+    ...CreateTypes.ResourceLikeTypes,
+  ].sort(alphabeticalOrder);
+
+  // For create command, this is only used in cases where resource name is provided to the command.
+  // e.g. "cyberismo remove demo/workflows/controlledDocument"
+  public static pluralLookupTable = new Map([...pluralLookUpForResources]);
+
+  // Lists all create-able resource types.
+  public static all(): string[] {
+    return CreateTypes.TargetTypes;
+  }
+}
+
+// Helper class for show command types.
+abstract class ShowTypes {
+  private static ResourceTypes = Resources;
+
+  // Command specific additions; these can also be shown with 'show'.
+  private static ResourceLikeTypes = [
+    'attachments',
+    'card',
+    'cards',
+    'labels',
+    'module',
+    'project',
+  ];
+
+  private static TargetTypes = [
+    ...ShowTypes.ResourceTypes,
+    ...ShowTypes.ResourceLikeTypes,
+  ];
+
+  public static pluralLookupTable = new Map([
+    ...pluralLookUpForResources,
+    ['module', 'modules'],
+  ]);
+
+  // Lists all show-able resource types.
+  public static all(): string[] {
+    return [
+      ...ShowTypes.pluralLookupTable.values(),
+      ...ShowTypes.TargetTypes,
+    ].sort(alphabeticalOrder);
+  }
+}
+
+// Helper class for remove command types.
+// Note that remove command is never used with plural names.
+abstract class RemoveTypes {
+  private static ResourceTypes = Resources;
+
+  // Command specific additions; these can also be affected with 'remove'.
+  private static ResourceLikeTypes = [
+    'attachment',
+    'card',
+    'label',
+    'link',
+    'module',
+  ];
+
+  private static TargetTypes = [
+    ...RemoveTypes.ResourceLikeTypes,
+    ...RemoveTypes.ResourceTypes,
+  ].sort(alphabeticalOrder);
+
+  // For remove command, this is only used in cases where resource name is provided to the command.
+  // e.g. "cyberismo remove demo/workflows/controlledDocument"
+  public static pluralLookupTable = new Map([...pluralLookUpForResources]);
+
+  // Lists all remove-able resource types.
+  public static all(): string[] {
+    return RemoveTypes.TargetTypes;
+  }
+}
+
+// Parser that helps with certain commands that are related to resources (create, show, remove).
+export class ResourceTypeParser {
+  private static parseTypes(
+    types: string[],
+    value: string,
+    pluralValues: Map<string, string>,
+  ): string {
+    // Known type.
+    if (types.includes(value)) {
+      return value;
+    }
+
+    // If it wasn't a known type, maybe it is a resource name
+    const parts = value.split('/');
+    if (parts && parts.length === 3) {
+      const type = parts.at(1) || '';
+      if (types.includes(type)) {
+        return value;
+      } else {
+        for (const plural of pluralValues.values()) {
+          if (type === plural) {
+            return value;
+          }
+        }
+      }
+    }
+    throw new Error(`Unknown type: '${value}'.\nSupported types are: '${types.join("', '")}'. Alternatively provide resource name (e.g "cyberismo show <prefix/type/identifier>").
+  `);
+  }
+
+  private static command(value: string) {
+    let typeValue;
+    if (value === 'remove') typeValue = RemoveTypes;
+    if (value === 'show') typeValue = ShowTypes;
+    if (value === 'create') typeValue = CreateTypes;
+    if (!typeValue) throw new Error('Unsupported command: ' + value);
+    return typeValue;
+  }
+
+  private static parseCommandTypes(type: string, category: string): string {
+    const commandType = ResourceTypeParser.command(category);
+    return ResourceTypeParser.parseTypes(
+      commandType.all(),
+      type,
+      commandType.pluralLookupTable,
+    );
+  }
+
+  /**
+   * Returns type targets related to 'command'.
+   * @param command command that targets need to be fetched to ('create', 'show', ...)
+   * @returns Array of type targets related to 'command'.
+   */
+  public static listTargets(command: string): string[] {
+    return ResourceTypeParser.command(command).all();
+  }
+
+  /**
+   * Parses remove command.
+   * @param type Argument 'type' from a command.
+   * @returns 'type' if it is a valid value. Throws if not.
+   */
+  public static parseRemoveTypes(type: string): string {
+    return ResourceTypeParser.parseCommandTypes(type, 'remove');
+  }
+
+  /**
+   * Parses create command.
+   * @param type Argument 'type' from a command.
+   * @returns 'type' if it is a valid value. Throws if not.
+   */
+  public static parseCreateTypes(type: string): string {
+    return ResourceTypeParser.parseCommandTypes(type, 'create');
+  }
+
+  /**
+   * Parses show command.
+   * @param type Argument 'type' from a command.
+   * @returns 'type' if it is a valid value. Throws if not.
+   */
+  public static parseShowTypes(type: string): string {
+    return ResourceTypeParser.parseCommandTypes(type, 'show');
+  }
+}

--- a/tools/data-handler/src/create.ts
+++ b/tools/data-handler/src/create.ts
@@ -427,6 +427,11 @@ export class Create extends EventEmitter {
     projectName: string,
   ) {
     projectPath = resolve(projectPath);
+
+    if (!projectPath) {
+      throw new Error('Cannot create project without a path');
+    }
+
     const projectFolders: string[] = ['.cards/local', 'cardRoot'];
 
     if (

--- a/tools/data-handler/src/index.ts
+++ b/tools/data-handler/src/index.ts
@@ -16,7 +16,6 @@ import {
   Commands,
   CommandManager,
   ExportFormats,
-  ShowTypes,
 } from './command-handler.js';
 import { requestStatus } from './interfaces/request-status-interfaces.js';
 import { UpdateOperations } from './resources/resource-object.js';
@@ -28,6 +27,5 @@ export {
   Commands,
   ExportFormats,
   requestStatus,
-  ShowTypes,
   UpdateOperations,
 };

--- a/tools/data-handler/src/macros/report/index.ts
+++ b/tools/data-handler/src/macros/report/index.ts
@@ -41,8 +41,6 @@ class ReportMacro extends BaseMacro {
 
   handleInject = async (context: MacroGenerationContext, data: unknown) => {
     const options = this.validate(data);
-    console.log(options);
-
     const project = new Project(context.projectPath);
     const resource = new ReportResource(project, resourceName(options.name));
     const report = await resource.show();

--- a/tools/data-handler/src/remove.ts
+++ b/tools/data-handler/src/remove.ts
@@ -204,6 +204,8 @@ export class Remove extends EventEmitter {
     targetName: string,
     ...rest: any[] // eslint-disable-line @typescript-eslint/no-explicit-any
   ) {
+    const strictNameCheck = true;
+
     if (type === 'attachment' && rest.length !== 1 && !rest[0]) {
       throw new Error(
         `Input validation error: must pass argument 'detail' if requesting to remove attachment`,
@@ -223,7 +225,7 @@ export class Remove extends EventEmitter {
     if (this.projectResource(type)) {
       const resource = Project.resourceObject(
         this.project,
-        resourceName(targetName),
+        resourceName(targetName, strictNameCheck),
       );
       return resource?.delete();
     } else {

--- a/tools/data-handler/src/resources/card-type-resource.ts
+++ b/tools/data-handler/src/resources/card-type-resource.ts
@@ -313,6 +313,11 @@ export class CardTypeResource extends FileResource {
    * @param workflowName Workflow name that this card type uses.
    */
   public async createCardType(workflowName: string) {
+    if (!workflowName) {
+      throw new Error(
+        `Cannot create cardType without providing workflow for it`,
+      );
+    }
     const validWorkflowName = await Validate.getInstance().validResourceName(
       'workflows',
       resourceNameToString(resourceName(workflowName)),

--- a/tools/data-handler/src/show.ts
+++ b/tools/data-handler/src/show.ts
@@ -359,7 +359,11 @@ export class Show {
   public async showResource(
     name: string,
   ): Promise<ResourceContent | undefined> {
-    const resource = Project.resourceObject(this.project, resourceName(name));
+    const strictNameCheck = true;
+    const resource = Project.resourceObject(
+      this.project,
+      resourceName(name, strictNameCheck),
+    );
     return resource?.show();
   }
 

--- a/tools/data-handler/src/utils/resource-utils.ts
+++ b/tools/data-handler/src/utils/resource-utils.ts
@@ -47,13 +47,21 @@ export function isResourceName(name: string): boolean {
 /**
  * Returns resource name parts (project prefix, type in plural, name of the resource).
  * @param resourceName Name of the resource (e.g. <prefix>/<type>/<name>)
+ * @param strict If true, does not allow names without 'prefix' and 'type'.
  * @throws if 'resourceName' is not valid resource name.
  * @returns resource name parts: project or module prefix, resource type (plural) and actual name of the resource.
+ * @todo: In the future, switch the default value of 'strict' to true. Only in certain cases should we accept names with just 'identifier'.
  */
-export function resourceName(resourceName: string): ResourceName {
+export function resourceName(
+  resourceName: string,
+  strict: boolean = false,
+): ResourceName {
   const parts = resourceName.split('/');
   // just resource identifier - type and prefix are unknown
   if (parts.length === 1 && parts.at(0) !== '') {
+    if (strict) {
+      throw new Error(`Name '${resourceName}' is not valid resource name`);
+    }
     return {
       prefix: '',
       type: '',

--- a/tools/data-handler/test/command-handler-show.test.ts
+++ b/tools/data-handler/test/command-handler-show.test.ts
@@ -35,7 +35,7 @@ describe('shows command', () => {
     rmSync(testDir, { recursive: true, force: true });
   });
 
-  describe('shows command', () => {
+  describe('show command', () => {
     it('show attachments - success()', async () => {
       const result = await commandHandler.command(
         Cmd.show,
@@ -181,6 +181,17 @@ describe('shows command', () => {
         expect(result.payload).to.not.equal(undefined);
       }
     });
+    it('show reports - success()', async () => {
+      const result = await commandHandler.command(
+        Cmd.show,
+        ['reports'],
+        optionsDecision,
+      );
+      const payloadAsArray = Object.values(result.payload || []);
+      expect(result.statusCode).to.equal(200);
+      expect(payloadAsArray.length).to.equal(1);
+      expect(payloadAsArray[0]).to.equal('decision/reports/testReport');
+    });
     it('show templates - success()', async () => {
       const result = await commandHandler.command(
         Cmd.show,
@@ -247,17 +258,6 @@ describe('shows command', () => {
       }
     });
     // @todo add test cases for error situations
-  });
-  it('show reports - success()', async () => {
-    const result = await commandHandler.command(
-      Cmd.show,
-      ['reports'],
-      optionsDecision,
-    );
-    const payloadAsArray = Object.values(result.payload || []);
-    expect(result.statusCode).to.equal(200);
-    expect(payloadAsArray.length).to.equal(1);
-    expect(payloadAsArray[0]).to.equal('decision/reports/testReport');
   });
 
   describe('show command with modules', () => {

--- a/tools/data-handler/test/show.test.ts
+++ b/tools/data-handler/test/show.test.ts
@@ -274,7 +274,7 @@ describe('show', () => {
       .showResource(templateName)
       .catch((error) =>
         expect(errorFunction(error)).to.equal(
-          `Unsupported resource type '${templateName}'`,
+          `Name '${templateName}' is not valid resource name`,
         ),
       );
   });

--- a/tools/data-handler/test/utils/resource-utils.test.ts
+++ b/tools/data-handler/test/utils/resource-utils.test.ts
@@ -35,6 +35,18 @@ describe('resource utils', () => {
     expect(type).to.equal('');
     expect(identifier).to.equal('test');
   });
+  it('resourceName with only identifier and using "strict" throws', () => {
+    const name = 'test';
+    const strictNameValidation = true;
+    try {
+      resourceName(name, strictNameValidation);
+    } catch (error) {
+      if (error instanceof Error)
+        expect(error.message).to.equal(
+          "Name 'test' is not valid resource name",
+        );
+    }
+  });
   it('resourceName with invalid names', () => {
     const invalidResourceNames = ['', 'test/test', 'test/test/test/test'];
     for (const invalidName of invalidResourceNames) {


### PR DESCRIPTION
Allow commands 'create', 'remove' and 'show' to be used also with resource names (<prefix>/<type>/<identifier>) without proving the type separately.

Earlier user needed to define the type with resources and as resource name contains type, it seems a bit redundant:
`
cyberismo show linkType ismsa/linkTypes/mitigates
`

Now, if user wants to skip the type, it is possible
`
cyberismo show ismsa/linkTypes/mitigates
`

The previous way is still supported.

There is quite a lot of code for such a simple change. This is due to that `Commander` does not really support "dynamic" commands (ie. argument can be different thing depending on context), it is all about defining the command before hand.

A lot of changes in other than CLI / `CommandHandler` files are due to better validation and checks. If it bothers reviewers, I can put these into another PRs.

Alternative way to implement this would be to have a separate command for using resources; for example ´show-res´ that would take a resource name. I decided not to do this, as we already have quite a lot of commands in the CLI.