### PR TITLE
INTDEV-751 Rename writes garbage to card type JSON files

### DIFF
--- a/tools/data-handler/src/resources/card-type-resource.ts
+++ b/tools/data-handler/src/resources/card-type-resource.ts
@@ -146,11 +146,12 @@ export class CardTypeResource extends FileResource {
       current.workflow,
       prefixes,
     );
-    await this.write(); // update own JSON immediately
     await Promise.all([
       super.updateHandleBars(existingName, this.content.name),
       super.updateCalculations(existingName, this.content.name),
     ]);
+    // Finally, write updated content.
+    await this.write();
   }
 
   // When a field is removed, remove it from all affected cards.

--- a/tools/data-handler/src/resources/field-type-resource.ts
+++ b/tools/data-handler/src/resources/field-type-resource.ts
@@ -46,6 +46,8 @@ export class FieldTypeResource extends FileResource {
       super.updateHandleBars(existingName, this.content.name),
       super.updateCalculations(existingName, this.content.name),
     ]);
+    // Finally, write updated content.
+    await this.write();
   }
 
   // Update dependant card types

--- a/tools/data-handler/src/resources/file-resource.ts
+++ b/tools/data-handler/src/resources/file-resource.ts
@@ -229,7 +229,6 @@ export class FileResource extends ResourceObject {
 
     this.fileName = newFilename;
     this.content.name = resourceNameToString(newName);
-    this.write();
   }
 
   // Show resource data as JSON.

--- a/tools/data-handler/src/resources/link-type-resource.ts
+++ b/tools/data-handler/src/resources/link-type-resource.ts
@@ -43,11 +43,12 @@ export class LinkTypeResource extends FileResource {
         this.updatePrefixInResourceName(item, prefixes),
       );
     }
-    await this.write();
     await Promise.all([
       super.updateHandleBars(existingName, this.content.name),
       super.updateCalculations(existingName, this.content.name),
     ]);
+    // Finally, write updated content.
+    await this.write();
   }
 
   /**
@@ -86,7 +87,7 @@ export class LinkTypeResource extends FileResource {
   public async rename(newName: ResourceName) {
     const existingName = this.content.name;
     await super.rename(newName);
-    await this.handleNameChange(existingName);
+    return this.handleNameChange(existingName);
   }
 
   /**

--- a/tools/data-handler/src/resources/report-resource.ts
+++ b/tools/data-handler/src/resources/report-resource.ts
@@ -63,6 +63,8 @@ export class ReportResource extends FolderResource {
       ),
       super.updateCalculations(existingName, this.content.name),
     ]);
+    // Finally, write updated content.
+    await this.write();
   }
 
   /**

--- a/tools/data-handler/src/resources/template-resource.ts
+++ b/tools/data-handler/src/resources/template-resource.ts
@@ -55,6 +55,8 @@ export class TemplateResource extends FolderResource {
       super.updateHandleBars(existingName, this.content.name),
       super.updateCalculations(existingName, this.content.name),
     ]);
+    // Finally, write updated content.
+    await this.write();
   }
 
   /**

--- a/tools/data-handler/src/resources/workflow-resource.ts
+++ b/tools/data-handler/src/resources/workflow-resource.ts
@@ -45,6 +45,8 @@ export class WorkflowResource extends FileResource {
       super.updateHandleBars(existingName, this.content.name),
       super.updateCalculations(existingName, this.content.name),
     ]);
+    // Finally, write updated content.
+    await this.write();
   }
 
   // Update dependant card types.


### PR DESCRIPTION
Renaming a project causes all resources to rename themselves. 

The faulty implementation wrote JSON file in the middle of operation and then wrote it again at the end of the operation. 
Since file operations are done with threads in nodeJS, this caused a race-condition in which the other write yielded some garbage to the file. 

Fixed by removing the "middle" write. Resource JSON is written after all operations related to renaming have been finished.