### PR TITLE
Fix: Fetch report data correctly for macros

### DIFF
--- a/tools/data-handler/src/macros/report/index.ts
+++ b/tools/data-handler/src/macros/report/index.ts
@@ -20,7 +20,8 @@ import Handlebars from 'handlebars';
 import BaseMacro from '../base-macro.js';
 import { validateJson } from '../../utils/validate.js';
 import TaskQueue from '../task-queue.js';
-import { Report } from '../../interfaces/resource-interfaces.js';
+import { ReportResource } from '../../resources/report-resource.js';
+import { resourceName } from '../../utils/resource-utils.js';
 
 export interface ReportOptions extends Record<string, string> {
   name: string;
@@ -43,7 +44,8 @@ class ReportMacro extends BaseMacro {
     console.log(options);
 
     const project = new Project(context.projectPath);
-    const report = await project.resource<Report>(options.name);
+    const resource = new ReportResource(project, resourceName(options.name));
+    const report = await resource.show();
 
     if (!report) throw new Error(`Report ${options} does not exist`);
 

--- a/tools/data-handler/src/resources/file-resource.ts
+++ b/tools/data-handler/src/resources/file-resource.ts
@@ -73,10 +73,16 @@ export class FileResource extends ResourceObject {
       this.resourceName.prefix = this.project.projectPrefix;
     }
     if (this.type) {
-      this.resourceFolder = this.project.paths.resourcePath(this.type);
-      this.fileName = resourceNameToPath(this.project, this.resourceName);
       this.moduleResource =
         this.resourceName.prefix !== this.project.projectPrefix;
+      this.resourceFolder = this.moduleResource
+        ? join(
+            this.project.paths.modulesFolder,
+            this.resourceName.prefix,
+            this.resourceName.type,
+          )
+        : this.project.paths.resourcePath(this.type);
+      this.fileName = resourceNameToPath(this.project, this.resourceName);
     }
     if (pathExists(this.fileName)) {
       this.content = readJsonFileSync(this.fileName);

--- a/tools/data-handler/test/resources.test.ts
+++ b/tools/data-handler/test/resources.test.ts
@@ -987,6 +987,56 @@ describe('resources', () => {
         }),
       );
     });
+    // Tests that report data can be shown from a module; ensures that
+    // all report files are reachable; even if their content is not validated.
+    it('show imported report', async () => {
+      const projectMini = new Project(minimalPath);
+      const calculateCmdMini = new Calculate(projectMini);
+      const createCmdMini = new Create(projectMini, calculateCmdMini);
+      const importCmdMini = new Import(projectMini, createCmdMini);
+      const collectorMini = new ResourceCollector(projectMini);
+      await importCmdMini.importProject(
+        decisionRecordsPath,
+        projectMini.basePath,
+      );
+      await collectorMini.moduleImported();
+      const res = new ReportResource(
+        projectMini,
+        resourceName('decision/reports/newREP'),
+      );
+      const data = await res.show();
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { contentTemplate, queryTemplate, ...others } = data;
+      expect(JSON.stringify(others)).to.equal(
+        JSON.stringify({
+          name: 'decision/reports/newREP',
+          metadata: {
+            name: 'decision/reports/newREP',
+            displayName: '',
+            description: '',
+            category: 'Uncategorised report',
+          },
+          schema: {
+            title: 'Report',
+            $id: 'reportMacroDefaultSchema',
+            description:
+              'A report object provides supplemental information about a report',
+            type: 'object',
+            properties: {
+              name: { description: 'The name of the report', type: 'string' },
+              cardKey: {
+                description:
+                  'Used to override the default cardKey, which is the cardKey of the card, in which the report macro is used',
+                type: 'string',
+              },
+            },
+            additionalProperties: false,
+            required: ['name'],
+          },
+        }),
+      );
+    });
+
     it('show template', async () => {
       const res = new TemplateResource(
         project,


### PR DESCRIPTION
Report resource is required to have its "auxiliary" data (schema et al) when it is instantiated within macros.

Second; the inner paths of module resources were set incorrectly; they always pointed to local resource folders.

Added also unit test that imported `report` can be shown and there are no errors.