### PR TITLE
INTDEV-649 Remove outdated CardOptions values

### DIFF
--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -40,8 +40,6 @@ import { errorFunction } from './utils/log-utils.js';
 // Generic options interface
 export interface CardsOptions {
   details?: boolean;
-  format?: string;
-  output?: string;
   projectPath?: string;
   repeat?: number;
 }


### PR DESCRIPTION
Values 'format' and 'output' are no longer used, so remove them.