### PR TITLE
INTDEV-817 Remove unnecessary 'pathExists' calls

### DIFF
--- a/tools/backend/src/routes/cards.ts
+++ b/tools/backend/src/routes/cards.ts
@@ -87,7 +87,7 @@ async function getCardDetails(
       fetchCardDetails,
       key,
     );
-  } catch (error) {
+  } catch {
     return { status: 400, message: `Card ${key} not found from project` };
   }
 
@@ -746,7 +746,7 @@ router.get('/:key/a/:attachment', async (c) => {
         'Cache-Control': 'no-store',
       },
     });
-  } catch (error) {
+  } catch {
     return c.text(
       `No attachment found from card ${key} and filename ${filename}`,
       404,

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -306,8 +306,7 @@ export class Commands {
         let parsedValue = '';
         try {
           parsedValue = JSON.parse(value);
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        } catch (error) {
+        } catch {
           parsedValue = value;
         }
 

--- a/tools/data-handler/src/commands/calculate.ts
+++ b/tools/data-handler/src/commands/calculate.ts
@@ -100,9 +100,7 @@ export class Calculate {
   private async generateCardTreeContent(parentCard: Card | undefined) {
     const destinationFileBase = this.project.paths.calculationCardsFolder;
     const promiseContainer = [];
-    if (!pathExists(destinationFileBase)) {
-      await mkdir(destinationFileBase, { recursive: true });
-    }
+    await mkdir(destinationFileBase, { recursive: true });
 
     const cards = await this.getCards(parentCard);
     for (const card of cards) {
@@ -179,9 +177,6 @@ export class Calculate {
 
   // Once card specific files have been done, write the the imports
   private async generateImports(folder: string, destinationFile: string) {
-    if (!pathExists(folder)) {
-      return;
-    }
     const files: string[] = getFilesSync(folder);
 
     const builder = new ClingoProgramBuilder().addComment(folder);
@@ -520,9 +515,7 @@ export class Calculate {
           this.project.paths.calculationCardsFolder,
           `${card.key}.lp`,
         );
-        if (pathExists(cardCalculationsFile)) {
-          await deleteFile(cardCalculationsFile);
-        }
+        await deleteFile(cardCalculationsFile);
         // Then, delete rows from cardTree.lp.
         filteredLines = filteredLines.filter(
           (line) => !line.includes(`cards/${card.key}.lp`),
@@ -631,8 +624,8 @@ export class Calculate {
         `Graph: Failed to read image file after generating graph: ${e}`,
       );
     } finally {
-      if (pathExists(filePath)) await rm(filePath);
-      if (pathExists(filePath + '.png')) await rm(filePath + '.png');
+      await rm(filePath, { force: true });
+      await rm(filePath + '.png', { force: true });
     }
 
     return fileData.toString('base64');

--- a/tools/data-handler/src/commands/create.ts
+++ b/tools/data-handler/src/commands/create.ts
@@ -506,10 +506,8 @@ export class Create {
 
     try {
       await writeFile(join(projectPath, '.gitignore'), this.gitIgnoreContent);
-    } catch (error) {
-      if (error instanceof Error) {
-        console.error('Failed to create project');
-      }
+    } catch {
+      console.error('Failed to create project');
     }
   }
 

--- a/tools/data-handler/src/commands/export.ts
+++ b/tools/data-handler/src/commands/export.ts
@@ -1,13 +1,15 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
 
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 // node
@@ -19,7 +21,6 @@ import Processor from '@asciidoctor/core';
 import { Calculate, Show } from './index.js';
 import { Card, FetchCardDetails } from '../interfaces/project-interfaces.js';
 import { CardType } from '../interfaces/resource-interfaces.js';
-import { pathExists } from '../utils/file-utils.js';
 import { Project } from '../containers/project.js';
 import { QueryResult } from '../types/queries.js';
 import { sortItems } from '../utils/lexorank.js';
@@ -276,14 +277,10 @@ export class Export {
     );
     let message = '';
     try {
-      if (pathExists(resultDocumentPath)) {
-        await truncate(resultDocumentPath, 0);
-      }
+      await truncate(resultDocumentPath, 0);
       message = `Using existing output file '${resultDocumentPath}'`;
-    } catch (error) {
-      if (error instanceof Error) {
-        message = `Creating output file '${resultDocumentPath}'`;
-      }
+    } catch {
+      message = `Creating output file '${resultDocumentPath}'`;
     }
 
     await this.toAdocFile(resultDocumentPath, cards);

--- a/tools/data-handler/src/commands/validate.ts
+++ b/tools/data-handler/src/commands/validate.ts
@@ -711,17 +711,17 @@ export class Validate {
     if (activeJsonSchema === undefined) {
       throw new Error(`Unknown schema '${schemaId}'`);
     } else {
-      if (!pathExists(projectPath)) {
+      let contentFile = '';
+      try {
+        contentFile = await readJsonFile(projectPath);
+      } catch {
         throw new Error(`Path is not valid ${projectPath}`);
-      } else {
-        const result = this.validator.validate(
-          await readJsonFile(projectPath),
-          activeJsonSchema,
-        );
-        for (const error of result.errors) {
-          const msg = `Schema '${schemaId}' validation Error: ${error.message}\n`;
-          validationErrors.push(msg);
-        }
+      }
+
+      const result = this.validator.validate(contentFile, activeJsonSchema);
+      for (const error of result.errors) {
+        const msg = `Schema '${schemaId}' validation Error: ${error.message}\n`;
+        validationErrors.push(msg);
       }
     }
     return validationErrors.join('\n');

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -1,13 +1,15 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
 
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 // node
@@ -768,8 +770,9 @@ export class Project extends CardContainer {
    */
   public async projectPrefixes(): Promise<string[]> {
     const prefixes: string[] = [this.projectPrefix];
-    if (pathExists(this.paths.modulesFolder)) {
-      const files = await readdir(this.paths.modulesFolder, {
+    let files;
+    try {
+      files = await readdir(this.paths.modulesFolder, {
         withFileTypes: true,
         recursive: true,
       });
@@ -786,6 +789,8 @@ export class Project extends CardContainer {
 
       const configurationPrefixes = await Promise.all(configurationPromises);
       prefixes.push(...configurationPrefixes);
+    } catch {
+      // do nothing if readdir throws
     }
 
     return prefixes;

--- a/tools/data-handler/src/macros/graph/index.ts
+++ b/tools/data-handler/src/macros/graph/index.ts
@@ -1,13 +1,15 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
 
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 import BaseMacro from '../base-macro.js';
@@ -92,11 +94,12 @@ class ReportMacro extends BaseMacro {
       throw new Error(`Graph: Model ${options.model} does not exist`);
     }
 
-    if (!pathExists(viewLocation)) {
+    let viewContent = '';
+    try {
+      viewContent = await readFile(viewLocation, { encoding: 'utf-8' });
+    } catch {
       throw new Error(`Graph: View ${options.view} does not exist`);
     }
-
-    const viewContent = await readFile(viewLocation, { encoding: 'utf-8' });
     const handlebarsContext = {
       cardKey: context.cardKey,
       ...options,

--- a/tools/data-handler/src/project-settings.ts
+++ b/tools/data-handler/src/project-settings.ts
@@ -56,12 +56,10 @@ export class ProjectConfiguration implements ProjectSettings {
     let settings;
     try {
       settings = readJsonFileSync(this.settingPath) as ProjectSettings;
-    } catch (error) {
-      if (error instanceof Error) {
-        throw new Error(
-          `Invalid path '${this.settingPath}' to configuration file`,
-        );
-      }
+    } catch {
+      throw new Error(
+        `Invalid path '${this.settingPath}' to configuration file`,
+      );
     }
     if (!settings) {
       throw new Error(

--- a/tools/data-handler/src/resources/file-resource.ts
+++ b/tools/data-handler/src/resources/file-resource.ts
@@ -1,16 +1,16 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
 
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
-
-/* eslint-disable @typescript-eslint/no-unused-vars */
 
 // node
 import { basename, join } from 'node:path';
@@ -122,9 +122,11 @@ export class FileResource extends ResourceObject {
       return;
     }
     //... otherwise read from disk and add to cache
-    if (pathExists(this.fileName)) {
+    try {
       this.content = readJsonFileSync(this.fileName);
       this.toCache();
+    } catch {
+      // do nothing, it is possible that file has not been created yet.
     }
   }
 
@@ -282,9 +284,7 @@ export class FileResource extends ResourceObject {
 
   // Reads content from file to memory.
   protected async read() {
-    if (pathExists(this.fileName)) {
-      this.content = await readJsonFile(this.fileName);
-    }
+    this.content = await readJsonFile(this.fileName);
   }
 
   // Renames resource.
@@ -336,6 +336,7 @@ export class FileResource extends ResourceObject {
   // Update resource; the base class makes some checks only.
   protected async update<Type>(
     key: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _op: Operation<Type>,
   ): Promise<void> {
     const content = this.data;
@@ -389,17 +390,14 @@ export class FileResource extends ResourceObject {
     }
 
     // Create folder for resources and add correct .schema file.
-    //todo: pathExists + mkdir
-    if (!pathExists(this.resourceFolder)) {
-      await mkdir(this.resourceFolder);
-      await writeJsonFile(
-        join(this.resourceFolder, '.schema'),
-        this.contentSchema,
-        {
-          flag: 'wx',
-        },
-      );
-    }
+    await mkdir(this.resourceFolder, { recursive: true });
+    await writeJsonFile(
+      join(this.resourceFolder, '.schema'),
+      this.contentSchema,
+      {
+        flag: 'wx',
+      },
+    );
     // Check if "name" has changed. Changing "name" means renaming the file.
     const nameInContent = resourceName(this.content.name).identifier + '.json';
     const currentFileName = basename(this.fileName);

--- a/tools/data-handler/src/resources/graph-model-resource.ts
+++ b/tools/data-handler/src/resources/graph-model-resource.ts
@@ -29,7 +29,7 @@ import {
   GraphModel,
   GraphModelMetadata,
 } from '../interfaces/resource-interfaces.js';
-import { pathExists, writeFileSafe } from '../utils/file-utils.js';
+import { writeFileSafe } from '../utils/file-utils.js';
 
 /**
  * Graph model resource class.
@@ -70,7 +70,17 @@ export class GraphModelResource extends FolderResource {
       await this.validate(newContent);
     }
 
-    return super.create(newContent);
+    await super.create(newContent);
+
+    // Create the internal folder in 'create', instead of 'write'.
+    const calculationsFile = join(this.internalFolder, 'model.lp');
+    await writeFileSafe(
+      calculationsFile,
+      `% add your calculations here for '${this.resourceName.identifier}'`,
+      {
+        flag: 'wx',
+      },
+    );
   }
 
   /**
@@ -189,16 +199,5 @@ export class GraphModelResource extends FolderResource {
    */
   public async write() {
     await super.write();
-
-    const calculationsFile = join(this.internalFolder, 'model.lp');
-    if (!pathExists(calculationsFile)) {
-      await writeFileSafe(
-        calculationsFile,
-        `% add your calculations here for '${this.resourceName.identifier}'`,
-        {
-          flag: 'wx',
-        },
-      );
-    }
   }
 }

--- a/tools/data-handler/src/resources/graph-view-resource.ts
+++ b/tools/data-handler/src/resources/graph-view-resource.ts
@@ -29,7 +29,7 @@ import {
   GraphView,
   GraphViewMetadata,
 } from '../interfaces/resource-interfaces.js';
-import { pathExists, writeFileSafe } from '../utils/file-utils.js';
+import { writeFileSafe } from '../utils/file-utils.js';
 
 /**
  * Graph view resource class.
@@ -70,7 +70,11 @@ export class GraphViewResource extends FolderResource {
       await this.validate(newContent);
     }
 
-    return super.create(newContent);
+    await super.create(newContent);
+    const handleBarFile = join(this.internalFolder, 'view.lp.hbs');
+    await writeFileSafe(handleBarFile, '', {
+      flag: 'wx',
+    });
   }
 
   /**
@@ -189,12 +193,5 @@ export class GraphViewResource extends FolderResource {
    */
   public async write() {
     await super.write();
-
-    const handleBarFile = join(this.internalFolder, 'view.lp.hbs');
-    if (!pathExists(handleBarFile)) {
-      await writeFileSafe(handleBarFile, '', {
-        flag: 'wx',
-      });
-    }
   }
 }

--- a/tools/data-handler/src/resources/report-resource.ts
+++ b/tools/data-handler/src/resources/report-resource.ts
@@ -1,13 +1,15 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
 
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { readdir, readFile } from 'node:fs/promises';
@@ -15,7 +17,7 @@ import { readFileSync } from 'node:fs';
 import { extname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { copyDir, pathExists } from '../utils/file-utils.js';
+import { copyDir } from '../utils/file-utils.js';
 import {
   Card,
   DefaultContent,
@@ -47,9 +49,7 @@ export class ReportResource extends FolderResource {
     this.initialize();
 
     const schemaPath = join(this.internalFolder, REPORT_SCHEMA_FILE);
-    this.reportSchema = pathExists(schemaPath)
-      ? JSON.parse(readFileSync(schemaPath).toString())
-      : undefined;
+    this.reportSchema = this.readSchemaFile(schemaPath);
   }
 
   // Path to content folder.
@@ -71,6 +71,16 @@ export class ReportResource extends FolderResource {
     ]);
     // Finally, write updated content.
     await this.write();
+  }
+
+  // Try to read schema file content
+  private readSchemaFile(path: string) {
+    try {
+      const schema = readFileSync(path);
+      return JSON.parse(schema.toString());
+    } catch {
+      return undefined;
+    }
   }
 
   /**

--- a/tools/data-handler/src/resources/template-resource.ts
+++ b/tools/data-handler/src/resources/template-resource.ts
@@ -1,13 +1,15 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
 
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { basename, dirname, join } from 'node:path';
@@ -23,7 +25,6 @@ import {
   resourceNameToString,
   sortCards,
 } from './folder-resource.js';
-import { pathExists } from '../utils/file-utils.js';
 import {
   TemplateConfiguration,
   TemplateMetadata,
@@ -200,10 +201,8 @@ export class TemplateResource extends FolderResource {
     // Create folder for cards and put proper content schema file there
     const schemaContentFile = join(this.cardsFolder, '.schema');
     await mkdir(this.cardsFolder, { recursive: true });
-    if (!pathExists(schemaContentFile)) {
-      await writeJsonFile(schemaContentFile, this.cardsSchema, {
-        flag: 'wx',
-      });
-    }
+    await writeJsonFile(schemaContentFile, this.cardsSchema, {
+      flag: 'wx',
+    });
   }
 }

--- a/tools/data-handler/src/utils/common-utils.ts
+++ b/tools/data-handler/src/utils/common-utils.ts
@@ -48,8 +48,7 @@ export function deepCompare(arg1: object, arg2: object): boolean {
 export function isBigInt(value: string): boolean {
   try {
     return BigInt(parseInt(value, 10)) !== BigInt(value);
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (e) {
+  } catch {
     return false;
   }
 }

--- a/tools/data-handler/src/utils/file-utils.ts
+++ b/tools/data-handler/src/utils/file-utils.ts
@@ -1,13 +1,15 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
 
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 import {
@@ -78,10 +80,8 @@ export async function deleteFile(path: string): Promise<boolean> {
   }
   try {
     await unlink(path);
-  } catch (error) {
-    if (error instanceof Error) {
-      console.error(`Cannot delete file '${path}'`);
-    }
+  } catch {
+    console.error(`Cannot delete file '${path}'`);
     return false;
   }
   return true;
@@ -132,14 +132,20 @@ export function getFilesSync(
   pathPrefix: string = '',
   files: string[] = [],
 ): string[] {
-  for (const entry of readdirSync(path, { withFileTypes: true })) {
-    const relativePath = pathPrefix ? join(pathPrefix, entry.name) : entry.name;
+  try {
+    for (const entry of readdirSync(path, { withFileTypes: true })) {
+      const relativePath = pathPrefix
+        ? join(pathPrefix, entry.name)
+        : entry.name;
 
-    if (entry.isFile()) {
-      files.push(relativePath);
-    } else if (entry.isDirectory()) {
-      getFilesSync(join(path, entry.name), relativePath, files);
+      if (entry.isFile()) {
+        files.push(relativePath);
+      } else if (entry.isDirectory()) {
+        getFilesSync(join(path, entry.name), relativePath, files);
+      }
     }
+  } catch {
+    // do nothing, wrong path, or no permissions to read the files
   }
   return files;
 }

--- a/tools/data-handler/src/utils/json.ts
+++ b/tools/data-handler/src/utils/json.ts
@@ -1,13 +1,15 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
 
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { readFileSync } from 'node:fs';
@@ -99,11 +101,18 @@ export function formatJson(json: object) {
  * @param filename file name (and path) to write.
  * @param json JSON object to format.
  * @param options Optional, write options
+ * @return true if write succeeded, false otherwise.
  */
 export async function writeJsonFile(
   filename: string | FileHandle,
   json: object,
   options?: object,
 ) {
-  await writeFile(filename, formatJson(json), options);
+  try {
+    await writeFile(filename, formatJson(json), options);
+    return true;
+  } catch {
+    // do nothing, file didn't exist, or no permissions to write
+  }
+  return false;
 }

--- a/tools/data-handler/src/utils/value-utils.ts
+++ b/tools/data-handler/src/utils/value-utils.ts
@@ -143,8 +143,7 @@ export function fromString<T>(value: T, to: DataType) {
       try {
         const tempDate = new Date((value as string) + 'Z').toUTCString();
         return new Date(tempDate).toISOString().slice(0, 10);
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      } catch (error) {
+      } catch {
         return null;
       }
     }
@@ -152,8 +151,7 @@ export function fromString<T>(value: T, to: DataType) {
       try {
         const tempDate = new Date((value as string) + 'Z').toUTCString();
         return new Date(tempDate).toISOString();
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      } catch (error) {
+      } catch {
         return null;
       }
     }

--- a/tools/data-handler/test/command-handler-create.test.ts
+++ b/tools/data-handler/test/command-handler-create.test.ts
@@ -636,10 +636,8 @@ describe('create command', () => {
     );
     try {
       await access(projectDir, fsConstants.R_OK);
-    } catch (error) {
-      if (error instanceof Error) {
-        assert(false, 'project folder could not be created');
-      }
+    } catch {
+      assert(false, 'project folder could not be created');
     }
     expect(result.statusCode).to.equal(200);
   });
@@ -657,10 +655,8 @@ describe('create command', () => {
     try {
       // nodeJS does not automatically expand paths with tilde
       await access(resolveTilde(path), fsConstants.F_OK);
-    } catch (error) {
-      if (error instanceof Error) {
-        assert(false, 'project folder could not be created');
-      }
+    } catch {
+      assert(false, 'project folder could not be created');
     }
     expect(result.statusCode).to.equal(200);
   });

--- a/tools/data-handler/test/command-handler-import.test.ts
+++ b/tools/data-handler/test/command-handler-import.test.ts
@@ -216,10 +216,8 @@ describe('import module', () => {
           invalidOptions,
         );
         assert(false, 'this should not be reached as the above throws');
-      } catch (error) {
-        if (error instanceof Error) {
-          // this block is here for linter
-        }
+      } catch {
+        // do nothing
       }
       expect(result.statusCode).to.equal(400);
       stubProjectPath.restore();

--- a/tools/data-handler/test/command-handler-transition.test.ts
+++ b/tools/data-handler/test/command-handler-transition.test.ts
@@ -78,11 +78,9 @@ describe('transition command', () => {
         {},
       );
       assert(false, 'this should not be reached as the above throws');
-    } catch (error) {
-      if (error instanceof Error) {
-        // missing path (if the project location cannot be deduced) throws
-        expect(true);
-      }
+    } catch {
+      // missing path (if the project location cannot be deduced) throws
+      expect(true);
     }
     stubProjectPath.restore();
   });

--- a/tools/data-handler/test/command-handler-validate.test.ts
+++ b/tools/data-handler/test/command-handler-validate.test.ts
@@ -24,10 +24,8 @@ describe('command-handler: validate command', () => {
     try {
       result = await commandHandler.command(Cmd.validate, [], {});
       assert(false, 'this should not be reached as the above throws');
-    } catch (error) {
-      if (error instanceof Error) {
-        // this block is here for linter
-      }
+    } catch {
+      // do nothing
     }
     expect(result.statusCode).to.equal(400);
     stubProjectPath.restore();

--- a/tools/data-handler/test/project.test.ts
+++ b/tools/data-handler/test/project.test.ts
@@ -379,7 +379,7 @@ describe('project', () => {
     if (card) {
       const previousContent = card.content;
       card.content += '\naddition';
-      await project.updateCardContent(card.key, card.content!, true);
+      await project.updateCardContent(card.key, card.content!);
       expect(card.content).not.to.equal(previousContent);
     }
   });
@@ -657,8 +657,7 @@ describe('project', () => {
     try {
       project.cardPathParts('decision_99');
       expect(false);
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (error) {
+    } catch {
       expect(true);
     }
   });

--- a/tools/data-handler/test/show.test.ts
+++ b/tools/data-handler/test/show.test.ts
@@ -119,10 +119,11 @@ describe('show', () => {
     // Parent
     const cardIdParent = 'decision_mycard';
     await writeFileSafe(join(cardRoot, cardIdParent, 'index.adoc'), '');
-    await writeJsonFile(
+    const parentWrite = await writeJsonFile(
       join(cardRoot, cardIdParent, 'index.json'),
       cardMetadata,
     );
+    expect(parentWrite).to.equal(true);
     mkdirSync(join(decisionRecordsPath, 'cardRoot', cardIdParent, 'a'));
 
     // Child
@@ -131,10 +132,11 @@ describe('show', () => {
       join(cardRoot, cardIdParent, 'c', cardIChild, 'index.adoc'),
       '',
     );
-    await writeJsonFile(
+    const childWrite = await writeJsonFile(
       join(cardRoot, cardIdParent, 'c', cardIChild, 'index.json'),
       cardMetadata,
     );
+    expect(childWrite).to.equal(true);
     await writeFileSafe(
       join(cardRoot, cardIdParent, 'c', cardIChild, 'a', 'image.png'),
       '',

--- a/tools/data-handler/test/utils/file-utils.test.ts
+++ b/tools/data-handler/test/utils/file-utils.test.ts
@@ -41,10 +41,8 @@ describe('file utils', () => {
     try {
       await access(destination);
       expect(true);
-    } catch (error) {
-      if (error instanceof Error) {
-        expect(false);
-      }
+    } catch {
+      expect(false);
     }
   });
   it('copyDir with hierarchy (success)', async () => {
@@ -56,10 +54,8 @@ describe('file utils', () => {
     try {
       await access(destination);
       expect(true);
-    } catch (error) {
-      if (error instanceof Error) {
-        expect(false);
-      }
+    } catch {
+      expect(false);
     }
   });
   it('deleteDir (success)', async () => {
@@ -69,10 +65,8 @@ describe('file utils', () => {
     try {
       await access(targetDir);
       expect(false);
-    } catch (error) {
-      if (error instanceof Error) {
-        expect(true);
-      }
+    } catch {
+      expect(true);
     }
   });
   it('deleteFile (success)', async () => {
@@ -88,10 +82,8 @@ describe('file utils', () => {
     try {
       await access(target);
       expect(false);
-    } catch (error) {
-      if (error instanceof Error) {
-        expect(true);
-      }
+    } catch {
+      expect(true);
     }
   });
   it('deleteFile - file missing', async () => {
@@ -102,6 +94,10 @@ describe('file utils', () => {
   it('getFilesSync (success)', () => {
     const files = getFilesSync('test/test-data/valid/minimal');
     expect(files.length).to.be.greaterThan(0);
+  });
+  it('getFilesSync - wrong path', () => {
+    const files = getFilesSync('test/test-data/valid/non-existing');
+    expect(files.length).to.equal(0);
   });
   it('pathExists (success)', () => {
     const path = '/';


### PR DESCRIPTION
Remove as many of the `pathExists` calls as possible. 

Generally, it is a bad code to first check if something exists and then try to read it. Instead just try to read the file / dir and handle the error / exception if any. This way we can avoid problematic timing issues when:
- check if file exists before an asynchronous read call... --> true, file exists
- before executing the read file, event loop runs some other asynchronous code that removes/renames the file
- ...original code resumes, and now fails, since file is no longer available

These sporadically cause some problems. Therefore, it is best to get rid of most of the "unnecessary" `pathExists` calls.

And it is also somewhat slower to first check the file existence and then read it than directly read it. However, we are talking about microsecond improvements, thus no one will notice.