### PR TITLE
INTDEV-806 Update 'cardtree.lp' correctly when card is deleted

### DIFF
--- a/tools/data-handler/src/commands/calculate.ts
+++ b/tools/data-handler/src/commands/calculate.ts
@@ -391,6 +391,7 @@ export class Calculate {
       let cardTreeContent = calculationsForTreeExist
         ? await readFile(cardTreeFile, 'utf-8')
         : '';
+      let filteredLines = cardTreeContent.split('\n');
       for (const card of affectedCards) {
         // First, delete card specific files.
         const cardCalculationsFile = join(
@@ -401,11 +402,10 @@ export class Calculate {
           await deleteFile(cardCalculationsFile);
         }
         // Then, delete rows from cardTree.lp.
-        const removeRow = `#include "cards/${card.key}.lp".\n`.replace(
-          /\\/g,
-          '/',
+        filteredLines = filteredLines.filter(
+          (line) => !line.includes(`cards/${card.key}.lp`),
         );
-        cardTreeContent = cardTreeContent.replace(removeRow, '');
+        cardTreeContent = filteredLines.join('\n');
       }
       if (calculationsForTreeExist) {
         await writeFileSafe(cardTreeFile, cardTreeContent);

--- a/tools/data-handler/test/command-handler-remove.test.ts
+++ b/tools/data-handler/test/command-handler-remove.test.ts
@@ -311,21 +311,6 @@ describe('remove command', () => {
       );
       expect(result.statusCode).to.equal(400);
     });
-    // todo: at some point move to own test file
-    it('Remove - remove card (success)', async () => {
-      const cardId = 'decision_5';
-      const project = new Project(decisionRecordsPath);
-      const calculateCmd = new Calculate(project);
-      const removeCmd = new Remove(project, calculateCmd);
-      await removeCmd
-        .remove('card', cardId)
-        .then(() => {
-          expect(true);
-        })
-        .catch(() => {
-          expect(false);
-        });
-    });
   });
 
   describe('removal attempts', () => {

--- a/tools/data-handler/test/remove.test.ts
+++ b/tools/data-handler/test/remove.test.ts
@@ -1,0 +1,55 @@
+import { expect } from 'chai';
+import { dirname, join } from 'node:path';
+import { mkdirSync, rmSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+
+import { copyDir, pathExists } from '../src/utils/file-utils.js';
+import { CommandManager } from '../src/command-manager.js';
+import { Remove } from '../src/commands/remove.js';
+
+import { fileURLToPath } from 'node:url';
+
+describe('remove card', () => {
+  const baseDir = dirname(fileURLToPath(import.meta.url));
+  const testDir = join(baseDir, 'tmp-remove-tests');
+  const decisionRecordsPath = join(testDir, 'valid/decision-records');
+  let commands: CommandManager;
+
+  before(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir('test/test-data/', testDir);
+    commands = new CommandManager(decisionRecordsPath);
+    await commands.calculateCmd.generate();
+  });
+
+  after(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('Remove - remove card that has children', async () => {
+    const calcDir = join(decisionRecordsPath, '.calc');
+    const cardTreeCalcFile = join(calcDir, 'cardTree.lp');
+    let cardTreeFileContent = (await readFile(cardTreeCalcFile)).toString();
+    const cardsCalcFile = join(calcDir, 'cards', 'decision_5.lp');
+    expect(pathExists(cardsCalcFile)).to.equal(true);
+    expect(cardTreeFileContent.includes('cards/decision_5.lp')).to.equal(true);
+
+    const cardId = 'decision_5';
+    const removeCmd = new Remove(commands.project, commands.calculateCmd);
+    await removeCmd
+      .remove('card', cardId)
+      .then(() => {
+        expect(true);
+      })
+      .catch(() => {
+        expect(false);
+      });
+
+    // After deleting the card, check that calculations files are correctly updated.
+    cardTreeFileContent = (await readFile(cardTreeCalcFile)).toString();
+    expect(cardTreeFileContent.includes('cards/decision_5.lp')).to.equal(false);
+    // Since decision_6 is decision_5's child, it should have been removed as well.
+    expect(cardTreeFileContent.includes('cards/decision_6.lp')).to.equal(false);
+    expect(pathExists(cardsCalcFile)).to.equal(false);
+  });
+});


### PR DESCRIPTION
When a card is deleted, the card and its children should be removed from `cardTree.lp`. 
That way there is no need to update the calculations when deletion occurs. 

The existing implementation assumed that cards have relative path, when they nowadays have absolute path. Therefore, the file remained unmodified. Fixed, by using only a partial name when updating the file.