### PR TITLE
INTDEV-775 Optimize find card functions

### DIFF
--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -480,23 +480,16 @@ export class Project extends CardContainer {
         }
       } else {
         const templates = await this.templates();
-        for (const template of templates) {
-          templateObject = new TemplateResource(
+        const searchPromises = templates.map((template) => {
+          const templateObj = new TemplateResource(
             this,
             resourceName(template.name),
           ).templateObject();
+          return templateObj.findSpecificCard(cardToFind as string, details);
+        });
 
-          // optimize: execute each find in template parallel
-          if (templateObject) {
-            card = await templateObject.findSpecificCard(
-              cardToFind as string,
-              details,
-            );
-            if (card) {
-              break;
-            }
-          }
-        }
+        const results = await Promise.all(searchPromises);
+        card = results.find((result) => result != null);
       }
     }
     return card;

--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -506,6 +506,17 @@ export class Template extends CardContainer {
     cardKey: string,
     details: FetchCardDetails = {},
   ): Promise<Card | undefined> {
+    const cardPrefix = cardKey.split('_').at(0);
+    const moduleCardFromProject =
+      this.basePath.includes('local') &&
+      this.project.projectPrefix !== cardPrefix;
+    const projectCardFromModule =
+      this.basePath.includes('modules') &&
+      this.project.projectPrefix === cardPrefix;
+    // If the result is impossible, return undefined.
+    if (moduleCardFromProject || projectCardFromModule) {
+      return undefined;
+    }
     return super.findCard(this.templateCardsPath, cardKey, details);
   }
 


### PR DESCRIPTION
Three small optimisations for finding cards: 

1) If result is impossible, return `undefined`. Impossible results are finding a module template card from project cards; or finding a project card from module template cards. 
2) Find cards from templates parallel instead of sequential. Consumes more memory, but should be generally faster.
3) Remove unnecessary `Regex` test when trying to find a card. There is no need to check if the searched cardKey complies with `Regex` pattern.

All in all, on my Mac these make showing a card from CLI ~10% faster. Can have more impact on slower machines.