### PR TITLE
INTDEV-709 use createElement instead of constructor directly

### DIFF
--- a/tools/app/app/components/ContentArea.tsx
+++ b/tools/app/app/components/ContentArea.tsx
@@ -512,9 +512,14 @@ export const ContentArea: React.FC<ContentAreaProps> = ({
       if (node.type === 'tag') {
         const macro = combinedMacros.find((m) => m.tagName === node.name);
         if (macro) {
-          return macro.component({
+          // This key should be unique for each macro
+          const key = `${node.name}-${Object.entries(node.attribs)
+            .map(([k, v]) => `${k}=${v}`)
+            .join('-')}`;
+          return React.createElement(macro.component, {
             ...node.attribs,
-            key: card.key,
+            key,
+            macroKey: card.key,
             preview,
           });
         }

--- a/tools/app/app/components/ContentArea.tsx
+++ b/tools/app/app/components/ContentArea.tsx
@@ -512,13 +512,8 @@ export const ContentArea: React.FC<ContentAreaProps> = ({
       if (node.type === 'tag') {
         const macro = combinedMacros.find((m) => m.tagName === node.name);
         if (macro) {
-          // This key should be unique for each macro
-          const key = `${node.name}-${Object.entries(node.attribs)
-            .map(([k, v]) => `${k}=${v}`)
-            .join('-')}`;
           return React.createElement(macro.component, {
-            ...node.attribs,
-            key,
+            ...node.attribs, // node attribs should contain the key
             macroKey: card.key,
             preview,
           });

--- a/tools/app/app/components/macros/CreateCards.tsx
+++ b/tools/app/app/components/macros/CreateCards.tsx
@@ -28,11 +28,11 @@ export default function CreateCards({
   buttonlabel,
   template,
   cardKey,
-  key,
+  macroKey,
   preview,
 }: CreateCardsProps) {
   const { t } = useTranslation();
-  const { createCard, isUpdating } = useCard(cardKey || key);
+  const { createCard, isUpdating } = useCard(cardKey || macroKey);
   const dispatch = useAppDispatch();
   const [loading, setLoading] = useState(false);
   const router = useAppRouter();

--- a/tools/app/app/components/macros/index.ts
+++ b/tools/app/app/components/macros/index.ts
@@ -17,9 +17,9 @@ import { ReactElement } from 'react';
 
 export interface MacroContext {
   /**
-   * The key inside of which the macro is rendered.
+   * The key inside of which the macro is rendered
    */
-  key: string;
+  macroKey: string;
   /**
    * True if the macro is rendered in preview mode.
    */

--- a/tools/data-handler/src/macros/index.ts
+++ b/tools/data-handler/src/macros/index.ts
@@ -230,6 +230,9 @@ export function handleMacroError(
   }
 }
 
+// This is used to generate unique keys for macros
+// There might be a better way to do this
+let macroCounter = 0;
 /**
  * Creates an injectable placeholder for a macro
  * @param macro - The macro to create the placeholder for
@@ -246,7 +249,7 @@ export function createHtmlPlaceholder(
     .join(' ');
 
   // start with a line change to ensure that passthrough ++++ is on its own line
-  return `\n++++\n<${macro.tagName}${optionString ? ` ${optionString}` : ''}></${macro.tagName}>\n++++`;
+  return `\n++++\n<${macro.tagName}${optionString ? ` ${optionString}` : ''} key="macro-${macroCounter++}"></${macro.tagName}>\n++++`;
 }
 
 /**

--- a/tools/data-handler/test/macros/index.test.ts
+++ b/tools/data-handler/test/macros/index.test.ts
@@ -210,7 +210,9 @@ describe('macros', () => {
     it('createHtmlPlaceholder (success) without data', () => {
       // note: depends on the order of execution
       const result = createHtmlPlaceholder(macro.metadata, {});
-      expect(result).to.equal('\n++++\n<test-tag-name key="macro-1"></test-tag-name>\n++++');
+      expect(result).to.equal(
+        '\n++++\n<test-tag-name key="macro-1"></test-tag-name>\n++++',
+      );
     });
     it('createAdmonition (success)', () => {
       const result = createAdmonition('WARNING', 'test-title', 'test-content');

--- a/tools/data-handler/test/macros/index.test.ts
+++ b/tools/data-handler/test/macros/index.test.ts
@@ -204,12 +204,13 @@ describe('macros', () => {
         test: 'test-data',
       });
       expect(result).to.equal(
-        '\n++++\n<test-tag-name test="test-data"></test-tag-name>\n++++',
+        '\n++++\n<test-tag-name test="test-data" key="macro-0"></test-tag-name>\n++++',
       );
     });
     it('createHtmlPlaceholder (success) without data', () => {
+      // note: depends on the order of execution
       const result = createHtmlPlaceholder(macro.metadata, {});
-      expect(result).to.equal('\n++++\n<test-tag-name></test-tag-name>\n++++');
+      expect(result).to.equal('\n++++\n<test-tag-name key="macro-1"></test-tag-name>\n++++');
     });
     it('createAdmonition (success)', () => {
       const result = createAdmonition('WARNING', 'test-title', 'test-content');

--- a/tools/data-handler/test/macros/index.test.ts
+++ b/tools/data-handler/test/macros/index.test.ts
@@ -203,15 +203,15 @@ describe('macros', () => {
       const result = createHtmlPlaceholder(macro.metadata, {
         test: 'test-data',
       });
-      expect(result).to.equal(
-        '\n++++\n<test-tag-name test="test-data" key="macro-0"></test-tag-name>\n++++',
+      expect(result).to.match(
+        /^\n\+{4}\n<test-tag-name test="test-data" key="macro-\d+"><\/test-tag-name>\n\+{4}$/,
       );
     });
     it('createHtmlPlaceholder (success) without data', () => {
       // note: depends on the order of execution
       const result = createHtmlPlaceholder(macro.metadata, {});
-      expect(result).to.equal(
-        '\n++++\n<test-tag-name key="macro-1"></test-tag-name>\n++++',
+      expect(result).to.match(
+        /^\n\+{4}\n<test-tag-name key="macro-\d+"><\/test-tag-name>\n\+{4}$/,
       );
     });
     it('createAdmonition (success)', () => {


### PR DESCRIPTION
Using constructor in react directly is bad practice so started using createElement itself. Also created a unique key for each macro, which is done on server side, since it's much easier to do so.

Issue: Without the given changes, React crashed because the current component detected that the amount of used hooks changed. This is because the macros were not tracked separately by React. This fix should also fix a lot of other bugs that might have resulted from using constructor directly without a unique key.