### PR TITLE
INTDEV-656 Allow resource identifiers to contain numbers

### DIFF
--- a/tools/data-handler/src/validate.ts
+++ b/tools/data-handler/src/validate.ts
@@ -417,7 +417,7 @@ export class Validate {
    * returns true if identifier is valid, and false otherwise.
    */
   public static isValidIdentifierName(identifier: string): boolean {
-    const validIdentifier = new RegExp('^[A-Za-z ._-]+$');
+    const validIdentifier = new RegExp('^[A-Za-z0-9 ._-]+$');
     const contentValidated = validIdentifier.test(identifier);
     const lengthValidated = identifier.length > 0 && identifier.length < 256;
     const notInvalidIdentifier = !invalidNames.test(identifier);

--- a/tools/data-handler/test/0_validate.test.ts
+++ b/tools/data-handler/test/0_validate.test.ts
@@ -335,12 +335,14 @@ describe('validate cmd tests', () => {
       'TEST',
       '_test',
       '-test',
+      'test111',
+      'test-222',
+      '2',
       'very-long-but-still-marvelously-valid-resource-name.that_canBe-used-as-a-resource-name',
     ];
     const invalidNames: string[] = [
       '',
-      'test2',
-      '2',
+      'testÄ',
       'test+too',
       'test*',
       'test$',

--- a/tools/data-handler/test/command-handler-create.test.ts
+++ b/tools/data-handler/test/command-handler-create.test.ts
@@ -412,7 +412,7 @@ describe('create command', () => {
     expect(result2.statusCode).to.equal(400);
   });
   it('fieldType with invalid name', async () => {
-    const name = `name1`;
+    const name = `nameÄ`;
     const dataType = 'integer';
     const result = await commandHandler.command(
       Cmd.create,

--- a/tools/data-handler/test/command-handler-update.test.ts
+++ b/tools/data-handler/test/command-handler-update.test.ts
@@ -136,7 +136,7 @@ describe('Update command tests', async () => {
   it('try to update file resource with invalid data', async () => {
     const name = `${project.projectPrefix}/workflows/simple`;
     const exists = await collector.resourceExists('workflows', name);
-    const invalidName = `${project.projectPrefix}/workflows/newName111`;
+    const invalidName = `${project.projectPrefix}/workflows/newName-ÄÄÄ`;
     expect(exists).to.equal(true);
 
     await update
@@ -146,7 +146,7 @@ describe('Update command tests', async () => {
       })
       .catch((error) => {
         expect(error.message).to.equal(
-          "Resource identifier must follow naming rules. Identifier 'newName111' is invalid",
+          "Resource identifier must follow naming rules. Identifier 'newName-ÄÄÄ' is invalid",
         );
       });
   });

--- a/tools/data-handler/test/resources.test.ts
+++ b/tools/data-handler/test/resources.test.ts
@@ -529,7 +529,7 @@ describe('resources', () => {
     it('try to create card type with invalid name', async () => {
       const res = new CardTypeResource(
         project,
-        resourceName('decision/cardTypes/new111'), // names cannot have digits
+        resourceName('decision/cardTypes/new-ööö'),
       );
       await res
         .createCardType('decision/workflows/decision')
@@ -537,7 +537,7 @@ describe('resources', () => {
         .catch((err) => {
           if (err instanceof Error) {
             expect(err.message).to.equal(
-              "Resource identifier must follow naming rules. Identifier 'new111' is invalid",
+              "Resource identifier must follow naming rules. Identifier 'new-ööö' is invalid",
             );
           }
         });
@@ -545,7 +545,7 @@ describe('resources', () => {
     it('try to create field type with invalid name', async () => {
       const res = new FieldTypeResource(
         project,
-        resourceName('decision/fieldTypes/new111'), // names cannot have digits
+        resourceName('decision/fieldTypes/new-ööö'),
       );
       await res
         .createFieldType('shortText')
@@ -553,7 +553,7 @@ describe('resources', () => {
         .catch((err) => {
           if (err instanceof Error) {
             expect(err.message).to.equal(
-              "Resource identifier must follow naming rules. Identifier 'new111' is invalid",
+              "Resource identifier must follow naming rules. Identifier 'new-ööö' is invalid",
             );
           }
         });
@@ -561,7 +561,7 @@ describe('resources', () => {
     it('try to create link type with invalid name', async () => {
       const res = new LinkTypeResource(
         project,
-        resourceName('decision/linkTypes/new111'), // names cannot have digits
+        resourceName('decision/linkTypes/new-ööö'),
       );
       await res
         .create()
@@ -569,7 +569,7 @@ describe('resources', () => {
         .catch((err) => {
           if (err instanceof Error) {
             expect(err.message).to.equal(
-              "Resource identifier must follow naming rules. Identifier 'new111' is invalid",
+              "Resource identifier must follow naming rules. Identifier 'new-ööö' is invalid",
             );
           }
         });
@@ -577,7 +577,7 @@ describe('resources', () => {
     it('try to create report with invalid name', async () => {
       const res = new ReportResource(
         project,
-        resourceName('decision/reports/new111'), // names cannot have digits
+        resourceName('decision/reports/new-ööö'),
       );
       await res
         .createReport()
@@ -585,7 +585,7 @@ describe('resources', () => {
         .catch((err) => {
           if (err instanceof Error) {
             expect(err.message).to.equal(
-              "Resource identifier must follow naming rules. Identifier 'new111' is invalid",
+              "Resource identifier must follow naming rules. Identifier 'new-ööö' is invalid",
             );
           }
         });
@@ -593,7 +593,7 @@ describe('resources', () => {
     it('try to create template with invalid name', async () => {
       const res = new TemplateResource(
         project,
-        resourceName('decision/templates/new111'), // names cannot have digits
+        resourceName('decision/templates/new-ööö'),
       );
       await res
         .create()
@@ -601,7 +601,7 @@ describe('resources', () => {
         .catch((err) => {
           if (err instanceof Error) {
             expect(err.message).to.equal(
-              "Resource identifier must follow naming rules. Identifier 'new111' is invalid",
+              "Resource identifier must follow naming rules. Identifier 'new-ööö' is invalid",
             );
           }
         });
@@ -609,7 +609,7 @@ describe('resources', () => {
     it('try to create workflow with invalid name', async () => {
       const res = new WorkflowResource(
         project,
-        resourceName('decision/workflows/new111'), // names cannot have digits
+        resourceName('decision/workflows/new-ööö'),
       );
       await res
         .create()
@@ -617,7 +617,7 @@ describe('resources', () => {
         .catch((err) => {
           if (err instanceof Error) {
             expect(err.message).to.equal(
-              "Resource identifier must follow naming rules. Identifier 'new111' is invalid",
+              "Resource identifier must follow naming rules. Identifier 'new-ööö' is invalid",
             );
           }
         });
@@ -625,7 +625,7 @@ describe('resources', () => {
     it('try to create card type with invalid type', async () => {
       const res = new CardTypeResource(
         project,
-        resourceName('decision/workflows/new-one'), // cannot create from workflows
+        resourceName('decision/workflows/new-one'),
       );
       await res
         .createCardType('decision/workflows/decision')
@@ -1251,14 +1251,14 @@ describe('resources', () => {
         });
       await res.delete();
     });
-    it('try to rename workflow - attempt to use illegal name', async () => {
+    it('try to rename workflow - attempt to use invalid name', async () => {
       const res = new WorkflowResource(
         project,
         resourceName('decision/workflows/newResForRename'),
       );
       await res.create();
       await res
-        .rename(resourceName('decision/workflows/newname111'))
+        .rename(resourceName('decision/workflows/newname-ööö'))
         .then(() => expect(false).to.equal(true))
         .catch((err) => {
           if (err instanceof Error) {
@@ -1542,7 +1542,7 @@ describe('resources', () => {
         .update('name', {
           name: 'change',
           target: '',
-          to: 'decision/fieldTypes/afterUpdate12121212',
+          to: 'decision/fieldTypes/afterUpdate-öööö',
         })
         .then(() => {
           expect(false).to.equal(true);

--- a/tools/schema/cardTreeDirectorySchema.json
+++ b/tools/schema/cardTreeDirectorySchema.json
@@ -481,7 +481,7 @@
           "type": "object",
           "additionalProperties": false,
           "patternProperties": {
-            "^[A-Za-z-_]+.json$": {
+            "^[A-Za-z0-9-_]+.json$": {
               "type": "object"
             },
             "^.schema$": {
@@ -626,7 +626,7 @@
               "type": "object",
               "additionalProperties": false,
               "patternProperties": {
-                "^[A-Za-z-_]+.json$": {
+                "^[A-Za-z0-9-_]+.json$": {
                   "type": "object",
                   "$comment": "Each file needs to be separately validated against 'contentSchema'",
                   "contentSchema": "templateSchema.json"

--- a/tools/schema/cardTypeSchema.json
+++ b/tools/schema/cardTypeSchema.json
@@ -9,13 +9,13 @@
       "description": "The name of the card type",
       "type": "string",
       "minLength": 1,
-      "pattern": "^[A-Za-z]*/?[A-Za-z]*/?[A-Za-z-_]+[.json]*$"
+      "pattern": "^[A-Za-z0-9]*/?[A-Za-z]*/?[A-Za-z-_]+[.json]*$"
     },
     "workflow": {
       "description": "The name of the workflow",
       "type": "string",
       "minLength": 1,
-      "pattern": "^[A-Za-z]*/?[A-Za-z]*/?[A-Za-z-_]+[.json]*$"
+      "pattern": "^[A-Za-z0-9]*/?[A-Za-z0-9]*/?[A-Za-z-_]+[.json]*$"
     },
     "customFields": {
       "type": "array",

--- a/tools/schema/reportSchema.json
+++ b/tools/schema/reportSchema.json
@@ -8,7 +8,7 @@
       "description": "The name of this report",
       "type": "string",
       "minLength": 1,
-      "pattern": "^[A-Za-z/._-]+$"
+      "pattern": "^[A-Za-z0-9/._-]+$"
     },
     "displayName": {
       "description": "The name of the report as it should be displayed in the user interface. For example, 'Children list'.",

--- a/tools/schema/templateSchema.json
+++ b/tools/schema/templateSchema.json
@@ -9,7 +9,7 @@
       "description": "The name of this template",
       "type": "string",
       "minLength": 1,
-      "pattern": "^[A-Za-z/._-]+$"
+      "pattern": "^[A-Za-z0-9/._-]+$"
     },
     "displayName": {
       "description": "The name of the template as it should be displayed in the user interface. For example, 'Decision'.",

--- a/tools/schema/workflowSchema.json
+++ b/tools/schema/workflowSchema.json
@@ -9,7 +9,7 @@
       "description": "The name of this workflow",
       "type": "string",
       "minLength": 1,
-      "pattern": "^[A-Za-z/._-]+$"
+      "pattern": "^[A-Za-z0-9/._-]+$"
     },
     "states": {
       "description": "The states of the workflow",


### PR DESCRIPTION
Allow resource identifiers (last part of "name") to consists of numbers; or contain numbers.