### PR TITLE
INTDEV-799 Change type of data in field type

### DIFF
--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -24,7 +24,7 @@ import {
   RemovableResourceTypes,
   ResourceTypes,
 } from './interfaces/project-interfaces.js';
-import { ResourceContent } from './interfaces/resource-interfaces.js';
+import { DataType, ResourceContent } from './interfaces/resource-interfaces.js';
 
 import { requestStatus } from './interfaces/request-status-interfaces.js';
 
@@ -197,7 +197,10 @@ export class Commands {
           await this.commands?.createCmd.createCardType(name, workflow);
         } else if (target === 'fieldType') {
           const [name, datatype] = rest;
-          await this.commands?.createCmd.createFieldType(name, datatype);
+          await this.commands?.createCmd.createFieldType(
+            name,
+            datatype as DataType,
+          );
         } else if (target === 'graphModel') {
           const [name] = rest;
           await this.commands?.createCmd.createGraphModel(name);

--- a/tools/data-handler/src/commands/create.ts
+++ b/tools/data-handler/src/commands/create.ts
@@ -24,7 +24,7 @@ import { Calculate, Validate } from './index.js';
 import { errorFunction } from '../utils/log-utils.js';
 import { Project } from '../containers/project.js';
 import { EMPTY_RANK, sortItems } from '../utils/lexorank.js';
-import { Link, LinkType } from '../interfaces/resource-interfaces.js';
+import { DataType, Link, LinkType } from '../interfaces/resource-interfaces.js';
 import { pathExists } from '../utils/file-utils.js';
 import { ProjectFile } from '../interfaces/project-interfaces.js';
 import { resourceName, resourceNameToString } from '../utils/resource-utils.js';
@@ -264,7 +264,7 @@ export class Create {
    * @param fieldTypeName name for the field type.
    * @param dataType data type for the field type
    */
-  public async createFieldType(fieldTypeName: string, dataType: string) {
+  public async createFieldType(fieldTypeName: string, dataType: DataType) {
     const fieldType = new FieldTypeResource(
       this.project,
       resourceName(fieldTypeName),

--- a/tools/data-handler/src/commands/validate.ts
+++ b/tools/data-handler/src/commands/validate.ts
@@ -1,13 +1,14 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
-
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 // node
@@ -45,6 +46,8 @@ import { resourceName } from '../utils/resource-utils.js';
 const invalidNames = new RegExp(
   '[<>:"/\\|?*\x00-\x1F]|^(?:aux|con|clock$|nul|prn|com[1-9]|lpt[1-9])$', // eslint-disable-line no-control-regex
 );
+
+const SHORT_TEXT_MAX_LENGTH = 80;
 
 import * as EmailValidator from 'email-validator';
 import { evaluateMacros } from '../macros/index.js';
@@ -443,7 +446,10 @@ export class Validate {
       return typeOfValue === field;
     }
     if (field === 'shortText') {
-      return typeOfValue === 'string' && this.length(<string>value) <= 80;
+      return (
+        typeOfValue === 'string' &&
+        this.length(<string>value) <= SHORT_TEXT_MAX_LENGTH
+      );
     }
     if (field === 'longText') {
       return typeOfValue === 'string';

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -95,6 +95,7 @@ export type FileContentType = 'adoc' | 'html';
 
 // Metadata content type.
 export type MetadataContent =
+  | bigint
   | number
   | boolean
   | string

--- a/tools/data-handler/src/interfaces/resource-interfaces.ts
+++ b/tools/data-handler/src/interfaces/resource-interfaces.ts
@@ -39,16 +39,16 @@ export interface CustomField {
 
 // Supported data types.
 export type DataType =
-  | 'shortText'
-  | 'longText'
-  | 'enum'
-  | 'number'
-  | 'integer'
   | 'boolean'
-  | 'list'
   | 'date'
   | 'dateTime'
-  | 'person';
+  | 'enum'
+  | 'integer'
+  | 'list'
+  | 'longText'
+  | 'number'
+  | 'person'
+  | 'shortText';
 
 // Custom field enum value
 export interface EnumDefinition {

--- a/tools/data-handler/src/resources/file-resource.ts
+++ b/tools/data-handler/src/resources/file-resource.ts
@@ -389,6 +389,7 @@ export class FileResource extends ResourceObject {
     }
 
     // Create folder for resources and add correct .schema file.
+    //todo: pathExists + mkdir
     if (!pathExists(this.resourceFolder)) {
       await mkdir(this.resourceFolder);
       await writeJsonFile(

--- a/tools/data-handler/src/utils/common-utils.ts
+++ b/tools/data-handler/src/utils/common-utils.ts
@@ -39,3 +39,17 @@ export function deepCompare(arg1: object, arg2: object): boolean {
   }
   return false;
 }
+
+/**
+ * Checks if string could be represented as BigInt.
+ * @param value String value
+ * @returns true, if 'value' can be represented as BigInt; false otherwise.
+ */
+export function isBigInt(value: string): boolean {
+  try {
+    return BigInt(parseInt(value, 10)) !== BigInt(value);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  } catch (e) {
+    return false;
+  }
+}

--- a/tools/data-handler/src/utils/value-utils.ts
+++ b/tools/data-handler/src/utils/value-utils.ts
@@ -1,0 +1,191 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2025
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { DataType } from '../interfaces/resource-interfaces.js';
+import { isBigInt } from '../utils/common-utils.js';
+import * as EmailValidator from 'email-validator';
+
+const SHORT_TEXT_MAX_LENGTH = 80;
+
+/**
+ * Checks if conversion 'from' 'to' can be done.
+ * @param from Data type to convert from
+ * @param to  Data type to convert to
+ * @returns true if conversion can be done, false otherwise.
+ */
+export function allowed(from: DataType, to: DataType) {
+  // Converting from strings is fine, except to enum.
+  if (from === 'longText' || from === 'shortText') {
+    switch (to) {
+      case 'boolean':
+      case 'date':
+      case 'dateTime':
+      case 'integer':
+      case 'list':
+      case 'longText':
+      case 'number':
+      case 'person':
+      case 'shortText':
+        return true;
+      default:
+        return false;
+    }
+  }
+  // Converting from<->to number formats is fine
+  if (
+    (from === 'number' && to === 'integer') ||
+    (from === 'integer' && to === 'number')
+  ) {
+    return true;
+  }
+
+  // Converting to strings is fine
+  if (to === 'shortText' || to === 'longText') {
+    return true;
+  }
+
+  // Converting from<->to date formats is fine
+  if (
+    (from === 'dateTime' && to === 'date') ||
+    (from === 'date' && to === 'dateTime')
+  ) {
+    return true;
+  }
+  // Everything else is forbidden.
+  return false;
+}
+
+/**
+ * Converts number value to other data types.
+ * @param value Value to convert
+ * @param to Date type to which value is converted to
+ * @returns converted value, or null if cannot convert
+ * Allowed conversions are
+ *  date -> dateTime
+ *  dateTime -> date
+ *  date/dateTime -> shortText/longText
+ */
+export function fromDate<T>(value: T, to: DataType) {
+  if (to === 'date') {
+    const tempDate = new Date(value as Date);
+    return new Date(tempDate).toISOString().slice(0, 10);
+  }
+  if (to === 'dateTime') {
+    const tempDate = new Date(value as Date);
+    return new Date(tempDate).toISOString();
+  }
+  if (to === 'longText' || to === 'shortText') {
+    return String(value);
+  }
+  return null;
+}
+
+/**
+ * Converts number value to other data types.
+ * @param value Value to convert
+ * @param to Date type to which value is converted to
+ * @returns converted value, or null if cannot convert
+ * Allowed conversions are
+ *  integer -> number
+ *  number -> integer
+ *  number/integer -> shortText
+ *  number/integer -> longText
+ */
+export function fromNumber<T>(value: T, to: DataType) {
+  if (to === 'integer') {
+    return Math.trunc(value as number);
+  }
+  if (to === 'longText') {
+    return String(value);
+  }
+  if (to === 'number') {
+    return Number(value);
+  }
+  if (to === 'shortText') {
+    const tempString = String(value);
+    return tempString.length > SHORT_TEXT_MAX_LENGTH ? null : tempString;
+  }
+  return null;
+}
+
+/**
+ * Converts string value to other data types.
+ * @param value Value to convert
+ * @param to Date type to which value is converted to
+ * @returns converted value, or null if cannot convert
+ * Allowed conversions are
+ *  longText -> shortText
+ *  shortText -> longText
+ *  longText/shortText -> integer
+ *  longText/shortText -> number
+ *  longText/shortText -> list
+ *  longText/shortText -> date/dateTime
+ *  longText/shortText -> boolean
+ */
+export function fromString<T>(value: T, to: DataType) {
+  switch (to) {
+    case 'boolean': {
+      if (value === 'true') return true;
+      if (value === 'false') return false;
+      return null;
+    }
+    case 'date': {
+      try {
+        const tempDate = new Date((value as string) + 'Z').toUTCString();
+        return new Date(tempDate).toISOString().slice(0, 10);
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      } catch (error) {
+        return null;
+      }
+    }
+    case 'dateTime': {
+      try {
+        const tempDate = new Date((value as string) + 'Z').toUTCString();
+        return new Date(tempDate).toISOString();
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      } catch (error) {
+        return null;
+      }
+    }
+    case 'integer': {
+      if (isBigInt(value as string)) {
+        return BigInt(value as string);
+      }
+      const tempInt = parseInt(value as string);
+      return isNaN(tempInt) ? null : tempInt;
+    }
+    case 'list': {
+      return (value as string).split(',');
+    }
+    case 'longText': {
+      return value;
+    }
+    case 'number': {
+      if (isBigInt(value as string)) {
+        return BigInt(value as string);
+      }
+      const tempNumber = parseFloat(value as string);
+      return isNaN(tempNumber) ? null : tempNumber;
+    }
+    case 'person': {
+      if (EmailValidator.validate(value as string)) {
+        return String(value);
+      }
+      return null;
+    }
+    case 'shortText': {
+      return (value as string).length > SHORT_TEXT_MAX_LENGTH ? null : value;
+    }
+  }
+  return null;
+}

--- a/tools/data-handler/test/resources.test.ts
+++ b/tools/data-handler/test/resources.test.ts
@@ -910,22 +910,6 @@ describe('resources', () => {
           }
         });
     });
-    it('try to create field type with invalid content', async () => {
-      const res = new FieldTypeResource(
-        project,
-        resourceName('decision/cardTypes/new-one'),
-      );
-      await res
-        .createFieldType('data-type-that-does-not-exist') // invalid data type
-        .then(() => expect(false).to.equal(true))
-        .catch((err) => {
-          if (err instanceof Error) {
-            expect(err.message).to.equal(
-              "Field type 'data-type-that-does-not-exist' not supported. Supported types shortText, longText, number, integer, boolean, enum, list, date, dateTime, person",
-            );
-          }
-        });
-    });
     it('data of card type', async () => {
       const res = new CardTypeResource(
         project,
@@ -1723,8 +1707,37 @@ describe('resources', () => {
           );
         });
     });
-    // @todo:
-    //it('update field type - change data type', async () => {});
+    it('update field type - change data type (number -> integer)', async () => {
+      let card6 = await project.cardDetailsById('decision_6', {
+        metadata: true,
+      });
+      if (card6 && card6.metadata) {
+        expect(card6.metadata['decision/fieldTypes/numberOfCommits']).equals(
+          1.5,
+        );
+      } else {
+        expect(false).equals(true);
+      }
+      const res = new FieldTypeResource(
+        project,
+        resourceName('decision/fieldTypes/numberOfCommits'),
+      );
+      await res.update('dataType', {
+        name: 'change',
+        target: '',
+        to: 'integer',
+      });
+      expect((res.data as FieldType).dataType).to.equal('integer');
+      card6 = await project.cardDetailsById('decision_6', {
+        metadata: true,
+      });
+      // Since data type was changed from number to integer, value has changed from 1.5 -> 1
+      if (card6 && card6.metadata) {
+        expect(card6.metadata['decision/fieldTypes/numberOfCommits']).equals(1);
+      } else {
+        expect(false).equals(true);
+      }
+    });
     it('update field type - change displayName and fieldDescription', async () => {
       const res = new FieldTypeResource(
         project,

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldTypes/numberOfCommits.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldTypes/numberOfCommits.json
@@ -2,5 +2,5 @@
     "name": "decision/fieldTypes/numberOfCommits",
     "displayName": "Number of commits",
     "fieldDescription": "How many commits have been done related to this task",
-    "dataType": "integer"
+    "dataType": "number"
 }

--- a/tools/data-handler/test/test-data/valid/decision-records/cardRoot/decision_5/c/decision_6/index.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/cardRoot/decision_5/c/decision_6/index.json
@@ -9,7 +9,7 @@
     "decision/fieldTypes/finished": null,
     "decision/fieldTypes/lastChangedDate": null,
     "decision/fieldTypes/lastChangedTimestamp": null,
-    "decision/fieldTypes/numberOfCommits": null,
+    "decision/fieldTypes/numberOfCommits": 1.5,
     "decision/fieldTypes/percentageReady": null,
     "decision/fieldTypes/responsible": null
 }

--- a/tools/data-handler/test/utils/value-utils.test.ts
+++ b/tools/data-handler/test/utils/value-utils.test.ts
@@ -1,0 +1,199 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import {
+  allowed,
+  fromDate,
+  fromNumber,
+  fromString,
+} from '../../src/utils/value-utils.js';
+import { DataType } from '../../src/interfaces/resource-interfaces.js';
+
+describe('data type conversions', () => {
+  const dataTypes: DataType[] = [
+    'boolean',
+    'date',
+    'dateTime',
+    'enum',
+    'integer',
+    'list',
+    'longText',
+    'number',
+    'person',
+    'shortText',
+  ];
+  // Map: fromType -> list of allowed types
+  const allowedConversions = new Map([
+    ['boolean', ['shortText', 'longText']],
+    ['date', ['dateTime', 'shortText', 'longText']],
+    ['dateTime', ['date', 'shortText', 'longText']],
+    ['enum', ['shortText', 'longText']],
+    ['integer', ['number', 'shortText', 'longText']],
+    ['list', ['shortText', 'longText']],
+    [
+      'longText',
+      [
+        'boolean',
+        'date',
+        'dateTime',
+        'integer',
+        'number',
+        'list',
+        'person',
+        'shortText',
+      ],
+    ],
+    ['number', ['integer', 'shortText', 'longText']],
+    ['person', ['shortText', 'longText']],
+    [
+      'shortText',
+      [
+        'boolean',
+        'date',
+        'dateTime',
+        'integer',
+        'number',
+        'list',
+        'person',
+        'longText',
+      ],
+    ],
+  ]);
+
+  it('allowed conversion', () => {
+    for (const typeFrom of dataTypes) {
+      for (const typeTo of dataTypes) {
+        // skip converting to same type
+        if (typeTo == typeFrom) {
+          continue;
+        }
+        const types = allowedConversions.get(typeFrom);
+        const result = allowed(typeFrom, typeTo);
+        if (result === true) {
+          expect(types).to.include(typeTo);
+        } else {
+          expect(types).to.not.include(typeTo);
+        }
+      }
+    }
+  });
+  it('convert from date', () => {
+    const value = '1970-01-01';
+    for (const type of dataTypes) {
+      const result = fromDate(value, type);
+      if (type === 'date' || type === 'longText' || type === 'shortText') {
+        expect(result).to.not.equal(null);
+        expect(result).to.equal('1970-01-01');
+      } else if (type === 'dateTime') {
+        expect(result).to.not.equal(null);
+        expect(result).to.equal('1970-01-01T00:00:00.000Z');
+      } else {
+        expect(result).to.equal(null);
+      }
+    }
+  });
+  it('convert from integer', () => {
+    const value = 555;
+    for (const type of dataTypes) {
+      const result = fromNumber(value, type);
+      if (type === 'longText' || type === 'shortText') {
+        expect(result).to.not.equal(null);
+        expect(result).to.equal('555');
+      } else if (type === 'integer' || type === 'number') {
+        expect(result).to.not.equal(null);
+        expect(result).to.equal(555);
+      } else {
+        expect(result).to.equal(null);
+      }
+    }
+  });
+  it('convert from number', () => {
+    const value = 555.555;
+    for (const type of dataTypes) {
+      const result = fromNumber(value, type);
+      if (type === 'longText' || type === 'shortText') {
+        expect(result).to.not.equal(null);
+        expect(result).to.equal('555.555');
+      } else if (type === 'integer') {
+        expect(result).to.not.equal(null);
+        expect(result).to.equal(555);
+      } else if (type === 'number') {
+        expect(result).to.not.equal(null);
+        expect(result).to.equal(555.555);
+      } else {
+        expect(result).to.equal(null);
+      }
+    }
+  });
+  it('convert from string', () => {
+    const value = 'hello there';
+    for (const type of dataTypes) {
+      const result = fromString(value, type);
+      if (type === 'longText' || type === 'shortText') {
+        expect(result).to.not.equal(null);
+        expect(result).to.equal('hello there');
+      } else if (type === 'list') {
+        expect(result).to.not.equal(null);
+        expect((result as string[]).length).to.equal(1);
+        expect((result as string[]).at(0)).to.equal('hello there');
+      } else {
+        expect(result).to.equal(null);
+      }
+    }
+  });
+  it('convert from string to "person"', () => {
+    const value = 'test.person@example.com';
+    const result = fromString(value, 'person');
+    expect(result).to.equal('test.person@example.com');
+  });
+  it('convert from string to "integer"', () => {
+    const value = '5';
+    let result = fromString(value, 'integer');
+    expect(result).to.equal(5);
+    const invalidValue = 'a';
+    result = fromString(invalidValue, 'integer');
+    expect(result).to.equal(null);
+  });
+  it('convert from string to "number"', () => {
+    const value = '5.5';
+    let result = fromString(value, 'number');
+    expect(result).to.equal(5.5);
+    const invalidValue = 'a';
+    result = fromString(invalidValue, 'number');
+    expect(result).to.equal(null);
+  });
+  it('convert from string to "date"', () => {
+    const value = '1970-01-01';
+    let result = fromString(value, 'date');
+    expect(result).to.equal('1970-01-01');
+    const invalidValue = 'a';
+    result = fromString(invalidValue, 'date');
+    expect(result).to.equal(null);
+  });
+  it('convert from string to "dateTime"', () => {
+    const value = '1970-01-01';
+    let result = fromString(value, 'dateTime');
+    expect(result).to.equal('1970-01-01T00:00:00.000Z');
+    const invalidValue = 'a';
+    result = fromString(invalidValue, 'dateTime');
+    expect(result).to.equal(null);
+  });
+  it('convert from string to "boolean"', () => {
+    const valueTrue = 'true';
+    const valueFalse = 'false';
+    let result = fromString(valueTrue, 'boolean');
+    expect(result).to.equal(true);
+    result = fromString(valueFalse, 'boolean');
+    expect(result).to.equal(false);
+    const invalidValue = 'a';
+    result = fromString(invalidValue, 'boolean');
+    expect(result).to.equal(null);
+  });
+  it('convert from string to "list"', () => {
+    const value = 'option1,option2';
+    const result = fromString(value, 'list');
+    expect((result as string[]).length).to.equal(2);
+    expect((result as string[]).at(0)).to.equal('option1');
+    expect((result as string[]).at(1)).to.equal('option2');
+  });
+});


### PR DESCRIPTION
From now on, it will be possible to change the data type of a field type through `update` command. 
The operation automatically changes all cards that use field type (through the card type), if it can. 

If the data type can be changed, but some of the card data cannot (for example to change field "email" from string to "person", but some card has invalid email address), the resource is changed and all value change operations that failed are logged (=shown to CLI user).

I included also possibility to use `BigInt` values, if `string` types have some gigantic number value in them. 
If reviewers think this is too much, I can omit it from this change. Remember that JS number values are actually only 52-bit floats/integers. Thus they are not compatible in the upper/lower range with let's say C/C++ 64-bit integers/floats. 
Recommendation is to use string types (`shortText`, `longText`) for storing large numerical values.

The allowed data type changes are: 
 - shortText/longText --> person, if valid email
 - shortText/longText --> integer/number, if can be parseNumber/parseInt'd
 - shortText/longText --> list, if text can be split with comma
 - shortText/longText --> date / datetime (if it can be parsed as date)
 - shortText/longText --> boolean, if string is "false" or "true"
- number --> integer, drop fractions
- integer --> number
- date --> dateTime
- dateTime --> date
- any --> shortText, unless too long
- any --> longText
Everything else is - for now - forbidden. 

Example:
`cyberismo update test/fieldTypes/dateTime change dataType date` --> changes dateTime to date in the given FT

A bit longer example; changing `boolean` to `shortText` and checking the card metadata:
<img width="745" alt="Screenshot 2025-04-15 at 11 14 07" src="https://github.com/user-attachments/assets/395fa713-e71f-42b6-b7bf-d71fc9f01b0a" />
<img width="687" alt="Screenshot 2025-04-15 at 11 14 36" src="https://github.com/user-attachments/assets/a92c7635-42f7-4847-9786-7d7264f670df" />
<img width="694" alt="Screenshot 2025-04-15 at 11 14 15" src="https://github.com/user-attachments/assets/d2093a82-6eb7-42f3-9b72-41bd84ea6ea3" />
