### PR TITLE
Fix disappearing tree

### DIFF
--- a/tools/app/app/components/TreeMenu.tsx
+++ b/tools/app/app/components/TreeMenu.tsx
@@ -154,30 +154,24 @@ export const TreeMenu: React.FC<TreeMenuProps> = ({
           {title}
         </Typography>
       </Link>
-      <Box
-        sx={{
-          flexGrow: 1,
+      <Tree
+        ref={treeRef}
+        data={tree}
+        openByDefault={false}
+        idAccessor={(node) => node.key}
+        childrenAccessor="children"
+        indent={16}
+        width={width}
+        height={height && titleHeight ? height - titleHeight : undefined}
+        rowHeight={28}
+        onMove={(n) => {
+          if (onMove && n.dragIds.length === 1) {
+            onMove(n.dragIds[0], n.parentId ?? 'root', n.index);
+          }
         }}
       >
-        <Tree
-          ref={treeRef}
-          data={tree}
-          openByDefault={false}
-          idAccessor={(node) => node.key}
-          childrenAccessor="children"
-          indent={16}
-          width={width}
-          height={height - titleHeight}
-          rowHeight={28}
-          onMove={(n) => {
-            if (onMove && n.dragIds.length === 1) {
-              onMove(n.dragIds[0], n.parentId ?? 'root', n.index);
-            }
-          }}
-        >
-          {RenderTree(onCardSelect)}
-        </Tree>
-      </Box>
+        {RenderTree(onCardSelect)}
+      </Tree>
     </Stack>
   );
 };

--- a/tools/app/app/lib/hooks/utils.ts
+++ b/tools/app/app/lib/hooks/utils.ts
@@ -10,7 +10,7 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { useMemo, useEffect, useState, useRef, useCallback } from 'react';
+import { useMemo, useEffect, useState, useCallback } from 'react';
 import { findParentCard } from '../utils';
 import { useTree } from '../api';
 
@@ -71,7 +71,10 @@ function getEntryValue(entry: ResizeObserverEntry, value: 'width' | 'height') {
  * @returns the width and height of the element and a ref to be attached to the element
  */
 export function useResizeObserver() {
-  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+  const [dimensions, setDimensions] = useState({
+    width: undefined,
+    height: undefined,
+  });
   const [node, setNode] = useState<HTMLElement | null>(null);
 
   const callbackRef = useCallback((node: HTMLElement | null) => {
@@ -82,12 +85,10 @@ export function useResizeObserver() {
     if (!node) return;
 
     const observer = new ResizeObserver((entries) => {
-      requestAnimationFrame(() => {
-        const entry = entries[0];
-        setDimensions({
-          width: getEntryValue(entry, 'width'),
-          height: getEntryValue(entry, 'height'),
-        });
+      const entry = entries[0];
+      setDimensions({
+        width: getEntryValue(entry, 'width'),
+        height: getEntryValue(entry, 'height'),
       });
     });
 
@@ -99,5 +100,7 @@ export function useResizeObserver() {
     };
   }, [node]);
 
-  return { ...dimensions, ref: callbackRef };
+  return useMemo(() => {
+    return { ...dimensions, ref: callbackRef };
+  }, [dimensions, callbackRef]);
 }

--- a/tools/app/cypress/e2e/app.cy.ts
+++ b/tools/app/cypress/e2e/app.cy.ts
@@ -87,7 +87,7 @@ describe('Navigation', () => {
     cy.get('[id="moveCardButton"]').click(); // Select Move option
 
     cy.get('button').contains(t['all']).click(); // Select All in Move dialog
-    cy.get('[role="dialog"] >>>>>>>>> [role="treeitem"]')
+    cy.get('[role="dialog"] >>>>>>>> [role="treeitem"]')
       .contains('Untitled page')
       .click(); // Select Untitled page
     cy.get('[role="dialog"] >>> button').contains(t['cancel']);


### PR DESCRIPTION
Looks like the issue was actually not in the resizeobserver. At the same time we also changed the treeview so that it contains two use-resize-observer calls and setting height to 0 seemed to cause issues. Fixed it by setting height to undefined if it is not yet available.

Tested with Chrome and Firefox