### PR TITLE
INTDEV-686 Add cards to template: set custom fields to null

### DIFF
--- a/tools/data-handler/test/command-handler-create.test.ts
+++ b/tools/data-handler/test/command-handler-create.test.ts
@@ -15,6 +15,9 @@ import { Calculate } from '../src/calculate.js';
 import { DefaultContent } from '../src/resources/create-defaults.js';
 import { CardListContainer } from '../src/interfaces/project-interfaces.js';
 import { FieldTypeResource } from '../src/resources/field-type-resource.js';
+import { Project } from '../src/containers/project.js';
+import { resourceName } from '../src/utils/resource-utils.js';
+import { TemplateResource } from '../src/resources/template-resource.js';
 
 // Create test artifacts in a temp folder.
 const baseDir = dirname(fileURLToPath(import.meta.url));
@@ -944,5 +947,31 @@ describe('create command', () => {
     expect(defaultContent.name).to.equal('test');
     expect(defaultContent.states.length).to.equal(3);
     expect(defaultContent.transitions.length).to.equal(3);
+  });
+  it('access default values for card (success)', () => {
+    const defaultCardType = DefaultContent.cardType('test', 'testWorkflow');
+    const defaultCard = DefaultContent.card(defaultCardType);
+    expect(defaultCard.cardType).to.equal('test');
+    expect(defaultCard.rank).to.equal('');
+    expect(defaultCard.title).to.equal('Untitled');
+    expect(defaultCard.workflowState).to.equal('');
+  });
+  it('access default values for card using real card type and template cards (success)', async () => {
+    const project = new Project(decisionRecordsPath);
+    const template = new TemplateResource(
+      project,
+      resourceName('decision/templates/decision'),
+    ).templateObject();
+    const templateCards = await template?.cards('', { metadata: true });
+
+    const cardType = DefaultContent.cardType(
+      'decision/cardTypes/decision',
+      'decision/workflows/decision',
+    );
+    const defaultCard = DefaultContent.card(cardType, templateCards);
+    expect(defaultCard.cardType).to.equal('decision/cardTypes/decision');
+    expect(defaultCard.rank).to.equal('0|b');
+    expect(defaultCard.title).to.equal('Untitled');
+    expect(defaultCard.workflowState).to.equal('');
   });
 });


### PR DESCRIPTION
When cards are added, set all non-calculated custom fields to 'null'.

I created a default card content function to `DefaultContent` static class. This cleans up `Template` class implementation. Also moved some related internal functions there. 

I also added tests for using the new default content.