### PR TITLE
Remove two unnecessary 'new Project' calls

### DIFF
--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -53,7 +53,7 @@ export class Template extends CardContainer {
     super(template.path!, templateName);
 
     // prevent constructing a new project object, if one is passed to this class.
-    this.project = project ? project : new Project(this.basePath);
+    this.project = project;
     // optimization - if template.path is set - use it
     this.templatePath =
       template.path && template.path.length > 0

--- a/tools/data-handler/src/import.ts
+++ b/tools/data-handler/src/import.ts
@@ -135,7 +135,7 @@ export class Import {
         `Input validation error: destination does not exist '${destination}'`,
       );
     }
-    const destinationProject = new Project(destination);
+    const destinationProject = this.project;
     const sourceProject = new Project(source);
     const modulePrefix = sourceProject.projectPrefix;
     const destinationPath = join(


### PR DESCRIPTION
Creating a new instance of `Project` is quite expensive operation and it should not be taken lightly. 

Removing two unnecessary calls to create a `Project` instance:
- from `Import` - the source project is always the one that `Import` class is having as a property
- from `Template` - the `project` parameter is no longer optional parameter - has not been for some time, so it shouldn't create a project ever