### PR TITLE
INTDEV-844 Allow public repos to be updated without username and token

### DIFF
--- a/tools/data-handler/src/module-manager.ts
+++ b/tools/data-handler/src/module-manager.ts
@@ -75,17 +75,19 @@ export class ModuleManager {
       module.name = this.repositoryName(module.location);
     }
     const repoUrl = new URL(module.location);
-    repoUrl.username = process.env.CYBERISMO_GIT_USER ?? '';
-    repoUrl.password = process.env.CYBERISMO_GIT_TOKEN ?? '';
-    if (!repoUrl.username) {
-      throw new Error(
-        `No user defined. Cannot clone git repo. Set CYBERISMO_GIT_USER environment variable`,
-      );
-    }
-    if (!repoUrl.password) {
-      throw new Error(
-        `No git token defined. Cannot clone git repo. Set CYBERISMO_GIT_TOKEN environment variable`,
-      );
+    if (process.env.CYBERISMO_GIT_USER && process.env.CYBERISMO_GIT_TOKEN) {
+      repoUrl.username = process.env.CYBERISMO_GIT_USER ?? '';
+      repoUrl.password = process.env.CYBERISMO_GIT_TOKEN;
+      if (!repoUrl.username) {
+        throw new Error(
+          `No user defined. Cannot clone git repo. Set CYBERISMO_GIT_USER environment variable`,
+        );
+      }
+      if (!repoUrl.password) {
+        throw new Error(
+          `No git token defined. Cannot clone git repo. Set CYBERISMO_GIT_TOKEN environment variable`,
+        );
+      }
     }
     await git.clone({
       fs,

--- a/tools/data-handler/src/module-manager.ts
+++ b/tools/data-handler/src/module-manager.ts
@@ -76,18 +76,8 @@ export class ModuleManager {
     }
     const repoUrl = new URL(module.location);
     if (process.env.CYBERISMO_GIT_USER && process.env.CYBERISMO_GIT_TOKEN) {
-      repoUrl.username = process.env.CYBERISMO_GIT_USER ?? '';
+      repoUrl.username = process.env.CYBERISMO_GIT_USER;
       repoUrl.password = process.env.CYBERISMO_GIT_TOKEN;
-      if (!repoUrl.username) {
-        throw new Error(
-          `No user defined. Cannot clone git repo. Set CYBERISMO_GIT_USER environment variable`,
-        );
-      }
-      if (!repoUrl.password) {
-        throw new Error(
-          `No git token defined. Cannot clone git repo. Set CYBERISMO_GIT_TOKEN environment variable`,
-        );
-      }
     }
     await git.clone({
       fs,

--- a/tools/data-handler/test/module-manager.test.ts
+++ b/tools/data-handler/test/module-manager.test.ts
@@ -84,7 +84,7 @@ describe('module-manager', () => {
         ),
       );
   });
-  it('try to import from incorrect local path', async () => {
+  it('try to import from incorrect git path', async () => {
     const gitModule = 'https://github.com/CyberismoCom/i-do-not-exist.git';
     await commands.importCmd
       .importModule(gitModule, commands.project.basePath)
@@ -98,7 +98,7 @@ describe('module-manager', () => {
           expect(false).to.equal(true);
         }
       });
-  });
+  }).timeout(10000);
   it('update all modules', async () => {
     let modules = await commands.showCmd.showModules();
     expect(modules.length).equals(0);
@@ -117,5 +117,5 @@ describe('module-manager', () => {
     await commands.importCmd.updateAllModules();
     modules = await commands.showCmd.showModules();
     expect(modules.length).equals(2);
-  });
+  }).timeout(10000);
 });

--- a/tools/data-handler/test/module-manager.test.ts
+++ b/tools/data-handler/test/module-manager.test.ts
@@ -86,9 +86,7 @@ describe('module-manager', () => {
     await commands.importCmd
       .importModule(gitModule, commands.project.basePath)
       .then(() => expect(false).to.equal(true))
-      .catch((error) =>
-        expect(error.message).to.equal('HTTP Error: 404 Not Found'),
-      );
+      .catch((error) => expect(error.message).to.includes('HTTP Error:'));
   });
   it('update all modules', async () => {
     let modules = await commands.showCmd.showModules();

--- a/tools/data-handler/test/module-manager.test.ts
+++ b/tools/data-handler/test/module-manager.test.ts
@@ -6,6 +6,9 @@ import { describe, it } from 'mocha';
 import { mkdirSync, rmSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
+// git client
+import { Errors } from 'isomorphic-git';
+
 import { copyDir } from '../src/utils/file-utils.js';
 import { fileURLToPath } from 'node:url';
 import { CommandManager } from '../src/command-manager.js';
@@ -86,7 +89,15 @@ describe('module-manager', () => {
     await commands.importCmd
       .importModule(gitModule, commands.project.basePath)
       .then(() => expect(false).to.equal(true))
-      .catch((error) => expect(error.message).to.includes('HTTP Error:'));
+      .catch((error) => {
+        if (error instanceof Errors.HttpError) {
+          expect(error).to.have.property('data');
+          expect(error.data).to.have.property('statusCode');
+          expect(error.data.statusCode).to.equal(404);
+        } else {
+          expect(false).to.equal(true);
+        }
+      });
   });
   it('update all modules', async () => {
     let modules = await commands.showCmd.showModules();


### PR DESCRIPTION
Adding even empty string for `username` and `password` (read: token) makes `git` to treat them as defined. This leads to a situation where when user did not had the environment variables (`CYBERISMO_GIT_USER` and `CYBERISMO_GIT_TOKEN`) defined, they are passed on as empty strings and then they are assumed to be the username and the token for this query. Which then leads to 401. 

Changing the implementation so that only if both environmental variables are defined, then they are added to the git url. 

Now for example adding a private repo module without credentials works correctly (i.e. you cannot do it):
<img width="871" alt="Screenshot 2025-04-29 at 6 46 21" src="https://github.com/user-attachments/assets/191ebcd2-c540-4e16-a555-a6f170e4b5a8" />

