### PR TITLE
INTDEV-805 Retrieve affected cards correctly in Calculate

### DIFF
--- a/tools/data-handler/src/commands/calculate.ts
+++ b/tools/data-handler/src/commands/calculate.ts
@@ -271,25 +271,16 @@ export class Calculate {
   }
 
   // Gets either all the cards (no parent), or a subtree.
-  private async getCards(parentCard: Card | undefined): Promise<Card[]> {
+  private async getCards(card: Card | undefined): Promise<Card[]> {
     let cards: Card[] = [];
-    if (parentCard) {
-      const card = await this.project.findSpecificCard(parentCard, {
-        metadata: true,
-        children: true,
-        content: false,
-        parent: false,
-      });
-      if (card && card.children) {
-        cards = Project.flattenCardArray(card.children);
-      }
-      if (card) {
-        card.children = [];
-        cards.unshift(card);
-      }
-    } else {
-      cards = await this.project.cards();
+    if (!card) {
+      return this.project.cards();
     }
+    if (card.children) {
+      cards = Project.flattenCardArray(card.children);
+    }
+    card.children = [];
+    cards.unshift(card);
     return cards;
   }
 
@@ -340,7 +331,12 @@ export class Calculate {
 
       let card: Card | undefined;
       if (cardKey) {
-        card = await this.project.findSpecificCard(cardKey);
+        card = await this.project.findSpecificCard(cardKey, {
+          metadata: true,
+          children: true,
+          content: false,
+          parent: false,
+        });
         if (!card) {
           throw new Error(`Card '${cardKey}' not found`);
         }

--- a/tools/data-handler/src/commands/remove.ts
+++ b/tools/data-handler/src/commands/remove.ts
@@ -105,7 +105,12 @@ export class Remove {
     await Promise.all(promiseContainer);
 
     // Calculations need to be updated before card is removed.
-    const card = await this.project.findSpecificCard(cardKey);
+    const card = await this.project.findSpecificCard(cardKey, {
+      metadata: true,
+      children: true,
+      content: false,
+      parent: false,
+    });
     if (card) {
       await this.calculateCmd.handleDeleteCard(card);
     }

--- a/tools/data-handler/test/project.test.ts
+++ b/tools/data-handler/test/project.test.ts
@@ -515,24 +515,6 @@ describe('project', () => {
     });
     expect(existingCard).to.not.equal(undefined);
   });
-  it('find certain card from project - using template card object and different details (success)', async () => {
-    const decisionRecordsPath = join(testDir, 'valid/decision-records');
-    const project = new Project(decisionRecordsPath);
-    expect(project).to.not.equal(undefined);
-
-    const existingCard = await project.findSpecificCard('decision_1', {
-      content: true,
-    });
-    expect(existingCard).to.not.equal(undefined);
-    if (existingCard) {
-      const sameReference = await project.findSpecificCard(existingCard, {
-        content: true,
-        metadata: true,
-        parent: true,
-      });
-      expect(sameReference).to.not.equal(undefined);
-    }
-  });
   it('check if project is created (success)', () => {
     const decisionRecordsPath = join(testDir, 'valid/decision-records');
     const project = new Project(decisionRecordsPath);


### PR DESCRIPTION
Fetch the needed details already in `Remove` (it is already fetching card details, so it could fetch ones that `Calculate` can use). Then use the card with received details in `Calculate`. Remove the extra fetch. It was only place where `Card` was used as a parameter for `findSpecificCard` and that API has broken at some point. Remove the `Card` parameter type support from `findSpecificCard` - use only card key string from now on.