### PR TITLE
Add missing projectPath to env variable

### DIFF
--- a/tools/backend/src/routes/cards.ts
+++ b/tools/backend/src/routes/cards.ts
@@ -99,7 +99,7 @@ async function getCardDetails(
   try {
     asciidocContent = await evaluateMacros(cardDetailsResponse.content || '', {
       mode: 'inject',
-      projectPath: process.env.npm_config_project_path || '',
+      projectPath: commands.project.basePath || '',
       cardKey: key,
     });
   } catch (error) {
@@ -555,7 +555,7 @@ router.post('/:key/parse', async (c) => {
     try {
       asciidocContent = await evaluateMacros(content, {
         mode: 'inject',
-        projectPath: process.env.npm_config_project_path || '',
+        projectPath: commands.project.basePath || '',
         cardKey: key,
       });
     } catch (error) {


### PR DESCRIPTION
Environment variable needed for report macros. Application worked fine when started without cyberismo app -p <project> flag, but did not resolve path properly when -p flag was used. This environment variable was left empty when Next.js was taken out, since it was set during the initialization of next.js server