### PR TITLE
INTDEV-127 Card instantiation: store template card key to card metadata

### DIFF
--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -225,6 +225,9 @@ export class Template extends CardContainer {
       const newMetadata = {
         ...card.metadata,
         ...customFields,
+        templateCardKey: [...templateIDMap]
+          .find(([, value]) => value === card.key)!
+          .at(0),
         workflowState: initialWorkflowState.toState,
         cardType: cardType.name,
         rank: cardWithRank?.metadata?.rank || card.metadata.rank || EMPTY_RANK,

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -45,6 +45,7 @@ export interface PredefinedCardMetadata {
   rank: string;
   lastTransitioned?: string;
   lastUpdated?: string;
+  templateCardKey?: string;
 }
 
 // todo: do we need in the future separation between module-template-cards and local template-cards

--- a/tools/data-handler/test/template.test.ts
+++ b/tools/data-handler/test/template.test.ts
@@ -91,7 +91,13 @@ describe('template', () => {
       fetchCardDetails,
     );
     expect(cardBefore?.children?.length).to.equal(0);
-    await template.createCards(cardBefore);
+
+    // Check that created cards are mapped from template cards.
+    const createdCards = await template.createCards(cardBefore);
+    const templateCards = await template.cards();
+    expect(
+      createdCards.map((item) => item.metadata?.templateCardKey),
+    ).to.have.same.members(templateCards.map((item) => item.key));
 
     // Two direct children should have been created
     const cardAfter = await project.findSpecificCard(

--- a/tools/schema/cardBaseSchema.json
+++ b/tools/schema/cardBaseSchema.json
@@ -66,6 +66,10 @@
         "required": ["cardKey", "linkType"],
         "additionalProperties": false
       }
+    },
+    "templateCardKey": {
+      "type": "string",
+      "description": "Card key from which this card has been instantiated"
     }
   },
   "required": ["title", "cardType", "workflowState", "rank"]


### PR DESCRIPTION
When card is instantiated, store the template card key to `templateCardKey` property of metadata.
This needs to be done in reverse-lookup (convert Map to array; use `find()` , but since this is a small map and requires no file operations, it is fast enough) to get the value from `Map`.