### PR TITLE
INTDEV-814 Use inline passthrough instead of block to avoid extra '+'s

### DIFF
--- a/tools/data-handler/src/macros/index.ts
+++ b/tools/data-handler/src/macros/index.ts
@@ -248,8 +248,8 @@ export function createHtmlPlaceholder(
     .map((key) => `${key}="${options[key]}"`)
     .join(' ');
 
-  // start with a line change to ensure that passthrough ++++ is on its own line
-  return `\n++++\n<${macro.tagName}${optionString ? ` ${optionString}` : ''} key="macro-${macroCounter++}"></${macro.tagName}>\n++++`;
+  // start with a line change to ensure that inline passthrough +++ is on its own line
+  return `\n+++\n<${macro.tagName}${optionString ? ` ${optionString}` : ''} key="macro-${macroCounter++}"></${macro.tagName}>\n+++\n`;
 }
 
 /**

--- a/tools/data-handler/test/macros/index.test.ts
+++ b/tools/data-handler/test/macros/index.test.ts
@@ -2,7 +2,6 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
-// ismo
 import {
   createAdmonition,
   createHtmlPlaceholder,
@@ -123,7 +122,6 @@ describe('macros', () => {
         expect(result).to.not.contain('<create-cards>');
       });
     });
-
     describe('scoreCard', () => {
       it('scoreCard inject (success)', async () => {
         const macro = `{{#scoreCard}}"title": "Scorecard", "value": 99, "unit": "%", "legend": "complete"{{/scoreCard}}`;
@@ -204,14 +202,14 @@ describe('macros', () => {
         test: 'test-data',
       });
       expect(result).to.match(
-        /^\n\+{4}\n<test-tag-name test="test-data" key="macro-\d+"><\/test-tag-name>\n\+{4}$/,
+        /^\n\+{3}\n<test-tag-name test="test-data" key="macro-\d+"><\/test-tag-name>\n\+{3}\n$/,
       );
     });
     it('createHtmlPlaceholder (success) without data', () => {
       // note: depends on the order of execution
       const result = createHtmlPlaceholder(macro.metadata, {});
       expect(result).to.match(
-        /^\n\+{4}\n<test-tag-name key="macro-\d+"><\/test-tag-name>\n\+{4}$/,
+        /^\n\+{3}\n<test-tag-name key="macro-\d+"><\/test-tag-name>\n\+{3}\n$/,
       );
     });
     it('createAdmonition (success)', () => {


### PR DESCRIPTION
Seems that using block passthrough (q.v. https://docs.asciidoctor.org/asciidoc/latest/pass/pass-block/) inside a table leaves extra plusses on either side of macro. 

Switch to using inline passthrough (q.v. https://docs.asciidoctor.org/asciidoc/latest/pass/pass-macro/); they seem to work both outside and inside of a table.