### PR TITLE
INTDEV-549 Show report results from CLI

### DIFF
--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -567,6 +567,28 @@ program
     handleResponse(result);
   });
 
+// Report command
+program
+  .command('report')
+  .description('Runs a report')
+  .argument(
+    '<parameters>',
+    'Path to parameters file. This file defines which report to run and what parameters to use.',
+  )
+  .argument(
+    '[output]',
+    'Optional output file; if omitted output will be directed to stdout',
+  )
+  .option('-p, --project-path [path]', `${pathGuideline}`)
+  .action(async (parameters: string, output: string, options: CardsOptions) => {
+    const result = await commandHandler.command(
+      Cmd.report,
+      [parameters, output],
+      options,
+    );
+    handleResponse(result);
+  });
+
 // Show command
 program
   .command('show')

--- a/tools/data-handler/src/commands/show.ts
+++ b/tools/data-handler/src/commands/show.ts
@@ -16,6 +16,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { spawn } from 'node:child_process';
+import { writeFile } from 'node:fs/promises';
 
 import mime from 'mime-types';
 
@@ -39,6 +40,9 @@ import { Project, ResourcesFrom } from '../containers/project.js';
 import { resourceName } from '../utils/resource-utils.js';
 import { TemplateResource } from '../resources/template-resource.js';
 import { UserPreferences } from '../utils/user-preferences.js';
+
+import ReportMacro from '../macros/report/index.js';
+import TaskQueue from '../macros/task-queue.js';
 
 /**
  * Show command.
@@ -320,6 +324,54 @@ export class Show {
    */
   public async showProject(): Promise<ProjectMetadata> {
     return this.project.show();
+  }
+
+  /**
+   * Shows report results for a given report name and card key.
+   * @param reportName Name of the report to show
+   * @param cardKey Card key to use for the report
+   * @param parameters Additional parameters for the report
+   * @param outputPath Optional output path for the report
+   * @returns Report results as a string
+   * @throws Error if the report does not exist
+   */
+  public async showReportResults(
+    reportName: string,
+    cardKey: string,
+    parameters: object,
+    outputPath?: string,
+  ): Promise<string> {
+    if (
+      !(await this.project.reports()).some(
+        (report) => report.name === reportName,
+      )
+    ) {
+      throw new Error(`Report '${reportName}' does not exist`);
+    }
+
+    const reportMacro = new ReportMacro(new TaskQueue());
+    const result = await reportMacro.handleInject(
+      {
+        projectPath: this.project.basePath,
+        cardKey: cardKey,
+        mode: 'static',
+      },
+      { name: reportName, ...parameters },
+    );
+
+    // Show the results either in the console or write to a file.
+    if (outputPath) {
+      try {
+        await writeFile(outputPath, result ?? '', 'utf-8');
+      } catch (error) {
+        if (error instanceof Error) {
+          throw new Error(
+            `Failed to write report to ${outputPath}: ${error.message}`,
+          );
+        }
+      }
+    }
+    return outputPath ? '' : (result ?? '');
   }
 
   /**

--- a/tools/data-handler/test/command-handler-report.test.ts
+++ b/tools/data-handler/test/command-handler-report.test.ts
@@ -1,0 +1,138 @@
+// testing
+import { expect } from 'chai';
+
+// node
+import { mkdirSync, rmSync } from 'node:fs';
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// cyberismo
+import { CardsOptions, Cmd, Commands } from '../src/command-handler.js';
+import { copyDir } from '../src/utils/file-utils.js';
+
+// validation tests do not modify the content - so they can use the original files
+const baseDir = dirname(fileURLToPath(import.meta.url));
+const testDir = join(baseDir, 'tmp-command-handler-report-tests');
+
+const decisionRecordsPath = join(testDir, 'valid/decision-records');
+
+const commandHandler: Commands = new Commands();
+const optionsDecision: CardsOptions = { projectPath: decisionRecordsPath };
+
+describe('report command', () => {
+  before(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir('test/test-data', testDir);
+    await commandHandler.command(Cmd.calc, ['generate'], optionsDecision);
+  });
+
+  after(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('run test report that returns no data', async () => {
+    const parameters = {
+      name: 'decision/reports/anotherReport',
+      parameters: {
+        cardKey: 'decision_1',
+      },
+    };
+    await writeFile(
+      join(testDir, 'report.json'),
+      JSON.stringify(parameters, null, 2),
+      { encoding: 'utf-8' },
+    );
+    const result = await commandHandler.command(
+      Cmd.report,
+      [join(testDir, 'report.json')],
+      optionsDecision,
+    );
+    expect(result.statusCode).to.equal(200);
+    // decision_1 card does not have children.
+    expect(result.message).to.include('No report result');
+  });
+  it('run test report that returns results', async () => {
+    const parameters = {
+      name: 'decision/reports/anotherReport',
+      parameters: {
+        cardKey: 'decision_5',
+      },
+    };
+    await writeFile(
+      join(testDir, 'report.json'),
+      JSON.stringify(parameters, null, 2),
+      { encoding: 'utf-8' },
+    );
+    const result = await commandHandler.command(
+      Cmd.report,
+      [join(testDir, 'report.json')],
+      optionsDecision,
+    );
+    expect(result.statusCode).to.equal(200);
+    // decision_1 card does not have children.
+    expect(result.message).to.include('xref');
+  });
+  it('run test report and put the results to an output file', async () => {
+    const parameters = {
+      name: 'decision/reports/anotherReport',
+      parameters: {
+        cardKey: 'decision_5',
+      },
+    };
+    const outputFile = join(testDir, 'report-output.txt');
+    await writeFile(
+      join(testDir, 'report.json'),
+      JSON.stringify(parameters, null, 2),
+      { encoding: 'utf-8' },
+    );
+    const result = await commandHandler.command(
+      Cmd.report,
+      [join(testDir, 'report.json'), outputFile],
+      optionsDecision,
+    );
+    expect(result.statusCode).to.equal(200);
+    await readFile(outputFile, { encoding: 'utf-8' }).then((data) => {
+      expect(data).to.include('xref');
+      expect(data).to.include('decision_6'); //decision_6 is decision_5's child
+    });
+  });
+  it('try to run test report that does not exist', async () => {
+    const parameters = {
+      name: 'decision/reports/i-do-not-exist',
+      parameters: {
+        cardKey: 'decision_5',
+      },
+    };
+    await writeFile(
+      join(testDir, 'report.json'),
+      JSON.stringify(parameters, null, 2),
+      { encoding: 'utf-8' },
+    );
+    const result = await commandHandler.command(
+      Cmd.report,
+      [join(testDir, 'report.json')],
+      optionsDecision,
+    );
+    expect(result.statusCode).to.equal(500);
+  });
+  it('try to run test report with incorrect parameters', async () => {
+    const parameters = {
+      name: 'decision/reports/anotherReport',
+      parameters: {
+        wrong: 'wrong',
+      },
+    };
+    await writeFile(
+      join(testDir, 'report.json'),
+      JSON.stringify(parameters, null, 2),
+      { encoding: 'utf-8' },
+    );
+    const result = await commandHandler.command(
+      Cmd.report,
+      [join(testDir, 'report.json')],
+      optionsDecision,
+    );
+    expect(result.statusCode).to.equal(500);
+  });
+});

--- a/tools/data-handler/test/command-handler-show.test.ts
+++ b/tools/data-handler/test/command-handler-show.test.ts
@@ -215,8 +215,9 @@ describe('shows command', () => {
       );
       const payloadAsArray = Object.values(result.payload || []);
       expect(result.statusCode).to.equal(200);
-      expect(payloadAsArray.length).to.equal(1);
-      expect(payloadAsArray[0]).to.equal('decision/reports/testReport');
+      expect(payloadAsArray.length).to.equal(2);
+      expect(payloadAsArray[0]).to.equal('decision/reports/anotherReport');
+      expect(payloadAsArray[1]).to.equal('decision/reports/testReport');
     });
     it('show templates - success()', async () => {
       const result = await commandHandler.command(

--- a/tools/data-handler/test/project.test.ts
+++ b/tools/data-handler/test/project.test.ts
@@ -648,8 +648,8 @@ describe('project', () => {
     const projectDecision = new Project(decisionRecordsPath);
     const miniDecision = new Project(miniRecordsPath);
     let files = await projectDecision.reportHandlerBarFiles();
-    // There are two handlebar files in the test project
-    expect(files.length).to.equal(2);
+    // There are four handlebar files in the test project
+    expect(files.length).to.equal(4);
     files = await miniDecision.reportHandlerBarFiles();
     // There are no handlebar files in the minimal report
     expect(files.length).to.equal(0);

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/reports/anotherReport.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/reports/anotherReport.json
@@ -1,0 +1,6 @@
+{
+    "displayName": "Another test report",
+    "description": "This would be description...",
+    "category": "Category",
+    "name": "decision/reports/anotherReport"
+}

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/reports/anotherReport/.schema
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/reports/anotherReport/.schema
@@ -1,0 +1,7 @@
+[
+  {
+    "version": 1,
+    "id": "reportSchema",
+    "file": "../anotherReport.json"
+  }
+]

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/reports/anotherReport/index.adoc.hbs
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/reports/anotherReport/index.adoc.hbs
@@ -1,0 +1,3 @@
+{{#each results}}
+* xref:{{this.key}}.adoc[{{this.title}}]
+{{/each}}

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/reports/anotherReport/parameterSchema.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/reports/anotherReport/parameterSchema.json
@@ -7,10 +7,7 @@
       "name": {
         "description": "The name of the report",
         "type": "string"
-      },
-      "key3": {
-        "type": "string"
       }
     },
-    "required": ["name", "key3"]
+    "required": ["name"]
   }

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/reports/anotherReport/query.lp.hbs
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/reports/anotherReport/query.lp.hbs
@@ -1,0 +1,2 @@
+select("title").
+result(Card) :- parent(Card, {{cardKey}}).


### PR DESCRIPTION
Add new command `report` that enables running reports from CLI. 

Command requires that a parameters file is provided as an input data and there is optional `outputFile` is results are wanted to had into a file instead of stdout. 

**Note** that I created a new branch (and PR) for this, since previous was using wrong JIRA ID.