### PR TITLE
INTDEV-629 Separate functions to validate labels and project names

### DIFF
--- a/tools/data-handler/src/create.ts
+++ b/tools/data-handler/src/create.ts
@@ -317,10 +317,8 @@ export class Create extends EventEmitter {
    * @param label The label being added
    */
   public async createLabel(cardKey: string, label: string) {
-    if (!Validate.isValidResourceName(label)) {
-      throw new Error(
-        `Labels must follow the same naming convention as resource names'`,
-      );
+    if (!Validate.isValidLabelName(label)) {
+      throw new Error(`Not a valid label name'`);
     }
 
     const card = await this.project.findSpecificCard(cardKey, {
@@ -475,7 +473,7 @@ export class Create extends EventEmitter {
         `Input validation error: prefix must be from 3 to 10 characters long. '${projectPrefix}' does not fulfill the condition.`,
       );
     }
-    if (!Validate.isValidResourceName(projectName)) {
+    if (!Validate.isValidProjectName(projectName)) {
       throw new Error(
         `Input validation error: invalid project name '${projectName}'`,
       );
@@ -490,7 +488,7 @@ export class Create extends EventEmitter {
       throw new Error('Project already exists');
     }
 
-    if (!Validate.isValidResourceName(projectName)) {
+    if (!Validate.isValidProjectName(projectName)) {
       throw new Error(
         `Input validation error: invalid project name '${projectName}'`,
       );

--- a/tools/data-handler/src/validate.ts
+++ b/tools/data-handler/src/validate.ts
@@ -389,16 +389,45 @@ export class Validate {
   }
 
   /**
-   * Validates that new name of a resource is according to naming convention.
-   * @param name: resource name
-   * returns true if name is valid, and false otherwise.
+   * Validates that new identifier of a resource is according to naming convention.
+   * @param identifier: resource identifier
+   * returns true if identifier is valid, and false otherwise.
    */
-  public static isValidResourceName(name: string): boolean {
+  public static isValidIdentifierName(identifier: string): boolean {
+    const validIdentifier = new RegExp('^[A-Za-z ._-]+$');
+    const contentValidated = validIdentifier.test(identifier);
+    const lengthValidated = identifier.length > 0 && identifier.length < 256;
+    const notInvalidIdentifier = !invalidNames.test(identifier);
+    return contentValidated && lengthValidated && notInvalidIdentifier;
+  }
+
+  /**
+   * Validates that 'name' can be used as a project name.
+   * @param name project name
+   * @returns true if name is valid, and false otherwise.
+   * @note that on Windows, if path + filename is longer than 256 characters, some file operations
+   *       are not possible. Thus, setting the maximum length of project name to 64 characters.
+   *       The 192 characters usually should be enough for the path.
+   */
+  public static isValidProjectName(name: string): boolean {
     const validName = new RegExp('^[A-Za-z ._-]+$');
     const contentValidated = validName.test(name);
-    const lengthValidated = name.length > 0 && name.length < 256;
+    const lengthValidated = name.length > 0 && name.length < 64;
     const notInvalidName = !invalidNames.test(name);
     return contentValidated && lengthValidated && notInvalidName;
+  }
+
+  /**
+   * Validates that 'name' can be used as label name.
+   * Labels are less restricted than other names, as they are never file names.
+   * @param name label name
+   * @returns true if name is valid, and false otherwise.
+   */
+  public static isValidLabelName(name: string): boolean {
+    const validName = new RegExp('^[-a-zA-Z0-9._-]+(?: [a-zA-Z0-9._-]+)*$');
+    const contentValidated = validName.test(name);
+    const lengthValidated = name.length > 0 && name.length < 256;
+    return contentValidated && lengthValidated;
   }
 
   // Validates that card's dataType can be used with JS types.
@@ -612,7 +641,7 @@ export class Validate {
         `Resource name must match the resource type. Type '${resource.type}' does not match '${resourceType}'`,
       );
     }
-    if (!Validate.isValidResourceName(resource.identifier)) {
+    if (!Validate.isValidIdentifierName(resource.identifier)) {
       throw new Error(
         `Resource identifier must follow naming rules. Identifier '${resource.identifier}' is invalid`,
       );
@@ -714,7 +743,7 @@ export class Validate {
         }
         if (field.isCalculated) {
           /* uncomment in COMPAT-PR: card.metadata[field.name] !== undefined
-          
+
           if (card.metadata[field.name] !== undefined) {
             validationErrors.push(
               `Card '${card.key}' not allowed to have a value in a calculated field '${field.name}'`,
@@ -785,7 +814,7 @@ export class Validate {
       } else {
         for (const label of card.metadata.labels) {
           // labels follow same name guidance as resource names
-          if (!Validate.isValidResourceName(label)) {
+          if (!Validate.isValidLabelName(label)) {
             validationErrors.push(
               `In card '${card.key}' label '${label}' does not follow naming rules`,
             );

--- a/tools/data-handler/test/0_validate.test.ts
+++ b/tools/data-handler/test/0_validate.test.ts
@@ -324,7 +324,7 @@ describe('validate cmd tests', () => {
     expect(separatedErrors[3]).to.equal(expectWrongType);
   });
 
-  it('validate that name follows naming rules', async () => {
+  it('validate that identifier follows naming rules', async () => {
     const validNames: string[] = [
       'test',
       'test-too',
@@ -349,11 +349,11 @@ describe('validate cmd tests', () => {
       'aux',
     ];
     for (const name of validNames) {
-      const valid = Validate.isValidResourceName(name);
+      const valid = Validate.isValidIdentifierName(name);
       expect(valid).to.equal(true);
     }
     for (const name of invalidNames) {
-      const invalid = Validate.isValidResourceName(name);
+      const invalid = Validate.isValidIdentifierName(name);
       expect(invalid).to.equal(false);
     }
   });
@@ -376,6 +376,65 @@ describe('validate cmd tests', () => {
     }
     for (const name of invalidNames) {
       const invalid = Validate.validateFolder(name);
+      expect(invalid).to.equal(false);
+    }
+  });
+  it('validate project names', async () => {
+    const validNames: string[] = [
+      'test',
+      'test-too',
+      'test_too',
+      'test too',
+      'test.too',
+      'Test',
+      'TEST',
+      '_test',
+      '-test',
+      'a'.repeat(63),
+    ];
+    const invalidNames: string[] = [
+      '',
+      'test2',
+      '2',
+      'test+too',
+      'test*',
+      'test$',
+      'lpt1',
+      'prn',
+      'aux',
+      'a'.repeat(65),
+    ];
+    for (const name of validNames) {
+      const valid = Validate.isValidProjectName(name);
+      expect(valid).to.equal(true);
+    }
+    for (const name of invalidNames) {
+      const invalid = Validate.isValidProjectName(name);
+      expect(invalid).to.equal(false);
+    }
+  });
+  it('validate label names', async () => {
+    const validNames: string[] = [
+      'test',
+      'test-too',
+      'test_too',
+      'test too',
+      'test.too',
+      'Test',
+      'TEST',
+      '_test',
+      '-test',
+      'very-long-but-still-marvelously-valid-resource-name.that_canBe-used-as-a-resource-name',
+      'test2',
+      '2',
+    ];
+    const invalidNames: string[] = ['', ' test2', '(test)', '2'.repeat(500)];
+    for (const name of validNames) {
+      const valid = Validate.isValidLabelName(name);
+      expect(valid).to.equal(true);
+    }
+    for (const name of invalidNames) {
+      const invalid = Validate.isValidLabelName(name);
       expect(invalid).to.equal(false);
     }
   });

--- a/tools/data-handler/test/command-handler-create.test.ts
+++ b/tools/data-handler/test/command-handler-create.test.ts
@@ -427,6 +427,15 @@ describe('create command', () => {
     expect(result.statusCode).to.equal(400);
   });
 
+  it('try create a label - whitespace character in the beginning of a name', async () => {
+    const result = await commandHandler.command(
+      Cmd.create,
+      ['label', 'decision_6', ' test'],
+      options,
+    );
+    expect(result.statusCode).to.equal(400);
+  });
+
   it('try create a label - empty name', async () => {
     const result = await commandHandler.command(
       Cmd.create,


### PR DESCRIPTION
Provide separate functions for validating labels and project names. Previously they were validated as resource names (read: identifiers). 

Labels now accept almost anything. They cannot start with whitespace and can then contain alphanumerical characters plus whitespace and '.', '_', '-'. 

Project names follow similar rules to identifiers, but should be at most 64 characters. This to avoid issues with some Windows configurations when path and filename is longer than 256 characters. The OS can be configured so that path can be 32k+characters, but we can't trust that every user would have it set up. The individual file name (sans path) can be 256 characters in Windows. 

Finally, renamed `isValidResourceName` to `isValidIdentifier` as it was actually just checking the identifier part of a resource name.

This will also fix https://cyberismo.atlassian.net/browse/INTDEV-651.