### PR TITLE
Replace deprecated recursive 'rmdir' with recursive 'rm'

### DIFF
--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -1,18 +1,19 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
-
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 // node
 import { basename, join, resolve, sep } from 'node:path';
-import { copyFile, mkdir, readdir, rmdir, writeFile } from 'node:fs/promises';
+import { copyFile, mkdir, readdir, rm, writeFile } from 'node:fs/promises';
 import { readdirSync } from 'node:fs';
 
 // Base class
@@ -318,7 +319,7 @@ export class Template extends CardContainer {
     // Delete card folders.
     const deleteAll: Promise<void>[] = [];
     cards.forEach((card) => {
-      deleteAll.push(rmdir(card.path, { recursive: true }));
+      deleteAll.push(rm(card.path, { force: true, recursive: true }));
     });
     await Promise.all(deleteAll);
   }


### PR DESCRIPTION
Noticed that we use one deprecated method (ref https://nodejs.org/api/deprecations.html#DEP0147)

Replace recursive `rmdir` with recursive `rm`.