### PR TITLE
INTDEV-771 Show command does not work with resource name parameter

### DIFF
--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -279,7 +279,11 @@ export class Commands {
       } else if (command === Cmd.show) {
         const [type, detail] = args;
         options.projectPath = this.projectPath;
-        return this.show(this.commandType(type), detail, options);
+        return this.show(
+          this.commandType(type),
+          this.commandTarget(type, detail),
+          options,
+        );
       } else if (command === Cmd.start) {
         await this.startApp();
       } else if (command === Cmd.transition) {

--- a/tools/data-handler/test/command-handler-create.test.ts
+++ b/tools/data-handler/test/command-handler-create.test.ts
@@ -282,6 +282,26 @@ describe('create command', () => {
     );
     expect(cardTypesCountBefore + 1).equals(cardTypesCountAfter);
   });
+  it('cardType with name only', async () => {
+    const cardTypesCountBefore = await countOfResources(
+      ['cardTypes'],
+      optionsMini,
+    );
+    const cardType = 'mini/cardTypes/test-test';
+    const workflow = 'mini/workflows/default';
+    const result = await commandHandler.command(
+      Cmd.create,
+      [cardType, workflow],
+      optionsMini,
+    );
+    console.error(result);
+    expect(result.statusCode).to.equal(200);
+    const cardTypesCountAfter = await countOfResources(
+      ['cardTypes'],
+      optionsMini,
+    );
+    expect(cardTypesCountBefore + 1).equals(cardTypesCountAfter);
+  });
   it('cardType invalid project', async () => {
     const cardType = 'test';
     const workflow = 'mini/workflows/default';

--- a/tools/data-handler/test/command-handler-remove.test.ts
+++ b/tools/data-handler/test/command-handler-remove.test.ts
@@ -222,6 +222,23 @@ describe('remove command', () => {
       );
       expect(result.statusCode).to.equal(200);
     });
+    it('remove cardType with name only', async () => {
+      // First create a cardType, then remove it
+      const name = 'testForCreationWithOutName';
+      const cardTypeName = `decision/cardTypes/${name}`;
+      const workflow = 'decision/workflows/decision';
+      let result = await commandHandler.command(
+        Cmd.create,
+        [cardTypeName, workflow],
+        options,
+      );
+      result = await commandHandler.command(
+        Cmd.remove,
+        [cardTypeName],
+        options,
+      );
+      expect(result.statusCode).to.equal(200);
+    });
     it('remove fieldType (success)', async () => {
       // First create a fieldType, then remove it
       const name = 'testForCreation';

--- a/tools/data-handler/test/command-handler-show.test.ts
+++ b/tools/data-handler/test/command-handler-show.test.ts
@@ -145,6 +145,17 @@ describe('shows command', () => {
         expect(result.payload).to.not.equal(undefined);
       }
     });
+    it('show particular card type with name only', async () => {
+      const result = await commandHandler.command(
+        Cmd.show,
+        ['decision/cardTypes/decision'],
+        optionsDecision,
+      );
+      expect(result.statusCode).to.equal(200);
+      if (result.payload) {
+        expect(result.payload).to.not.equal(undefined);
+      }
+    });
     it('shows labels - success()', async () => {
       const result = await commandHandler.command(
         Cmd.show,


### PR DESCRIPTION
Now that `show` (and `create` and `remove`) support both the old way of getting specific parameter (`show cardType <name>` ) and new way (`show <name>`), the parameters are jiggled around to have support for two different ways of calling. 

If call is using new way, it is converted to be "old type" of call by deducing the `type` parameter from resource name.
Then the actual `name` parameter (which is now missing), is copied from the only parameter received.

The `show` command was missing that last line; other commands have it. Fixed by adding the missing part.


Additionally - added unit tests for each command using `name` directly without `type` information.