### PR TITLE
INTDEV-653 Implement templates and reports as new type of resources

### DIFF
--- a/content/defaultReport/report.json
+++ b/content/defaultReport/report.json
@@ -1,5 +1,0 @@
-{
-  "displayName": "Example report",
-  "description": "A description of the example report",
-  "category": "Uncategorised report"
-}

--- a/tools/cli/test/cli.test.ts
+++ b/tools/cli/test/cli.test.ts
@@ -150,7 +150,7 @@ describe('Cli BAT test', function () {
   });
   it('Create a new cardtype that uses the new workflow', function (done) {
     exec(
-      `cd ../../.tmp/cyberismo-cli&&cyberismo create cardType cardTypeTest workflowTest&&cyberismo validate`,
+      `cd ../../.tmp/cyberismo-cli&&cyberismo create cardType cardTypeTest bat/workflows/workflowTest&&cyberismo validate`,
       (error, stdout, _stderr) => {
         if (error != null) {
           log(error);
@@ -218,7 +218,7 @@ describe('Cli BAT test', function () {
       },
     );
   });
-  it('Create a card from the new cardtype', function (done) {
+  it('Create a card from the new template', function (done) {
     exec(
       `cd ../../.tmp/cyberismo-cli&&cyberismo create card bat/templates/templateTest&&cyberismo validate`,
       (error, stdout, _stderr) => {

--- a/tools/data-handler/src/calculate.ts
+++ b/tools/data-handler/src/calculate.ts
@@ -45,6 +45,12 @@ import {
 } from './utils/clingo-facts.js';
 import { ClingoProgramBuilder } from './utils/clingo-program-builder.js';
 import { generateRandomString } from './utils/random.js';
+import {
+  CardType,
+  FieldType,
+  LinkType,
+  Workflow,
+} from './interfaces/resource-interfaces.js';
 
 // Class that calculates with logic program card / project level calculations.
 export class Calculate {
@@ -74,7 +80,7 @@ export class Calculate {
     const promises = [];
 
     for (const cardType of await Promise.all(
-      cardTypes.map((c) => this.project.cardType(c.name)),
+      cardTypes.map((c) => this.project.resource<CardType>(c.name)),
     )) {
       if (!cardType) continue;
 
@@ -99,7 +105,7 @@ export class Calculate {
     const promises = [];
     // loop through workflows
     for (const workflow of await Promise.all(
-      workflows.map((m) => this.project.workflow(m.name)),
+      workflows.map((m) => this.project.resource<Workflow>(m.name)),
     )) {
       if (!workflow) continue;
 
@@ -159,7 +165,7 @@ export class Calculate {
     const promises = [];
 
     for (const fieldType of await Promise.all(
-      fieldTypes.map((m) => this.project.fieldType(m.name)),
+      fieldTypes.map((m) => this.project.resource<FieldType>(m.name)),
     )) {
       if (!fieldType) continue;
 
@@ -205,7 +211,7 @@ export class Calculate {
     const promises = [];
 
     for (const linkType of await Promise.all(
-      linkTypes.map((c) => this.project.linkType(c.name)),
+      linkTypes.map((c) => this.project.resource<LinkType>(c.name)),
     )) {
       if (!linkType) continue;
 

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -23,15 +23,8 @@ import {
   ProjectMetadata,
   RemovableResourceTypes,
   ResourceTypes,
-  TemplateConfiguration,
 } from './interfaces/project-interfaces.js';
-import {
-  CardType,
-  FieldType,
-  LinkType,
-  ReportMetadata,
-  Workflow,
-} from './interfaces/resource-interfaces.js';
+import { ResourceContent } from './interfaces/resource-interfaces.js';
 
 import { requestStatus } from './interfaces/request-status-interfaces.js';
 
@@ -587,14 +580,9 @@ export class Commands {
       | Card
       | CardAttachment[]
       | CardListContainer[]
-      | CardType
-      | FieldType
-      | LinkType
       | ModuleSettings
       | ProjectMetadata
-      | ReportMetadata
-      | TemplateConfiguration
-      | Workflow
+      | ResourceContent
       | string[]
       | undefined
     >;
@@ -622,6 +610,8 @@ export class Commands {
       case 'cardType':
       case 'fieldType':
       case 'linkType':
+      case 'report':
+      case 'template':
       case 'workflow':
         promise = this.commands!.showCmd.showResource(detail);
         break;
@@ -646,14 +636,8 @@ export class Commands {
       case 'project':
         promise = this.commands!.showCmd.showProject();
         break;
-      case 'report':
-        promise = this.commands!.showCmd.showReport(detail);
-        break;
       case 'reports':
         promise = this.commands!.showCmd.showReports();
-        break;
-      case 'template':
-        promise = this.commands!.showCmd.showTemplate(detail);
         break;
       case 'templates':
         promise = this.commands!.showCmd.showTemplates();

--- a/tools/data-handler/src/command-manager.ts
+++ b/tools/data-handler/src/command-manager.ts
@@ -50,12 +50,7 @@ export class CommandManager {
 
     this.showCmd = new Show(this.project);
     this.calculateCmd = new Calculate(this.project);
-    this.createCmd = new Create(
-      this.project,
-      this.calculateCmd,
-      this.validateCmd,
-      [],
-    );
+    this.createCmd = new Create(this.project, this.calculateCmd);
     this.editCmd = new Edit(this.project, this.calculateCmd);
     this.exportCmd = new Export(this.project, this.calculateCmd, this.showCmd);
     this.exportSiteCmd = new ExportSite(
@@ -80,7 +75,6 @@ export class CommandManager {
    * Add such calls here.
    */
   public async initialize() {
-    await this.createCmd.setProjectPrefixes();
     await this.project.collectModuleResources();
   }
 

--- a/tools/data-handler/src/containers/card-container.ts
+++ b/tools/data-handler/src/containers/card-container.ts
@@ -343,25 +343,23 @@ export class CardContainer {
 
   // Persists card content.
   protected async saveCard(card: Card) {
+    await this.saveCardContent(card);
+    await this.saveCardMetadata(card);
+  }
+
+  // Persists card metadata.
+  protected async saveCardContent(card: Card) {
     if (card.content != null) {
       const contentFile = join(card.path, CardContainer.cardContentFile);
       await writeFile(contentFile, card.content);
-      return;
     }
-    if (card.metadata) {
-      const metadataFile = join(card.path, CardContainer.cardMetadataFile);
-      await writeJsonFile(metadataFile, card.metadata);
-      return;
-    }
-    throw new Error(`No content for card ${card.key}`);
   }
+
   // Persists card metadata.
   protected async saveCardMetadata(card: Card) {
-    if (card.metadata) {
+    if (card.metadata != null) {
       const metadataFile = join(card.path, CardContainer.cardMetadataFile);
       await writeJsonFile(metadataFile, card.metadata);
-      return;
     }
-    throw new Error(`No metadata for card ${card.key}`);
   }
 }

--- a/tools/data-handler/src/export-site.ts
+++ b/tools/data-handler/src/export-site.ts
@@ -22,12 +22,13 @@ import { fileURLToPath } from 'node:url';
 import git from 'isomorphic-git';
 import { dump } from 'js-yaml';
 
+import { Calculate } from './calculate.js';
 import { Card } from './interfaces/project-interfaces.js';
+import { CardType } from '../src/interfaces/resource-interfaces.js';
 import { errorFunction } from './utils/log-utils.js';
 import { Export } from './export.js';
 import { Project } from './containers/project.js';
 import { sortItems } from './utils/lexorank.js';
-import { Calculate } from './calculate.js';
 import { Show } from './show.js';
 
 interface ExportOptions {
@@ -227,7 +228,7 @@ export class ExportSite extends Export {
 
       let tempContent: string = '';
       if (card.metadata) {
-        const cardTypeForCard = await this.project.cardType(
+        const cardTypeForCard = await this.project.resource<CardType>(
           card.metadata?.cardType,
         );
         tempContent = '\n= ';

--- a/tools/data-handler/src/export.ts
+++ b/tools/data-handler/src/export.ts
@@ -17,15 +17,14 @@ import { dirname, join } from 'node:path';
 // asciidoctor
 import Processor from '@asciidoctor/core';
 
+import { Calculate } from './calculate.js';
 import { Card, FetchCardDetails } from './interfaces/project-interfaces.js';
 import { CardType } from './interfaces/resource-interfaces.js';
 import { pathExists } from './utils/file-utils.js';
 import { Project } from './containers/project.js';
-
-import { sortItems } from './utils/lexorank.js';
 import { QueryResult } from './types/queries.js';
 import { Show } from './show.js';
-import { Calculate } from './calculate.js';
+import { sortItems } from './utils/lexorank.js';
 
 const attachmentFolder: string = 'a';
 
@@ -102,7 +101,7 @@ export class Export {
       }
 
       if (card.metadata) {
-        const cardTypeForCard = await this.project.cardType(
+        const cardTypeForCard = await this.project.resource<CardType>(
           card.metadata?.cardType,
         );
         const metaDataContent = this.metaToAdoc(card, cardTypeForCard);

--- a/tools/data-handler/src/import.ts
+++ b/tools/data-handler/src/import.ts
@@ -13,12 +13,15 @@
 // node
 import { join } from 'node:path';
 
+import { CardType } from './interfaces/resource-interfaces.js';
 import { copyDir } from './utils/file-utils.js';
-import { Project } from './containers/project.js';
-import { readCsvFile } from './utils/csv.js';
-import { Validate } from './validate.js';
 import { Create } from './create.js';
+import { Project } from './containers/project.js';
 import { pathExists } from './utils/file-utils.js';
+import { readCsvFile } from './utils/csv.js';
+import { resourceName } from './utils/resource-utils.js';
+import { TemplateResource } from './resources/template-resource.js';
+import { Validate } from './validate.js';
 
 export class Import {
   constructor(
@@ -47,8 +50,11 @@ export class Import {
 
     for (const row of csv) {
       const { title, template, description, labels, ...customFields } = row;
-      const templateObject =
-        await this.project.createTemplateObjectByName(template);
+      const templateResource = new TemplateResource(
+        this.project,
+        resourceName(template),
+      );
+      const templateObject = templateResource.templateObject();
       if (!templateObject) {
         throw new Error(`Template '${template}' not found`);
       }
@@ -71,7 +77,7 @@ export class Import {
       const card = await this.project.findSpecificCard(cardKey, {
         metadata: true,
       });
-      const cardType = await this.project.cardType(
+      const cardType = await this.project.resource<CardType>(
         card?.metadata?.cardType || '',
       );
 

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -10,7 +10,7 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Link, TemplateMetadata } from './resource-interfaces.js';
+import { Link, TemplateConfiguration } from './resource-interfaces.js';
 
 // Single card; either in project or in template.
 export interface Card {
@@ -186,13 +186,8 @@ export type ResourceTypes =
   | 'templates'
   | 'workflows';
 
-// Template configuration details.
-export interface TemplateConfiguration {
-  name: string;
-  path: string;
-  numberOfCards: number;
-  metadata: TemplateMetadata;
-}
+// Re-export Template Configuration to avoid unnecessary changes to other files.
+export { TemplateConfiguration };
 
 // Name for a card (consists of prefix and a random 8-character base36 string; e.g. 'test_abcd1234')
 export const CardNameRegEx = new RegExp(/^[a-z]+_[0-9a-z]+$/);

--- a/tools/data-handler/src/interfaces/resource-interfaces.ts
+++ b/tools/data-handler/src/interfaces/resource-interfaces.ts
@@ -72,7 +72,13 @@ export interface FieldType extends ResourceBaseMetadata {
 }
 
 // File-based resources metadata content.
-export type ResourceContent = CardType | FieldType | LinkType | Workflow;
+export type ResourceContent =
+  | CardType
+  | FieldType
+  | LinkType
+  | ReportMetadata
+  | TemplateMetadata
+  | Workflow;
 
 // Link content.
 export interface Link {
@@ -91,7 +97,8 @@ export interface LinkType extends ResourceBaseMetadata {
 }
 
 // Report resource.
-export interface Report extends ResourceBaseMetadata {
+export interface Report {
+  name: string;
   metadata: ReportMetadata;
   contentTemplate: string;
   queryTemplate: string;
@@ -110,15 +117,13 @@ export interface ResourceBaseMetadata {
   name: string;
 }
 
-// Resource's metadata. There are based from ResourceBaseMetadata.
-export type ResourceMetadataType =
-  | CalculationMetadata
-  | CardType
-  | FieldType
-  | LinkType
-  | Report
-  | TemplateMetadata
-  | Workflow;
+// Template configuration details.
+export interface TemplateConfiguration {
+  name: string;
+  path: string;
+  numberOfCards: number;
+  metadata: TemplateMetadata;
+}
 
 // Template configuration content details.
 export interface TemplateMetadata extends ResourceBaseMetadata {

--- a/tools/data-handler/src/macros/report/index.ts
+++ b/tools/data-handler/src/macros/report/index.ts
@@ -20,6 +20,7 @@ import Handlebars from 'handlebars';
 import BaseMacro from '../base-macro.js';
 import { validateJson } from '../../utils/validate.js';
 import TaskQueue from '../task-queue.js';
+import { Report } from '../../interfaces/resource-interfaces.js';
 
 export interface ReportOptions extends Record<string, string> {
   name: string;
@@ -42,7 +43,7 @@ class ReportMacro extends BaseMacro {
     console.log(options);
 
     const project = new Project(context.projectPath);
-    const report = await project.report(options.name);
+    const report = await project.resource<Report>(options.name);
 
     if (!report) throw new Error(`Report ${options} does not exist`);
 

--- a/tools/data-handler/src/move.ts
+++ b/tools/data-handler/src/move.ts
@@ -27,6 +27,9 @@ import {
 import { ActionGuard } from './permissions/action-guard.js';
 import { Calculate } from './calculate.js';
 
+import { resourceName } from './utils/resource-utils.js';
+import { TemplateResource } from './resources/template-resource.js';
+
 // @todo - we should have project wide constants, so that if we need them, only the const value needs to be changed.
 const ROOT: string = 'root';
 
@@ -310,7 +313,11 @@ export class Move {
     // rebalance templates
     const templates = await this.project.templates(ResourcesFrom.localOnly);
     for (const template of templates) {
-      const templateObject = await this.project.createTemplateObject(template);
+      const templateResource = new TemplateResource(
+        this.project,
+        resourceName(template.name),
+      );
+      const templateObject = templateResource.templateObject();
 
       if (!templateObject) {
         throw new Error(`Template '${template.name}' not found`);
@@ -409,7 +416,7 @@ export class Move {
     // since we don't know if 'root' is templateRoot or cardRoot, we need to check the card
     if (parentCardKey === ROOT) {
       if (Project.isTemplateCard(card)) {
-        const template = await this.project.createTemplateObjectFromCard(card);
+        const template = this.project.createTemplateObjectFromCard(card);
         if (!template) {
           throw new Error(
             `Cannot find template for the template card '${card.key}'`,

--- a/tools/data-handler/src/resources/create-defaults.ts
+++ b/tools/data-handler/src/resources/create-defaults.ts
@@ -10,18 +10,35 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import { CardMetadata } from '../interfaces/project-interfaces.js';
 import {
   CardType,
   DataType,
   FieldType,
   Link,
   LinkType,
+  ReportMetadata,
   TemplateMetadata,
   WorkflowCategory,
   Workflow,
-} from './interfaces/resource-interfaces.js';
+} from '../interfaces/resource-interfaces.js';
 
 export abstract class DefaultContent {
+  /**
+   * Default content for a card.
+   * @parm cardType Name of a card type
+   * @returns Default content for card.
+   */
+  static card(cardType: string): CardMetadata {
+    return {
+      title: 'Untitled',
+      cardType: cardType,
+      workflowState: '',
+      rank: '',
+      links: [],
+    };
+  }
+
   /**
    * Default content for card type.
    * @param cardTypeName card type name
@@ -73,7 +90,7 @@ export abstract class DefaultContent {
    * @param linkTypeName link type name
    * @returns Default content for link type.
    */
-  static linkTypeContent(linkTypeName: string): LinkType {
+  static linkType(linkTypeName: string): LinkType {
     return {
       name: linkTypeName,
       outboundDisplayName: linkTypeName,
@@ -85,11 +102,27 @@ export abstract class DefaultContent {
   }
 
   /**
+   * Default content for report type.
+   * @param reportName report name
+   * @returns Default content for report type.
+   */
+  static report(reportName: string): ReportMetadata {
+    return {
+      name: reportName,
+      displayName: '',
+      description: '',
+      category: 'Uncategorised report',
+    };
+  }
+
+  /**
    * Default template content
    * @returns Default template content
    */
-  public static templateContent(templateName: string): TemplateMetadata {
-    return { name: templateName };
+  public static template(templateName: string): TemplateMetadata {
+    return {
+      name: templateName,
+    };
   }
 
   /**
@@ -97,7 +130,7 @@ export abstract class DefaultContent {
    * @param {string} workflowName workflow name
    * @returns Default content for workflow JSON values.
    */
-  public static workflowContent(workflowName: string): Workflow {
+  public static workflow(workflowName: string): Workflow {
     return {
       name: workflowName,
       states: [

--- a/tools/data-handler/src/resources/folder-resource.ts
+++ b/tools/data-handler/src/resources/folder-resource.ts
@@ -1,0 +1,105 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { join } from 'node:path';
+import { mkdir, rm } from 'node:fs/promises';
+
+import { FileResource, Operation } from './file-resource.js';
+import { Project } from '../containers/project.js';
+import { ResourceContent } from '../interfaces/resource-interfaces.js';
+import { ResourceFolderType } from '../interfaces/project-interfaces.js';
+import { ResourceName } from '../utils/resource-utils.js';
+
+export { type Operation };
+
+/**
+ * Folder type resource class. These are resources that have their own folders for content.
+ */
+export class FolderResource extends FileResource {
+  protected internalFolder: string = '';
+
+  constructor(project: Project, name: ResourceName, type: ResourceFolderType) {
+    super(project, name, type);
+  }
+
+  /**
+   * Creates a new folder type object. Base class writes the object to disk automatically.
+   * @param newContent Content for the type.
+   */
+  protected async create(newContent?: ResourceContent) {
+    await super.create(newContent);
+    await mkdir(this.internalFolder, { recursive: true });
+  }
+
+  /**
+   * Returns content data.
+   */
+  public get data() {
+    return super.data;
+  }
+
+  /**
+   * Deletes file(s) from disk and clears out the memory resident object.
+   */
+  protected async delete() {
+    await rm(this.internalFolder, { recursive: true, force: true });
+    return super.delete();
+  }
+
+  protected initialize(): void {
+    super.initialize();
+
+    this.internalFolder = join(
+      this.resourceFolder,
+      this.resourceName.identifier,
+    );
+  }
+
+  /**
+   * Renames resource metadata file and renames memory resident object 'name'.
+   * @param newName New name for the resource.
+   */
+  protected async rename(newName: ResourceName) {
+    return super.rename(newName);
+  }
+
+  /**
+   * Shows metadata of the resource.
+   * @returns resource type's metadata.
+   */
+  protected async show(): Promise<ResourceContent> {
+    return super.show() as Promise<ResourceContent>;
+  }
+
+  /**
+   * Updates resource.
+   * @param key Key to modify
+   * @param op Operation to perform on 'key'
+   */
+  protected async update<Type>(key: string, op: Operation<Type>) {
+    return super.update(key, op);
+  }
+
+  /**
+   * Writes resource content to disk.
+   */
+  protected async write() {
+    return super.write();
+  }
+
+  /**
+   * Validates the resource. If object is invalid, throws.
+   */
+  protected async validate(content?: object) {
+    return super.validate(content);
+  }
+}

--- a/tools/data-handler/src/resources/report-resource.ts
+++ b/tools/data-handler/src/resources/report-resource.ts
@@ -1,0 +1,185 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { readdir, readFile } from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
+import { extname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { copyDir, pathExists } from '../utils/file-utils.js';
+import { DefaultContent } from './create-defaults.js';
+import { FolderResource, Operation } from './folder-resource.js';
+import { Project } from '../containers/project.js';
+import { ResourceName, resourceNameToString } from '../utils/resource-utils.js';
+import { Report, ReportMetadata } from '../interfaces/resource-interfaces.js';
+import { Schema } from 'jsonschema';
+
+const CARD_CONTENT_HANDLEBAR_FILE = 'index.adoc.hbs';
+const QUERY_HANDLEBAR_FILE = 'query.lp.hbs';
+const REPORT_SCHEMA_FILE = 'parameterSchema.json';
+
+/**
+ * Report resource class.
+ */
+export class ReportResource extends FolderResource {
+  private reportSchema: Schema;
+  constructor(project: Project, name: ResourceName) {
+    super(project, name, 'reports');
+
+    this.contentSchemaId = 'reportSchema';
+    this.contentSchema = super.contentSchemaContent(this.contentSchemaId);
+
+    this.initialize();
+
+    const schemaPath = join(this.internalFolder, REPORT_SCHEMA_FILE);
+    this.reportSchema = pathExists(schemaPath)
+      ? JSON.parse(readFileSync(schemaPath).toString())
+      : undefined;
+  }
+
+  // Path to content folder.
+  // @todo: create the files' content dynamically.
+  private defaultReportLocation: string = join(
+    fileURLToPath(import.meta.url),
+    '../../../../../content/defaultReport',
+  );
+
+  // When resource name changes.
+  private async handleNameChange(existingName: string) {
+    await Promise.all([
+      super.updateHandleBars(
+        existingName,
+        this.content.name,
+        await this.handleBarFiles(),
+      ),
+      super.updateCalculations(existingName, this.content.name),
+    ]);
+  }
+
+  /**
+   * Sets new metadata into the report object.
+   * @param newContent metadata content for the template.
+   * @throws if 'newContent' is not valid.
+   */
+  public async createReport() {
+    const defaultContent = DefaultContent.report(
+      resourceNameToString(this.resourceName),
+    );
+
+    await super.create(defaultContent);
+
+    // Copy report default structure to destination.
+    await copyDir(this.defaultReportLocation, this.internalFolder);
+  }
+
+  /**
+   * Returns resource content.
+   */
+  public get data(): ReportMetadata {
+    return super.data as ReportMetadata;
+  }
+
+  /**
+   * Deletes file and folder that this resource is based on.
+   */
+  public async delete() {
+    return super.delete();
+  }
+
+  /**
+   * Returns list of handlebar filenames that this report has.
+   * @returns list of handlebar filenames that this report has.
+   */
+  public async handleBarFiles() {
+    return (
+      await readdir(this.internalFolder, {
+        withFileTypes: true,
+        recursive: true,
+      })
+    )
+      .filter((dirent) => {
+        return dirent.isFile() && extname(dirent.name) === '.hbs';
+      })
+      .map((item) => join(item.parentPath, item.name));
+  }
+
+  /**
+   * Renames the object and the file.
+   * @param newName New name for the resource.
+   */
+  public async rename(newName: ResourceName) {
+    const existingName = this.content.name;
+    await super.rename(newName);
+    return this.handleNameChange(existingName);
+  }
+
+  /**
+   * Shows metadata of the resource.
+   * @returns template metadata.
+   */
+  public async show(): Promise<Report> {
+    const reportMetadata = (await super.show()) as ReportMetadata;
+    return {
+      name: resourceNameToString(this.resourceName),
+      metadata: reportMetadata,
+      contentTemplate: (
+        await readFile(join(this.internalFolder, CARD_CONTENT_HANDLEBAR_FILE))
+      ).toString(),
+      queryTemplate: (
+        await readFile(join(this.internalFolder, QUERY_HANDLEBAR_FILE))
+      ).toString(),
+      schema: this.reportSchema,
+    };
+  }
+
+  /**
+   * Updates report resource.
+   * @param key Key to modify
+   * @param op Operation to perform on 'key'
+   * @throws if key is unknown.
+   */
+  public async update<Type>(key: string, op: Operation<Type>) {
+    const nameChange = key === 'name';
+    const existingName = this.content.name;
+
+    await super.update(key, op);
+
+    const content = { ...(this.content as ReportMetadata) };
+
+    if (key === 'name') {
+      content.name = super.handleScalar(op) as string;
+    } else if (key === 'displayName') {
+      content.displayName = super.handleScalar(op) as string;
+    } else if (key === 'description') {
+      content.description = super.handleScalar(op) as string;
+    } else if (key === 'category') {
+      content.category = super.handleScalar(op) as string;
+    }
+
+    await super.postUpdate(content, key, op);
+
+    // Renaming this template causes that references to its name must be updated.
+    if (nameChange) {
+      await this.handleNameChange(existingName);
+    }
+  }
+
+  /**
+   * Validates report.
+   * @throws when there are validation errors.
+   * @param content Content to be validated.
+   * @note If content is not provided, base class validation will use resource's current content.
+   */
+  public async validate(content?: object) {
+    return super.validate(content);
+  }
+}

--- a/tools/data-handler/src/resources/template-resource.ts
+++ b/tools/data-handler/src/resources/template-resource.ts
@@ -1,0 +1,184 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { basename, dirname, join } from 'node:path';
+import { mkdir } from 'node:fs/promises';
+
+import { DefaultContent } from './create-defaults.js';
+import { FolderResource, Operation } from './folder-resource.js';
+import { pathExists } from '../utils/file-utils.js';
+import { Project } from '../containers/project.js';
+import { ResourceName, resourceNameToString } from '../utils/resource-utils.js';
+import {
+  TemplateConfiguration,
+  TemplateMetadata,
+} from '../interfaces/resource-interfaces.js';
+import { Template } from '../containers/template.js';
+import { writeJsonFile } from '../utils/json.js';
+
+/**
+ * Template resource class.
+ */
+export class TemplateResource extends FolderResource {
+  private cardContainer: Template;
+  private cardsFolder = '';
+  private cardsSchema = super.contentSchemaContent('cardBaseSchema');
+
+  constructor(project: Project, name: ResourceName) {
+    super(project, name, 'templates');
+
+    this.contentSchemaId = 'templateSchema';
+    this.contentSchema = super.contentSchemaContent(this.contentSchemaId);
+
+    this.initialize();
+    this.cardsFolder = join(this.internalFolder, 'c');
+
+    // Each template resource contains a template card container (with template cards).
+    this.cardContainer = new Template(this.project, {
+      name: basename(this.fileName),
+      path: dirname(this.fileName),
+    });
+  }
+
+  // When resource name changes.
+  private async handleNameChange(existingName: string) {
+    await Promise.all([
+      super.updateHandleBars(existingName, this.content.name),
+      super.updateCalculations(existingName, this.content.name),
+    ]);
+  }
+
+  /**
+   * Sets new metadata into the template object.
+   * @param newContent metadata content for the template.
+   * @throws if 'newContent' is not valid.
+   */
+  public async create(newContent?: TemplateMetadata) {
+    if (!newContent) {
+      newContent = DefaultContent.template(
+        resourceNameToString(this.resourceName),
+      );
+    } else {
+      await this.validate(newContent);
+    }
+
+    return super.create(newContent);
+  }
+
+  /**
+   * Returns content data.
+   */
+  public get data(): TemplateMetadata {
+    return super.data as TemplateMetadata;
+  }
+
+  /**
+   * Deletes file and folder that this resource is based on.
+   */
+  public async delete() {
+    return super.delete();
+  }
+
+  /**
+   * Renames the object and the file.
+   * @param newName New name for the resource.
+   */
+  public async rename(newName: ResourceName) {
+    const existingName = this.content.name;
+    await super.rename(newName);
+    return this.handleNameChange(existingName);
+  }
+
+  /**
+   * Shows metadata of the resource.
+   * @returns template metadata.
+   */
+  public async show(): Promise<TemplateConfiguration> {
+    const templateMetadata = (await super.show()) as TemplateMetadata;
+    const container = this.templateObject();
+
+    return {
+      metadata: templateMetadata,
+      name: resourceNameToString(this.resourceName),
+      path: this.fileName,
+      numberOfCards: (await container.listCards()).length,
+    };
+  }
+
+  /**
+   * Returns template card container object.
+   * @returns template container object
+   */
+  public templateObject(): Template {
+    return this.cardContainer;
+  }
+
+  /**
+   * Updates template resource.
+   * @param key Key to modify
+   * @param op Operation to perform on 'key'
+   * @throws if key is unknown.
+   */
+  public async update<Type>(key: string, op: Operation<Type>) {
+    const nameChange = key === 'name';
+    const existingName = this.content.name;
+
+    await super.update(key, op);
+
+    const content = { ...(this.content as TemplateMetadata) };
+
+    if (key === 'name') {
+      content.name = super.handleScalar(op) as string;
+    } else if (key === 'displayName') {
+      content.displayName = super.handleScalar(op) as string;
+    } else if (key === 'description') {
+      content.description = super.handleScalar(op) as string;
+    } else if (key === 'category') {
+      content.category = super.handleScalar(op) as string;
+    } else {
+      throw new Error(`Unknown property '${key}' for Template`);
+    }
+
+    await super.postUpdate(content, key, op);
+
+    // Renaming this template causes that references to its name must be updated.
+    if (nameChange) {
+      await this.handleNameChange(existingName);
+    }
+  }
+
+  /**
+   * Validates template.
+   * @throws when there are validation errors.
+   * @param content Content to be validated.
+   * @note If content is not provided, base class validation will use resource's current content.
+   */
+  public async validate(content?: object) {
+    return super.validate(content);
+  }
+
+  /**
+   * Create the template's cards folder.
+   */
+  public async write() {
+    await super.write();
+
+    // Create folder for cards and put proper content schema file there
+    const schemaContentFile = join(this.cardsFolder, '.schema');
+    await mkdir(this.cardsFolder, { recursive: true });
+    if (!pathExists(schemaContentFile)) {
+      await writeJsonFile(schemaContentFile, this.cardsSchema, {
+        flag: 'wx',
+      });
+    }
+  }
+}

--- a/tools/data-handler/src/resources/workflow-resource.ts
+++ b/tools/data-handler/src/resources/workflow-resource.ts
@@ -17,7 +17,7 @@ import {
   WorkflowTransition,
 } from '../interfaces/resource-interfaces.js';
 import { CardTypeResource } from './card-type-resource.js';
-import { DefaultContent } from '../create-defaults.js';
+import { DefaultContent } from './create-defaults.js';
 import { ChangeOperation, FileResource, Operation } from './file-resource.js';
 import { Project, ResourcesFrom } from '../containers/project.js';
 import {
@@ -42,7 +42,6 @@ export class WorkflowResource extends FileResource {
   // When resource name changes.
   private async handleNameChange(existingName: string) {
     await Promise.all([
-      this.updateCardTypes(existingName),
       super.updateHandleBars(existingName, this.content.name),
       super.updateCalculations(existingName, this.content.name),
     ]);
@@ -74,13 +73,20 @@ export class WorkflowResource extends FileResource {
    */
   public async create(newContent?: Workflow) {
     if (!newContent) {
-      newContent = DefaultContent.workflowContent(
+      newContent = DefaultContent.workflow(
         resourceNameToString(this.resourceName),
       );
     } else {
       await this.validate(newContent);
     }
     return super.create(newContent);
+  }
+
+  /**
+   * Returns content data.
+   */
+  public get data(): Workflow {
+    return super.data as Workflow;
   }
 
   /**
@@ -146,6 +152,7 @@ export class WorkflowResource extends FileResource {
     // Renaming this workflow causes that references to its name must be updated.
     if (nameChange) {
       await this.handleNameChange(existingName);
+      await this.updateCardTypes(existingName);
     }
   }
 

--- a/tools/data-handler/src/utils/clingo-facts.ts
+++ b/tools/data-handler/src/utils/clingo-facts.ts
@@ -144,7 +144,7 @@ export const createCardFacts = async (card: Card, project: Project) => {
 
         if (!isPredefinedField(field)) {
           // field is a custom field, find it
-          const fieldType = await project.fieldType(field);
+          const fieldType = await project.resource<FieldType>(field);
           if (!fieldType) {
             continue;
           }

--- a/tools/data-handler/test/command-handler-create.test.ts
+++ b/tools/data-handler/test/command-handler-create.test.ts
@@ -12,7 +12,7 @@ import { fileURLToPath } from 'node:url';
 import { CardsOptions, Cmd, Commands } from '../src/command-handler.js';
 import { copyDir, deleteDir, resolveTilde } from '../src/utils/file-utils.js';
 import { Calculate } from '../src/calculate.js';
-import { DefaultContent } from '../src/create-defaults.js';
+import { DefaultContent } from '../src/resources/create-defaults.js';
 import { CardListContainer } from '../src/interfaces/project-interfaces.js';
 import { FieldTypeResource } from '../src/resources/field-type-resource.js';
 
@@ -324,7 +324,7 @@ describe('create command', () => {
       ['fieldTypes'],
       optionsMini,
     );
-    const fieldTypes = FieldTypeResource.fieldTypes();
+    const fieldTypes = FieldTypeResource.fieldDataTypes();
     for (const fieldType of fieldTypes) {
       const name = `ft_${fieldType}`;
       const result = await commandHandler.command(
@@ -710,7 +710,7 @@ describe('create command', () => {
       optionsMini,
     );
     const templateName = 'template-name_first';
-    const templateContent = '{}';
+    const templateContent = '';
     const result = await commandHandler.command(
       Cmd.create,
       ['template', templateName, templateContent],
@@ -726,7 +726,7 @@ describe('create command', () => {
   it('template with "local"', async () => {
     // local is no longer a valid name part.
     const templateName = 'local/templates/template-name_second';
-    const templateContent = '{}';
+    const templateContent = '';
     const result = await commandHandler.command(
       Cmd.create,
       ['template', templateName, templateContent],
@@ -735,7 +735,7 @@ describe('create command', () => {
     expect(result.statusCode).to.equal(400);
   });
   it('template with default parameters (success)', async () => {
-    const templateName = 'validname';
+    const templateName = 'validName';
     const templateContent = '';
     const result = await commandHandler.command(
       Cmd.create,
@@ -766,7 +766,7 @@ describe('create command', () => {
   });
   it('template with "loc"', async () => {
     const templateName = 'loc/templates/template-name_second';
-    const templateContent = '{}';
+    const templateContent = '';
     const result = await commandHandler.command(
       Cmd.create,
       ['template', templateName, templateContent],
@@ -776,7 +776,7 @@ describe('create command', () => {
   });
   it('template with "123"', async () => {
     const templateName = 'loc/123';
-    const templateContent = '{}';
+    const templateContent = '';
     const result = await commandHandler.command(
       Cmd.create,
       ['template', templateName, templateContent],
@@ -786,7 +786,7 @@ describe('create command', () => {
   });
   it('template invalid project', async () => {
     const templateName = 'validName';
-    const templateContent = '{}';
+    const templateContent = '';
     const invalidOptions = { projectPath: join(testDir, 'no-such-project') };
     const result = await commandHandler.command(
       Cmd.create,
@@ -797,7 +797,7 @@ describe('create command', () => {
   });
   it('template invalid template name', async () => {
     const templateName = 'aux';
-    const templateContent = '{}';
+    const templateContent = '';
     const result = await commandHandler.command(
       Cmd.create,
       ['template', templateName, templateContent],
@@ -807,7 +807,7 @@ describe('create command', () => {
   });
   it('template already exists', async () => {
     const templateName = 'decision/templates/decision';
-    const templateContent = '{}';
+    const templateContent = '';
     const result = await commandHandler.command(
       Cmd.create,
       ['template', templateName, templateContent],
@@ -934,13 +934,13 @@ describe('create command', () => {
     expect(result.statusCode).to.equal(400);
   });
   it('access default parameters for template (success)', () => {
-    const defaultContent = DefaultContent.templateContent('testName');
+    const defaultContent = DefaultContent.template('testName');
     expect(defaultContent.displayName).to.equal(undefined);
     expect(defaultContent.category).to.equal(undefined);
     expect(defaultContent.description).to.equal(undefined);
   });
   it('access default parameters for workflow (success)', () => {
-    const defaultContent = DefaultContent.workflowContent('test');
+    const defaultContent = DefaultContent.workflow('test');
     expect(defaultContent.name).to.equal('test');
     expect(defaultContent.states.length).to.equal(3);
     expect(defaultContent.transitions.length).to.equal(3);

--- a/tools/data-handler/test/show.test.ts
+++ b/tools/data-handler/test/show.test.ts
@@ -253,28 +253,28 @@ describe('show', () => {
     const results = await showCmd.showProject();
     expect(results).to.not.equal(undefined);
   });
-  it('showTemplate (success)', async () => {
+  it('showResource - template (success)', async () => {
     const templateName = 'decision/templates/decision';
-    const results = await showCmd.showTemplate(templateName);
+    const results = await showCmd.showResource(templateName);
     expect(results).to.not.equal(undefined);
   });
-  it('showTemplate - empty template name', async () => {
+  it('showResource - template with no name', async () => {
     const templateName = '';
     await showCmd
-      .showTemplate(templateName)
+      .showResource(templateName)
       .catch((error) =>
         expect(errorFunction(error)).to.equal(
-          `Template '' does not exist in the project`,
+          `Must define resource name to query its details`,
         ),
       );
   });
-  it('showTemplate - template does not exist in project', async () => {
+  it('showResource - template does not exist in project', async () => {
     const templateName = 'i-do-not-exist';
     await showCmd
-      .showTemplate(templateName)
+      .showResource(templateName)
       .catch((error) =>
         expect(errorFunction(error)).to.equal(
-          `Template 'i-do-not-exist' does not exist in the project`,
+          `Unsupported resource type '${templateName}'`,
         ),
       );
   });

--- a/tools/data-handler/test/template.test.ts
+++ b/tools/data-handler/test/template.test.ts
@@ -10,7 +10,9 @@ import { fileURLToPath } from 'node:url';
 import { Card, FileContentType } from '../src/interfaces/project-interfaces.js';
 import { copyDir } from '../src/utils/file-utils.js';
 import { Project } from '../src/containers/project.js';
+import { resourceName } from '../src/utils/resource-utils.js';
 import { Template } from '../src/containers/template.js';
+import { TemplateResource } from '../src/resources/template-resource.js';
 
 // Create test artifacts in a temp directory.
 const baseDir = dirname(fileURLToPath(import.meta.url));
@@ -163,13 +165,27 @@ describe('template', () => {
     expect(attachments.length).to.equal(0);
   });
   it('check that template does not exist, then create it', async () => {
-    const templateName = 'idontexistyet';
-    const template = new Template(project, { name: templateName, path: '' });
+    const templateName = 'decision/templates/idontexistyet';
+    const template = new Template(project, {
+      name: templateName,
+      path: '',
+    });
 
     expect(template.isCreated()).to.equal(false);
-    const success = await template.create({ name: templateName });
+
+    const templateResource = new TemplateResource(
+      project,
+      resourceName('decision/templates/idontexistyet'),
+    );
+    await templateResource
+      .create()
+      .then(() => {
+        expect(true);
+      })
+      .catch(() => {
+        expect(false);
+      });
     expect(template.isCreated()).to.equal(true);
-    expect(success).to.not.equal(undefined);
   });
   it('check template paths', async () => {
     const template = new Template(project, {
@@ -251,7 +267,10 @@ describe('template', () => {
     }
   });
   it('try to add card to a template that does not exist on disk', async () => {
-    const template = new Template(project, { name: 'i-dont-exist', path: '' });
+    const template = new Template(project, {
+      name: 'i-dont-exist',
+      path: '',
+    });
 
     await template
       .addCard('decision/cardTypes/decision')
@@ -365,13 +384,10 @@ describe('template', () => {
     expect(existingCard).to.not.equal(undefined);
   });
   it('show template details', async () => {
-    const template = new Template(project, {
-      name: 'decision/templates/decision',
-      path: '',
-    });
-
-    const templateProject = template.templateProject;
-    expect(templateProject).to.equal(project);
+    const template = new TemplateResource(
+      project,
+      resourceName('decision/templates/decision'),
+    );
 
     const templateDetails = await template.show();
     expect(templateDetails.name).to.equal('decision/templates/decision');

--- a/tools/data-handler/test/test-data/invalid/invalid-card-has-wrong-state/cardRoot/decision_7/index.json
+++ b/tools/data-handler/test/test-data/invalid/invalid-card-has-wrong-state/cardRoot/decision_7/index.json
@@ -1,5 +1,5 @@
 {
-    "cardType": "decision/cardtTypes/decisionWrongWF",
+    "cardType": "decision/cardTypes/decisionWrongWF",
     "title": "Decision Records",
     "workflowState": "Draft",
     "decision/fieldTypes/obsoletedBy": null,

--- a/tools/schema/cardTreeDirectorySchema.json
+++ b/tools/schema/cardTreeDirectorySchema.json
@@ -627,7 +627,9 @@
               "additionalProperties": false,
               "patternProperties": {
                 "^[A-Za-z-_]+.json$": {
-                  "type": "object"
+                  "type": "object",
+                  "$comment": "Each file needs to be separately validated against 'contentSchema'",
+                  "contentSchema": "templateSchema.json"
                 },
                 "^.schema$": {
                   "type": "object"

--- a/tools/schema/templateSchema.json
+++ b/tools/schema/templateSchema.json
@@ -23,5 +23,6 @@
       "description": "The category of the template. For example, 'Decision'.",
       "type": "string"
     }
-  }
+  },
+  "required": ["name"]
 }


### PR DESCRIPTION
Change 'report' and 'template' to the new resource-system.

Additionally, replace all of the code that was related to old resource-system with new kinds of implementations. Remove all remnants from the old system.

Additionally, re-implement "rename" command using resources, instead of command reading and writing JSON files.