### PR TITLE
INTDEV-793 Rename internal folder when resource 'name' changes

### DIFF
--- a/tools/data-handler/src/resources/folder-resource.ts
+++ b/tools/data-handler/src/resources/folder-resource.ts
@@ -10,8 +10,8 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { join } from 'node:path';
-import { mkdir, rm } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+import { mkdir, rename, rm } from 'node:fs/promises';
 
 import { ResourceFolderType } from '../interfaces/project-interfaces.js';
 import {
@@ -20,6 +20,7 @@ import {
   FileResource,
   Operation,
   Project,
+  resourceName,
   ResourceName,
   resourceNameToString,
   sortCards,
@@ -118,6 +119,15 @@ export class FolderResource extends FileResource {
    * Writes resource content to disk.
    */
   protected async write() {
+    const folderName = basename(this.internalFolder);
+
+    // Check if "name" has changed. Changing "name" means renaming the file.
+    const nameInContent = resourceName(this.content.name).identifier;
+    if (folderName !== nameInContent) {
+      const newFolderName = join(this.resourceFolder, nameInContent);
+      await rename(this.internalFolder, newFolderName);
+      this.internalFolder = newFolderName;
+    }
     return super.write();
   }
 

--- a/tools/data-handler/src/resources/template-resource.ts
+++ b/tools/data-handler/src/resources/template-resource.ts
@@ -195,6 +195,7 @@ export class TemplateResource extends FolderResource {
    */
   public async write() {
     await super.write();
+    this.cardsFolder = join(this.internalFolder, 'c');
 
     // Create folder for cards and put proper content schema file there
     const schemaContentFile = join(this.cardsFolder, '.schema');


### PR DESCRIPTION
Folder-resource's internal folder doesn't change when resource `name` is changed. The metadata JSON file is correctly renamed.

The problem affects all of the folder-based resources (templates and reports; and incoming graphViews and graphModels). 
