### PR TITLE
INTDEV-454 Add statusIndicator

### DIFF
--- a/calculations/queries/tree.lp
+++ b/calculations/queries/tree.lp
@@ -1,4 +1,4 @@
-select("title";"workflowStateCategory";"progress";"rank";"cardType").
+select("title";"statusIndicator";"progress";"rank";"cardType").
 result(Card) :- card(Card), not parent(Card, _), not hiddenInTreeView(Card).
 childResult(Parent, Card, "children") :- card(Card), parent(Card, Parent), not hiddenInTreeView(Card).
 order(Level, "children", 1, "rank", "ASC") :-

--- a/tools/app/__tests__/api.test.ts
+++ b/tools/app/__tests__/api.test.ts
@@ -140,11 +140,9 @@ test('tree endpoint returns proper data', async () => {
   expect(result[0].key).toBe('decision_5');
   expect(result[0].title).toBe('Decision Records');
   expect(result[0].rank).toBe('0|a');
-  expect(result[0].workflowStateCategory).toBe('initial');
   expect(result[0].children?.at(0)?.key).toBe('decision_6');
   expect(result[0].children?.at(0)?.title).toBe(
     'Document Decisions with Decision Records',
   );
   expect(result[0].children?.at(0)?.rank).toBe('0|a');
-  expect(result[0].children?.at(0)?.workflowStateCategory).toBe('closed');
 });

--- a/tools/app/app/components/TreeMenu.tsx
+++ b/tools/app/app/components/TreeMenu.tsx
@@ -16,10 +16,12 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { getStateColor } from '../lib/utils';
 import { Box, Chip, Stack, Typography } from '@mui/joy';
 import { Tree, NodeRendererProps, NodeApi, TreeApi } from 'react-arborist';
-import { FiberManualRecord } from '@mui/icons-material';
+import { FiberManualRecord, Error as ErrorIcon } from '@mui/icons-material';
 import { QueryResult } from '@cyberismocom/data-handler/types/queries';
 import Link from 'next/link';
 import { useResizeObserver } from '../lib/hooks';
+import { useTranslation } from 'react-i18next';
+
 type TreeMenuProps = {
   title?: string;
   selectedCardKey: string | null;
@@ -37,6 +39,45 @@ const RenderTree = (
     dragHandle,
   }: NodeRendererProps<QueryResult<'tree'>>) {
     const progress = node.data.progress;
+
+    const renderStatusIndicator = () => {
+      const statusIndicator = node.data.statusIndicator;
+
+      if (!statusIndicator || statusIndicator === 'none') {
+        return null;
+      }
+
+      if (statusIndicator === 'error') {
+        return (
+          <ErrorIcon
+            color="error"
+            sx={{
+              marginRight: 1,
+              fontSize: 15,
+              alignSelf: 'center',
+            }}
+          />
+        );
+      }
+
+      return (
+        <Box
+          color={getStateColor(statusIndicator)}
+          display="flex"
+          alignItems="center"
+          alignSelf="center"
+          width={10}
+          height={10}
+          marginRight={1}
+        >
+          <FiberManualRecord
+            sx={{
+              fontSize: 15,
+            }}
+          />
+        </Box>
+      );
+    };
 
     return (
       <Box
@@ -71,25 +112,7 @@ const RenderTree = (
             cursor: 'pointer',
           }}
         />
-        {node.data.workflowStateCategory && (
-          // Status color circle
-          <Box
-            color={getStateColor(node.data.workflowStateCategory)}
-            visibility={progress ? 'hidden' : 'visible'}
-            display="flex"
-            alignItems="center"
-            alignSelf="center"
-            width={10}
-            height={10}
-            marginRight={1}
-          >
-            <FiberManualRecord
-              sx={{
-                fontSize: 15,
-              }}
-            />
-          </Box>
-        )}
+        {renderStatusIndicator()}
         <Typography
           level="title-sm"
           noWrap

--- a/tools/app/app/components/TreeMenu.tsx
+++ b/tools/app/app/components/TreeMenu.tsx
@@ -43,20 +43,23 @@ const RenderTree = (
     const renderStatusIndicator = () => {
       const statusIndicator = node.data.statusIndicator;
 
-      if (!statusIndicator || statusIndicator === 'none') {
-        return null;
-      }
-
       if (statusIndicator === 'error') {
         return (
-          <ErrorIcon
-            color="error"
-            sx={{
-              marginRight: 1,
-              fontSize: 15,
-              alignSelf: 'center',
-            }}
-          />
+          <Box
+            display="flex"
+            alignItems="center"
+            alignSelf="center"
+            width={10}
+            height={10}
+            marginRight={1}
+          >
+            <ErrorIcon
+              color="error"
+              sx={{
+                fontSize: 15,
+              }}
+            />
+          </Box>
         );
       }
 

--- a/tools/app/app/lib/utils.ts
+++ b/tools/app/app/lib/utils.ts
@@ -377,7 +377,7 @@ export function getStateColor(category: string | undefined) {
     case WorkflowCategory.closed:
       return '#51BC51'; // 'success.400'
     default:
-      return 'black';
+      return 'transparent';
   }
 }
 

--- a/tools/data-handler/src/interfaces/resource-interfaces.ts
+++ b/tools/data-handler/src/interfaces/resource-interfaces.ts
@@ -139,6 +139,7 @@ export enum WorkflowCategory {
   initial = 'initial',
   active = 'active',
   closed = 'closed',
+  none = 'none',
 }
 
 // Workflow state.

--- a/tools/data-handler/src/types/queries.ts
+++ b/tools/data-handler/src/types/queries.ts
@@ -21,6 +21,8 @@ import {
 
 export type LinkDirection = 'inbound' | 'outbound';
 
+export type StatusIndicator = WorkflowCategory | 'error';
+
 export interface CalculationLink {
   displayName: string;
   key: string;
@@ -87,7 +89,7 @@ interface TreeQueryResult extends BaseResult {
   rank: string;
   title: string;
   cardType: string;
-  workflowStateCategory?: WorkflowCategory;
+  statusIndicator?: StatusIndicator;
   children?: TreeQueryResult[];
 }
 

--- a/tools/data-handler/test/calculate.test.ts
+++ b/tools/data-handler/test/calculate.test.ts
@@ -8,7 +8,6 @@ import { copyDir } from '../src/utils/file-utils.js';
 import { fileURLToPath } from 'node:url';
 import { Project } from '../src/containers/project.js';
 import { QueryResult } from '../src/types/queries.js';
-import { WorkflowCategory } from '../src/interfaces/resource-interfaces.js';
 
 use(chaiAsPromised);
 
@@ -19,7 +18,6 @@ const expectedTree: QueryResult<'tree'>[] = [
     cardType: 'decision/cardTypes/simplepage',
     links: [],
     rank: '0|a',
-    workflowStateCategory: WorkflowCategory.initial,
     children: [
       {
         key: 'decision_6',
@@ -29,7 +27,6 @@ const expectedTree: QueryResult<'tree'>[] = [
         rank: '0|a',
         notifications: [],
         policyChecks: { successes: [], failures: [] },
-        workflowStateCategory: WorkflowCategory.closed,
         deniedOperations: {
           transition: [],
           move: [],

--- a/tools/schema/workflowSchema.json
+++ b/tools/schema/workflowSchema.json
@@ -26,7 +26,7 @@
           },
           "category": {
             "description": "The category of a workflow state",
-            "enum": ["initial", "active", "closed"]
+            "enum": ["none", "initial", "active", "closed"]
           }
         },
         "required": ["name", "category"]


### PR DESCRIPTION
Added the statusIndicator and removed workflowStateCategory. It still exists for each card still, but it is currently not used anywhere. Confirmed the given logic works with cyberismo-isms(swap cardtype with cardType)