### PR TITLE
Add missing import statement

### DIFF
--- a/resources/calculations/common/main.lp
+++ b/resources/calculations/common/main.lp
@@ -9,5 +9,6 @@
 #include "base.lp".
 #include "cardTree.lp".
 #include "resourceImports.lp".
+#include "calculations.lp".
 #include "modules.lp".
 #include "pythonFunctions.lp".


### PR DESCRIPTION
When https://github.com/CyberismoCom/cyberismo/pull/594 was done, there was a rename of `lp`-files.
Existing `modules.lp` was renamed to `calculations.lp` and a new `modules.lp` was included in the fact generation.
Unfortunately, the `calculations.lp` was not included in the clingo program.

Adding the missing import.