### PR TITLE
INTDEV-712 Support for applying changes when card state changes

### DIFF
--- a/calculations/queries/onCreation.lp
+++ b/calculations/queries/onCreation.lp
@@ -1,0 +1,44 @@
+{{#each cardKeys}}
+createdCard({{this}}).
+{{/each}}
+
+updateField(Card, CreateTransition, AffectedCard, Field, NewValue) :-
+    createdCard(Card),
+    onTransitionSetField(Card, CreateTransition, AffectedCard, Field, NewValue),
+    field(Card, "cardType", CardType),
+    field(CardType, "workflow", Workflow),
+    workflowTransition(Workflow, CreateTransition, "", _),
+    not editingFieldDenied(AffectedCard, Field, _).
+
+executeTransition(Card, CreateTransition, AffectedCard, TransitionToExecute) :-
+    createdCard(Card),
+    onTransitionExecuteTransition(Card, CreateTransition, AffectedCard, TransitionToExecute),
+    field(Card, "cardType", CardType),
+    field(CardType, "workflow", Workflow),
+    workflowTransition(Workflow, CreateTransition, "", _),
+    not transitionDenied(AffectedCard, TransitionToExecute, _).
+
+selectAll.
+
+result(transitionSideEffects).
+
+childResult(transitionSideEffects, @concatenate("updateFields", Card, CreateTransition, AffectedCard, Field, NewValue), "updateFields") :-
+    updateField(Card, CreateTransition, AffectedCard, Field, NewValue).
+
+field(@concatenate("updateFields", Card, CreateTransition, AffectedCard, Field, NewValue), "card", AffectedCard) :-
+    updateField(Card, CreateTransition, AffectedCard, Field, NewValue).
+
+field(@concatenate("updateFields", Card, CreateTransition, AffectedCard, Field, NewValue), "field", Field) :-
+    updateField(Card, CreateTransition, AffectedCard, Field, NewValue).
+
+field(@concatenate("updateFields", Card, CreateTransition, AffectedCard, Field, NewValue), "newValue", NewValue) :-
+    updateField(Card, CreateTransition, AffectedCard, Field, NewValue).
+
+childResult(transitionSideEffects, @concatenate("executeTransition", Card, CreateTransition, AffectedCard, TransitionToExecute), "executeTransition") :-
+    executeTransition(Card, CreateTransition, AffectedCard, TransitionToExecute).
+
+field(@concatenate("executeTransition", Card, CreateTransition, AffectedCard, TransitionToExecute), "card", AffectedCard) :-
+    executeTransition(Card, CreateTransition, AffectedCard, TransitionToExecute).
+
+field(@concatenate("executeTransition", Card, CreateTransition, AffectedCard, TransitionToExecute), "transitionToExecute", TransitionToExecute) :-
+    executeTransition(Card, CreateTransition, AffectedCard, TransitionToExecute).

--- a/calculations/queries/onTransition.lp
+++ b/calculations/queries/onTransition.lp
@@ -1,0 +1,26 @@
+selectAll.
+
+result(transitionSideEffects).
+
+childResult(transitionSideEffects, @concatenate("updateFields", {{cardKey}}, "{{transition}}", AffectedCard, Field, NewValue), "updateFields") :-
+    onTransitionSetField({{cardKey}}, "{{transition}}", AffectedCard, Field, NewValue),
+    not editingFieldDenied(AffectedCard, Field, _).
+
+field(@concatenate("updateFields", {{cardKey}}, "{{transition}}", AffectedCard, Field, NewValue), "card", AffectedCard) :-
+    onTransitionSetField({{cardKey}}, "{{transition}}", AffectedCard, Field, NewValue).
+
+field(@concatenate("updateFields", {{cardKey}}, "{{transition}}", AffectedCard, Field, NewValue), "field", Field) :-
+    onTransitionSetField({{cardKey}}, "{{transition}}", AffectedCard, Field, NewValue).
+
+field(@concatenate("updateFields", {{cardKey}}, "{{transition}}", AffectedCard, Field, NewValue), "newValue", NewValue) :-
+    onTransitionSetField({{cardKey}}, "{{transition}}", AffectedCard, Field, NewValue).
+
+childResult(transitionSideEffects, @concatenate("executeTransition", {{cardKey}}, "{{transition}}", AffectedCard, TransitionToExecute), "executeTransition") :-
+    onTransitionExecuteTransition({{cardKey}}, "{{transition}}", AffectedCard, TransitionToExecute),
+    not transitionDenied(AffectedCard, TransitionToExecute, _).
+
+field(@concatenate("executeTransition", {{cardKey}}, "{{transition}}", AffectedCard, TransitionToExecute), "card", AffectedCard) :-
+    onTransitionExecuteTransition({{cardKey}}, "{{transition}}", AffectedCard, TransitionToExecute).
+
+field(@concatenate("executeTransition", {{cardKey}}, "{{transition}}", AffectedCard, TransitionToExecute), "transitionToExecute", TransitionToExecute) :-
+    onTransitionExecuteTransition({{cardKey}}, "{{transition}}", AffectedCard, TransitionToExecute).

--- a/tools/data-handler/src/card-metadata-updater.ts
+++ b/tools/data-handler/src/card-metadata-updater.ts
@@ -1,0 +1,182 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2025
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { CardMetadata } from './interfaces/project-interfaces.js';
+import { FieldType } from './interfaces/resource-interfaces.js';
+import { FieldTypeResource } from './resources/field-type-resource.js';
+import { logger } from './utils/log-utils.js';
+import { Project } from './containers/project.js';
+import { UpdateField } from './types/queries.js';
+
+/**
+ * Card metadata update result.
+ */
+interface CardUpdateResult {
+  success: boolean;
+  errors: string[];
+}
+
+/**
+ * Handles the updating of card metadata from clingo query result.
+ *
+ * todo: Once 'Card' class is created, the functionality in this class
+ *       can be incorporated there and this class can be removed.
+ */
+export class CardMetadataUpdater {
+  /**
+   * Applies a given array of changes to card(s).
+   * @param project Current project.
+   * @param fieldsToUpdate Array of field updates. Each update consists of cardKey, fieldName and new value.
+   */
+  public static async apply(
+    project: Project,
+    fieldsToUpdate: UpdateField[],
+  ): Promise<void> {
+    if (!fieldsToUpdate || fieldsToUpdate.length === 0) {
+      return;
+    }
+    const updates = CardMetadataUpdater.groupChangesByCard(fieldsToUpdate);
+    const updatePromises: Promise<CardUpdateResult>[] = [];
+
+    for (const [cardKey, changes] of updates.entries()) {
+      updatePromises.push(
+        CardMetadataUpdater.updateCardMetadata(project, cardKey, changes),
+      );
+    }
+
+    const results = await Promise.all(updatePromises);
+    CardMetadataUpdater.reportErrors(results);
+  }
+
+  // Applies a single field change to a card's metadata.
+  private static async applyFieldChange(
+    project: Project,
+    metadata: CardMetadata,
+    change: UpdateField,
+  ): Promise<CardUpdateResult> {
+    const result: CardUpdateResult = {
+      success: true,
+      errors: [],
+    };
+
+    if (change.field === 'title' || change.field === 'workflowState') {
+      metadata[change.field] = FieldTypeResource.fromClingoResult(
+        change.newValue as string,
+        'shortText',
+      );
+      return result;
+    }
+
+    if (change.field === 'cardType' || change.field === 'rank') {
+      result.success = false;
+      result.errors.push(
+        `For card ${change.card} cannot change card's ${change.field}.`,
+      );
+      return result;
+    }
+
+    const fieldType = await project.resource<FieldType>(change.field);
+    if (!fieldType) {
+      result.success = false;
+      result.errors.push(
+        `Field type '${change.field}' from transition change does not exist in the project.`,
+      );
+      return result;
+    }
+
+    metadata[change.field] = FieldTypeResource.fromClingoResult(
+      change.newValue as string,
+      fieldType.dataType,
+    );
+
+    return result;
+  }
+
+  // Groups changes by card key. Returns grouped map. Mapping is by cardKey.
+  private static groupChangesByCard(
+    fieldsToUpdate: UpdateField[],
+  ): Map<string, UpdateField[]> {
+    const updatesByCardKey = new Map<string, UpdateField[]>();
+
+    fieldsToUpdate.forEach((change) => {
+      const cardKey = change.card;
+      if (!updatesByCardKey.has(cardKey)) {
+        updatesByCardKey.set(cardKey, []);
+      }
+
+      const cardChanges = updatesByCardKey.get(cardKey);
+      if (cardChanges) {
+        cardChanges.push({
+          field: change.field,
+          card: change.card,
+          newValue: change.newValue,
+        });
+      }
+    });
+
+    return updatesByCardKey;
+  }
+
+  // Reports errors from update operations to the logger.
+  private static reportErrors(results: CardUpdateResult[]) {
+    const allErrors = results
+      .filter((result) => !result.success)
+      .flatMap((result) => result.errors);
+
+    if (allErrors.length > 0) {
+      allErrors.push('On transition change to card(s) can not be applied.');
+      logger.error(allErrors.join('\n'));
+    }
+  }
+
+  // Updates a single card's metadata with the provided changes.
+  private static async updateCardMetadata(
+    project: Project,
+    cardKey: string,
+    changes: UpdateField[],
+  ): Promise<CardUpdateResult> {
+    const result: CardUpdateResult = {
+      success: true,
+      errors: [],
+    };
+
+    const card = await project.findSpecificCard(cardKey, {
+      metadata: true,
+    });
+    if (!card || !card.metadata) {
+      result.success = false;
+      result.errors.push(
+        `Card ${cardKey} does not exist in the project. Changes cannot be applied.`,
+      );
+      return result;
+    }
+
+    const updatePromises = changes.map((change) =>
+      CardMetadataUpdater.applyFieldChange(project, card.metadata!, change),
+    );
+    const updateResults = await Promise.all(updatePromises);
+
+    for (const updateResult of updateResults) {
+      if (!updateResult.success) {
+        result.success = false;
+        result.errors.push(...updateResult.errors);
+      }
+    }
+
+    if (result.success) {
+      project.updateCardMetadata(card, card.metadata, true);
+    }
+    return result;
+  }
+}

--- a/tools/data-handler/src/types/queries.ts
+++ b/tools/data-handler/src/types/queries.ts
@@ -76,19 +76,33 @@ export interface ParseResult<T extends BaseResult> {
  * Generic types for named queries
  */
 
-export const queries = ['tree', 'card'] as const;
+export const queries = ['card', 'onCreation', 'onTransition', 'tree'] as const;
 
 export type QueryName = (typeof queries)[number];
 
 export type QueryMap = {
-  tree: TreeQueryResult;
   card: CardQueryResult;
+  onCreation: FieldsToUpdateQueryResult;
+  onTransition: FieldsToUpdateQueryResult;
+  tree: TreeQueryResult;
 };
 export type QueryResult<T extends QueryName> = QueryMap[T];
 
 /**
  * Define all the queries below
  */
+interface CardQueryResult extends BaseResult {
+  progress?: string;
+  rank: string;
+  title: string;
+  cardType: string;
+  workflowState: string;
+  lastUpdated: string;
+  fields?: CardQueryField[];
+}
+interface FieldsToUpdateQueryResult extends BaseResult {
+  updateFields: UpdateField[];
+}
 interface TreeQueryResult extends BaseResult {
   progress?: string;
   rank: string;
@@ -98,14 +112,10 @@ interface TreeQueryResult extends BaseResult {
   children?: TreeQueryResult[];
 }
 
-interface CardQueryResult extends BaseResult {
-  progress?: string;
-  rank: string;
-  title: string;
-  cardType: string;
-  workflowState: string;
-  lastUpdated: string;
-  fields?: CardQueryField[];
+export interface UpdateField {
+  card: string;
+  field: string;
+  newValue: string;
 }
 
 interface EnumValue {

--- a/tools/data-handler/test/calculate.test.ts
+++ b/tools/data-handler/test/calculate.test.ts
@@ -69,7 +69,7 @@ describe('calculate', () => {
       rmSync(testDir, { recursive: true, force: true });
     }, 5000);
   });
-  it('run named query successfully', async () => {
+  it('run named queries successfully', async () => {
     const query = 'tree';
 
     const res = await calculate.runQuery(query);
@@ -79,8 +79,17 @@ describe('calculate', () => {
     delete res[0].children?.[0].workflowState;
     delete res[0].lastUpdated;
     delete res[0].children?.[0].lastUpdated;
-
     expect(res).to.deep.equal(expectedTree);
+
+    // todo: run also 'card' query
+
+    // Run onTransition and onCreation queries even if they don't return anything.
+    const onTransitionQuery = 'onTransition';
+    let changes = await calculate.runQuery(onTransitionQuery);
+    expect(changes.length).to.equal(0);
+    const onCreationQuery = 'onCreation';
+    changes = await calculate.runQuery(onCreationQuery);
+    expect(changes.length).to.equal(0);
   });
   it('run clingraph successfully', async () => {
     const res = await calculate.runGraph({

--- a/tools/data-handler/test/command-handler-rank.test.ts
+++ b/tools/data-handler/test/command-handler-rank.test.ts
@@ -7,6 +7,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 // cyberismo
+import { Calculate } from '../src/calculate.js';
 import { CardsOptions, Cmd, Commands } from '../src/command-handler.js';
 import { Project } from '../src/containers/project.js';
 import { Show } from '../src/show.js';
@@ -58,7 +59,10 @@ describe('rank command', () => {
       options,
     );
 
-    await commandHandler.command(Cmd.show, ['templates'], options);
+    // To avoid logged errors from clingo queries during tests, generate calculations.
+    const project = new Project(decisionRecordsPath);
+    const calculate = new Calculate(project);
+    await calculate.generate();
 
     childCardKey = childResult.affectsCards![0];
   });

--- a/tools/data-handler/test/command-handler-remove.test.ts
+++ b/tools/data-handler/test/command-handler-remove.test.ts
@@ -190,6 +190,12 @@ describe('remove command', () => {
       const attachment = 'the-needle.heic';
       const attachmentPath = join(testDir, 'attachments' + sep + attachment);
       const card = await createCard(commandHandler);
+
+      // To avoid logged errors from clingo queries during tests, generate calculations.
+      const project = new Project(decisionRecordsPath);
+      const calculate = new Calculate(project);
+      await calculate.generate();
+
       const cardId = card.affectsCards![0];
       await commandHandler.command(
         Cmd.create,

--- a/tools/data-handler/test/field-type-from-clingo.test.ts
+++ b/tools/data-handler/test/field-type-from-clingo.test.ts
@@ -1,0 +1,106 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2025
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+  for more details.
+
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { expect } from 'chai';
+
+import { deepCompare } from '../src/utils/common-utils.js';
+import { FieldTypeResource as FT } from '../src/resources/field-type-resource.js';
+
+describe('clingo results to fieldType dataType', () => {
+  it('convert to boolean', () => {
+    expect(FT.fromClingoResult('true', 'boolean')).to.equal(true);
+    expect(FT.fromClingoResult('false', 'boolean')).to.equal(false);
+    expect(FT.fromClingoResult('other', 'boolean')).to.equal(false);
+    expect(FT.fromClingoResult('null', 'boolean')).to.equal(null);
+    expect(FT.fromClingoResult('', 'boolean')).to.equal('');
+  });
+  it('convert to number', () => {
+    expect(FT.fromClingoResult('1', 'number')).to.equal(1);
+    expect(FT.fromClingoResult('-1', 'number')).to.equal(-1);
+    expect(FT.fromClingoResult('1.4', 'number')).to.equal(1.4);
+    expect(FT.fromClingoResult('-1.4000001', 'number')).to.equal(-1.4000001);
+    expect(FT.fromClingoResult('null', 'number')).to.equal(null);
+    expect(FT.fromClingoResult('', 'number')).to.equal('');
+  });
+  it('convert to integer', () => {
+    expect(FT.fromClingoResult('1', 'integer')).to.equal(1);
+    expect(FT.fromClingoResult('-1', 'integer')).to.equal(-1);
+    expect(FT.fromClingoResult('1.4', 'integer')).to.equal(1);
+    expect(FT.fromClingoResult('-1.4000001', 'integer')).to.equal(-1);
+    expect(FT.fromClingoResult('null', 'integer')).to.equal(null);
+    expect(FT.fromClingoResult('', 'integer')).to.equal('');
+  });
+  it('convert to shortText', () => {
+    expect(FT.fromClingoResult('abc', 'shortText')).to.equal('abc');
+    expect(FT.fromClingoResult('abc abc', 'shortText')).to.equal('abc abc');
+    expect(FT.fromClingoResult('ß', 'shortText')).to.equal('ß');
+    expect(FT.fromClingoResult('null', 'shortText')).to.equal(null);
+    expect(FT.fromClingoResult('', 'shortText')).to.equal('');
+  });
+  it('convert to longText', () => {
+    const veryLongText =
+      '0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_0123456789_';
+    expect(FT.fromClingoResult('abc', 'longText')).to.equal('abc');
+    expect(FT.fromClingoResult('abc abc', 'longText')).to.equal('abc abc');
+    expect(FT.fromClingoResult(veryLongText, 'longText')).to.equal(
+      veryLongText,
+    );
+    expect(FT.fromClingoResult('ß', 'longText')).to.equal('ß');
+    expect(FT.fromClingoResult('null', 'longText')).to.equal(null);
+    expect(FT.fromClingoResult('', 'longText')).to.equal('');
+  });
+  it('convert enum', () => {
+    expect(FT.fromClingoResult('option1', 'enum')).to.equal('option1');
+    expect(FT.fromClingoResult('null', 'enum')).to.equal(null);
+    expect(FT.fromClingoResult('', 'enum')).to.equal('');
+  });
+  it('convert list', () => {
+    expect(
+      deepCompare(FT.fromClingoResult('(option1, option2)', 'list'), [
+        'option1',
+        'option2',
+      ]),
+    ).to.equal(true);
+    expect(deepCompare(FT.fromClingoResult('()', 'list'), [])).to.equal(true);
+    expect(FT.fromClingoResult('null', 'list')).to.equal(null);
+    expect(FT.fromClingoResult('', 'list')).to.equal('');
+  });
+  it('convert date', () => {
+    const epoch = new Date('1973-01-01').toISOString();
+    expect(FT.fromClingoResult(epoch, 'date')).to.equal('1973-01-01');
+    expect(FT.fromClingoResult('1972', 'date')).to.equal('1972-01-01');
+    expect(FT.fromClingoResult('null', 'date')).to.equal(null);
+    expect(FT.fromClingoResult('', 'date')).to.equal('');
+  });
+  it('convert dateTime', () => {
+    const epoch = new Date('1973-01-01').toISOString();
+    expect(FT.fromClingoResult(epoch, 'dateTime')).to.equal(
+      '1973-01-01T00:00:00.000Z',
+    );
+    expect(FT.fromClingoResult('null', 'dateTime')).to.equal(null);
+    expect(FT.fromClingoResult('', 'dateTime')).to.equal('');
+  });
+  it('convert person', () => {
+    const person = 'person@null.local';
+    const noDomain = 'person';
+    const onlyDomain = '@null.local';
+    expect(FT.fromClingoResult(person, 'person')).to.equal(person);
+    expect(FT.fromClingoResult(noDomain, 'person')).to.equal(null);
+    expect(FT.fromClingoResult(onlyDomain, 'person')).to.equal(null);
+    expect(FT.fromClingoResult('null', 'person')).to.equal(null);
+    expect(FT.fromClingoResult('', 'person')).to.equal('');
+  });
+});


### PR DESCRIPTION
Two new internal queries added: 
1) `onTransition` which is executed when state change for a card occurs. 
2) `onCreation` which is executed when cards are created. 

These queries return both "updateFields" array that define fields that need to be changed.

**LIMITATIONS**
Currently, `cardType` and `rank` cannot be changed through queries.
The first since it would basically require the card to be re-written and all new values provided; easier to just delete and then create a new card with a new type. 
The second since I doubt that users can provide valid rank as lexorank value. 

Noticed during implementation of this feature that "static" card metadata could also be fieldtypes which would in some cases make the implementation here and there a bit simpler. Ticket: https://cyberismo.atlassian.net/browse/INTDEV-782

We don't support chaining of transition changes yet. This means that a query would change state of a card to A which would again cause another card to change state and so on. This is due to limitations of running the query in `transition` command. It would require recursion to another transition command, which I find rather distasteful. Instead, when we implement `Card` class, it can easily execute the `onTransition` query whenever its workflow state changes. 