### PR TITLE
INTDEV-670 Remove use-resize-observer and fix scroll bug

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,9 +149,6 @@ importers:
       swr:
         specifier: ^2.2.5
         version: 2.2.5(react@18.3.1)
-      use-resize-observer:
-        specifier: ^9.1.0
-        version: 9.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.4.2
@@ -957,9 +954,6 @@ packages:
 
   '@jsdevtools/ono@7.1.3':
     resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
-
-  '@juggle/resize-observer@3.4.0':
-    resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
 
   '@lezer/common@1.2.3':
     resolution: {integrity: sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==}
@@ -2102,9 +2096,6 @@ packages:
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
-
-  cliui@7.0.4:
-    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -5029,12 +5020,6 @@ packages:
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
-  use-resize-observer@9.1.0:
-    resolution: {integrity: sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==}
-    peerDependencies:
-      react: 16.8.0 - 18
-      react-dom: 16.8.0 - 18
-
   use-sync-external-store@1.2.2:
     resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
     peerDependencies:
@@ -6184,8 +6169,6 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.0
 
   '@jsdevtools/ono@7.1.3': {}
-
-  '@juggle/resize-observer@3.4.0': {}
 
   '@lezer/common@1.2.3': {}
 
@@ -11149,12 +11132,6 @@ snapshots:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
-
-  use-resize-observer@9.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@juggle/resize-observer': 3.4.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
 
   use-sync-external-store@1.2.2(react@18.3.1):
     dependencies:

--- a/tools/app/__tests__/components.test.tsx
+++ b/tools/app/__tests__/components.test.tsx
@@ -7,21 +7,21 @@ import { WorkflowCategory } from '../../data-handler/src/interfaces/resource-int
 import { useTranslation } from 'react-i18next';
 import { QueryResult } from '@cyberismocom/data-handler/types/queries';
 
-// mock resize observer
-global.ResizeObserver = class {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
-};
-
-// mock useAppRouter
-
-jest.mock('../app/lib/hooks', () => ({
-  useAppRouter: jest.fn(() => ({
-    push: jest.fn(),
-  })),
-}));
-
+// mock useAppRouter and useResizeObserver
+jest.mock('../app/lib/hooks', () => {
+  let callCount = 0;
+  return {
+    useAppRouter: jest.fn(() => ({
+      push: jest.fn(),
+    })),
+    useResizeObserver: jest.fn(() => {
+      if (callCount++ % 2 === 0) {
+        return { width: 800, height: 2000, ref: jest.fn() }; // Main container height
+      }
+      return { width: 800, height: 50, ref: jest.fn() }; // Title bar height
+    }),
+  };
+});
 jest.mock('react-i18next', () => ({
   useTranslation: jest.fn(),
 }));

--- a/tools/app/app/components/TreeMenu.tsx
+++ b/tools/app/app/components/TreeMenu.tsx
@@ -16,11 +16,10 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { getStateColor } from '../lib/utils';
 import { Box, Chip, Stack, Typography } from '@mui/joy';
 import { Tree, NodeRendererProps, NodeApi, TreeApi } from 'react-arborist';
-import useResizeObserver from 'use-resize-observer';
 import { FiberManualRecord } from '@mui/icons-material';
 import { QueryResult } from '@cyberismocom/data-handler/types/queries';
 import Link from 'next/link';
-
+import { useResizeObserver } from '../lib/hooks';
 type TreeMenuProps = {
   title: string;
   selectedCardKey: string | null;
@@ -129,8 +128,9 @@ export const TreeMenu: React.FC<TreeMenuProps> = ({
   onCardSelect,
   tree,
 }) => {
-  const { ref, width, height } = useResizeObserver();
   const treeRef = useRef();
+  const { width, height, ref } = useResizeObserver();
+  const { height: titleHeight, ref: titleRef } = useResizeObserver();
 
   useEffect(() => {
     // unfortunately react arborist does not provide a type for the ref
@@ -147,8 +147,9 @@ export const TreeMenu: React.FC<TreeMenuProps> = ({
       bgcolor="#f0f0f0"
       height="100%"
       width="100%"
+      ref={ref}
     >
-      <Link href="/cards" style={{ textDecoration: 'none' }}>
+      <Link href="/cards" style={{ textDecoration: 'none' }} ref={titleRef}>
         <Typography level="h4" marginBottom={2}>
           {title}
         </Typography>
@@ -157,7 +158,6 @@ export const TreeMenu: React.FC<TreeMenuProps> = ({
         sx={{
           flexGrow: 1,
         }}
-        ref={ref}
       >
         <Tree
           ref={treeRef}
@@ -166,8 +166,8 @@ export const TreeMenu: React.FC<TreeMenuProps> = ({
           idAccessor={(node) => node.key}
           childrenAccessor="children"
           indent={16}
-          width={(width || 0) - 1}
-          height={height}
+          width={width}
+          height={height - titleHeight}
           rowHeight={28}
           onMove={(n) => {
             if (onMove && n.dragIds.length === 1) {

--- a/tools/app/app/lib/hooks/utils.ts
+++ b/tools/app/app/lib/hooks/utils.ts
@@ -10,7 +10,7 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { useMemo } from 'react';
+import { useMemo, useEffect, useState, useRef, useCallback } from 'react';
 import { findParentCard } from '../utils';
 import { useTree } from '../api';
 
@@ -42,4 +42,37 @@ export function createFunctionGuard<T extends unknown[], U>(
       return fn(...args);
     }
   };
+}
+/**
+ * This hook is used to observe the size of a DOM element.
+ * @returns the width and height of the element and a ref to be attached to the element
+ */
+export function useResizeObserver() {
+  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+  const [node, setNode] = useState<HTMLElement | null>(null);
+
+  const callbackRef = useCallback((node: HTMLElement | null) => {
+    setNode(node);
+  }, []);
+
+  useEffect(() => {
+    if (!node) return;
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      setDimensions({
+        width: entry.contentRect.width,
+        height: entry.contentRect.height,
+      });
+    });
+
+    observer.observe(node);
+
+    return () => {
+      observer.unobserve(node);
+      observer.disconnect();
+    };
+  }, [node]);
+
+  return { ...dimensions, ref: callbackRef };
 }

--- a/tools/app/package.json
+++ b/tools/app/package.json
@@ -46,8 +46,7 @@
     "react-redux": "^9.1.2",
     "react-resizable-panels": "^2.1.6",
     "redux-persist": "^6.0.0",
-    "swr": "^2.2.5",
-    "use-resize-observer": "^9.1.0"
+    "swr": "^2.2.5"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.2",


### PR DESCRIPTION
We took the reference for use-resize-observer from the wrong object so I fixed it. Also removed the use-resize-observer dependency, because it was fairly easy to do for our case and the module does not support React 19 #138 