### PR TITLE
INTDEV-802 Controlling modules in a project

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -60,3 +60,6 @@ jobs:
     - run: pnpm build
     - run: pnpm link --global
     - run: pnpm test
+      env:
+        CYBERISMO_GIT_USER: ${{ secrets.CYBERISMO_GIT_USER }}
+        CYBERISMO_GIT_TOKEN: ${{ secrets.CYBERISMO_GIT_TOKEN }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -64,3 +64,6 @@ jobs:
     - run: pnpm build
     - run: pnpm link --global
     - run: pnpm test
+      env:
+        CYBERISMO_GIT_USER: ${{ secrets.CYBERISMO_GIT_USER }}
+        CYBERISMO_GIT_TOKEN: ${{ secrets.CYBERISMO_GIT_TOKEN }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,6 +270,9 @@ importers:
       tslib:
         specifier: ^2.6.2
         version: 2.8.1
+      write-json-file:
+        specifier: ^6.0.0
+        version: 6.0.0
     devDependencies:
       '@types/js-yaml':
         specifier: ^4.0.9
@@ -2003,6 +2006,10 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  detect-indent@7.0.1:
+    resolution: {integrity: sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==}
+    engines: {node: '>=12.20'}
+
   diff3@0.0.3:
     resolution: {integrity: sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==}
 
@@ -2615,6 +2622,10 @@ packages:
   is-plain-obj@2.1.0:
     resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
     engines: {node: '>=8'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -3521,6 +3532,10 @@ packages:
   sonic-boom@4.0.1:
     resolution: {integrity: sha512-hTSD/6JMLyT4r9zeof6UtuBDpjJ9sO08/nmS5djaA9eozT9oOlNdpXSnzcgj4FTqpk3nkLrs61l4gip9r1HCrQ==}
 
+  sort-keys@5.1.0:
+    resolution: {integrity: sha512-aSbHV0DaBcr7u0PVHXzM6NbZNAtrr9sF6+Qfs9UUVG7Ll3jQ6hHi8F/xqIIcn2rvIVbr0v/2zyjSdwSV47AgLQ==}
+    engines: {node: '>=12'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -3989,6 +4004,14 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  write-file-atomic@5.0.1:
+    resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  write-json-file@6.0.0:
+    resolution: {integrity: sha512-MNHcU3f9WxnNyR6MxsYSj64Jz0+dwIpisWKWq9gqLj/GwmA9INg3BZ3vt70/HB3GEwrnDQWr4RPrywnhNzmUFA==}
+    engines: {node: '>=18'}
 
   ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
@@ -5881,6 +5904,8 @@ snapshots:
 
   dequal@2.0.3: {}
 
+  detect-indent@7.0.1: {}
+
   diff3@0.0.3: {}
 
   diff@5.2.0: {}
@@ -6534,6 +6559,8 @@ snapshots:
   is-path-inside@3.0.3: {}
 
   is-plain-obj@2.1.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -7473,6 +7500,10 @@ snapshots:
     dependencies:
       atomic-sleep: 1.0.0
 
+  sort-keys@5.1.0:
+    dependencies:
+      is-plain-obj: 4.1.0
+
   source-map-js@1.2.1: {}
 
   source-map@0.5.7:
@@ -7914,6 +7945,18 @@ snapshots:
       strip-ansi: 7.1.0
 
   wrappy@1.0.2: {}
+
+  write-file-atomic@5.0.1:
+    dependencies:
+      imurmurhash: 0.1.4
+      signal-exit: 4.1.0
+
+  write-json-file@6.0.0:
+    dependencies:
+      detect-indent: 7.0.1
+      is-plain-obj: 4.1.0
+      sort-keys: 5.1.0
+      write-file-atomic: 5.0.1
 
   ws@8.18.0: {}
 

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -1,19 +1,19 @@
 #!/usr/bin/env node
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
-
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { Argument, Command } from 'commander';
 import confirm from '@inquirer/confirm';
-
 import {
   CardsOptions,
   Cmd,
@@ -390,13 +390,16 @@ const importCmd = program.command('import');
 // Import module
 importCmd
   .command('module')
-  .description('Imports another project to this project as a module.')
+  .description(
+    'Imports another project to this project as a module. Source can be local relative file path, or git HTTPS URL.',
+  )
   .argument('<source>', 'Path to import from')
+  .argument('[branch]', 'When using git URL defines the branch. Default: main')
   .option('-p, --project-path [path]', `${pathGuideline}`)
-  .action(async (source: string, options: CardsOptions) => {
+  .action(async (source: string, branch: string, options: CardsOptions) => {
     const result = await commandHandler.command(
       Cmd.import,
-      ['module', source],
+      ['module', source, branch],
       options,
     );
     handleResponse(result);
@@ -650,6 +653,16 @@ program
       handleResponse(result);
     },
   );
+
+// Updates all modules in the project.
+program
+  .command('update-modules')
+  .description('Updates all imported modules with latest versions')
+  .option('-p, --project-path [path]', `${pathGuideline}`)
+  .action(async (options: CardsOptions) => {
+    const result = await commandHandler.command(Cmd.updateModules, [], options);
+    handleResponse(result);
+  });
 
 // Validate command
 program

--- a/tools/data-handler/package.json
+++ b/tools/data-handler/package.json
@@ -49,7 +49,8 @@
     "jsonschema": "^1.4.1",
     "mime-types": "^3.0.1",
     "pino": "^9.6.0",
-    "tslib": "^2.6.2"
+    "tslib": "^2.6.2",
+    "write-json-file": "^6.0.0"
   },
   "type": "module"
 }

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -1,13 +1,14 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
-
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { dirname, join, resolve } from 'node:path';
@@ -19,7 +20,7 @@ import {
   CardAttachment,
   CardListContainer,
   FileContentType,
-  ModuleSettings,
+  ModuleContent,
   ProjectMetadata,
   RemovableResourceTypes,
   ResourceTypes,
@@ -63,6 +64,7 @@ export enum Cmd {
   start = 'start',
   transition = 'transition',
   update = 'update',
+  updateModules = 'update-modules',
   validate = 'validate',
 }
 
@@ -249,8 +251,8 @@ export class Commands {
       } else if (command === Cmd.import) {
         const target = args.splice(0, 1)[0];
         if (target === 'module') {
-          const [source] = args;
-          await this.import(source);
+          const [source, branch] = args;
+          await this.import(source, branch);
         }
         if (target === 'csv') {
           const [csvFile, cardKey] = args;
@@ -317,6 +319,8 @@ export class Commands {
           parsedValue,
           newValue ? JSON.parse(newValue) : undefined,
         );
+      } else if (command === Cmd.updateModules) {
+        await this.commands?.importCmd.updateAllModules();
       } else if (command === Cmd.validate) {
         return this.validate();
       } else {
@@ -446,8 +450,12 @@ export class Commands {
   }
 
   // Imports another project to the 'destination' project as a module.
-  private async import(source: string): Promise<void> {
-    return this.commands?.importCmd.importProject(source, this.projectPath);
+  private async import(source: string, branch?: string) {
+    return this.commands?.importCmd.importModule(
+      source,
+      this.projectPath,
+      branch,
+    );
   }
 
   // Imports cards from a CSV file to a project.
@@ -501,7 +509,7 @@ export class Commands {
       | Card
       | CardAttachment[]
       | CardListContainer[]
-      | ModuleSettings
+      | ModuleContent
       | ProjectMetadata
       | ResourceContent
       | string[]

--- a/tools/data-handler/src/commands/create.ts
+++ b/tools/data-handler/src/commands/create.ts
@@ -62,6 +62,7 @@ export class Create {
       content: {
         cardKeyPrefix: '$PROJECT-PREFIX',
         name: '$PROJECT-NAME',
+        modules: [],
       },
       name: Project.projectConfigFileName,
     },

--- a/tools/data-handler/src/commands/remove.ts
+++ b/tools/data-handler/src/commands/remove.ts
@@ -189,7 +189,7 @@ export class Remove {
       throw new Error(`Module '${moduleName}' not found`);
     }
     await deleteDir(module.path);
-    await this.project.collectModuleResources();
+    await this.project.removeModule(moduleName);
   }
 
   /**

--- a/tools/data-handler/src/commands/show.ts
+++ b/tools/data-handler/src/commands/show.ts
@@ -1,13 +1,14 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
-
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 // node
@@ -23,7 +24,7 @@ import {
   CardAttachment,
   Card,
   CardListContainer,
-  ModuleSettings,
+  ModuleContent,
   ProjectFetchCardDetails,
   ProjectMetadata,
   Resource,
@@ -287,7 +288,7 @@ export class Show {
    * @param moduleName name of a module
    * @returns details of a module.
    */
-  public async showModule(moduleName: string): Promise<ModuleSettings> {
+  public async showModule(moduleName: string): Promise<ModuleContent> {
     const moduleDetails = await this.project.module(moduleName);
     if (!moduleDetails) {
       throw new Error(`Module '${moduleName}' does not exist in the project`);
@@ -311,22 +312,6 @@ export class Show {
    */
   public async showModules(): Promise<string[]> {
     return (await this.project.modules()).map((item) => item.name).sort();
-  }
-
-  /**
-   * Shows all modules with full details in a project.
-   * @returns all modules with full details in a project.
-   * @todo: unused; remove?
-   */
-  public async showModulesWithDetails(): Promise<
-    (ModuleSettings | undefined)[]
-  > {
-    const promiseContainer = [];
-    for (const module of await this.project.modules()) {
-      promiseContainer.push(this.project.module(module.name));
-    }
-    const results = await Promise.all(promiseContainer);
-    return results.filter((item) => item);
   }
 
   /**

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -105,7 +105,7 @@ export type MetadataContent =
   | undefined;
 
 // Module content
-export interface ModuleSettings extends ProjectSettings {
+export interface ModuleContent extends ProjectSettings {
   path: string;
   calculations: string[];
   cardTypes: string[];
@@ -130,6 +130,7 @@ export interface ProjectMetadata {
   name: string;
   path: string;
   prefix: string;
+  modules: string[];
   numberOfCards: number;
 }
 
@@ -137,6 +138,14 @@ export interface ProjectMetadata {
 export interface ProjectSettings {
   cardKeyPrefix: string;
   name: string;
+  modules: ModuleSetting[];
+}
+
+// Module configuration.
+export interface ModuleSetting {
+  name: string;
+  location: string;
+  branch?: string;
 }
 
 // Resources that are possible to remove.

--- a/tools/data-handler/src/module-manager.ts
+++ b/tools/data-handler/src/module-manager.ts
@@ -1,0 +1,292 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2025
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import fs from 'node:fs';
+import { join } from 'node:path';
+import { mkdir, readdir, rm } from 'node:fs/promises';
+
+import git from 'isomorphic-git';
+import http from 'isomorphic-git/http/node/index.js';
+
+import { copyDir, deleteDir, pathExists } from './utils/file-utils.js';
+import { Import } from './commands/index.js';
+import { ModuleSetting } from './interfaces/project-interfaces.js';
+import { Project } from './containers/project.js';
+import { readJsonFile } from './utils/json.js';
+import { Validate } from './commands/index.js';
+
+/**
+ * Class that handles module updates and imports.
+ */
+export class ModuleManager {
+  private modules: ModuleSetting[] = [];
+  private tempModulesDir: string = '';
+  constructor(
+    private project: Project,
+    private importCmd: Import,
+  ) {
+    this.tempModulesDir = join(this.project.paths.tempFolder, 'modules');
+  }
+
+  private async addFileContents(sourcePath: string, destinationPath: string) {
+    // Copy files.
+    await copyDir(sourcePath, destinationPath);
+
+    // Update the resources.
+    await this.project.collectModuleResources();
+  }
+
+  // Handles a branch of a repository.
+  private async branch(module: ModuleSetting) {
+    if (module.branch === 'main' || module.branch === '' || !module.branch)
+      return;
+
+    await git.checkout({
+      fs,
+      dir: join(this.tempModulesDir, module.name),
+      ref: module.branch,
+    });
+    console.error(`... Switched to '${module.branch}' branch`);
+  }
+
+  // Handles cloning of a repository.
+  private async clone(module: ModuleSetting): Promise<string> {
+    if (!module.name || module.name === '') {
+      module.name = this.repositoryName(module.location);
+    }
+    const repoUrl = new URL(module.location);
+    repoUrl.username = process.env.CYBERISMO_GIT_USER || '';
+    repoUrl.password = process.env.CYBERISMO_GIT_TOKEN || '';
+    if (!repoUrl.username) {
+      throw new Error(
+        `No user defined. Cannot clone git repo. Set CYBERISMO_GIT_USER environment variable`,
+      );
+    }
+    if (!repoUrl.password) {
+      throw new Error(
+        `No git token defined. Cannot clone git repo. Set CYBERISMO_GIT_TOKEN environment variable`,
+      );
+    }
+    await git.clone({
+      fs,
+      http,
+      dir: join(this.tempModulesDir, module.name),
+      url: repoUrl.toString(),
+      depth: 1,
+    });
+    console.log(`... Cloned '${module.name}' to a temporary folder`);
+    return module.name;
+  }
+
+  // Updates one module that is read from local file system.
+  private async handleFileModule(module: ModuleSetting) {
+    this.removeProtocolFromLocation(module);
+    await this.remove(module);
+    await this.importFromFolder(module);
+  }
+
+  // Updates one module that is received from Git.
+  private async handleGitModule(module: ModuleSetting) {
+    await this.clone(module);
+    await this.branch(module);
+    await this.remove(module);
+    await this.importFromTemp(module);
+  }
+
+  // Updates one module.
+  private async handleModule(module: ModuleSetting) {
+    return this.isFileModule(module)
+      ? this.handleFileModule(module)
+      : this.handleGitModule(module);
+  }
+
+  // Handles importing a module from module settings 'location'
+  private async importFromFolder(module: ModuleSetting) {
+    await this.importCmd.updateExistingModule(module.location);
+    console.log(`... Imported module '${module.name}' to the project`);
+  }
+
+  // Handles importing a module from '.temp' folder
+  private async importFromTemp(module: ModuleSetting) {
+    await this.importCmd.updateExistingModule(
+      join(this.tempModulesDir, module.name),
+    );
+    console.log(`... Imported module '${module.name}' to the project`);
+  }
+
+  private isFileModule(module: ModuleSetting): boolean {
+    if (!module.location) return false;
+    return module.location.startsWith('file:');
+  }
+
+  // Prepares '.temp/modules' for cloning
+  private async prepare() {
+    await mkdir(this.tempModulesDir, { recursive: true });
+    for (const file of await readdir(this.tempModulesDir)) {
+      await rm(join(this.tempModulesDir, file), {
+        force: true,
+        recursive: true,
+      });
+    }
+  }
+
+  // Returns whether to use git or file system for handling the module.
+  private protocol(module: ModuleSetting) {
+    return this.isFileModule(module) ? 'file' : 'git';
+  }
+
+  // Remove module files.
+  private async removeModuleFiles(moduleName: string) {
+    const module = await this.project.module(moduleName);
+    if (!module) {
+      throw new Error(`Module '${moduleName}' not found`);
+    }
+    await deleteDir(module.path);
+  }
+
+  // Handles removing an imported module.
+  private async remove(module: ModuleSetting) {
+    try {
+      await this.removeModuleFiles(module.name);
+      console.log(`... Removed imported module '${module.name}'`);
+    } catch (error) {
+      if (error instanceof Error)
+        console.error(
+          `... New imported module '${module.name}', skipping remove`,
+        );
+    }
+  }
+
+  // Updates module's 'location' not to have 'protocol:' in the beginning (only for "file:" needed).
+  private removeProtocolFromLocation(module: ModuleSetting) {
+    const protocol = this.protocol(module);
+    module.location = module.location.substring(
+      protocol.length + 1,
+      module.location.length,
+    );
+  }
+
+  // Gets repository name from gitUrl
+  private repositoryName(gitUrl: string): string {
+    const last = gitUrl.lastIndexOf('/');
+    const repoName = gitUrl.substring(last + 1, gitUrl.length - 4); //remove trailing ".git"
+    return repoName;
+  }
+
+  // Sets modules property.
+  private setModules() {
+    const modules = this.project.configuration.modules;
+    if (modules) {
+      this.modules = modules;
+    }
+  }
+
+  // Checks that module prefix is not in use in the project
+  private async validatePrefix(modulePrefix: string) {
+    // Do not allow modules with same prefixes.
+    const currentlyUsedPrefixes = await this.project.projectPrefixes();
+    if (currentlyUsedPrefixes.includes(modulePrefix)) {
+      throw new Error(
+        `Imported project has a prefix '${modulePrefix}' that is already used in the project. Cannot import from module.`,
+      );
+    }
+  }
+
+  /**
+   * Imports module from local file path.
+   * @param source Path to import from.
+   * @param destination is this really needed???
+   */
+  public async importFileModule(source: string, destination?: string) {
+    if (!Validate.validateFolder(source)) {
+      throw new Error(
+        `Input validation error: folder name is invalid '${source}'`,
+      );
+    }
+    if (!pathExists(source)) {
+      throw new Error(
+        `Input validation error: cannot find project '${source}'`,
+      );
+    }
+    if (destination && !pathExists(destination)) {
+      throw new Error(
+        `Input validation error: destination does not exist '${destination}'`,
+      );
+    }
+    const sourceProject = new Project(source);
+    const modulePrefix = sourceProject.projectPrefix;
+    const destinationPath = join(
+      this.project.paths.modulesFolder,
+      modulePrefix,
+    );
+    const sourcePath = sourceProject.paths.resourcesFolder;
+
+    await this.validatePrefix(modulePrefix);
+
+    // Copy files.
+    await this.addFileContents(sourcePath, destinationPath);
+    return modulePrefix;
+  }
+
+  /**
+   * Imports module from gitUrl.
+   * @param source Git URL to import from.
+   * @returns module prefix as defined in its CardsConfig.json
+   */
+  public async importGitModule(source: string) {
+    const repoName = await this.clone({
+      name: '',
+      location: source,
+    });
+    await this.branch({ name: repoName, location: source });
+    const clonePath = join(this.project.paths.tempFolder, 'modules', repoName);
+    const projectConfiguration = join(
+      clonePath,
+      '.cards',
+      'local',
+      'cardsConfig.json',
+    );
+    try {
+      const projectSettings = await readJsonFile(projectConfiguration);
+      const modulePrefix = projectSettings['cardKeyPrefix'] as string;
+      await this.validatePrefix(modulePrefix);
+      const sourcePath = join(clonePath, '.cards', 'local');
+      const destinationPath = join(
+        this.project.paths.modulesFolder,
+        modulePrefix,
+      );
+      await this.addFileContents(sourcePath, destinationPath);
+      return modulePrefix;
+    } catch (e) {
+      if (e instanceof Error) throw new Error(e.message);
+    }
+  }
+
+  /**
+   * Updates all imported modules.
+   */
+  public async update() {
+    this.setModules();
+    await this.prepare();
+
+    if (this.modules.length === 0) {
+      throw new Error(`No modules in the project!`);
+    }
+
+    for (const module of this.modules) {
+      await this.handleModule(module);
+    }
+    await deleteDir(this.tempModulesDir);
+    await this.project.collectModuleResources();
+  }
+}

--- a/tools/data-handler/test/command-handler-import.test.ts
+++ b/tools/data-handler/test/command-handler-import.test.ts
@@ -154,6 +154,13 @@ describe('import module', () => {
         optionsMini,
       );
       expect(result.statusCode).to.equal(200);
+
+      // Remove the module so that it won't affect other tests
+      result = await commandHandler.command(
+        Cmd.remove,
+        ['module', 'decision'],
+        optionsMini,
+      );
     });
     it('create empty project and import two modules', async () => {
       const prefix = 'proj';
@@ -175,7 +182,6 @@ describe('import module', () => {
             ['module', minimalPath],
             testOptions,
           );
-
           expect(result.statusCode).to.equal(200);
           result = await commandHandler.command(
             Cmd.show,

--- a/tools/data-handler/test/command-handler-show.test.ts
+++ b/tools/data-handler/test/command-handler-show.test.ts
@@ -10,7 +10,7 @@ import { fileURLToPath } from 'node:url';
 import { CardsOptions, Cmd, Commands } from '../src/command-handler.js';
 import { copyDir } from '../src/utils/file-utils.js';
 import { errorFunction } from '../src/utils/log-utils.js';
-import { ModuleSettings } from '../src/interfaces/project-interfaces.js';
+import { ModuleContent } from '../src/interfaces/project-interfaces.js';
 import { Project } from '../src/containers/project.js';
 import { Show } from '../src/commands/index.js';
 
@@ -338,7 +338,7 @@ describe('shows command', () => {
       );
       expect(result.statusCode).to.equal(200);
       expect(result.payload).to.not.equal(undefined);
-      const module = result.payload as ModuleSettings;
+      const module = result.payload as ModuleContent;
       expect(module.cardKeyPrefix).to.equal('mini');
       expect(module.name).to.equal('minimal');
       expect(module.path).to.equal(

--- a/tools/data-handler/test/module-manager.test.ts
+++ b/tools/data-handler/test/module-manager.test.ts
@@ -1,0 +1,112 @@
+// testing
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+// node
+import { mkdirSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { copyDir } from '../src/utils/file-utils.js';
+import { fileURLToPath } from 'node:url';
+import { CommandManager } from '../src/command-manager.js';
+
+describe('module-manager', () => {
+  const baseDir = dirname(fileURLToPath(import.meta.url));
+  const testDir = join(baseDir, 'tmp-module-manager-tests');
+  const decisionRecordsPath = join(testDir, 'valid/decision-records');
+  let commands: CommandManager;
+
+  beforeEach(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir('test/test-data/', testDir);
+    commands = new CommandManager(decisionRecordsPath);
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+    rmSync(join(testDir, '.temp'), { recursive: true, force: true });
+  });
+
+  it('import local module', async () => {
+    const localModule = join(testDir, 'valid/minimal');
+    await commands.importCmd.importModule(
+      localModule,
+      commands.project.basePath,
+    );
+    const modules = await commands.showCmd.showModules();
+    expect(modules.length).equals(1);
+  });
+  it('import git module', async () => {
+    const gitModule = 'https://github.com/CyberismoCom/module-base.git';
+    await commands.importCmd.importModule(gitModule, commands.project.basePath);
+    const modules = await commands.showCmd.showModules();
+    expect(modules.length).equals(1);
+  });
+  it('try to import duplicate local modules', async () => {
+    const localModule = join(testDir, 'valid/minimal');
+    await commands.importCmd.importModule(
+      localModule,
+      commands.project.basePath,
+    );
+    await commands.importCmd
+      .importModule(localModule, commands.project.basePath)
+      .then(() => expect(false).equal(true))
+      .catch((error) =>
+        expect(error.message).to.equal(
+          `Imported project has a prefix 'mini' that is already used in the project. Cannot import from module.`,
+        ),
+      );
+  });
+  it('try to import duplicate git modules', async () => {
+    const gitModule = 'https://github.com/CyberismoCom/module-base.git';
+    await commands.importCmd.importModule(gitModule, commands.project.basePath);
+
+    await commands.importCmd
+      .importModule(gitModule, commands.project.basePath)
+      .then(() => expect(false).equal(true))
+      .catch((error) =>
+        expect(error.message).to.equal(
+          `Imported project has a prefix 'base' that is already used in the project. Cannot import from module.`,
+        ),
+      );
+  });
+  it('try to import from incorrect local path', async () => {
+    const localModule = join(testDir, 'valid/i-do-not-exist');
+    await commands.importCmd
+      .importModule(localModule, commands.project.basePath)
+      .then(() => expect(false).to.equal(true))
+      .catch((error) =>
+        expect(error.message).to.include(
+          `Input validation error: cannot find project`,
+        ),
+      );
+  });
+  it('try to import from incorrect local path', async () => {
+    const gitModule = 'https://github.com/CyberismoCom/i-do-not-exist.git';
+    await commands.importCmd
+      .importModule(gitModule, commands.project.basePath)
+      .then(() => expect(false).to.equal(true))
+      .catch((error) =>
+        expect(error.message).to.equal('HTTP Error: 404 Not Found'),
+      );
+  });
+  it('update all modules', async () => {
+    let modules = await commands.showCmd.showModules();
+    expect(modules.length).equals(0);
+    const localModule = join(testDir, 'valid/minimal');
+    await commands.importCmd.importModule(
+      localModule,
+      commands.project.basePath,
+    );
+
+    const gitModule = 'https://github.com/CyberismoCom/module-base.git';
+    await commands.importCmd.importModule(gitModule, commands.project.basePath);
+
+    modules = await commands.showCmd.showModules();
+    expect(modules.length).equals(2);
+
+    await commands.importCmd.updateAllModules();
+    modules = await commands.showCmd.showModules();
+    expect(modules.length).equals(2);
+  });
+});

--- a/tools/data-handler/test/resources.test.ts
+++ b/tools/data-handler/test/resources.test.ts
@@ -213,7 +213,7 @@ describe('resources', () => {
       const templatesCount = (await collector.resources('templates')).length;
       const workflowsCount = (await collector.resources('workflows')).length;
 
-      await importCmd.importProject(minimalPath, project.basePath);
+      await importCmd.importModule(minimalPath, project.basePath);
       await collector.moduleImported();
 
       const calcCountAgain = (await collector.resources('calculations')).length;
@@ -1147,7 +1147,7 @@ describe('resources', () => {
       const createCmdMini = new Create(projectMini, calculateCmdMini);
       const importCmdMini = new Import(projectMini, createCmdMini);
       const collectorMini = new ResourceCollector(projectMini);
-      await importCmdMini.importProject(
+      await importCmdMini.importModule(
         decisionRecordsPath,
         projectMini.basePath,
       );

--- a/tools/data-handler/test/show.test.ts
+++ b/tools/data-handler/test/show.test.ts
@@ -235,10 +235,6 @@ describe('show', () => {
     const results = await showCmd.showModules();
     expect(results).to.not.equal(undefined);
   });
-  it('showModulesWithDetails (success)', async () => {
-    const results = await showCmd.showModulesWithDetails();
-    expect(results).to.not.equal(undefined);
-  });
   it('showProject (success)', async () => {
     const results = await showCmd.showProject();
     expect(results).to.not.equal(undefined);

--- a/tools/schema/cardsConfigSchema.json
+++ b/tools/schema/cardsConfigSchema.json
@@ -17,6 +17,28 @@
       "type": "string",
       "minLength": 1,
       "pattern": "^[A-Za-z ._-]+$"
+    },
+    "modules": {
+      "description": "List of modules that have been included in the project",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Module name (project prefix). Must be unique.",
+            "type": "string"
+          },
+          "location": {
+            "description": "URI that is either a git URL with HTTPS, or relative file reference",
+            "type": "string"
+          },
+          "branch": {
+            "description": "If using git URL in 'location' defines git branch. If empty, assumed to be 'main'. ",
+            "type": "string"
+          }
+        },
+        "required": ["name", "location"]
+      }
     }
   },
   "required": ["cardKeyPrefix"]


### PR DESCRIPTION
Means to add / remove and update modules from CLI. 

Changes to commands: 
* `cyberismo add module <name>`
* `cyberismo remove module <name>`

New command:
* `cyberismo update-modules`

Modules are now stored into an array in `cardsConfig.json`. Each module can be either from file system (starting with `file:`), or from git (starting with `https`). Once add command is given, the location (url or path) is written to project configuration. The name of the module is automatically fetched from module's  own configuration prefix. There is no support for importing a module with a different name. Removal works with prefixes as well; module must be of course imported first. When running an update, it will make local copies of modules to `.temp` and then remove the existing and copying the temp-copy in its place.

Using git modules requires use of environmental variables: `CYBERISMO_GIT_TOKEN` and `CYBERISMO_GIT_USER` 
The first must be set to a user's GitHub token. See here how to create them: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens . We can later investigate if we could use shared company wide token.
The second one needs to be your Github user name.
These together allow program to pull data from Git.

**Limitations:**
* modules cannot be imported with an alias; must be using module's prefix. It would be doable to import with alias by copying the module first to a temp-folder and then running a rename operation on the module.
* only supports HTTPS for git repositories for now; SSH support needs to be done in a latter tasks
* I have not tested whether or not it works for repositories not in GitHub; probably not.

Additional changes that were done:
* `ProjectSettings` is no longer singleton, since it didn't make sense to have it as singleton when the `Project` that used the class wasn't.
* Removed function `showModulesWithDetails` as it was not used
* Renamed `ModuleSettings` interface to `ModuleContent` to avoid mixing it up with `ModuleSetting` interface (and it is now more descriptive)