### PR TITLE
Add check that template exists when adding cards to it

### DIFF
--- a/tools/cli/test/cli.test.ts
+++ b/tools/cli/test/cli.test.ts
@@ -206,7 +206,7 @@ describe('Cli BAT test', function () {
   });
   it('Add a card of the new cardtype to the newly created template', function (done) {
     exec(
-      `cd ../../.tmp/cyberismo-cli&&cyberismo add base/templates/templateTest bat/cardTypes/cardTypeTest&&cyberismo validate`,
+      `cd ../../.tmp/cyberismo-cli&&cyberismo add bat/templates/templateTest bat/cardTypes/cardTypeTest&&cyberismo validate`,
       (error, stdout, _stderr) => {
         if (error != null) {
           log(error);

--- a/tools/data-handler/src/create.ts
+++ b/tools/data-handler/src/create.ts
@@ -31,7 +31,7 @@ import {
 } from './interfaces/resource-interfaces.js';
 import { errorFunction } from './utils/log-utils.js';
 import { readJsonFile, writeJsonFile } from './utils/json.js';
-import { Project } from './containers/project.js';
+import { Project, ResourcesFrom } from './containers/project.js';
 import { Template } from './containers/template.js';
 import { EMPTY_RANK, sortItems } from './utils/lexorank.js';
 import { fileURLToPath } from 'node:url';
@@ -131,6 +131,13 @@ export class Create extends EventEmitter {
     // Use slice to get a copy of a string.
     const origTemplateName = templateName.slice(0);
     templateName = resourceNameToString(resourceName(templateName));
+
+    const templates = await this.project.templates(ResourcesFrom.all);
+    const found = templates.find((item) => item.name === templateName);
+    if (!found) {
+      throw new Error(`Template '${templateName}' not found from the project`);
+    }
+
     const templateObject = new Template(
       this.project,
       { name: templateName, path: '' }, // Template can deduce its own path

--- a/tools/data-handler/test/command-handler-add.test.ts
+++ b/tools/data-handler/test/command-handler-add.test.ts
@@ -32,7 +32,7 @@ describe('add command', () => {
   it('add template card (success)', async () => {
     const result = await commandHandler.command(
       Cmd.add,
-      ['decision', 'decision/cardTypes/decision'],
+      ['decision/templates/decision', 'decision/cardTypes/decision'],
       options,
     );
     expect(result.statusCode).to.equal(200);
@@ -55,7 +55,11 @@ describe('add command', () => {
   it('add template card to under a parent (success)', async () => {
     const result = await commandHandler.command(
       Cmd.add,
-      ['decision', 'decision/cardTypes/decision', 'decision_1'],
+      [
+        'decision/templates/decision',
+        'decision/cardTypes/decision',
+        'decision_1',
+      ],
       options,
     );
     expect(result.statusCode).to.equal(200);
@@ -63,7 +67,7 @@ describe('add command', () => {
   it('try to add template card to non-existent template', async () => {
     const result = await commandHandler.command(
       Cmd.add,
-      ['idontexists', 'decision/cardTypes/decision'],
+      ['decision/templates/idontexists', 'decision/cardTypes/decision'],
       options,
     );
     expect(result.statusCode).to.equal(400);
@@ -71,7 +75,11 @@ describe('add command', () => {
   it('try to add template card to non-existent template parent card', async () => {
     const result = await commandHandler.command(
       Cmd.add,
-      ['decision', 'decision/cardTypes/decision', 'decision_999'],
+      [
+        'decision/templates/decision',
+        'decision/cardTypes/decision',
+        'decision_999',
+      ],
       options,
     );
     expect(result.statusCode).to.equal(400);
@@ -79,7 +87,7 @@ describe('add command', () => {
   it('try to add template card with invalid path', async () => {
     const result = await commandHandler.command(
       Cmd.add,
-      ['decision', 'decision/cardTypes/decision'],
+      ['decision/templates/decision', 'decision/cardTypes/decision'],
       { projectPath: 'random-path' },
     );
     expect(result.statusCode).to.equal(400);
@@ -88,7 +96,7 @@ describe('add command', () => {
     options.repeat = -1;
     const result = await commandHandler.command(
       Cmd.add,
-      ['decision', 'decision/cardTypes/decision'],
+      ['decision/templates/decision', 'decision/cardTypes/decision'],
       options,
     );
     expect(result.statusCode).to.equal(400);


### PR DESCRIPTION
When adding cards to a template, it doesn't check that the template actually exists, if its identifier matches and other template's identifier that exists in the project. :)

Unfortunately the tests - both BAT and unit tests - related to the feature were both broken in their own ways.

Add the check - use the whole name, not just identifier. 
Fix also the tests.