### PR TITLE
INTDEV-772 Add resource types 'graphModels' and 'graphViews'

### DIFF
--- a/tools/app/app/api/fieldTypes/route.tsx
+++ b/tools/app/app/api/fieldTypes/route.tsx
@@ -46,7 +46,7 @@ export async function GET() {
     });
   }
 
-  const response = await commands.showCmd.showFieldTypes();
+  const response = await commands.showCmd.showResources('fieldTypes');
   if (response) {
     const fieldTypes = await Promise.all(
       response.map((fieldType: string) =>

--- a/tools/app/app/api/linkTypes/route.tsx
+++ b/tools/app/app/api/linkTypes/route.tsx
@@ -46,7 +46,7 @@ export async function GET() {
     });
   }
 
-  const response = await commands.showCmd.showLinkTypes();
+  const response = await commands.showCmd.showResources('linkTypes');
   if (response) {
     const linkTypes = await Promise.all(
       response.map((linkType: string) =>

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -76,6 +76,12 @@ const additionalHelpForCreate = `Sub-command help:
       <name> Name for fieldType. ${nameGuideline}
       <dataType> Type of field. You can list field types in a project with "show fieldTypes" command.
 
+  create graphModel <name>, where
+      <name> Name for graph model. ${nameGuideline}
+
+  create graphView <name>, where
+      <name> Name for graph view. ${nameGuideline}
+
   create label <cardKey> <labelName>, where
       <cardKey> Card key of the label
       <labelName> Name for the new label
@@ -272,6 +278,8 @@ program
         !resourceName &&
         !parameter1 &&
         type !== 'card' &&
+        type !== 'graphModel' &&
+        type !== 'graphView' &&
         type !== 'linkType' &&
         type !== 'report' &&
         type !== 'template' &&

--- a/tools/cli/src/resource-type-parser.ts
+++ b/tools/cli/src/resource-type-parser.ts
@@ -14,6 +14,8 @@
 const Resources = [
   'cardType',
   'fieldType',
+  'graphModel',
+  'graphView',
   'linkType',
   'report',
   'template',
@@ -24,6 +26,8 @@ const Resources = [
 const pluralLookUpForResources = new Map([
   ['cardType', 'cardTypes'],
   ['fieldType', 'fieldTypes'],
+  ['graphModel', 'graphModels'],
+  ['graphView', 'graphViews'],
   ['linkType', 'linkTypes'],
   ['report', 'reports'],
   ['template', 'templates'],

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -198,6 +198,12 @@ export class Commands {
         } else if (target === 'fieldType') {
           const [name, datatype] = rest;
           await this.commands?.createCmd.createFieldType(name, datatype);
+        } else if (target === 'graphModel') {
+          const [name] = rest;
+          await this.commands?.createCmd.createGraphModel(name);
+        } else if (target === 'graphView') {
+          const [name] = rest;
+          await this.commands?.createCmd.createGraphView(name);
         } else if (target == 'label') {
           const [cardKey, label] = rest;
           await this.commands?.createCmd.createLabel(cardKey, label);
@@ -518,6 +524,8 @@ export class Commands {
         break;
       case 'cardType':
       case 'fieldType':
+      case 'graphView':
+      case 'graphModel':
       case 'linkType':
       case 'report':
       case 'template':
@@ -525,16 +533,17 @@ export class Commands {
         promise = this.commands!.showCmd.showResource(detail, options.showUse);
         break;
       case 'cardTypes':
-        promise = this.commands!.showCmd.showCardTypes();
-        break;
       case 'fieldTypes':
-        promise = this.commands!.showCmd.showFieldTypes();
+      case 'graphModels':
+      case 'graphViews':
+      case 'linkTypes':
+      case 'reports':
+      case 'templates':
+      case 'workflows':
+        promise = this.commands!.showCmd.showResources(type);
         break;
       case 'labels':
         promise = this.commands!.showCmd.showLabels();
-        break;
-      case 'linkTypes':
-        promise = this.commands!.showCmd.showLinkTypes();
         break;
       case 'module':
         promise = this.commands!.showCmd.showModule(detail);
@@ -544,15 +553,6 @@ export class Commands {
         break;
       case 'project':
         promise = this.commands!.showCmd.showProject();
-        break;
-      case 'reports':
-        promise = this.commands!.showCmd.showReports();
-        break;
-      case 'templates':
-        promise = this.commands!.showCmd.showTemplates();
-        break;
-      case 'workflows':
-        promise = this.commands!.showCmd.showWorkflows();
         break;
       case 'attachment': // fallthrough - not implemented yet
       case 'link': // fallthrough - not implemented yet

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -51,6 +51,8 @@ import { Validate } from '../validate.js';
 
 import { CardTypeResource } from '../resources/card-type-resource.js';
 import { FieldTypeResource } from '../resources/field-type-resource.js';
+import { GraphModelResource } from '../resources/graph-model-resource.js';
+import { GraphViewResource } from '../resources/graph-view-resource.js';
 import { LinkTypeResource } from '../resources/link-type-resource.js';
 import { ReportResource } from '../resources/report-resource.js';
 import { TemplateResource } from '../resources/template-resource.js';
@@ -518,6 +520,28 @@ export class Project extends CardContainer {
   }
 
   /**
+   * Returns an array of all the graph models in the project.
+   * @param from  Defines where resources are collected from.
+   * @returns array of all the graph models in the project.
+   */
+  public async graphModels(
+    from: ResourcesFrom = ResourcesFrom.all,
+  ): Promise<Resource[]> {
+    return this.resources.resources('graphModels', from);
+  }
+
+  /**
+   * Returns an array of all the graph views in the project.
+   * @param from  Defines where resources are collected from.
+   * @returns array of all the graph views in the project.
+   */
+  public async graphViews(
+    from: ResourcesFrom = ResourcesFrom.all,
+  ): Promise<Resource[]> {
+    return this.resources.resources('graphViews', from);
+  }
+
+  /**
    * Checks if a given card is part of this project.
    * @param cardKey card to check.
    * @returns true if a given card is found from project, false otherwise.
@@ -708,6 +732,12 @@ export class Project extends CardContainer {
         ],
         fieldTypes: [
           ...(await this.resources.collectResourcesFromModules('fieldTypes')),
+        ],
+        graphModels: [
+          ...(await this.resources.collectResourcesFromModules('graphModels')),
+        ],
+        graphViews: [
+          ...(await this.resources.collectResourcesFromModules('graphViews')),
         ],
         linkTypes: [
           ...(await this.resources.collectResourcesFromModules('linkTypes')),
@@ -942,6 +972,10 @@ export class Project extends CardContainer {
       return new CardTypeResource(project, name);
     } else if (name.type === 'fieldTypes') {
       return new FieldTypeResource(project, name);
+    } else if (name.type === 'graphModels') {
+      return new GraphModelResource(project, name);
+    } else if (name.type === 'graphViews') {
+      return new GraphViewResource(project, name);
     } else if (name.type === 'linkTypes') {
       return new LinkTypeResource(project, name);
     } else if (name.type === 'reports') {

--- a/tools/data-handler/src/containers/project/project-paths.ts
+++ b/tools/data-handler/src/containers/project/project-paths.ts
@@ -28,6 +28,8 @@ export class ProjectPaths {
       ['calculations', this.calculationProjectFolder],
       ['cardTypes', this.cardTypesFolder],
       ['fieldTypes', this.fieldTypesFolder],
+      ['graphModels', this.graphModelsFolder],
+      ['graphViews', this.graphViewsFolder],
       ['linkTypes', this.linkTypesFolder],
       ['modules', this.modulesFolder],
       ['reports', this.reportsFolder],
@@ -62,6 +64,14 @@ export class ProjectPaths {
 
   public get fieldTypesFolder(): string {
     return join(this.resourcesFolder, 'fieldTypes');
+  }
+
+  public get graphModelsFolder(): string {
+    return join(this.resourcesFolder, 'graphModels');
+  }
+
+  public get graphViewsFolder(): string {
+    return join(this.resourcesFolder, 'graphViews');
   }
 
   public get linkTypesFolder(): string {

--- a/tools/data-handler/src/containers/project/resource-collector.ts
+++ b/tools/data-handler/src/containers/project/resource-collector.ts
@@ -41,6 +41,8 @@ class ResourceCollection {
   public calculations: Resource[] = [];
   public cardTypes: Resource[] = [];
   public fieldTypes: Resource[] = [];
+  public graphModels: Resource[] = [];
+  public graphViews: Resource[] = [];
   public linkTypes: Resource[] = [];
   public reports: Resource[] = [];
   public templates: Resource[] = [];
@@ -55,6 +57,8 @@ class ResourceCollection {
     if (type === 'calculations') return this.calculations;
     if (type === 'cardTypes') return this.cardTypes;
     if (type === 'fieldTypes') return this.fieldTypes;
+    if (type === 'graphViews') return this.graphViews;
+    if (type === 'graphModels') return this.graphModels;
     if (type === 'linkTypes') return this.linkTypes;
     if (type === 'reports') return this.reports;
     if (type === 'templates') return this.templates;
@@ -132,6 +136,12 @@ export class ResourceCollector {
       ];
       this.modules.fieldTypes = [
         ...(await this.addResources(modules, 'fieldTypes')),
+      ];
+      this.modules.graphModels = [
+        ...(await this.addResources(modules, 'graphModels')),
+      ];
+      this.modules.graphViews = [
+        ...(await this.addResources(modules, 'graphViews')),
       ];
       this.modules.linkTypes = [
         ...(await this.addResources(modules, 'linkTypes')),
@@ -230,6 +240,8 @@ export class ResourceCollector {
       'calculations',
       'cardTypes',
       'fieldTypes',
+      'graphModels',
+      'graphViews',
       'linkTypes',
       'reports',
       'templates',
@@ -272,6 +284,12 @@ export class ResourceCollector {
         break;
       case 'fieldTypes':
         addItem(this.local.fieldTypes, resource);
+        break;
+      case 'graphModels':
+        addItem(this.local.graphModels, resource);
+        break;
+      case 'graphViews':
+        addItem(this.local.graphViews, resource);
         break;
       case 'linkTypes':
         addItem(this.local.linkTypes, resource);

--- a/tools/data-handler/src/create.ts
+++ b/tools/data-handler/src/create.ts
@@ -33,6 +33,8 @@ import { writeJsonFile } from './utils/json.js';
 
 import { CardTypeResource } from './resources/card-type-resource.js';
 import { FieldTypeResource } from './resources/field-type-resource.js';
+import { GraphModelResource } from './resources/graph-model-resource.js';
+import { GraphViewResource } from './resources/graph-view-resource.js';
 import { LinkTypeResource } from './resources/link-type-resource.js';
 import { ReportResource } from './resources/report-resource.js';
 import { TemplateResource } from './resources/template-resource.js';
@@ -276,6 +278,30 @@ export class Create extends EventEmitter {
       resourceName(fieldTypeName),
     );
     await fieldType.createFieldType(dataType);
+  }
+
+  /**
+   * Creates a new graph model.
+   * @param graphModelName name for the graph model.
+   */
+  public async createGraphModel(graphModelName: string) {
+    const graphModel = new GraphModelResource(
+      this.project,
+      resourceName(graphModelName),
+    );
+    await graphModel.create();
+  }
+
+  /**
+   * Creates a new graph view.
+   * @param graphModelName name for the graph view.
+   */
+  public async createGraphView(graphViewName: string) {
+    const graphView = new GraphViewResource(
+      this.project,
+      resourceName(graphViewName),
+    );
+    await graphView.create();
   }
 
   /**

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -109,6 +109,8 @@ export interface ModuleSettings extends ProjectSettings {
   calculations: string[];
   cardTypes: string[];
   fieldTypes: string[];
+  graphModels: string[];
+  graphViews: string[];
   linkTypes: string[];
   reports: string[];
   templates: string[];
@@ -142,6 +144,8 @@ export type RemovableResourceTypes =
   | 'card'
   | 'cardType'
   | 'fieldType'
+  | 'graphModel'
+  | 'graphView'
   | 'link'
   | 'linkType'
   | 'module'
@@ -161,6 +165,8 @@ export type ResourceFolderType =
   | 'calculations'
   | 'cardTypes'
   | 'fieldTypes'
+  | 'graphModels'
+  | 'graphViews'
   | 'linkTypes'
   | 'modules'
   | 'reports'
@@ -170,22 +176,16 @@ export type ResourceFolderType =
 // All resource types; both singular and plural.
 export type ResourceTypes =
   | RemovableResourceTypes
+  | ResourceFolderType
   | 'attachments'
   | 'calculation'
-  | 'calculations'
   | 'cards'
-  | 'cardTypes'
-  | 'fieldTypes'
   | 'label'
   | 'labels'
   | 'links'
-  | 'linkTypes'
   | 'modules'
   | 'project'
-  | 'projects'
-  | 'reports'
-  | 'templates'
-  | 'workflows';
+  | 'projects';
 
 // Re-export Template Configuration to avoid unnecessary changes to other files.
 export { TemplateConfiguration };

--- a/tools/data-handler/src/interfaces/resource-interfaces.ts
+++ b/tools/data-handler/src/interfaces/resource-interfaces.ts
@@ -65,14 +65,27 @@ export interface FieldType extends ResourceBaseMetadata {
   enumValues?: Array<EnumDefinition>;
 }
 
-// File-based resources metadata content.
-export type ResourceContent =
-  | CardType
-  | FieldType
-  | LinkType
-  | ReportMetadata
-  | TemplateMetadata
-  | Workflow;
+// Graph model content.
+export interface GraphModelMetadata extends ResourceBaseMetadata {
+  category?: string;
+  description?: string;
+  displayName: string;
+}
+
+export interface GraphModel extends GraphModelMetadata {
+  calculationFile: string;
+}
+
+// Graph view content.
+export interface GraphViewMetadata extends ResourceBaseMetadata {
+  category?: string;
+  description?: string;
+  displayName: string;
+}
+
+export interface GraphView extends GraphViewMetadata {
+  handleBarFile: string;
+}
 
 // Link content.
 export interface Link {
@@ -111,6 +124,17 @@ export interface ResourceBaseMetadata {
   name: string;
   usedIn?: string[];
 }
+
+// All resources metadata content.
+export type ResourceContent =
+  | CardType
+  | FieldType
+  | GraphModel
+  | GraphView
+  | LinkType
+  | ReportMetadata
+  | TemplateMetadata
+  | Workflow;
 
 // Template configuration details.
 export interface TemplateConfiguration {

--- a/tools/data-handler/src/remove.ts
+++ b/tools/data-handler/src/remove.ts
@@ -39,6 +39,8 @@ export class Remove extends EventEmitter {
     return (
       type === 'cardType' ||
       type === 'fieldType' ||
+      type === 'graphModel' ||
+      type === 'graphView' ||
       type === 'linkType' ||
       type === 'report' ||
       type === 'template' ||

--- a/tools/data-handler/src/rename.ts
+++ b/tools/data-handler/src/rename.ts
@@ -24,6 +24,8 @@ import { Template } from './containers/template.js';
 
 import { CardTypeResource } from './resources/card-type-resource.js';
 import { FieldTypeResource } from './resources/field-type-resource.js';
+import { GraphModelResource } from './resources/graph-model-resource.js';
+import { GraphViewResource } from './resources/graph-view-resource.js';
 import { LinkTypeResource } from './resources/link-type-resource.js';
 import { ReportResource } from './resources/report-resource.js';
 import { TemplateResource } from './resources/template-resource.js';
@@ -200,6 +202,7 @@ export class Rename extends EventEmitter {
       : name;
   }
 
+  // @todo: merge all update-functions
   // Updates card type's metadata.
   private async updateCardTypeMetadata(cardTypeName: string) {
     const cardType = new CardTypeResource(
@@ -217,6 +220,28 @@ export class Rename extends EventEmitter {
     );
     return fieldType.rename(
       resourceName(this.updateResourceName(fieldTypeName)),
+    );
+  }
+
+  // Updates graph model's metadata.
+  private async updateGraphModelMetadata(graphModelName: string) {
+    const graphModel = new GraphModelResource(
+      this.project,
+      resourceName(graphModelName),
+    );
+    return graphModel.rename(
+      resourceName(this.updateResourceName(graphModelName)),
+    );
+  }
+
+  // Updates graph view's metadata.
+  private async updateGraphViewMetadata(graphViewName: string) {
+    const graphView = new GraphViewResource(
+      this.project,
+      resourceName(graphViewName),
+    );
+    return graphView.rename(
+      resourceName(this.updateResourceName(graphViewName)),
     );
   }
 
@@ -285,7 +310,7 @@ export class Rename extends EventEmitter {
     this.project.collectLocalResources();
 
     // Rename local resources.
-    // It is better to rename the resources in this order: card types, field types
+    // It is better to rename the resources in this order: card types, field types, then others
 
     // Rename all card types and custom fields in them.
     const cardTypes = await this.project.cardTypes(ResourcesFrom.localOnly);
@@ -305,6 +330,18 @@ export class Rename extends EventEmitter {
       await this.updateFieldTypeMetadata(fieldType.name);
     }
     console.info('Updated field types');
+
+    const graphModels = await this.project.graphModels(ResourcesFrom.localOnly);
+    for (const graphModel of graphModels) {
+      await this.updateGraphModelMetadata(graphModel.name);
+    }
+    console.info('Updated graph models');
+
+    const graphViews = await this.project.graphViews(ResourcesFrom.localOnly);
+    for (const graphView of graphViews) {
+      await this.updateGraphViewMetadata(graphView.name);
+    }
+    console.info('Updated graph views');
 
     const linkTypes = await this.project.linkTypes(ResourcesFrom.localOnly);
     for (const linkType of linkTypes) {

--- a/tools/data-handler/src/resources/create-defaults.ts
+++ b/tools/data-handler/src/resources/create-defaults.ts
@@ -15,6 +15,8 @@ import {
   CardType,
   DataType,
   FieldType,
+  GraphModelMetadata,
+  GraphViewMetadata,
   Link,
   LinkType,
   ReportMetadata,
@@ -98,6 +100,32 @@ export abstract class DefaultContent {
       value.enumValues = [{ enumValue: 'value1' }, { enumValue: 'value2' }];
     }
     return value;
+  }
+
+  /**
+   * Default content for graph model.
+   * @param graphModelName graph model name
+   * @returns Default content for graph model.
+   */
+  static graphModel(graphModelName: string): GraphModelMetadata {
+    return {
+      name: graphModelName,
+      displayName: '',
+      description: '',
+    };
+  }
+
+  /**
+   * Default content for graph view.
+   * @param graphViewName graph view name
+   * @returns Default content for graph view.
+   */
+  static graphView(graphViewName: string): GraphViewMetadata {
+    return {
+      name: graphViewName,
+      displayName: '',
+      description: '',
+    };
   }
 
   /**

--- a/tools/data-handler/src/resources/graph-model-resource.ts
+++ b/tools/data-handler/src/resources/graph-model-resource.ts
@@ -1,0 +1,204 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2025
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { readdir } from 'node:fs/promises';
+import { extname, join } from 'node:path';
+
+import {
+  Card,
+  DefaultContent,
+  FolderResource,
+  Operation,
+  Project,
+  ResourceName,
+  resourceNameToString,
+  sortCards,
+} from './folder-resource.js';
+import {
+  GraphModel,
+  GraphModelMetadata,
+} from '../interfaces/resource-interfaces.js';
+import { pathExists, writeFileSafe } from '../utils/file-utils.js';
+
+/**
+ * Graph model resource class.
+ */
+export class GraphModelResource extends FolderResource {
+  constructor(project: Project, name: ResourceName) {
+    super(project, name, 'graphModels');
+
+    this.contentSchemaId = 'graphModelSchema';
+    this.contentSchema = super.contentSchemaContent(this.contentSchemaId);
+
+    this.initialize();
+  }
+
+  // When resource name changes.
+  private async handleNameChange(existingName: string) {
+    await Promise.all([
+      super.updateHandleBars(existingName, this.content.name, [
+        await this.calculationFile(),
+      ]),
+      super.updateCalculations(existingName, this.content.name),
+    ]);
+    // Finally, write updated content.
+    await this.write();
+  }
+
+  /**
+   * Sets new metadata into the graph model object graph model.
+   * @param newContent metadata content for the graph model.
+   * @throws if 'newContent' is not valid.
+   */
+  public async create(newContent?: GraphModelMetadata) {
+    if (!newContent) {
+      newContent = DefaultContent.graphModel(
+        resourceNameToString(this.resourceName),
+      );
+    } else {
+      await this.validate(newContent);
+    }
+
+    return super.create(newContent);
+  }
+
+  /**
+   * Returns resource content.
+   */
+  public get data(): GraphModel {
+    return super.data as GraphModel;
+  }
+
+  /**
+   * Deletes file and folder that this resource is based on.
+   */
+  public async delete() {
+    return super.delete();
+  }
+
+  /**
+   * Returns calculation file that this graph model has.
+   * @returns calculation file name that this graph model has.
+   */
+  public async calculationFile(nameOnly: boolean = false): Promise<string> {
+    return (
+      await readdir(this.internalFolder, {
+        withFileTypes: true,
+        recursive: true,
+      })
+    )
+      .filter((dirent) => dirent.isFile() && extname(dirent.name) === '.lp')
+      .map((item) => (nameOnly ? item.name : join(item.parentPath, item.name)))
+      .at(0)!;
+  }
+
+  /**
+   * Renames the object and the file.
+   * @param newName New name for the resource.
+   */
+  public async rename(newName: ResourceName) {
+    const existingName = this.content.name;
+    await super.rename(newName);
+    return this.handleNameChange(existingName);
+  }
+
+  /**
+   * Shows metadata of the resource.
+   * @returns graph model metadata.
+   */
+  public async show(): Promise<GraphModel> {
+    const showOnlyFileName = true;
+    const baseData = (await super.show()) as GraphModelMetadata;
+    return {
+      ...baseData,
+      calculationFile: await this.calculationFile(showOnlyFileName),
+    };
+  }
+
+  /**
+   * Updates graph model resource.
+   * @param key Key to modify
+   * @param op Operation to perform on 'key'
+   * @throws if key is unknown.
+   */
+  public async update<Type>(key: string, op: Operation<Type>) {
+    const nameChange = key === 'name';
+    const existingName = this.content.name;
+
+    await super.update(key, op);
+
+    const content = { ...(this.content as GraphModel) };
+
+    if (key === 'name') {
+      content.name = super.handleScalar(op) as string;
+    } else if (key === 'displayName') {
+      content.displayName = super.handleScalar(op) as string;
+    } else if (key === 'description') {
+      content.description = super.handleScalar(op) as string;
+    } else if (key === 'category') {
+      content.category = super.handleScalar(op) as string;
+    }
+
+    await super.postUpdate(content, key, op);
+
+    // Renaming this graph model causes that references to its name must be updated.
+    if (nameChange) {
+      await this.handleNameChange(existingName);
+    }
+  }
+
+  /**
+   * List where this resource is used.
+   * Always returns card key references first, then calculation references.
+   *
+   * @param cards Optional. Check these cards for usage of this resource. If undefined, will check all cards.
+   * @returns array of card keys and calculation filenames that refer this resource.
+   */
+  public async usage(cards?: Card[]): Promise<string[]> {
+    const allCards = cards ?? (await super.cards());
+    const [relevantCards, calculations] = await Promise.all([
+      super.usage(allCards),
+      super.calculations(),
+    ]);
+    return [...relevantCards.sort(sortCards), ...calculations];
+  }
+
+  /**
+   * Validates graphModel.
+   * @throws when there are validation errors.
+   * @param content Content to be validated.
+   * @note If content is not provided, base class validation will use resource's current content.
+   */
+  public async validate(content?: object) {
+    return super.validate(content);
+  }
+
+  /**
+   *  Create the graph model's folder and calculation file.
+   */
+  public async write() {
+    await super.write();
+
+    const calculationsFile = join(this.internalFolder, 'model.lp');
+    if (!pathExists(calculationsFile)) {
+      await writeFileSafe(
+        calculationsFile,
+        `% add your calculations here for '${this.resourceName.identifier}'`,
+        {
+          flag: 'wx',
+        },
+      );
+    }
+  }
+}

--- a/tools/data-handler/src/resources/graph-view-resource.ts
+++ b/tools/data-handler/src/resources/graph-view-resource.ts
@@ -1,0 +1,200 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2025
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { readdir } from 'node:fs/promises';
+import { extname, join } from 'node:path';
+
+import {
+  Card,
+  DefaultContent,
+  FolderResource,
+  Operation,
+  Project,
+  ResourceName,
+  resourceNameToString,
+  sortCards,
+} from './folder-resource.js';
+import {
+  GraphView,
+  GraphViewMetadata,
+} from '../interfaces/resource-interfaces.js';
+import { pathExists, writeFileSafe } from '../utils/file-utils.js';
+
+/**
+ * Graph view resource class.
+ */
+export class GraphViewResource extends FolderResource {
+  constructor(project: Project, name: ResourceName) {
+    super(project, name, 'graphViews');
+
+    this.contentSchemaId = 'graphViewSchema';
+    this.contentSchema = super.contentSchemaContent(this.contentSchemaId);
+
+    this.initialize();
+  }
+
+  // When resource name changes.
+  private async handleNameChange(existingName: string) {
+    await Promise.all([
+      super.updateHandleBars(existingName, this.content.name, [
+        await this.handleBarFile(),
+      ]),
+      super.updateCalculations(existingName, this.content.name),
+    ]);
+    // Finally, write updated content.
+    await this.write();
+  }
+
+  /**
+   * Sets new metadata into the graph view object.
+   * @param newContent metadata content for the graph view.
+   * @throws if 'newContent' is not valid.
+   */
+  public async create(newContent?: GraphViewMetadata) {
+    if (!newContent) {
+      newContent = DefaultContent.graphView(
+        resourceNameToString(this.resourceName),
+      );
+    } else {
+      await this.validate(newContent);
+    }
+
+    return super.create(newContent);
+  }
+
+  /**
+   * Returns resource content.
+   */
+  public get data(): GraphView {
+    return super.data as GraphView;
+  }
+
+  /**
+   * Deletes file and folder that this resource is based on.
+   */
+  public async delete() {
+    return super.delete();
+  }
+
+  /**
+   * Returns handlebar filename that this graph view has.
+   * @returns handlebar filename that this graph view has.
+   */
+  public async handleBarFile(nameOnly: boolean = false): Promise<string> {
+    return (
+      await readdir(this.internalFolder, {
+        withFileTypes: true,
+        recursive: true,
+      })
+    )
+      .filter((dirent) => dirent.isFile() && extname(dirent.name) === '.hbs')
+      .map((item) => (nameOnly ? item.name : join(item.parentPath, item.name)))
+      .at(0)!;
+  }
+
+  /**
+   * Renames the object and the file.
+   * @param newName New name for the resource.
+   */
+  public async rename(newName: ResourceName) {
+    const existingName = this.content.name;
+    await super.rename(newName);
+    return this.handleNameChange(existingName);
+  }
+
+  /**
+   * Shows metadata of the resource.
+   * @returns graph view metadata.
+   */
+  public async show(): Promise<GraphView> {
+    const showOnlyFileName = true;
+    const baseData = (await super.show()) as GraphViewMetadata;
+    return {
+      ...baseData,
+      handleBarFile: await this.handleBarFile(showOnlyFileName),
+    };
+  }
+
+  /**
+   * Updates graph view resource.
+   * @param key Key to modify
+   * @param op Operation to perform on 'key'
+   * @throws if key is unknown.
+   */
+  public async update<Type>(key: string, op: Operation<Type>) {
+    const nameChange = key === 'name';
+    const existingName = this.content.name;
+
+    await super.update(key, op);
+
+    const content = { ...(this.content as GraphView) };
+
+    if (key === 'name') {
+      content.name = super.handleScalar(op) as string;
+    } else if (key === 'displayName') {
+      content.displayName = super.handleScalar(op) as string;
+    } else if (key === 'description') {
+      content.description = super.handleScalar(op) as string;
+    } else if (key === 'category') {
+      content.category = super.handleScalar(op) as string;
+    }
+
+    await super.postUpdate(content, key, op);
+
+    // Renaming this graph view causes that references to its name must be updated.
+    if (nameChange) {
+      await this.handleNameChange(existingName);
+    }
+  }
+
+  /**
+   * List where this resource is used.
+   * Always returns card key references first, then calculation references.
+   *
+   * @param cards Optional. Check these cards for usage of this resource. If undefined, will check all cards.
+   * @returns array of card keys and calculation filenames that refer this resource.
+   */
+  public async usage(cards?: Card[]): Promise<string[]> {
+    const allCards = cards ?? (await super.cards());
+    const [relevantCards, calculations] = await Promise.all([
+      super.usage(allCards),
+      super.calculations(),
+    ]);
+    return [...relevantCards.sort(sortCards), ...calculations];
+  }
+
+  /**
+   * Validates graph view.
+   * @throws when there are validation errors.
+   * @param content Content to be validated.
+   * @note If content is not provided, base class validation will use resource's current content.
+   */
+  public async validate(content?: object) {
+    return super.validate(content);
+  }
+
+  /**
+   *  Create the graph view's folder and handlebar file.
+   */
+  public async write() {
+    await super.write();
+
+    const handleBarFile = join(this.internalFolder, 'view.lp.hbs');
+    if (!pathExists(handleBarFile)) {
+      await writeFileSafe(handleBarFile, '', {
+        flag: 'wx',
+      });
+    }
+  }
+}

--- a/tools/data-handler/src/resources/report-resource.ts
+++ b/tools/data-handler/src/resources/report-resource.ts
@@ -75,7 +75,7 @@ export class ReportResource extends FolderResource {
 
   /**
    * Sets new metadata into the report object.
-   * @param newContent metadata content for the template.
+   * @param newContent metadata content for the report.
    * @throws if 'newContent' is not valid.
    */
   public async createReport() {
@@ -130,7 +130,7 @@ export class ReportResource extends FolderResource {
 
   /**
    * Shows metadata of the resource.
-   * @returns template metadata.
+   * @returns report metadata.
    */
   public async show(): Promise<Report> {
     const reportMetadata = (await super.show()) as ReportMetadata;
@@ -173,7 +173,7 @@ export class ReportResource extends FolderResource {
 
     await super.postUpdate(content, key, op);
 
-    // Renaming this template causes that references to its name must be updated.
+    // Renaming this report causes that references to its name must be updated.
     if (nameChange) {
       await this.handleNameChange(existingName);
     }

--- a/tools/data-handler/test/resources.test.ts
+++ b/tools/data-handler/test/resources.test.ts
@@ -23,6 +23,8 @@ import {
 
 import { CardTypeResource } from '../src/resources/card-type-resource.js';
 import { FieldTypeResource } from '../src/resources/field-type-resource.js';
+import { GraphModelResource } from '../src/resources/graph-model-resource.js';
+import { GraphViewResource } from '../src/resources/graph-view-resource.js';
 import { LinkTypeResource } from '../src/resources/link-type-resource.js';
 import { ReportResource } from '../src/resources/report-resource.js';
 import { TemplateResource } from '../src/resources/template-resource.js';
@@ -33,6 +35,8 @@ import {
   CustomField,
   EnumDefinition,
   FieldType,
+  GraphModel,
+  GraphView,
   LinkType,
   ReportMetadata,
   TemplateMetadata,
@@ -82,6 +86,8 @@ describe('resources', () => {
       expect((await collector.resources('calculations')).length).to.equal(0);
       expect((await collector.resources('cardTypes')).length).to.equal(0);
       expect((await collector.resources('fieldTypes')).length).to.equal(0);
+      expect((await collector.resources('graphModels')).length).to.equal(0);
+      expect((await collector.resources('graphViews')).length).to.equal(0);
       expect((await collector.resources('linkTypes')).length).to.equal(0);
       expect((await collector.resources('reports')).length).to.equal(0);
       expect((await collector.resources('templates')).length).to.equal(0);
@@ -92,6 +98,8 @@ describe('resources', () => {
       const calcCount = (await collector.resources('calculations')).length;
       const cardTypesCount = (await collector.resources('cardTypes')).length;
       const fieldTypesCount = (await collector.resources('fieldTypes')).length;
+      const graphModelCount = (await collector.resources('graphModels')).length;
+      const graphViewCount = (await collector.resources('graphViews')).length;
       const linkTypesCount = (await collector.resources('linkTypes')).length;
       const reportsCount = (await collector.resources('reports')).length;
       const templatesCount = (await collector.resources('templates')).length;
@@ -100,6 +108,8 @@ describe('resources', () => {
       expect(calcCount).not.to.equal(0);
       expect(cardTypesCount).not.to.equal(0);
       expect(fieldTypesCount).not.to.equal(0);
+      expect(graphModelCount).not.to.equal(0);
+      expect(graphViewCount).not.to.equal(0);
       expect(linkTypesCount).not.to.equal(0);
       expect(reportsCount).not.to.equal(0);
       expect(templatesCount).not.to.equal(0);
@@ -113,6 +123,10 @@ describe('resources', () => {
         .length;
       const fieldTypesCountAgain = (await collector.resources('fieldTypes'))
         .length;
+      const graphModelCountAgain = (await collector.resources('graphModels'))
+        .length;
+      const graphViewCountAgain = (await collector.resources('graphViews'))
+        .length;
       const linkTypesCountAgain = (await collector.resources('linkTypes'))
         .length;
       const reportsCountAgain = (await collector.resources('reports')).length;
@@ -124,6 +138,8 @@ describe('resources', () => {
       expect(calcCount).to.equal(calcCountAgain);
       expect(cardTypesCount).to.equal(cardTypesCountAgain);
       expect(fieldTypesCount).to.equal(fieldTypesCountAgain);
+      expect(graphModelCount).to.equal(graphModelCountAgain);
+      expect(graphViewCount).to.equal(graphViewCountAgain);
       expect(linkTypesCount).to.equal(linkTypesCountAgain);
       expect(reportsCount).to.equal(reportsCountAgain);
       expect(templatesCount).to.equal(templatesCountAgain);
@@ -137,6 +153,10 @@ describe('resources', () => {
         await collector.collectResourcesFromModules('cardTypes');
       const moduleFieldTypes =
         await collector.collectResourcesFromModules('fieldTypes');
+      const moduleGraphModels =
+        await collector.collectResourcesFromModules('graphModels');
+      const moduleGraphViews =
+        await collector.collectResourcesFromModules('graphViews');
       const moduleLinkTypes =
         await collector.collectResourcesFromModules('linkTypes');
       const moduleReports =
@@ -150,6 +170,8 @@ describe('resources', () => {
       expect(moduleCalcs.length).to.equal(0);
       expect(moduleCardTypes.length).to.equal(0);
       expect(moduleFieldTypes.length).to.equal(0);
+      expect(moduleGraphModels.length).to.equal(0);
+      expect(moduleGraphViews.length).to.equal(0);
       expect(moduleLinkTypes.length).to.equal(0);
       expect(moduleReports.length).to.equal(0);
       expect(moduleTemplates.length).to.equal(0);
@@ -163,6 +185,12 @@ describe('resources', () => {
       );
       expect((await collector.resources('fieldTypes')).length).to.equal(
         fieldTypesCount,
+      );
+      expect((await collector.resources('graphModels')).length).to.equal(
+        graphModelCount,
+      );
+      expect((await collector.resources('graphViews')).length).to.equal(
+        graphViewCount,
       );
       expect((await collector.resources('linkTypes')).length).to.equal(
         linkTypesCount,
@@ -182,7 +210,7 @@ describe('resources', () => {
       const collector = new ResourceCollector(project);
 
       // Store the resource counts before import.
-      // Note that minimal project does not have fieldTypes, linkTypes or reports
+      // Note that minimal project does not have fieldTypes, graphModels, graphViews, linkTypes or reports
       collector.collectLocalResources();
       const calcCount = (await collector.resources('calculations')).length;
       const cardTypesCount = (await collector.resources('cardTypes')).length;
@@ -291,6 +319,10 @@ describe('resources', () => {
           await createCmd.createTemplate(nameForResource, '');
         } else if (type === 'reports') {
           await createCmd.createReport(nameForResource);
+        } else if (type === 'graphModels') {
+          await createCmd.createGraphModel(nameForResource);
+        } else if (type === 'graphViews') {
+          await createCmd.createGraphView(nameForResource);
         } else {
           expect(false).to.equal(true);
         }
@@ -312,8 +344,10 @@ describe('resources', () => {
         expect(exists).to.equal(false);
       }
 
-      checkResource('templates');
+      checkResource('graphModels');
+      checkResource('graphViews');
       checkResource('reports');
+      checkResource('templates');
     });
   });
 
@@ -345,7 +379,7 @@ describe('resources', () => {
       expect(found).to.equal(undefined);
       await res.createCardType('decision/workflows/decision');
       const after = await project.cardTypes();
-      found = after.find((item) => item.name === 'decision/cardTypes/newCT');
+      found = after.find((item) => item.name === res.data.name);
       expect(found).to.not.equal(undefined);
     });
     it('create field type', async () => {
@@ -360,7 +394,37 @@ describe('resources', () => {
       expect(found).to.equal(undefined);
       await res.createFieldType('shortText');
       const after = await project.fieldTypes();
-      found = after.find((item) => item.name === 'decision/fieldTypes/newFT');
+      found = after.find((item) => item.name === res.data.name);
+      expect(found).to.not.equal(undefined);
+    });
+    it('create graph model', async () => {
+      const res = new GraphModelResource(
+        project,
+        resourceName('decision/graphModels/newGM'),
+      );
+      const before = await project.graphModels();
+      let found = before.find(
+        (item) => item.name === 'decision/graphModels/newGM',
+      );
+      expect(found).to.equal(undefined);
+      await res.create();
+      const after = await project.graphModels();
+      found = after.find((item) => item.name === res.data.name);
+      expect(found).to.not.equal(undefined);
+    });
+    it('create graph view', async () => {
+      const res = new GraphViewResource(
+        project,
+        resourceName('decision/graphViews/newGV'),
+      );
+      const before = await project.graphViews();
+      let found = before.find(
+        (item) => item.name === 'decision/graphViews/newGV',
+      );
+      expect(found).to.equal(undefined);
+      await res.create();
+      const after = await project.graphViews();
+      found = after.find((item) => item.name === res.data.name);
       expect(found).to.not.equal(undefined);
     });
     it('create link type', async () => {
@@ -375,7 +439,7 @@ describe('resources', () => {
       expect(found).to.equal(undefined);
       await res.create();
       const after = await project.linkTypes();
-      found = after.find((item) => item.name === 'decision/linkTypes/newLT');
+      found = after.find((item) => item.name === res.data.name);
       expect(found).to.not.equal(undefined);
     });
     it('create link type with provided content', async () => {
@@ -436,7 +500,7 @@ describe('resources', () => {
       expect(found).to.equal(undefined);
       await res.createReport();
       const after = await project.reports();
-      found = after.find((item) => item.name === 'decision/reports/newREP');
+      found = after.find((item) => item.name === res.data.name);
       expect(found).to.not.equal(undefined);
     });
     it('create template', async () => {
@@ -451,7 +515,7 @@ describe('resources', () => {
       expect(found).to.equal(undefined);
       await res.create();
       const after = await project.templates();
-      found = after.find((item) => item.name === 'decision/templates/newTEMP');
+      found = after.find((item) => item.name === res.data.name);
       expect(found).to.not.equal(undefined);
     });
     it('create template with provided content', async () => {
@@ -507,7 +571,7 @@ describe('resources', () => {
       expect(found).to.equal(undefined);
       await res.create();
       const after = await project.workflows();
-      found = after.find((item) => item.name === 'decision/workflows/newWF');
+      found = after.find((item) => item.name === res.data.name);
       expect(found).to.not.equal(undefined);
     });
     it('create workflow with provided content', async () => {
@@ -570,6 +634,38 @@ describe('resources', () => {
           if (err instanceof Error) {
             expect(err.message).to.equal(
               "Resource identifier must follow naming rules. Identifier 'new-ööö' is invalid",
+            );
+          }
+        });
+    });
+    it('try to create graph model with invalid name', async () => {
+      const res = new GraphModelResource(
+        project,
+        resourceName('decision/graphModels/newÄ'),
+      );
+      await res
+        .create()
+        .then(() => expect(false).to.equal(true))
+        .catch((err) => {
+          if (err instanceof Error) {
+            expect(err.message).to.equal(
+              "Resource identifier must follow naming rules. Identifier 'newÄ' is invalid",
+            );
+          }
+        });
+    });
+    it('try to create graph view with invalid name', async () => {
+      const res = new GraphViewResource(
+        project,
+        resourceName('decision/graphViews/newÖ'),
+      );
+      await res
+        .create()
+        .then(() => expect(false).to.equal(true))
+        .catch((err) => {
+          if (err instanceof Error) {
+            expect(err.message).to.equal(
+              "Resource identifier must follow naming rules. Identifier 'newÖ' is invalid",
             );
           }
         });
@@ -654,90 +750,10 @@ describe('resources', () => {
           }
         });
     });
-    it('try to create link type with invalid type', async () => {
-      const res = new LinkTypeResource(
-        project,
-        resourceName('decision/workflows/new-one'), // cannot create from workflows
-      );
-      await res
-        .create()
-        .then(() => expect(false).to.equal(true))
-        .catch((err) => {
-          if (err instanceof Error) {
-            expect(err.message).to.equal(
-              "Resource name must match the resource type. Type 'workflows' does not match 'linkTypes'",
-            );
-          }
-        });
-    });
-    it('try to create workflow with invalid type', async () => {
-      const res = new WorkflowResource(
-        project,
-        resourceName('decision/linkTypes/new-one'), // cannot create from link types
-      );
-      await res
-        .create()
-        .then(() => expect(false).to.equal(true))
-        .catch((err) => {
-          if (err instanceof Error) {
-            expect(err.message).to.equal(
-              "Resource name must match the resource type. Type 'linkTypes' does not match 'workflows'",
-            );
-          }
-        });
-    });
-    it('try to create card type with invalid project prefix', async () => {
-      const res = new CardTypeResource(
-        project,
-        resourceName('diipadaapa/cardTypes/new-one'), // cannot create from unknown prefix
-      );
-      await res
-        .createCardType('decision/workflows/decision')
-        .then(() => expect(false).to.equal(true))
-        .catch((err) => {
-          if (err instanceof Error) {
-            expect(err.message).to.equal(
-              "Resource name can only refer to project that it is part of. Prefix 'diipadaapa' is not included in '[decision]'",
-            );
-          }
-        });
-    });
-    it('try to create field type with invalid project prefix', async () => {
-      const res = new FieldTypeResource(
-        project,
-        resourceName('diipadaapa/fieldTypes/new-one'), // cannot create from unknown prefix
-      );
-      await res
-        .createFieldType('shortText')
-        .then(() => expect(false).to.equal(true))
-        .catch((err) => {
-          if (err instanceof Error) {
-            expect(err.message).to.equal(
-              "Resource name can only refer to project that it is part of. Prefix 'diipadaapa' is not included in '[decision]'",
-            );
-          }
-        });
-    });
-    it('try to create link type with invalid project prefix', async () => {
-      const res = new LinkTypeResource(
-        project,
-        resourceName('diipadaapa/linkTypes/new-one'), // cannot create from unknown prefix
-      );
-      await res
-        .create()
-        .then(() => expect(false).to.equal(true))
-        .catch((err) => {
-          if (err instanceof Error) {
-            expect(err.message).to.equal(
-              "Resource name can only refer to project that it is part of. Prefix 'diipadaapa' is not included in '[decision]'",
-            );
-          }
-        });
-    });
-    it('try to create report with invalid project prefix', async () => {
+    it('try to create field type with invalid type', async () => {
       const res = new ReportResource(
         project,
-        resourceName('diipadaapa/reports/new-one'), // cannot create from unknown prefix
+        resourceName('decision/workflows/new-one'), // cannot create from workflows
       );
       await res
         .createReport()
@@ -745,39 +761,129 @@ describe('resources', () => {
         .catch((err) => {
           if (err instanceof Error) {
             expect(err.message).to.equal(
-              "Resource name can only refer to project that it is part of. Prefix 'diipadaapa' is not included in '[decision]'",
+              "Resource name must match the resource type. Type 'workflows' does not match 'reports'",
             );
           }
         });
     });
-    it('try to create template with invalid project prefix', async () => {
-      const res = new TemplateResource(
+    it('try to create resources with invalid types', async () => {
+      const resources = [
+        // cannot create any of these with 'cardTypes' in name
+        new GraphModelResource(
+          project,
+          resourceName('decision/cardTypes/new-one'),
+        ),
+        new GraphViewResource(
+          project,
+          resourceName('decision/cardTypes/new-one'),
+        ),
+        new LinkTypeResource(
+          project,
+          resourceName('decision/cardTypes/new-one'),
+        ),
+        new TemplateResource(
+          project,
+          resourceName('decision/cardTypes/new-one'),
+        ),
+        new WorkflowResource(
+          project,
+          resourceName('decision/cardTypes/new-one'),
+        ),
+      ];
+      for (const res of resources) {
+        await res
+          .create()
+          .then(() => expect(false).to.equal(true))
+          .catch((err) => {
+            if (err instanceof Error) {
+              expect(err.message).to.include(
+                "Resource name must match the resource type. Type 'cardTypes' does not match",
+              );
+            }
+          });
+      }
+    });
+    it('try to create card type with invalid project prefix', async () => {
+      const res = new CardTypeResource(
         project,
-        resourceName('diipadaapa/templates/new-one'), // cannot create from unknown prefix
+        resourceName('unknown/cardTypes/new-one'),
       );
       await res
-        .create()
+        .createCardType('decision/workflows/decision')
         .then(() => expect(false).to.equal(true))
         .catch((err) => {
           if (err instanceof Error) {
             expect(err.message).to.equal(
-              "Resource name can only refer to project that it is part of. Prefix 'diipadaapa' is not included in '[decision]'",
+              "Resource name can only refer to project that it is part of. Prefix 'unknown' is not included in '[decision]'",
             );
           }
         });
     });
-    it('try to create workflow with invalid project prefix', async () => {
-      const res = new WorkflowResource(
+    it('try to create field type with invalid project prefix', async () => {
+      const res = new FieldTypeResource(
         project,
-        resourceName('diipadaapa/workflows/new-one'), // cannot create from unknown prefix
+        resourceName('unknown/fieldTypes/new-one'),
       );
       await res
-        .create()
+        .createFieldType('shortText')
         .then(() => expect(false).to.equal(true))
         .catch((err) => {
           if (err instanceof Error) {
             expect(err.message).to.equal(
-              "Resource name can only refer to project that it is part of. Prefix 'diipadaapa' is not included in '[decision]'",
+              "Resource name can only refer to project that it is part of. Prefix 'unknown' is not included in '[decision]'",
+            );
+          }
+        });
+    });
+    it('try to create resources with invalid project prefix', async () => {
+      // Include only resources that can be created with call to 'create()'
+      const resources = [
+        new GraphModelResource(
+          project,
+          resourceName('unknown/graphModels/new-one'),
+        ),
+        new GraphViewResource(
+          project,
+          resourceName('unknown/graphViews/new-one'),
+        ),
+        new LinkTypeResource(
+          project,
+          resourceName('unknown/linkTypes/new-one'),
+        ),
+        new TemplateResource(
+          project,
+          resourceName('unknown/templates/new-one'),
+        ),
+        new WorkflowResource(
+          project,
+          resourceName('unknown/workflows/new-one'),
+        ),
+      ];
+      for (const res of resources) {
+        await res
+          .create()
+          .then(() => expect(false).to.equal(true))
+          .catch((err) => {
+            if (err instanceof Error) {
+              expect(err.message).to.equal(
+                "Resource name can only refer to project that it is part of. Prefix 'unknown' is not included in '[decision]'",
+              );
+            }
+          });
+      }
+    });
+    it('try to create report with invalid project prefix', async () => {
+      const res = new ReportResource(
+        project,
+        resourceName('unknown/reports/new-one'),
+      );
+      await res
+        .createReport()
+        .then(() => expect(false).to.equal(true))
+        .catch((err) => {
+          if (err instanceof Error) {
+            expect(err.message).to.equal(
+              "Resource name can only refer to project that it is part of. Prefix 'unknown' is not included in '[decision]'",
             );
           }
         });
@@ -838,6 +944,32 @@ describe('resources', () => {
         JSON.stringify({
           name: 'decision/fieldTypes/newFT',
           dataType: 'shortText',
+        }),
+      );
+    });
+    it('data of graph model', async () => {
+      const res = new GraphModelResource(
+        project,
+        resourceName('decision/graphModels/newGM'),
+      );
+      expect(JSON.stringify(res.data)).to.equal(
+        JSON.stringify({
+          name: 'decision/graphModels/newGM',
+          displayName: '',
+          description: '',
+        }),
+      );
+    });
+    it('data of graph view', async () => {
+      const res = new GraphViewResource(
+        project,
+        resourceName('decision/graphViews/newGV'),
+      );
+      expect(JSON.stringify(res.data)).to.equal(
+        JSON.stringify({
+          name: 'decision/graphViews/newGV',
+          displayName: '',
+          description: '',
         }),
       );
     });
@@ -930,6 +1062,36 @@ describe('resources', () => {
         JSON.stringify({
           name: 'decision/fieldTypes/newFT',
           dataType: 'shortText',
+        }),
+      );
+    });
+    it('show graph model', async () => {
+      const res = new GraphModelResource(
+        project,
+        resourceName('decision/graphModels/newGM'),
+      );
+      const data = await res.show();
+      expect(JSON.stringify(data)).to.equal(
+        JSON.stringify({
+          name: 'decision/graphModels/newGM',
+          displayName: '',
+          description: '',
+          calculationFile: 'model.lp',
+        }),
+      );
+    });
+    it('show graph view', async () => {
+      const res = new GraphViewResource(
+        project,
+        resourceName('decision/graphViews/newGV'),
+      );
+      const data = await res.show();
+      expect(JSON.stringify(data)).to.equal(
+        JSON.stringify({
+          name: 'decision/graphViews/newGV',
+          displayName: '',
+          description: '',
+          handleBarFile: 'view.lp.hbs',
         }),
       );
     });
@@ -1075,89 +1237,71 @@ describe('resources', () => {
         }),
       );
     });
-    it('validate card type', async () => {
-      const res = new CardTypeResource(
-        project,
-        resourceName('decision/cardTypes/newCT'),
-      );
-      await res.validate().catch(() => expect(false).to.equal(true));
+    it('validate resources', async () => {
+      const resources = [
+        new CardTypeResource(project, resourceName('decision/cardTypes/newCT')),
+        new FieldTypeResource(
+          project,
+          resourceName('decision/fieldTypes/newFT'),
+        ),
+        new GraphModelResource(
+          project,
+          resourceName('decision/graphModels/newGM'),
+        ),
+        new GraphViewResource(
+          project,
+          resourceName('decision/graphViews/newGV'),
+        ),
+        new LinkTypeResource(project, resourceName('decision/linkTypes/newLT')),
+        new ReportResource(project, resourceName('decision/reports/newREP')),
+        new TemplateResource(
+          project,
+          resourceName('decision/templates/newTEMP'),
+        ),
+        new WorkflowResource(project, resourceName('decision/workflows/newWF')),
+      ];
+      for (const resource of resources) {
+        await resource.validate().catch(() => expect(false).to.equal(true));
+      }
     });
-    it('validate field type', async () => {
-      const res = new FieldTypeResource(
-        project,
-        resourceName('decision/fieldTypes/newFT'),
-      );
-      await res.validate().catch(() => expect(false).to.equal(true));
-    });
-    it('validate link type', async () => {
-      const res = new LinkTypeResource(
-        project,
-        resourceName('decision/linkTypes/newLT'),
-      );
-      await res.validate().catch(() => expect(false).to.equal(true));
-    });
-    it('validate report', async () => {
-      const res = new ReportResource(
-        project,
-        resourceName('decision/reports/newREP'),
-      );
-      await res.validate().catch(() => expect(false).to.equal(true));
-    });
-    it('validate template', async () => {
-      const res = new TemplateResource(
-        project,
-        resourceName('decision/templates/newTEMP'),
-      );
-      await res.validate().catch(() => expect(false).to.equal(true));
-    });
-    it('validate workflow', async () => {
-      const res = new WorkflowResource(
-        project,
-        resourceName('decision/workflows/newWF'),
-      );
-      await res.validate().catch(() => expect(false).to.equal(true));
-    });
-    it('try to validate missing card type', async () => {
-      const res = new CardTypeResource(
-        project,
-        resourceName('decision/cardTypes/i-do-not-exist'),
-      );
-      await res.validate().catch(() => expect(true).to.equal(true));
-    });
-    it('try to validate missing field type', async () => {
-      const res = new FieldTypeResource(
-        project,
-        resourceName('decision/fieldTypes/i-do-not-exist'),
-      );
-      await res.validate().catch(() => expect(true).to.equal(true));
-    });
-    it('try to validate missing link type', async () => {
-      const res = new LinkTypeResource(
-        project,
-        resourceName('decision/linkTypes/i-do-not-exist'),
-      );
-      await res.validate().catch(() => expect(true).to.equal(true));
-    });
-    it('try to validate missing report', async () => {
-      const res = new ReportResource(
-        project,
-        resourceName('decision/reports/i-do-not-exist'),
-      );
-      await res.validate().catch(() => expect(true).to.equal(true));
-    });
-    it('try to validate missing template', async () => {
-      const res = new TemplateResource(
-        project,
-        resourceName('decision/templates/i-do-not-exist'),
-      );
-      await res.validate().catch(() => expect(true).to.equal(true));
-    });
-    it('try to validate missing workflow', async () => {
-      const res = new WorkflowResource(
-        project,
-        resourceName('decision/workflows/i-do-not-exist'),
-      );
-      await res.validate().catch(() => expect(true).to.equal(true));
+    it('try to validate missing resource types', async () => {
+      const resources = [
+        new CardTypeResource(
+          project,
+          resourceName('decision/cardTypes/i-do-not-exist'),
+        ),
+        new FieldTypeResource(
+          project,
+          resourceName('decision/fieldTypes/i-do-not-exist'),
+        ),
+        new GraphModelResource(
+          project,
+          resourceName('decision/graphModels/i-do-not-exist'),
+        ),
+        new GraphViewResource(
+          project,
+          resourceName('decision/graphViews/i-do-not-exist'),
+        ),
+        new LinkTypeResource(
+          project,
+          resourceName('decision/linkTypes/i-do-not-exist'),
+        ),
+        new ReportResource(
+          project,
+          resourceName('decision/reports/i-do-not-exist'),
+        ),
+        new TemplateResource(
+          project,
+          resourceName('decision/templates/i-do-not-exist'),
+        ),
+        new WorkflowResource(
+          project,
+          resourceName('decision/workflows/i-do-not-exist'),
+        ),
+      ];
+      for (const resource of resources) {
+        await resource.validate().catch(() => expect(true).to.equal(true));
+      }
     });
     it('rename card type', async () => {
       const res = new CardTypeResource(
@@ -1167,6 +1311,26 @@ describe('resources', () => {
       await res.createCardType('decision/workflows/decision');
       await res.rename(resourceName('decision/cardTypes/newname'));
       expect(res.data.name).equals('decision/cardTypes/newname');
+      await res.delete();
+    });
+    it('rename graph model', async () => {
+      const res = new GraphModelResource(
+        project,
+        resourceName('decision/graphModels/newResForRename'),
+      );
+      await res.create();
+      await res.rename(resourceName('decision/graphModels/newname'));
+      expect(res.data.name).equals('decision/graphModels/newname');
+      await res.delete();
+    });
+    it('rename graph view', async () => {
+      const res = new GraphViewResource(
+        project,
+        resourceName('decision/graphViews/newResForRename'),
+      );
+      await res.create();
+      await res.rename(resourceName('decision/graphViews/newname'));
+      expect(res.data.name).equals('decision/graphViews/newname');
       await res.delete();
     });
     it('rename field type', async () => {
@@ -1634,6 +1798,58 @@ describe('resources', () => {
       expect(data.outboundDisplayName).to.equal('outbound');
       expect(data.enableLinkDescription).to.equal(true);
     });
+    it('update graph model scalar values', async () => {
+      const res = new GraphModelResource(
+        project,
+        resourceName('decision/graphModels/newGraphModel'),
+      );
+      await res.create();
+      await res.update('displayName', {
+        name: 'change',
+        target: '',
+        to: 'updated',
+      });
+      await res.update('description', {
+        name: 'change',
+        target: '',
+        to: 'updated',
+      });
+      await res.update('category', {
+        name: 'change',
+        target: '',
+        to: 'updated',
+      });
+      const data = res.data as GraphModel;
+      expect(data.displayName).to.equal('updated');
+      expect(data.description).to.equal('updated');
+      expect(data.category).to.equal('updated');
+    });
+    it('update graph view scalar values', async () => {
+      const res = new GraphViewResource(
+        project,
+        resourceName('decision/graphViews/newGraphView'),
+      );
+      await res.create();
+      await res.update('displayName', {
+        name: 'change',
+        target: '',
+        to: 'updated',
+      });
+      await res.update('description', {
+        name: 'change',
+        target: '',
+        to: 'updated',
+      });
+      await res.update('category', {
+        name: 'change',
+        target: '',
+        to: 'updated',
+      });
+      const data = res.data as GraphView;
+      expect(data.displayName).to.equal('updated');
+      expect(data.description).to.equal('updated');
+      expect(data.category).to.equal('updated');
+    });
     it('update link type arrays', async () => {
       const res = new LinkTypeResource(
         project,
@@ -1880,6 +2096,26 @@ describe('resources', () => {
       const after = await project.fieldTypes();
       found = after.find((item) => item.name === name);
     });
+    it('delete graph model', async () => {
+      const name = 'decision/graphModels/newGM';
+      const res = new GraphModelResource(project, resourceName(name));
+      const before = await project.graphModels();
+      let found = before.find((item) => item.name === name);
+      expect(found).to.not.equal(undefined);
+      await res.delete();
+      const after = await project.graphModels();
+      found = after.find((item) => item.name === name);
+    });
+    it('delete graph view', async () => {
+      const name = 'decision/graphViews/newGV';
+      const res = new GraphViewResource(project, resourceName(name));
+      const before = await project.graphViews();
+      let found = before.find((item) => item.name === name);
+      expect(found).to.not.equal(undefined);
+      await res.delete();
+      const after = await project.graphViews();
+      found = after.find((item) => item.name === name);
+    });
     it('delete link type', async () => {
       const name = 'decision/linkTypes/newLT';
       const res = new LinkTypeResource(project, resourceName(name));
@@ -1942,6 +2178,36 @@ describe('resources', () => {
       const name = 'decision/fieldTypes/nonExisting';
       const res = new FieldTypeResource(project, resourceName(name));
       const before = await project.fieldTypes();
+      const found = before.find((item) => item.name === name);
+      expect(found).to.equal(undefined);
+      await res
+        .delete()
+        .then(() => expect(false).to.equal(true))
+        .catch((error) =>
+          expect(error.message).to.equal(
+            `Resource 'nonExisting' does not exist in the project`,
+          ),
+        );
+    });
+    it('try to delete graph model that does not exist', async () => {
+      const name = 'decision/graphModels/nonExisting';
+      const res = new GraphModelResource(project, resourceName(name));
+      const before = await project.graphModels();
+      const found = before.find((item) => item.name === name);
+      expect(found).to.equal(undefined);
+      await res
+        .delete()
+        .then(() => expect(false).to.equal(true))
+        .catch((error) =>
+          expect(error.message).to.equal(
+            `Resource 'nonExisting' does not exist in the project`,
+          ),
+        );
+    });
+    it('try to delete graph view that does not exist', async () => {
+      const name = 'decision/graphViews/nonExisting';
+      const res = new GraphModelResource(project, resourceName(name));
+      const before = await project.graphViews();
       const found = before.find((item) => item.name === name);
       expect(found).to.equal(undefined);
       await res
@@ -2045,6 +2311,20 @@ describe('resources', () => {
         .then((references) =>
           expect(references).to.include('decision/cardTypes/decision'),
         );
+    });
+    it('check usage of graphModel resource', async () => {
+      const name = 'decision/graphModels/test';
+      const res = new GraphModelResource(project, resourceName(name));
+      await res
+        .usage()
+        .then((references) => expect(references.length).to.equal(0));
+    });
+    it('check usage of graphView resource', async () => {
+      const name = 'decision/graphViews/test';
+      const res = new GraphViewResource(project, resourceName(name));
+      await res
+        .usage()
+        .then((references) => expect(references.length).to.equal(0));
     });
     it('check usage of linkType resource', async () => {
       const name = 'decision/linkTypes/test';

--- a/tools/data-handler/test/show.test.ts
+++ b/tools/data-handler/test/show.test.ts
@@ -185,16 +185,8 @@ describe('show', () => {
         ),
       );
   });
-  it('showCardTypes (success)', async () => {
-    const results = await showCmd.showCardTypes();
-    expect(results).to.not.equal(undefined);
-  });
   it('showCardTypesWithDetails (success)', async () => {
     const results = await showCmd.showCardTypesWithDetails();
-    expect(results).to.not.equal(undefined);
-  });
-  it('showFieldTypes (success)', async () => {
-    const results = await showCmd.showFieldTypes();
     expect(results).to.not.equal(undefined);
   });
   it('showResource - field type (success)', async () => {
@@ -211,10 +203,6 @@ describe('show', () => {
           `FieldType '${fieldTypeName}' does not exist in the project`,
         ),
       );
-  });
-  it('showLinkTypes (success)', async () => {
-    const results = await showCmd.showLinkTypes();
-    expect(results).to.not.equal(undefined);
   });
   it('showResource - link type (success)', async () => {
     const fieldTypeName = 'decision/linkTypes/test';
@@ -278,9 +266,28 @@ describe('show', () => {
         ),
       );
   });
-  it('showTemplates (success)', async () => {
-    const results = await showCmd.showTemplates();
-    expect(results).to.not.equal(undefined);
+  it('showResources - valid types', async () => {
+    const validResourceTypes = [
+      'cardTypes',
+      'fieldTypes',
+      'graphViews',
+      'graphModels',
+      'linkTypes',
+      'reports',
+      'templates',
+      'workflows',
+    ];
+    for (const type of validResourceTypes) {
+      const results = await showCmd.showResources(type);
+      expect(results).to.not.equal(undefined);
+    }
+  });
+  it('showResources - invalid type', async () => {
+    const validResourceTypes = ['unknown'];
+    for (const type of validResourceTypes) {
+      const results = await showCmd.showResources(type);
+      expect(results.length).to.equal(0);
+    }
   });
   it('showTemplatesWithDetails (success)', async () => {
     const results = await showCmd.showTemplatesWithDetails();
@@ -310,10 +317,6 @@ describe('show', () => {
           `Workflow '${workflowName}' does not exist in the project`,
         ),
       );
-  });
-  it('showWorkflows (success)', async () => {
-    const results = await showCmd.showWorkflows();
-    expect(results).to.not.equal(undefined);
   });
   it('showWorkflowsWithDetails (success)', async () => {
     const results = await showCmd.showWorkflowsWithDetails();

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/graphModels/.schema
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/graphModels/.schema
@@ -1,0 +1,6 @@
+[
+  {
+    "version": 1,
+    "id": "graphModelSchema"
+  }
+]

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/graphModels/test.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/graphModels/test.json
@@ -1,0 +1,6 @@
+{
+    "displayName": "Test graph model",
+    "description": "This would be description...",
+    "category": "None",
+    "name": "decision/graphModels/test"
+}

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/graphViews/.schema
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/graphViews/.schema
@@ -1,0 +1,6 @@
+[
+  {
+    "version": 1,
+    "id": "graphViewSchema"
+  }
+]

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/graphViews/test.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/graphViews/test.json
@@ -1,0 +1,6 @@
+{
+    "displayName": "Test graph view",
+    "description": "This would be description...",
+    "category": "None",
+    "name": "decision/graphViews/test"
+}

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/graphViews/test/view.lp.hbs
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/graphViews/test/view.lp.hbs
@@ -1,0 +1,2 @@
+select("title").
+result(Card) :- parent(Card, {{cardKey}}).

--- a/tools/schema/graphMacroBaseSchema.json
+++ b/tools/schema/graphMacroBaseSchema.json
@@ -1,7 +1,7 @@
 {
   "title": "Graph",
   "$id": "graphMacroBaseSchema",
-  "description": "A graph object provides suppplemental information about a graph",
+  "description": "A graph object provides supplemental information about a graph",
   "type": "object",
   "properties": {
     "model": {

--- a/tools/schema/graphModelSchema.json
+++ b/tools/schema/graphModelSchema.json
@@ -1,0 +1,28 @@
+{
+  "title": "GraphModel",
+  "$id": "graphModelSchema",
+  "description": "A graph model object provides data for graph views",
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "The name of this graph model",
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9/._-]+$"
+    },
+    "displayName": {
+      "description": "The name of the graph model as it should be displayed in the user interface. For example, 'Workflow data'.",
+      "type": "string"
+    },
+    "description": {
+      "description": "A description of the graph model. For example, 'Workflow data defines necessary data elements to show workflow graphically.'.",
+      "type": "string"
+    },
+    "category": {
+      "description": "The category of the graph model. For example, 'UserModels'.",
+      "type": "string"
+    }
+  },
+  "required": ["name", "displayName"],
+  "additionalProperties": false
+}

--- a/tools/schema/graphViewSchema.json
+++ b/tools/schema/graphViewSchema.json
@@ -1,0 +1,28 @@
+{
+  "title": "GraphView",
+  "$id": "graphViewSchema",
+  "description": "A graph view object provides means to show graph model data to users",
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "The name of this graph view",
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9/._-]+$"
+    },
+    "displayName": {
+      "description": "The name of the graph view as it should be displayed in the user interface. For example, 'Workflow view'.",
+      "type": "string"
+    },
+    "description": {
+      "description": "A description of the graph view. For example, 'Workflow view defines ways how to show workflow data to the user'.",
+      "type": "string"
+    },
+    "category": {
+      "description": "The category of the graph view. For example, 'UserViews'.",
+      "type": "string"
+    }
+  },
+  "required": ["name", "displayName"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
Add two new resource types: graph models and graph views.
New resources support all available commands and functionalities (no calculations for them are being generate at the moment though).

Removed resource-specific `show` functions from `show` command; and instead use a generic `showResource()` instead.


**Migrator**
Unzip the package.
In the unzipped directory, execute `node migrator.js <path to the root of a project>`
The tool automatically converts existing graph models and graph views to have proper configuration files and the resource folder to have correct `.schema` file in place. After migration, please check that the migration worked correctly by running validation.  Do not migrate content repos until this PR has been merged.
[migrate_graph_resources.zip](https://github.com/user-attachments/files/19383571/migrate_graph_resources.zip)
