### PR TITLE
INTDEV-773 Create calculation files for modules, reports and templates

### DIFF
--- a/tools/data-handler/src/commands/move.ts
+++ b/tools/data-handler/src/commands/move.ts
@@ -44,7 +44,7 @@ export class Move {
     let card: Card | undefined;
     const templateCard = await this.project.isTemplateCard(cardKey);
     if (templateCard) {
-      card = (await this.project.templateCards(options)).find(
+      card = (await this.project.allTemplateCards(options)).find(
         (card) => card.key === cardKey,
       );
     } else {

--- a/tools/data-handler/src/commands/show.ts
+++ b/tools/data-handler/src/commands/show.ts
@@ -274,7 +274,7 @@ export class Show {
    */
   public async showLabels(): Promise<string[]> {
     const cards = await this.project.showProjectCards();
-    const templateCards = await this.project.templateCards({
+    const templateCards = await this.project.allTemplateCards({
       metadata: true,
       children: true,
     });

--- a/tools/data-handler/src/commands/validate.ts
+++ b/tools/data-handler/src/commands/validate.ts
@@ -558,7 +558,7 @@ export class Validate {
 
         // Finally, validate that each card is correct
         const cards = await project.cards();
-        cards.push(...(await project.templateCards()));
+        cards.push(...(await project.allTemplateCards()));
 
         for (const card of cards) {
           if (card.metadata) {

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -496,7 +496,7 @@ export class Project extends CardContainer {
    * @todo: This is only used from 'remove'. Could it use the static checker?
    */
   public async isTemplateCard(cardKey: string): Promise<boolean> {
-    const templateCards = await this.templateCards();
+    const templateCards = await this.allTemplateCards();
     return templateCards.find((card) => card.key === cardKey) != null;
   }
 
@@ -1022,22 +1022,36 @@ export class Project extends CardContainer {
    * @param cardDetails which details to fetch. Optional.
    * @returns all the template cards from the project
    */
-  public async templateCards(cardDetails?: FetchCardDetails): Promise<Card[]> {
+  public async allTemplateCards(
+    cardDetails?: FetchCardDetails,
+  ): Promise<Card[]> {
     const templates = await this.templates();
     const cards: Card[] = [];
     for (const template of templates) {
-      const templateObject = new TemplateResource(
-        this,
-        resourceName(template.name),
-      ).templateObject();
-      const templateCards = await templateObject?.cards('', cardDetails);
-      if (templateCards) {
-        for (const card of templateCards) {
-          cards.push(card);
-        }
-      }
+      const templateCards = await this.templateCards(
+        template.name,
+        cardDetails,
+      );
+      if (templateCards) cards.push(...templateCards);
     }
     return cards;
+  }
+
+  /**
+   * Returns cards from single template.
+   * @param templateName Name of the template
+   * @param cardDetails Card information
+   * @returns List of cards from template.
+   */
+  public async templateCards(
+    templateName: string,
+    cardDetails?: FetchCardDetails,
+  ): Promise<Card[]> {
+    const templateObject = new TemplateResource(
+      this,
+      resourceName(templateName),
+    ).templateObject();
+    return await templateObject?.cards('', cardDetails);
   }
 
   /**

--- a/tools/data-handler/src/resources/field-type-resource.ts
+++ b/tools/data-handler/src/resources/field-type-resource.ts
@@ -156,7 +156,7 @@ export class FieldTypeResource extends FileResource {
         metadata: true,
       })
     ).filter((card) => affectedCard(card));
-    const templateCards = (await this.project.templateCards())
+    const templateCards = (await this.project.allTemplateCards())
       .filter((card) => !card.path.includes('modules'))
       .filter((card) => affectedCard(card));
     const allCards = [...projectCards, ...templateCards];

--- a/tools/data-handler/src/resources/file-resource.ts
+++ b/tools/data-handler/src/resources/file-resource.ts
@@ -201,7 +201,7 @@ export class FileResource extends ResourceObject {
         content: true,
         metadata: true,
       })),
-      ...(await this.project.templateCards({
+      ...(await this.project.allTemplateCards({
         content: true,
         metadata: true,
       })),

--- a/tools/data-handler/src/utils/clingo-fact-builder.ts
+++ b/tools/data-handler/src/utils/clingo-fact-builder.ts
@@ -80,7 +80,7 @@ export class ClingoFactBuilder {
    * @returns this for chaining
    */
   addLiteralArgument(literal: string): ClingoFactBuilder {
-    this.arguments.push(new LiteralBuildler(literal));
+    this.arguments.push(new LiteralBuilder(literal));
     return this;
   }
 
@@ -160,7 +160,7 @@ export class ClingoFactBuilder {
   }
 }
 
-class LiteralBuildler extends ClingoFactBuilder {
+class LiteralBuilder extends ClingoFactBuilder {
   build() {
     return this.predicate;
   }

--- a/tools/data-handler/test/project.test.ts
+++ b/tools/data-handler/test/project.test.ts
@@ -435,7 +435,7 @@ describe('project', () => {
     const decisionRecordsPath = join(testDir, 'valid/decision-records');
     const project = new Project(decisionRecordsPath);
     expect(project).to.not.equal(undefined);
-    const templateCards = await project.templateCards();
+    const templateCards = await project.allTemplateCards();
     expect(templateCards.length).to.be.greaterThan(0);
     if (templateCards && templateCards.at(0)) {
       const template = project.createTemplateObjectFromCard(
@@ -488,6 +488,20 @@ describe('project', () => {
     expect(Project.isCreated(decisionRecordsPath)).to.equal(true);
     expect(Project.isCreated('idontexist')).to.equal(false);
     expect(Project.isCreated('')).to.equal(false);
+  });
+  it('fetch template cards', async () => {
+    const decisionRecordsPath = join(testDir, 'valid/decision-records');
+    const project = new Project(decisionRecordsPath);
+    // You get the same cards if you fetch all template cards in one call...
+    let templateCards = await project.allTemplateCards();
+    expect(templateCards.length).to.be.greaterThan(0);
+    // ...or fetch all templates, and then all cards for that template.
+    const templates = await project.templates();
+    for (const template of templates) {
+      const cards = await project.templateCards(template.name);
+      templateCards = templateCards.filter((item) => cards.includes(item));
+    }
+    expect(templateCards.length).to.equal(0);
   });
   it('list project cards (success)', async () => {
     const decisionRecordsPath = join(testDir, 'valid/decision-records');

--- a/tools/schema/cardTreeDirectorySchema.json
+++ b/tools/schema/cardTreeDirectorySchema.json
@@ -144,6 +144,10 @@
                   "description": "A logic program that contains basic common definitions that are the same in all cards projects",
                   "type": "object"
                 },
+                "calculations.lp": {
+                  "description": "A logic program that only includes all the logic programs from modules, including the calculations from the local content",
+                  "type": "object"
+                },
                 "cardTree.lp": {
                   "description": "A logic program that only includes all the card-specific logic programs",
                   "type": "object"
@@ -152,12 +156,12 @@
                   "description": "A logic program that only includes all the logic programs generated from resources",
                   "type": "object"
                 },
-                "modules.lp": {
-                  "description": "A logic program that only includes all the logic programs from modules, including the calculations from the local content",
-                  "type": "object"
-                },
                 "main.lp": {
                   "description": "The main logic program",
+                  "type": "object"
+                },
+                "modules.lp": {
+                  "description": "",
                   "type": "object"
                 },
                 "queryLanguage.lp": {


### PR DESCRIPTION
Add facts from modules, reports and templates.

I decided to rename the current logo program file `modules.lp` to `calculations.lp` since the file actually collect the separate calculation files from modules. The new `modules.lp` contain the facts from the modules (basically names and prefixes).