### PR TITLE
Use translated loading text instead of hard coded

### DIFF
--- a/tools/app/src/components/LoadingGate.tsx
+++ b/tools/app/src/components/LoadingGate.tsx
@@ -26,8 +26,9 @@ const LoadingGate: React.FC<LoadingGateProps> = ({
   loadingIndicator,
   children,
 }) => {
+  const { t } = useTranslation();
+
   if (isLoading || values?.some((value) => value === null)) {
-    const { t } = useTranslation();
     return loadingIndicator ? loadingIndicator : <div>{t('loading')}</div>;
   }
 

--- a/tools/app/src/components/LoadingGate.tsx
+++ b/tools/app/src/components/LoadingGate.tsx
@@ -11,6 +11,7 @@
 */
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface LoadingGateProps {
   values?: any[];
@@ -26,7 +27,8 @@ const LoadingGate: React.FC<LoadingGateProps> = ({
   children,
 }) => {
   if (isLoading || values?.some((value) => value === null)) {
-    return loadingIndicator ? loadingIndicator : <div>Loading...</div>;
+    const { t } = useTranslation();
+    return loadingIndicator ? loadingIndicator : <div>{t('loading')}</div>;
   }
 
   return <>{children}</>;


### PR DESCRIPTION
As we already have `Loading...` text, use it from translation file, instead of hard coded string.