### PR TITLE
Rename base/fieldTypes/progress as progress

### DIFF
--- a/calculations/common/base.lp
+++ b/calculations/common/base.lp
@@ -48,3 +48,6 @@ dataType((FieldType, EnumValue), "enumValue", "longText") :-
 hiddenInTreeView(Card) :-
     ancestor(Card, Ancestor),
     hiddenInTreeView(Ancestor).
+
+% TODO: remove this compatibility rule, once content repositories have been updated (INTDEV-666)
+field(Card, "progress", Progress) :- field(Card, "base/fieldTypes/progress", Progress).

--- a/calculations/queries/tree.lp
+++ b/calculations/queries/tree.lp
@@ -1,4 +1,4 @@
-select("title";"workflowStateCategory";"base/fieldTypes/progress";"rank";"cardType").
+select("title";"workflowStateCategory";"progress";"rank";"cardType").
 result(Card) :- card(Card), not parent(Card, _), not hiddenInTreeView(Card).
 childResult(Parent, Card, "children") :- card(Card), parent(Card, Parent), not hiddenInTreeView(Card).
 order(Level, "children", 1, "rank", "ASC") :-

--- a/tools/app/app/components/TreeMenu.tsx
+++ b/tools/app/app/components/TreeMenu.tsx
@@ -36,7 +36,7 @@ const RenderTree = (
     style,
     dragHandle,
   }: NodeRendererProps<QueryResult<'tree'>>) {
-    const progress = node.data['base/fieldTypes/progress'];
+    const progress = node.data.progress;
 
     return (
       <Box

--- a/tools/data-handler/src/export.ts
+++ b/tools/data-handler/src/export.ts
@@ -187,7 +187,7 @@ export class Export {
 
     card.path = cardDetailsResponse.path;
     card.metadata = cardDetailsResponse.metadata;
-    card.metadata!.progress = treeQueryResult['base/fieldTypes/progress'];
+    card.metadata!.progress = treeQueryResult.progress;
     card.content = asciiDocContent;
     card.attachments = cardDetailsResponse.attachments;
 

--- a/tools/data-handler/src/types/queries.ts
+++ b/tools/data-handler/src/types/queries.ts
@@ -80,7 +80,7 @@ export type QueryResult<T extends QueryName> = QueryMap[T];
  * Define all the queries below
  */
 interface TreeQueryResult extends BaseResult {
-  'base/fieldTypes/progress'?: string;
+  progress?: string;
   rank: string;
   title: string;
   cardType: string;
@@ -89,7 +89,7 @@ interface TreeQueryResult extends BaseResult {
 }
 
 interface CardQueryResult extends BaseResult {
-  'base/fieldTypes/progress'?: string;
+  progress?: string;
   rank: string;
   title: string;
   cardType: string;


### PR DESCRIPTION
 For now, there is a compatibility rule in place as well.

I tested that both the old and the new styles of enabling progress metrics work.