### PR TITLE
INTDEV-580 Allow 'enum' value to be updated

### DIFF
--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -603,7 +603,10 @@ program
   )
   .argument('<key>', 'Detail to be changed')
   .argument('<value>', 'Value for a detail')
-  .argument('[newValue]', 'When using "change" define new value for detail')
+  .argument(
+    '[newValue]',
+    'When using "change" define new value for detail.\nWhen using "remove" provide optional replacement value for removed value',
+  )
   .action(
     async (
       resourceName: string,

--- a/tools/data-handler/src/commands/update.ts
+++ b/tools/data-handler/src/commands/update.ts
@@ -65,6 +65,9 @@ export class Update {
       (op as RankOperation<Type>).target = value;
     } else if (operation === 'remove') {
       (op as RemoveOperation<Type>).target = value;
+      (op as RemoveOperation<Type>).replacementValue = optionalDetail
+        ? optionalDetail
+        : undefined;
     }
 
     await resource?.update(key, op);

--- a/tools/data-handler/src/resources/array-handler.ts
+++ b/tools/data-handler/src/resources/array-handler.ts
@@ -48,6 +48,7 @@ export class ArrayHandler<T> {
     if (index === -1) {
       index = array.findIndex((element) => {
         const nameOnlyElement = { name: element['name' as keyof T] };
+        if (nameOnlyElement.name === undefined) return false;
         return deepCompare(nameOnlyElement as object, item as object);
       });
     }

--- a/tools/data-handler/src/resources/card-type-resource.ts
+++ b/tools/data-handler/src/resources/card-type-resource.ts
@@ -95,29 +95,29 @@ export class CardTypeResource extends FileResource {
       content: true,
     };
 
+    if (op && op.name === 'rank') return;
+
+    // Collect both project cards and template cards.
+    const cards = await this.collectCards(cardContent);
+
     if (op && op.name === 'change') {
       const from = (op as ChangeOperation<string>).target;
       const to = (op as ChangeOperation<string>).to;
 
-      // Collect both project cards and template cards.
-      const cards = await this.collectCards(cardContent);
       // Then update them all parallel.
       const promises: Promise<void>[] = [];
       for (const card of cards) {
         promises.push(this.updateCardMetadata(card, from, to));
       }
       await Promise.all(promises);
-    } else if (op && (op.name === 'add' || op.name === 'remove')) {
-      const cards = await this.collectCards(cardContent);
-      if (op.name === 'add') {
-        // todo: target can be string here as well? Fix at some point
-        const item = (op as AddOperation<Type>).target as CustomField;
-        await this.handleAddNewField(cards, item);
-      } else {
-        // todo: target can be string here as well? Fix at some point
-        const item = (op as RemoveOperation<Type>).target as CustomField;
-        await this.handleRemoveField(cards, item);
-      }
+    } else if (op && op.name === 'add') {
+      // todo: target can be string here as well? Fix at some point
+      const item = (op as AddOperation<Type>).target as CustomField;
+      await this.handleAddNewField(cards, item);
+    } else if (op && op.name === 'remove') {
+      // todo: target can be string here as well? Fix at some point
+      const item = (op as RemoveOperation<Type>).target as CustomField;
+      await this.handleRemoveField(cards, item);
     }
   }
 

--- a/tools/data-handler/src/resources/resource-object.ts
+++ b/tools/data-handler/src/resources/resource-object.ts
@@ -55,6 +55,7 @@ export type RankOperation<T> = BaseOperation<T> & {
 // Remove item from an array.
 export type RemoveOperation<T> = BaseOperation<T> & {
   name: 'remove';
+  replacementValue?: T;
 };
 
 export type Operation<T> =

--- a/tools/schema/resources/fieldTypeSchema.json
+++ b/tools/schema/resources/fieldTypeSchema.json
@@ -38,7 +38,8 @@
           "enumDescription": {
             "type": "string"
           }
-        }
+        },
+        "required": ["enumValue"]
       }
     }
   },


### PR DESCRIPTION
Allow field type with `enum` data type to be updated with `update` command. 
All operations (`add`, `change` or `remove`) are supported.

The operations need to be mostly implemented as exceptions in `FieldTypeResource` class since `enum` values do not have the generic object structure that other resources have (If they'd be `{"name": <value of enum>, "displayName": <display name>, "description": <description>}` this would be somewhat simpler change.
Alternatively, we could handle the "special case of ''enumValue" in the `ArrayHandler`.

There was a bug in the `ArrayHandler` class. The search for existing value ended up comparing `undefined` to `undefined` when trying to find `name` from the object. Therefore it assumed - incorrectly - that value already existed.

I also added support for providing a "replacement value" for removed enum value (only with `remove` update operation). The replacement enum value is automatically changed to relevant cards after the removed enum value has been removed from field type. One could argue that the replacement value could be provided with `change` update operation as well, but it would make the API even more horrible than it currently is (`cyberismo update <fieldType> change enumValues <current value in JSON> <updated value in JSON>`). If someone thinks it must be done, I can add it to the PR later. 
Also, I made a new ticket: https://cyberismo.atlassian.net/browse/INTDEV-798 to add similar support for other `remove` places in the code. 

Additionally, noticed that `fieldTypeSchema` does not require `enumValue`, thus made it mandatory. 
Finally, I simplified one card type function, even if it wasn't actually related to this PR.
