### PR TITLE
SECURITY FIX: Use non-greedy regex

### DIFF
--- a/tools/data-handler/src/macros/index.ts
+++ b/tools/data-handler/src/macros/index.ts
@@ -107,7 +107,7 @@ export function registerMacros(
  * @param input
  */
 export function macroCount(input: string): number {
-  const regex = /{{#.+}}/g;
+  const regex = /{{#[\w\s-]+?}}/g;
   const match = input.match(regex);
   return match ? match.length : 0;
 }


### PR DESCRIPTION
Code scanning tools complain about this regex that it might cause performance issues on some content. 
Replace the regex with non-greedy one.

See details from: https://github.com/CyberismoCom/cyberismo/security/code-scanning/37