### PR TITLE
INTDEV-778 Transition: Write all changes to metadata in one operation

### DIFF
--- a/tools/data-handler/src/transition.ts
+++ b/tools/data-handler/src/transition.ts
@@ -15,7 +15,6 @@ import { EventEmitter } from 'node:events';
 
 import { ActionGuard } from './permissions/action-guard.js';
 import { Calculate } from './calculate.js';
-import { Card } from './interfaces/project-interfaces.js';
 import {
   CardType,
   Workflow,
@@ -33,14 +32,6 @@ export class Transition extends EventEmitter {
       'transitioned',
       this.calculateCmd.handleCardChanged.bind(this.calculateCmd),
     );
-  }
-
-  // Sets card state
-  private async setCardState(card: Card, state: string) {
-    if (card.metadata) {
-      card.metadata.workflowState = state;
-      this.project.updateCardMetadata(card, card.metadata);
-    }
   }
 
   /**
@@ -113,9 +104,9 @@ export class Transition extends EventEmitter {
     await actionGuard.checkPermission('transition', cardKey, transition.name);
 
     // Write new state
-    await this.setCardState(details, found.toState);
-    // If update succeeds, update last transition timestamp
+    details.metadata.workflowState = found.toState;
+    details.metadata.lastUpdated = new Date().toISOString();
     details.metadata.lastTransitioned = new Date().toISOString();
-    await this.project.updateCardMetadata(details, details.metadata);
+    return this.project.updateCardMetadata(details, details.metadata);
   }
 }


### PR DESCRIPTION
There was a recent fix to transitions (INTDEV-774). 
The fix to that exposed a problem in current transition operation that surfaces sporadically:
- write metadata for state change
- this will cause calculations to be updated
- meanwhile, another write to same metadata is issued to update the timestamps

Sometimes either the READ op (for calculations) or WRITE op (for timestamps) will fail. 
This is probably due to racing condition trying to access the same file.

As a fix, write all changes to the metadata (state & timestamps) in one operation.