### PR TITLE
Fix: schema file name incorrect + do not allow extra files

### DIFF
--- a/tools/schema/cardTreeDirectorySchema.json
+++ b/tools/schema/cardTreeDirectorySchema.json
@@ -501,6 +501,7 @@
               "properties": {
                 "files": {
                   "type": "object",
+                  "additionalProperties": false,
                   "properties": {
                     "index.adoc.hbs": {
                       "type": "object"
@@ -508,7 +509,7 @@
                     "query.lp.hbs": {
                       "type": "object"
                     },
-                    "parametersSchema.json": {
+                    "parameterSchema.json": {
                       "type": "object"
                     },
                     ".schema": {


### PR DESCRIPTION
Currently, report schema allows that any file can be in the report's folder. 
Make it more strict - only allow listed files. 

Additionally, there is a typo in the schema file. Fix the typo.