### PR TITLE
INTDEV-774 Look for card from appropriate places only

### DIFF
--- a/tools/data-handler/src/command-manager.ts
+++ b/tools/data-handler/src/command-manager.ts
@@ -62,11 +62,7 @@ export class CommandManager {
     this.moveCmd = new Move(this.project, this.calculateCmd);
     this.removeCmd = new Remove(this.project, this.calculateCmd);
     this.renameCmd = new Rename(this.project, this.calculateCmd);
-    this.transitionCmd = new Transition(
-      this.project,
-      this.calculateCmd,
-      this.editCmd,
-    );
+    this.transitionCmd = new Transition(this.project, this.calculateCmd);
     this.updateCmd = new Update(this.project);
   }
 

--- a/tools/data-handler/src/containers/card-container.ts
+++ b/tools/data-handler/src/containers/card-container.ts
@@ -129,11 +129,11 @@ export class CardContainer {
     details: FetchCardDetails = {},
     foundCards: Card[],
   ): Promise<Card[]> {
-    const entries = await readdir(path, { withFileTypes: true });
     if (foundCards.length > 0) {
       return foundCards;
     }
 
+    const entries = await readdir(path, { withFileTypes: true });
     let asciiDocProcessor;
     // optimization: do not create AsciiDoctor Processor, unless it is needed.
     if (details.contentType && details.contentType === 'html') {

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -172,9 +172,14 @@ export class Project extends CardContainer {
     newValue: MetadataContent,
     skipValidation: boolean = false,
   ) {
-    const card = await this.findCard(this.basePath, cardKey, {
-      metadata: true,
-    });
+    const templateCard = await this.isTemplateCard(cardKey);
+    const card = await this.findCard(
+      templateCard ? this.paths.templatesFolder : this.paths.cardRootFolder,
+      cardKey,
+      {
+        metadata: true,
+      },
+    );
     if (!card) {
       throw new Error(`Card '${cardKey}' does not exist in the project`);
     }

--- a/tools/data-handler/src/transition.ts
+++ b/tools/data-handler/src/transition.ts
@@ -21,14 +21,12 @@ import {
   Workflow,
   WorkflowState,
 } from './interfaces/resource-interfaces.js';
-import { Edit } from './edit.js';
 import { Project } from './containers/project.js';
 
 export class Transition extends EventEmitter {
   constructor(
     private project: Project,
     private calculateCmd: Calculate,
-    private editCmd: Edit,
   ) {
     super();
     this.addListener(
@@ -47,8 +45,8 @@ export class Transition extends EventEmitter {
 
   /**
    * Transitions a card from its current state to a new state.
-   * @param {string} cardKey card key
-   * @param {string} transition which transition to do
+   * @param cardKey card key
+   * @param transition which transition to do
    */
   public async cardTransition(cardKey: string, transition: WorkflowState) {
     // Card details
@@ -115,11 +113,9 @@ export class Transition extends EventEmitter {
     await actionGuard.checkPermission('transition', cardKey, transition.name);
 
     // Write new state
-    await this.setCardState(details, found.toState); //todo: instead, this could just use project.updateCardMetadata
-    await this.editCmd.editCardMetadata(
-      details.key,
-      'lastTransitioned',
-      new Date().toISOString(),
-    );
+    await this.setCardState(details, found.toState);
+    // If update succeeds, update last transition timestamp
+    details.metadata.lastTransitioned = new Date().toISOString();
+    await this.project.updateCardMetadata(details, details.metadata);
   }
 }


### PR DESCRIPTION
Previously, `findCard` tried to look for - recursively - all the subfolders of a project. Including `.git` and `.calc`. 
This caused some issues when `.calc` folder content was deleted while recursion was ongoing (transition caused calculation files to be deleted as part of new calculations). 

As a fix; only look certain subfolders when updating the card. Project cards from `cardRoot` and template cards from `.card/local/templates`. Module cards are never updated. 

Additional two optimisations: 

1) Do not call `readdir` if already having found the card.
2) Do not write `lastTransitioned` through Edit command, but directly after transition, if it succeeds.