### PR TITLE
INTDEV-811 Optimize showProjectCards function

### DIFF
--- a/tools/data-handler/src/utils/card-utils.ts
+++ b/tools/data-handler/src/utils/card-utils.ts
@@ -10,6 +10,20 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import { sep } from 'node:path';
+
+// Helper function to find the parent path from a card path
+export const findParentPath = (cardPath: string): string | null => {
+  const pathParts = cardPath.split(sep);
+  const hasChildren = pathParts.lastIndexOf('c');
+
+  if (hasChildren <= 0) return null;
+
+  const parentPathParts = [...pathParts];
+  parentPathParts.splice(hasChildren, 1);
+  return parentPathParts.slice(0, hasChildren).join(sep);
+};
+
 /**
  * Sorts array of cards first using prefix and then using ID.
  * Prefixes are returned in alphabetical order, and then in numeric order within same prefix.

--- a/tools/data-handler/test/utils/card-utils.test.ts
+++ b/tools/data-handler/test/utils/card-utils.test.ts
@@ -11,9 +11,17 @@
 */
 
 import { expect } from 'chai';
-import { sortCards } from '../../src/utils/card-utils.js';
+import { findParentPath, sortCards } from '../../src/utils/card-utils.js';
+import { sep } from 'path';
 
 describe('card utils', () => {
+  it('findParentPath', () => {
+    const parent = findParentPath(`cardRoot${sep}card_1${sep}c${sep}card_2`);
+    expect(parent).to.equal(`cardRoot${sep}card_1`);
+    const noChildren = findParentPath(`cardRoot${sep}card_1`);
+    expect(noChildren).to.equal(null);
+  });
+
   it('sort cards', () => {
     const cards = ['aaa_999', 'aaa_111', 'zzz_111', 'zzz_999', 'aaa_999'];
     cards.sort(sortCards);


### PR DESCRIPTION
Instead of function level recursion, use `readdir` with `recursive: true`.

First, builds up a card map for the cards, then fetches metadata for each card and finally builds the hierarchy. 

This takes roughly 70% of the time that the previous implementation took on my Mac. App calls this once per change (status change, or edit metadata), so the gains are cumulative.  

Noted while checking the performance that nodeJS (or Mac file system?) caches `readdir` results. If you need to make a performance improvement, call the `readdir` function once before measurements with the path you are using. That way you can compare different implementations side-by-side. 