### PR TITLE
INTDEV-578 Do not allow 'remove' when resource is in use

### DIFF
--- a/tools/data-handler/src/containers/card-container.ts
+++ b/tools/data-handler/src/containers/card-container.ts
@@ -236,7 +236,12 @@ export class CardContainer {
     details: FetchCardDetails = {},
     directChildrenOnly: boolean = false,
   ): Promise<Card[]> {
-    const entries = await readdir(path, { withFileTypes: true });
+    let entries = [];
+    try {
+      entries = await readdir(path, { withFileTypes: true });
+    } catch {
+      return cards;
+    }
     let finish = false;
     const currentPaths: string[] = [];
 

--- a/tools/data-handler/src/resources/folder-resource.ts
+++ b/tools/data-handler/src/resources/folder-resource.ts
@@ -13,13 +13,29 @@
 import { join } from 'node:path';
 import { mkdir, rm } from 'node:fs/promises';
 
-import { FileResource, Operation } from './file-resource.js';
-import { Project } from '../containers/project.js';
-import { ResourceContent } from '../interfaces/resource-interfaces.js';
 import { ResourceFolderType } from '../interfaces/project-interfaces.js';
-import { ResourceName } from '../utils/resource-utils.js';
+import {
+  Card,
+  DefaultContent,
+  FileResource,
+  Operation,
+  Project,
+  ResourceName,
+  resourceNameToString,
+  sortCards,
+} from './file-resource.js';
+import { ResourceContent } from '../interfaces/resource-interfaces.js';
 
-export { type Operation };
+export {
+  Card,
+  DefaultContent,
+  FileResource,
+  type Operation,
+  Project,
+  ResourceName,
+  resourceNameToString,
+  sortCards,
+};
 
 /**
  * Folder type resource class. These are resources that have their own folders for content.
@@ -51,8 +67,8 @@ export class FolderResource extends FileResource {
    * Deletes file(s) from disk and clears out the memory resident object.
    */
   protected async delete() {
+    await super.delete();
     await rm(this.internalFolder, { recursive: true, force: true });
-    return super.delete();
   }
 
   protected initialize(): void {
@@ -87,6 +103,15 @@ export class FolderResource extends FileResource {
    */
   protected async update<Type>(key: string, op: Operation<Type>) {
     return super.update(key, op);
+  }
+
+  /**
+   * Returns an array of card keys, and/or resource names where this resource is used.
+   * @param cards Optional. If defined, only these cards are checked.
+   * @returns an array of card keys, and/or resource names where this resource is used.
+   */
+  protected async usage(cards?: Card[]): Promise<string[]> {
+    return super.usage(cards);
   }
 
   /**

--- a/tools/data-handler/src/resources/resource-object.ts
+++ b/tools/data-handler/src/resources/resource-object.ts
@@ -17,9 +17,9 @@ import { readFile, writeFile } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 
 import { ArrayHandler } from './array-handler.js';
+import { Card, ResourceFolderType } from '../interfaces/project-interfaces.js';
 import { Project, ResourcesFrom } from '../containers/project.js';
 import { ResourceContent } from '../interfaces/resource-interfaces.js';
-import { ResourceFolderType } from '../interfaces/project-interfaces.js';
 import { ResourceName } from '../utils/resource-utils.js';
 
 // Possible operations to perform when doing "update"
@@ -74,6 +74,7 @@ export abstract class AbstractResource {
     key: string,
     operation: Operation<Type>,
   ): Promise<void>; // change one key of resource
+  protected abstract usage(cards?: Card[]): Promise<string[]>; // list of card keys or resource names where this resource is used in
   protected abstract validate(content?: object): Promise<void>; // validate the content
   protected abstract write(): Promise<void>; // write content to disk
 }
@@ -106,6 +107,9 @@ export class ResourceObject extends AbstractResource {
     return {} as ResourceContent;
   }
   protected async update<Type>(_key: string, _op: Operation<Type>) {}
+  protected async usage(_cards?: Card[]): Promise<string[]> {
+    return [];
+  }
   protected async validate(_content?: object) {}
   protected async write() {}
 

--- a/tools/data-handler/src/utils/card-utils.ts
+++ b/tools/data-handler/src/utils/card-utils.ts
@@ -1,0 +1,38 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * Sorts array of cards first using prefix and then using ID.
+ * Prefixes are returned in alphabetical order, and then in numeric order within same prefix.
+ * For example, test_za1, test_aa7 and demo_aaa are sorted to: demo_aaa, test_aa7, test_za1.
+ * @param a First card to be sorted
+ * @param b Second card to be sorted
+ * @returns Cards ordered; first by prefixes, then by ID.
+ */
+export const sortCards = (a: string, b: string) => {
+  const aParts = a.split('_');
+  const bParts = b.split('_');
+  if (aParts[0] !== bParts[0]) {
+    if (aParts[0] > bParts[0]) return 1;
+    if (aParts[0] < bParts[0]) return -1;
+    return 0;
+  }
+  if (a.length > b.length) {
+    return 1;
+  }
+  if (a.length < b.length) {
+    return -1;
+  }
+  if (aParts[1] > bParts[1]) return 1;
+  if (aParts[1] < bParts[1]) return -1;
+  return 0;
+};

--- a/tools/data-handler/test/command-handler-remove.test.ts
+++ b/tools/data-handler/test/command-handler-remove.test.ts
@@ -206,8 +206,16 @@ describe('remove command', () => {
       expect(result.statusCode).to.equal(200);
     });
     it('remove cardType (success)', async () => {
-      const cardTypeName = 'decision/cardTypes/decision';
-      const result = await commandHandler.command(
+      // First create a cardType, then remove it
+      const name = 'testForCreation';
+      const workflow = 'decision/workflows/decision';
+      let result = await commandHandler.command(
+        Cmd.create,
+        ['cardType', name, workflow],
+        options,
+      );
+      const cardTypeName = `decision/cardTypes/${name}`;
+      result = await commandHandler.command(
         Cmd.remove,
         ['cardType', cardTypeName],
         options,
@@ -215,8 +223,16 @@ describe('remove command', () => {
       expect(result.statusCode).to.equal(200);
     });
     it('remove fieldType (success)', async () => {
-      const fieldTypeName = 'decision/fieldTypes/finished';
-      const result = await commandHandler.command(
+      // First create a fieldType, then remove it
+      const name = 'testForCreation';
+      const dataType = 'integer';
+      let result = await commandHandler.command(
+        Cmd.create,
+        ['fieldType', name, dataType],
+        options,
+      );
+      const fieldTypeName = `decision/fieldTypes/${name}`;
+      result = await commandHandler.command(
         Cmd.remove,
         ['fieldType', fieldTypeName],
         options,
@@ -224,8 +240,15 @@ describe('remove command', () => {
       expect(result.statusCode).to.equal(200);
     });
     it('remove report (success)', async () => {
-      const report = 'decision/reports/testReport';
-      const result = await commandHandler.command(
+      // First create a report, then remove it
+      const name = 'testForCreation';
+      let result = await commandHandler.command(
+        Cmd.create,
+        ['report', name],
+        options,
+      );
+      const report = `decision/reports/${name}`;
+      result = await commandHandler.command(
         Cmd.remove,
         ['report', report],
         options,
@@ -242,13 +265,29 @@ describe('remove command', () => {
       expect(result.statusCode).to.equal(200);
     });
     it('remove workflow (success)', async () => {
-      const workflowName = 'decision/workflows/decision';
-      const result = await commandHandler.command(
+      // First create a workflow, then remove it
+      const name = 'testForCreation';
+      let result = await commandHandler.command(
+        Cmd.create,
+        ['workflow', name],
+        options,
+      );
+      const workflowName = `decision/workflows/${name}`;
+      result = await commandHandler.command(
         Cmd.remove,
         ['workflow', workflowName],
         options,
       );
       expect(result.statusCode).to.equal(200);
+    });
+    it('try to remove workflow that this is still used', async () => {
+      const workflowName = `decision/workflows/decision`;
+      const result = await commandHandler.command(
+        Cmd.remove,
+        ['workflow', workflowName],
+        options,
+      );
+      expect(result.statusCode).to.equal(400);
     });
     // todo: at some point move to own test file
     it('Remove - remove card (success)', async () => {

--- a/tools/data-handler/test/resources.test.ts
+++ b/tools/data-handler/test/resources.test.ts
@@ -1956,7 +1956,7 @@ describe('resources', () => {
     it('try to delete link type that does not exist', async () => {
       const name = 'decision/linkTypes/nonExisting';
       const res = new LinkTypeResource(project, resourceName(name));
-      const before = await project.cardTypes();
+      const before = await project.linkTypes();
       const found = before.find((item) => item.name === name);
       expect(found).to.equal(undefined);
       await res
@@ -1971,7 +1971,7 @@ describe('resources', () => {
     it('try to delete report that does not exist', async () => {
       const name = 'decision/reports/nonExisting';
       const res = new ReportResource(project, resourceName(name));
-      const before = await project.cardTypes();
+      const before = await project.reports();
       const found = before.find((item) => item.name === name);
       expect(found).to.equal(undefined);
       await res
@@ -1986,7 +1986,7 @@ describe('resources', () => {
     it('try to delete template that does not exist', async () => {
       const name = 'decision/templates/nonExisting';
       const res = new TemplateResource(project, resourceName(name));
-      const before = await project.cardTypes();
+      const before = await project.templates();
       const found = before.find((item) => item.name === name);
       expect(found).to.equal(undefined);
       await res
@@ -2001,7 +2001,7 @@ describe('resources', () => {
     it('try to delete workflow that does not exist', async () => {
       const name = 'decision/workflows/nonExisting';
       const res = new WorkflowResource(project, resourceName(name));
-      const before = await project.cardTypes();
+      const before = await project.workflows();
       const found = before.find((item) => item.name === name);
       expect(found).to.equal(undefined);
       await res
@@ -2011,6 +2011,69 @@ describe('resources', () => {
           expect(error.message).to.equal(
             `Resource 'nonExisting' does not exist in the project`,
           ),
+        );
+    });
+    it('try to check usage of nonExisting resource', async () => {
+      const name = 'decision/workflows/nonExisting';
+      const res = new WorkflowResource(project, resourceName(name));
+      const before = await project.workflows();
+      const found = before.find((item) => item.name === name);
+      expect(found).to.equal(undefined);
+      await res
+        .usage()
+        .then(() => expect(false).to.equal(true))
+        .catch((error) =>
+          expect(error.message).to.equal(
+            `Resource 'nonExisting' does not exist in the project`,
+          ),
+        );
+    });
+    it('check usage of cardType resource', async () => {
+      const name = 'decision/cardTypes/decision';
+      const res = new CardTypeResource(project, resourceName(name));
+      await res.usage().then((references) => {
+        expect(references).to.include('decision_1');
+        expect(references).to.include('decision_6');
+        expect(references).to.include('decision/linkTypes/testTypes');
+      });
+    });
+    it('check usage of fieldType resource', async () => {
+      const name = 'decision/fieldTypes/finished';
+      const res = new FieldTypeResource(project, resourceName(name));
+      await res
+        .usage()
+        .then((references) =>
+          expect(references).to.include('decision/cardTypes/decision'),
+        );
+    });
+    it('check usage of linkType resource', async () => {
+      const name = 'decision/linkTypes/test';
+      const res = new LinkTypeResource(project, resourceName(name));
+      await res
+        .usage()
+        .then((references) => expect(references.length).to.equal(0)); // no references to this linkType
+    });
+    it('check usage of report resource', async () => {
+      const name = 'decision/reports/testReport';
+      const res = new ReportResource(project, resourceName(name));
+      await res
+        .usage()
+        .then((references) => expect(references).to.include('decision_5'));
+    });
+    it('check usage of template resource', async () => {
+      const name = 'decision/templates/simplepage';
+      const res = new TemplateResource(project, resourceName(name));
+      await res
+        .usage()
+        .then((references) => expect(references).to.include('decision_5'));
+    });
+    it('check usage of workflow resource', async () => {
+      const name = 'decision/workflows/decision';
+      const res = new WorkflowResource(project, resourceName(name));
+      await res
+        .usage()
+        .then((references) =>
+          expect(references).to.include('decision/cardTypes/decision'),
         );
     });
   });

--- a/tools/data-handler/test/utils/card-utils.test.ts
+++ b/tools/data-handler/test/utils/card-utils.test.ts
@@ -1,0 +1,26 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { expect } from 'chai';
+import { sortCards } from '../../src/utils/card-utils.js';
+
+describe('card utils', () => {
+  it('sort cards', () => {
+    const cards = ['aaa_999', 'aaa_111', 'zzz_111', 'zzz_999', 'aaa_999'];
+    cards.sort(sortCards);
+    expect(cards.at(0)).to.equal('aaa_111');
+    expect(cards.at(1)).to.equal('aaa_999');
+    expect(cards.at(2)).to.equal('aaa_999');
+    expect(cards.at(3)).to.equal('zzz_111');
+    expect(cards.at(4)).to.equal('zzz_999');
+  });
+});


### PR DESCRIPTION
Add new API `usage` to resources. This returns an array of references (card keys, resource names, or calculation file names) where the resource is used. Array is always returned so that card key references are first, then resource names and finally calculation filenames. Cards are sorted first by project prefix, then by card ID. Duplicates are removed by using a `Set`. This is not performance critical for now, thus using `Array` -> `Set` -> `Array` is fine. If it is seen as a problem, `Set` can be replaced with a `filter -> includes-indexOf` call, though it can be slower.

For future consideration. The references could be returned in subarrays (`card-references: [...], resource-references: [...], calculation-references: [...]`), if we need to use the references for anything. For now it is enough to know that the resource is still used. 

Additionally, cleaned up resource `imports` so that base classes re-`export` items that are used by inherited classes. This tidies up the imports in inherited classes, as imports mostly come from base classes.