### PR TITLE
INTDEV-822 allow v20

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "glob-parent": "latest"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=20.0.0 || >=22.0.0"
   },
   "private": true,
   "scripts": {


### PR DESCRIPTION
Dependabot uses v20 so let's allow it. Unfortunately, this means that if user runs with v20, it is allowed.