### PR TITLE
INTDEV-795 Remove EventEmitters and call 'Calculate' directly

### DIFF
--- a/tools/data-handler/src/commands/create.ts
+++ b/tools/data-handler/src/commands/create.ts
@@ -1,13 +1,14 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
-
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 // node
@@ -18,7 +19,6 @@ import {
   mkdir,
   writeFile,
 } from 'node:fs/promises';
-import { EventEmitter } from 'node:events';
 
 import { Calculate, Validate } from './index.js';
 import { errorFunction } from '../utils/log-utils.js';
@@ -45,18 +45,11 @@ import { WorkflowResource } from '../resources/workflow-resource.js';
 /**
  * Handles all create commands.
  */
-export class Create extends EventEmitter {
+export class Create {
   constructor(
     private project: Project,
     private calculateCmd: Calculate,
-  ) {
-    super();
-
-    this.addListener(
-      'created',
-      this.calculateCmd.handleNewCards.bind(this.calculateCmd),
-    );
-  }
+  ) {}
 
   static JSONFileContent: ProjectFile[] = [
     {
@@ -242,7 +235,7 @@ export class Create extends EventEmitter {
 
     const createdCards = await templateObject.createCards(specificCard);
     if (createdCards.length > 0) {
-      this.emit('created', createdCards);
+      await this.calculateCmd.handleNewCards(createdCards);
       // Note: This assumes that parent keys will be ahead of 'a' in the sort order.
       const sorted = sortItems(createdCards, (item) => {
         return `${item.parent === 'root' ? 'a' : item.parent}${item.metadata?.rank || EMPTY_RANK}`;

--- a/tools/data-handler/src/commands/remove.ts
+++ b/tools/data-handler/src/commands/remove.ts
@@ -1,17 +1,17 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
-
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 // node
-import { EventEmitter } from 'node:events';
 import { join, sep } from 'node:path';
 
 import { ActionGuard } from '../permissions/action-guard.js';
@@ -26,13 +26,11 @@ const MODULES_PATH = `${sep}modules${sep}`;
 /**
  * Remove command.
  */
-export class Remove extends EventEmitter {
+export class Remove {
   constructor(
     private project: Project,
     private calculateCmd: Calculate,
-  ) {
-    super();
-  }
+  ) {}
 
   // True, if resource is a project resource
   private projectResource(type: RemovableResourceTypes): boolean {
@@ -112,10 +110,6 @@ export class Remove extends EventEmitter {
       await this.calculateCmd.handleDeleteCard(card);
     }
     await deleteDir(cardFolder);
-
-    if (card) {
-      this.emit('removed', card);
-    }
   }
 
   // removes label from project

--- a/tools/data-handler/src/commands/rename.ts
+++ b/tools/data-handler/src/commands/rename.ts
@@ -1,18 +1,18 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
-
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 // node
 import { assert } from 'node:console';
-import { EventEmitter } from 'node:events';
 import { join } from 'node:path';
 import { rename, readdir, readFile, writeFile } from 'node:fs/promises';
 
@@ -36,21 +36,14 @@ const FILE_TYPES_WITH_PREFIX_REFERENCES = ['adoc', 'hbs', 'json', 'lp'];
 /**
  * Class that handles 'rename' command.
  */
-export class Rename extends EventEmitter {
+export class Rename {
   private from: string = '';
   private to: string = '';
 
   constructor(
     private project: Project,
     private calculateCmd: Calculate,
-  ) {
-    super();
-
-    this.addListener(
-      'renamed',
-      this.calculateCmd.generate.bind(this.calculateCmd),
-    );
-  }
+  ) {}
 
   // Renames a card and all of its attachments (if it is a project card).
   private async renameCard(re: RegExp, card: Card): Promise<void> {
@@ -384,6 +377,6 @@ export class Rename extends EventEmitter {
     this.project.collectLocalResources();
     console.info('Collected renamed resources');
 
-    this.emit('renamed');
+    return this.calculateCmd.generate();
   }
 }

--- a/tools/data-handler/src/commands/transition.ts
+++ b/tools/data-handler/src/commands/transition.ts
@@ -1,20 +1,18 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
-
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-// node
-import { EventEmitter } from 'node:events';
-
 import { ActionGuard } from '../permissions/action-guard.js';
-import { Calculate } from './index.js';
+import { Calculate } from './calculate.js';
 import {
   CardType,
   Workflow,
@@ -23,17 +21,11 @@ import {
 import { CardMetadataUpdater } from '../card-metadata-updater.js';
 import { Project } from '../containers/project.js';
 
-export class Transition extends EventEmitter {
+export class Transition {
   constructor(
     private project: Project,
     private calculateCmd: Calculate,
-  ) {
-    super();
-    this.addListener(
-      'transitioned',
-      this.calculateCmd.handleCardChanged.bind(this.calculateCmd),
-    );
-  }
+  ) {}
 
   /**
    * Transitions a card from its current state to a new state.


### PR DESCRIPTION
Four commands affected. For some reason in INTDEV-671 the `emit` was already removed from `Transition` command, but the `EventEmitter` inheritance was left as-is. 

I also changed the Copyright blocks to NOT have 80+ characters per row for the changed sources.