### PR TITLE
INTDEV-777 Filter out calculated fields when instantiating cards

### DIFF
--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -212,13 +212,15 @@ export class Template extends CardContainer {
       }
 
       const cardWithRank = parentCards.find((c) => c.key === card.key);
-      const customFields = cardType.customFields.reduce(
-        (acc, field) => ({
-          ...acc,
-          [field.name]: card.metadata?.[field.name] || null,
-        }),
-        {},
-      );
+      const customFields = cardType.customFields
+        .filter((item) => !item.isCalculated)
+        .reduce(
+          (acc, field) => ({
+            ...acc,
+            [field.name]: card.metadata?.[field.name] || null,
+          }),
+          {},
+        );
 
       const newMetadata = {
         ...card.metadata,

--- a/tools/data-handler/src/validate.ts
+++ b/tools/data-handler/src/validate.ts
@@ -780,12 +780,13 @@ export class Validate {
           );
         }
         continue;
-      }
-      if (card.metadata[field.name] === undefined) {
-        validationErrors.push(
-          `Card '${card.key}' is missing custom field '${field.name}'`,
-        );
-        continue;
+      } else {
+        if (card.metadata[field.name] === undefined) {
+          validationErrors.push(
+            `Card '${card.key}' is missing custom field '${field.name}'`,
+          );
+          continue;
+        }
       }
 
       const fieldType = await this.getAndCacheResource(

--- a/tools/data-handler/test/command-handler-create.test.ts
+++ b/tools/data-handler/test/command-handler-create.test.ts
@@ -13,7 +13,10 @@ import { CardsOptions, Cmd, Commands } from '../src/command-handler.js';
 import { copyDir, deleteDir, resolveTilde } from '../src/utils/file-utils.js';
 import { Calculate } from '../src/calculate.js';
 import { DefaultContent } from '../src/resources/create-defaults.js';
-import { CardListContainer } from '../src/interfaces/project-interfaces.js';
+import {
+  Card,
+  CardListContainer,
+} from '../src/interfaces/project-interfaces.js';
 import { FieldTypeResource } from '../src/resources/field-type-resource.js';
 import { Project } from '../src/containers/project.js';
 import { resourceName } from '../src/utils/resource-utils.js';
@@ -203,6 +206,21 @@ describe('create command', () => {
       options,
     );
     expect(result.statusCode).to.equal(200);
+
+    // Check that created card contains custom fields, but not calculated fields
+    const createdCard = result.affectsCards?.at(0) || '';
+    const cardDetails = (
+      await commandHandler.command(Cmd.show, ['card', createdCard], options)
+    ).payload;
+    if (cardDetails) {
+      console.error(cardDetails);
+      expect((cardDetails as Card).metadata).to.not.include.keys(
+        'decision/fieldTypes/obsoletedBy',
+      );
+      expect((cardDetails as Card).metadata).to.include.keys(
+        'decision/fieldTypes/admins',
+      );
+    }
   });
 
   it('card incorrect template name', async () => {
@@ -294,7 +312,6 @@ describe('create command', () => {
       [cardType, workflow],
       optionsMini,
     );
-    console.error(result);
     expect(result.statusCode).to.equal(200);
     const cardTypesCountAfter = await countOfResources(
       ['cardTypes'],

--- a/tools/data-handler/test/test-data/invalid/invalid-card-has-wrong-state/.cards/local/cardtypes/decision.json
+++ b/tools/data-handler/test/test-data/invalid/invalid-card-has-wrong-state/.cards/local/cardtypes/decision.json
@@ -3,7 +3,8 @@
     "workflow": "decision/workflows/decision",
     "customFields": [
         {
-            "name": "decision/fieldTypes/obsoletedBy"
+            "name": "decision/fieldTypes/obsoletedBy",
+            "isCalculated": true
         }
     ],
     "alwaysVisibleFields": [ "decision/fieldTypes/obsoletedBy" ],

--- a/tools/data-handler/test/test-data/invalid/invalid-card-has-wrong-state/.cards/local/cardtypes/decisionWrongWF.json
+++ b/tools/data-handler/test/test-data/invalid/invalid-card-has-wrong-state/.cards/local/cardtypes/decisionWrongWF.json
@@ -3,7 +3,8 @@
     "workflow": "i-dont-exist",
     "customFields": [
         {
-            "name": "decision/fieldTypes/obsoletedBy"
+            "name": "decision/fieldTypes/obsoletedBy",
+            "isCalculated": true
         }
     ],
     "alwaysVisibleFields": [ "decision/fieldTypes/obsoletedBy" ],

--- a/tools/data-handler/test/test-data/invalid/invalid-card-has-wrong-state/.cards/local/templates/decision/c/decision_1/index.json
+++ b/tools/data-handler/test/test-data/invalid/invalid-card-has-wrong-state/.cards/local/templates/decision/c/decision_1/index.json
@@ -2,7 +2,6 @@
     "cardType": "decision/cardTypes/decision",
     "title": "Untitled",
     "workflowState": "Draft",
-    "decision/fieldTypes/obsoletedBy": null,
     "rank": "0|a",
     "lastUpdated": "2024-09-13T11:49:45.184Z"
 }

--- a/tools/data-handler/test/test-data/invalid/invalid-card-has-wrong-state/cardRoot/decision_5/c/decision_6/index.json
+++ b/tools/data-handler/test/test-data/invalid/invalid-card-has-wrong-state/cardRoot/decision_5/c/decision_6/index.json
@@ -2,6 +2,5 @@
     "cardType": "decision/cardTypes/decision",
     "title": "Document Decisions with Decision Records",
     "workflowState": "IdontExist",
-    "decision/fieldTypes/obsoletedBy": null,
     "rank": "0|a"
 }

--- a/tools/data-handler/test/test-data/invalid/invalid-card-has-wrong-state/cardRoot/decision_5/index.json
+++ b/tools/data-handler/test/test-data/invalid/invalid-card-has-wrong-state/cardRoot/decision_5/index.json
@@ -2,7 +2,6 @@
     "cardType": "IdontExist",
     "title": "Decision Records",
     "workflowState": "Draft",
-    "decision/fieldTypes/obsoletedBy": null,
     "rank": "0|a",
     "lastUpdated": "2024-09-13T11:49:45.176Z"
 }

--- a/tools/data-handler/test/test-data/invalid/invalid-card-has-wrong-state/cardRoot/decision_7/index.json
+++ b/tools/data-handler/test/test-data/invalid/invalid-card-has-wrong-state/cardRoot/decision_7/index.json
@@ -2,7 +2,6 @@
     "cardType": "decision/cardTypes/decisionWrongWF",
     "title": "Decision Records",
     "workflowState": "Draft",
-    "decision/fieldTypes/obsoletedBy": null,
     "rank": "0|m",
     "lastUpdated": "2024-09-13T11:49:45.180Z"
 }

--- a/tools/data-handler/test/test-data/invalid/invalid-card-has-wrong-state/cardRoot/decision_8/index.json
+++ b/tools/data-handler/test/test-data/invalid/invalid-card-has-wrong-state/cardRoot/decision_8/index.json
@@ -2,7 +2,6 @@
     "cardType": "decision/cardTypes/decisionWrongMissingWF",
     "title": "Decision Records",
     "workflowState": "Draft",
-    "decision/fieldTypes/obsoletedBy": null,
     "rank": "0|z",
     "lastUpdated": "2024-09-13T11:49:45.182Z"
 }

--- a/tools/data-handler/test/test-data/invalid/invalid-cardsconfig.json/.cards/local/cardtypes/decision.json
+++ b/tools/data-handler/test/test-data/invalid/invalid-cardsconfig.json/.cards/local/cardtypes/decision.json
@@ -4,6 +4,7 @@
     "customFields": [
         {
             "name": "decision/fieldTypes/obsoletedBy",
+            "isCalculated": true,
             "displayName": "Obsoleted By"
         }
     ]

--- a/tools/data-handler/test/test-data/invalid/invalid-cardsconfig.json/.cards/local/templates/decision/c/decision_1/index.json
+++ b/tools/data-handler/test/test-data/invalid/invalid-cardsconfig.json/.cards/local/templates/decision/c/decision_1/index.json
@@ -3,6 +3,5 @@
     "title": "Untitled",
     "workflowState": "Draft",
     "rank": "0|a",
-    "lastUpdated": "2024-09-13T11:49:45.184Z",
-    "decision/fieldTypes/obsoletedBy": null
+    "lastUpdated": "2024-09-13T11:49:45.184Z"
 }

--- a/tools/data-handler/test/test-data/invalid/invalid-wrong-resource-names/.cards/local/templates/decision/c/decision_1/index.json
+++ b/tools/data-handler/test/test-data/invalid/invalid-wrong-resource-names/.cards/local/templates/decision/c/decision_1/index.json
@@ -2,7 +2,6 @@
     "cardType": "decision/cardTypes/decision",
     "title": "Untitled",
     "workflowState": "Draft",
-    "decision/fieldTypes/obsoletedBy": null,
     "rank": "0|a",
     "lastUpdated": "2024-09-13T11:49:45.184Z"
 }

--- a/tools/data-handler/test/test-data/invalid/missing-cardsconfig.json/.cards/local/templates/decision/c/decision_1/index.json
+++ b/tools/data-handler/test/test-data/invalid/missing-cardsconfig.json/.cards/local/templates/decision/c/decision_1/index.json
@@ -1,6 +1,5 @@
 {
     "cardType": "decision/cardTypes/decision",
     "title": "Untitled",
-    "workflowState": "Draft",
-    "decision/fieldTypes/obsoletedBy": null
+    "workflowState": "Draft"
 }

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/cardTypes/decision.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/cardTypes/decision.json
@@ -3,7 +3,8 @@
     "workflow": "decision/workflows/decision",
     "customFields": [
         {
-            "name": "decision/fieldTypes/obsoletedBy"
+            "name": "decision/fieldTypes/obsoletedBy",
+            "isCalculated": true
         },
         {
             "name": "decision/fieldTypes/admins"

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/templates/decision/c/decision_1/index.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/templates/decision/c/decision_1/index.json
@@ -4,7 +4,6 @@
     "workflowState": "Draft",
     "rank": "0|a",
     "lastUpdated": "2024-07-12T11:07:35.266Z",
-    "decision/fieldTypes/obsoletedBy": null,
     "decision/fieldTypes/admins": null,
     "decision/fieldTypes/commitDescription": null,
     "decision/fieldTypes/finished": null,

--- a/tools/data-handler/test/test-data/valid/decision-records/cardRoot/decision_5/c/decision_6/index.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/cardRoot/decision_5/c/decision_6/index.json
@@ -4,7 +4,6 @@
     "workflowState": "Approved",
     "rank": "0|a",
     "lastUpdated": "2024-09-30T14:17:52.214Z",
-    "decision/fieldTypes/obsoletedBy": null,
     "decision/fieldTypes/admins": null,
     "decision/fieldTypes/commitDescription": null,
     "decision/fieldTypes/finished": null,


### PR DESCRIPTION
When instantiating cards from template to JSON files, the calculated fields can just be skipped. 

Additionally, add to tests a calculated field ("obsoletedBy"). Change test assets accordingly and add a check to one of the tests that ensures that calculated field value is not copied to JSON file.