### PR TITLE
Add SVG based graph support

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,6 +246,9 @@ importers:
       directory-schema-validator:
         specifier: ^1.0.17
         version: 1.0.17
+      dompurify:
+        specifier: ^3.2.5
+        version: 3.2.5
       email-validator:
         specifier: ^2.0.4
         version: 2.0.4
@@ -258,6 +261,9 @@ importers:
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
       json-schema:
         specifier: ^0.4.0
         version: 0.4.0
@@ -277,9 +283,15 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
     devDependencies:
+      '@types/dompurify':
+        specifier: ^3.2.0
+        version: 3.2.0
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
+      '@types/jsdom':
+        specifier: ^21.1.7
+        version: 21.1.7
       '@types/json-schema':
         specifier: ^7.0.15
         version: 7.0.15
@@ -1338,6 +1350,10 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/dompurify@3.2.0':
+    resolution: {integrity: sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==}
+    deprecated: This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.
+
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
@@ -1346,6 +1362,9 @@ packages:
 
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
+  '@types/jsdom@21.1.7':
+    resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -1389,6 +1408,12 @@ packages:
 
   '@types/sizzle@2.3.9':
     resolution: {integrity: sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
@@ -2115,6 +2140,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.2.5:
+    resolution: {integrity: sha512-mLPd29uoRe9HpvwP2TxClGQBzGXeEC/we/q+bFlmPPmj2p2Ugl3r6ATu/UU1v77DXNcehiBg9zsr1dREyA/dJQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -5516,11 +5544,21 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/dompurify@3.2.0':
+    dependencies:
+      dompurify: 3.2.5
+
   '@types/estree@1.0.7': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
   '@types/js-yaml@4.0.9': {}
+
+  '@types/jsdom@21.1.7':
+    dependencies:
+      '@types/node': 22.15.1
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.2.1
 
   '@types/json-schema@7.0.15': {}
 
@@ -5558,6 +5596,11 @@ snapshots:
   '@types/sinonjs__fake-timers@8.1.5': {}
 
   '@types/sizzle@2.3.9': {}
+
+  '@types/tough-cookie@4.0.5': {}
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/use-sync-external-store@0.0.6': {}
 
@@ -6361,6 +6404,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.2.5:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:

--- a/tools/app/src/components/modals/svgViewerModal.tsx
+++ b/tools/app/src/components/modals/svgViewerModal.tsx
@@ -1,0 +1,360 @@
+import React, { useState, useCallback, useEffect, useRef } from 'react';
+import {
+  Modal,
+  Box,
+  Stack,
+  IconButton,
+  Typography,
+  Backdrop,
+} from '@mui/material';
+import { Add, Remove, Autorenew, Close } from '@mui/icons-material';
+import { Link } from 'react-router';
+
+export interface SvgViewerModalProps {
+  open: boolean;
+  svgMarkup: string;
+  onClose: () => void;
+  padding?: number;
+}
+
+interface Size {
+  width: number;
+  height: number;
+}
+
+// Pixel height of the persistent top control bar
+const CONTROL_BAR_HEIGHT = 44;
+const MIN_ZOOM = 0.25;
+const MAX_ZOOM = 8;
+const ZOOM_STEP = 1.25;
+
+// To allow backbutton to close the modal, not to change the page
+function useBackButtonModal(open: boolean, onClose: () => void) {
+  const pushedRef = useRef(false);
+
+  useEffect(() => {
+    if (!open || pushedRef.current) return;
+
+    window.history.pushState(null, '');
+    pushedRef.current = true;
+
+    const handlePop = () => {
+      if (pushedRef.current) {
+        pushedRef.current = false;
+        onClose();
+      }
+      window.removeEventListener('popstate', handlePop);
+      window.history.replaceState(null, '');
+    };
+
+    window.addEventListener('popstate', handlePop);
+  }, [open, onClose]);
+}
+
+const SvgViewerModal: React.FC<SvgViewerModalProps> = ({
+  open,
+  svgMarkup,
+  onClose,
+  padding = 32,
+}) => {
+  useBackButtonModal(open, onClose);
+
+  const [zoom, setZoom] = useState(1);
+  const [naturalSize, setNaturalSize] = useState<Size | null>(null);
+
+  const svgHolderRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  /* ---------- fit & center on open ---------- */
+  useEffect(() => {
+    if (!open) return;
+
+    const id = requestAnimationFrame(() => {
+      const svg = svgHolderRef.current?.querySelector('svg');
+      if (!svg) return;
+
+      let width =
+        (svg as SVGSVGElement).width?.baseVal?.value || svg.getBBox().width;
+      let height =
+        (svg as SVGSVGElement).height?.baseVal?.value || svg.getBBox().height;
+      if (!width || !height) {
+        const rect = svg.getBoundingClientRect();
+        width = rect.width;
+        height = rect.height;
+      }
+      const intrinsic = { width, height };
+      setNaturalSize(intrinsic);
+
+      const viewW = window.innerWidth - padding * 2;
+      const viewH = window.innerHeight - CONTROL_BAR_HEIGHT - padding * 2;
+      const fit = Math.min(viewW / width, viewH / height, 1);
+      setZoom(fit);
+
+      requestAnimationFrame(() => {
+        const scroll = scrollRef.current;
+        if (!scroll) return;
+        scroll.scrollLeft = Math.max(0, (width * fit - scroll.clientWidth) / 2);
+        scroll.scrollTop = Math.max(
+          0,
+          (height * fit - scroll.clientHeight) / 2,
+        );
+      });
+    });
+
+    return () => cancelAnimationFrame(id);
+  }, [open, padding]);
+
+  /* ---------- zoom helpers ---------- */
+  const applyZoom = (factor: number, localX?: number, localY?: number) => {
+    if (!naturalSize) return;
+    const scroll = scrollRef.current;
+    if (!scroll) return;
+
+    const oldZoom = zoom;
+    const newZoom = Math.min(Math.max(oldZoom * factor, MIN_ZOOM), MAX_ZOOM);
+    if (newZoom === oldZoom) return;
+
+    const cx = localX ?? scroll.clientWidth / 2;
+    const cy = localY ?? scroll.clientHeight / 2;
+
+    const contentX = (scroll.scrollLeft + cx) / oldZoom;
+    const contentY = (scroll.scrollTop + cy) / oldZoom;
+
+    setZoom(newZoom);
+
+    requestAnimationFrame(() => {
+      scroll.scrollLeft = contentX * newZoom - cx;
+      scroll.scrollTop = contentY * newZoom - cy;
+    });
+  };
+
+  const zoomIn = useCallback(() => applyZoom(ZOOM_STEP), [zoom, naturalSize]);
+  const zoomOut = useCallback(
+    () => applyZoom(1 / ZOOM_STEP),
+    [zoom, naturalSize],
+  );
+  const resetZoom = useCallback(() => setZoom(1), []);
+
+  /* ---------- wheel zoom (always) ---------- */
+  /* ---------- wheel / pinch zoom ---------- */
+  /* ---------- wheel / pinch / shift zoom ---------- */
+  const handleWheel = (e: React.WheelEvent) => {
+    // Track‑pad pinch in Chrome/Safari sets ctrlKey=true.
+    // For mouse users we use **Shift+Wheel** so we don’t clash with browser‑level Ctrl+Wheel zoom.
+    const wantZoom = e.ctrlKey || e.metaKey || e.shiftKey;
+    if (!wantZoom) return; // plain scroll → pan
+
+    e.preventDefault();
+    const factor = e.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP;
+    const rect = scrollRef.current!.getBoundingClientRect();
+    applyZoom(factor, e.clientX - rect.left, e.clientY - rect.top);
+  };
+
+  /* ---------- drag to pan ---------- */
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    let startX = 0,
+      startY = 0,
+      sl = 0,
+      st = 0;
+    let dragging = false;
+    let moved = false;
+
+    const clickBlocker = (e: MouseEvent) => {
+      if (!e.ctrlKey && !e.metaKey) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    };
+
+    const down = (e: PointerEvent) => {
+      if (e.button !== 0) return;
+      dragging = true;
+      moved = false;
+      el.setPointerCapture(e.pointerId);
+      startX = e.clientX;
+      startY = e.clientY;
+      sl = el.scrollLeft;
+      st = el.scrollTop;
+      (el.style as CSSStyleDeclaration).cursor = 'grabbing';
+      el.addEventListener('click', clickBlocker, true);
+      e.preventDefault();
+    };
+
+    const move = (e: PointerEvent) => {
+      if (!dragging) return;
+      const dx = e.clientX - startX;
+      const dy = e.clientY - startY;
+      if (!moved && (Math.abs(dx) > 3 || Math.abs(dy) > 3)) moved = true;
+      el.scrollLeft = sl - dx;
+      el.scrollTop = st - dy;
+    };
+
+    const endDrag = (e: PointerEvent) => {
+      if (!dragging) return;
+      dragging = false;
+      el.releasePointerCapture(e.pointerId);
+      (el.style as CSSStyleDeclaration).cursor = 'grab';
+      setTimeout(() => el.removeEventListener('click', clickBlocker, true), 0);
+    };
+
+    el.addEventListener('pointerdown', down);
+    el.addEventListener('pointermove', move);
+    el.addEventListener('pointerup', endDrag);
+    el.addEventListener('pointerleave', endDrag);
+
+    (el.style as CSSStyleDeclaration).cursor = 'grab';
+    (el.style as CSSStyleDeclaration).userSelect = 'none';
+    (el.style as CSSStyleDeclaration).touchAction = 'none';
+
+    return () => {
+      el.removeEventListener('pointerdown', down);
+      el.removeEventListener('pointermove', move);
+      el.removeEventListener('pointerup', endDrag);
+      el.removeEventListener('pointerleave', endDrag);
+      el.removeEventListener('click', clickBlocker, true);
+      (el.style as CSSStyleDeclaration).cursor = 'auto';
+    };
+  }, [open]);
+
+  /* ---------- intercept link clicks (non-drag) ---------- */
+  useEffect(() => {
+    if (!open) return;
+    const holder = svgHolderRef.current;
+    if (!holder) return;
+
+    const listener = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (target.closest('a')) {
+        if (!e.ctrlKey && !e.metaKey) {
+          e.preventDefault();
+          e.stopPropagation();
+        }
+      }
+    };
+    holder.addEventListener('click', listener);
+    return () => holder.removeEventListener('click', listener);
+  }, [open]);
+
+  /* ---------- scaled dimensions ---------- */
+  const sizeStyle = naturalSize
+    ? { width: naturalSize.width * zoom, height: naturalSize.height * zoom }
+    : undefined;
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      keepMounted
+      slots={{ backdrop: Backdrop }}
+      slotProps={{
+        backdrop: {
+          sx: {
+            pointerEvents: 'auto',
+            zIndex: 1300,
+          },
+        },
+      }}
+    >
+      <Box
+        sx={{
+          position: 'fixed',
+          inset: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          bgcolor: 'background.paper',
+          zIndex: 1301,
+          pointerEvents: 'auto',
+        }}
+      >
+        {/* help text */}
+        <Typography
+          variant="caption"
+          sx={{
+            position: 'absolute',
+            bottom: 4,
+            right: 8,
+            zIndex: 20,
+            bgcolor: 'rgba(0,0,0,0.6)',
+            color: 'white',
+            px: 1,
+            py: 0.5,
+            borderRadius: 1,
+            userSelect: 'none',
+          }}
+        >
+          Pinch or Shift+Wheel = Zoom • Scroll/Drag = Pan • Ctrl/Cmd+Click =
+          Follow link
+        </Typography>
+
+        {/* control bar */}
+        <Stack
+          bgcolor="black"
+          height="44px"
+          direction="row"
+          alignItems="center"
+          position="fixed"
+          top={0}
+          left={0}
+          right={0}
+          zIndex={1400}
+        >
+          <Box marginLeft={2} height="19px">
+            <Link to="/cards">
+              <img
+                src="/images/cyberismo.png"
+                alt="Cyberismo"
+                width="102"
+                height="19"
+              />
+            </Link>
+          </Box>
+          {open && (
+            <Box
+              sx={{
+                position: 'absolute',
+                left: '50%',
+                transform: 'translateX(-50%)',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1, // nice even spacing
+              }}
+            >
+              <IconButton sx={{ color: 'white' }} onClick={zoomOut}>
+                <Remove />
+              </IconButton>
+              <IconButton sx={{ color: 'white' }} onClick={resetZoom}>
+                <Autorenew />
+              </IconButton>
+              <IconButton sx={{ color: 'white' }} onClick={zoomIn}>
+                <Add />
+              </IconButton>
+              <IconButton sx={{ color: 'white' }} onClick={onClose}>
+                <Close />
+              </IconButton>
+            </Box>
+          )}
+        </Stack>
+        <Box
+          ref={scrollRef}
+          sx={{
+            marginTop: '44px',
+            flex: 1,
+            overflow: 'auto',
+          }}
+          onWheel={handleWheel}
+        >
+          <Box
+            ref={svgHolderRef}
+            style={sizeStyle}
+            dangerouslySetInnerHTML={{ __html: svgMarkup }}
+          />
+        </Box>
+      </Box>
+    </Modal>
+  );
+};
+
+export default SvgViewerModal;

--- a/tools/app/src/globals.css
+++ b/tools/app/src/globals.css
@@ -24,6 +24,10 @@
   background-color: #0b6bcb;
 }
 
+.cyberismo-svg-wrapper svg {
+  max-height: 100vh;
+}
+
 /* Add margin for inline macro buttons */
 .doc .MuiButton-root {
   margin-top: 12px;

--- a/tools/data-handler/package.json
+++ b/tools/data-handler/package.json
@@ -27,7 +27,9 @@
     "./macros/*": "./dist/macros/*.js"
   },
   "devDependencies": {
+    "@types/dompurify": "^3.2.0",
     "@types/js-yaml": "^4.0.9",
+    "@types/jsdom": "^21.1.7",
     "@types/json-schema": "^7.0.15",
     "@types/mime-types": "^2.1.4",
     "@types/sinon": "^17.0.4",
@@ -42,10 +44,12 @@
     "async-mutex": "^0.5.0",
     "csv-parse": "^5.6.0",
     "directory-schema-validator": "^1.0.17",
+    "dompurify": "^3.2.5",
     "email-validator": "^2.0.4",
     "handlebars": "^4.7.8",
     "isomorphic-git": "^1.30.1",
     "js-yaml": "^4.1.0",
+    "jsdom": "^26.1.0",
     "json-schema": "^0.4.0",
     "jsonschema": "^1.4.1",
     "mime-types": "^3.0.1",

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -419,6 +419,7 @@ export class Commands {
     if (!this.commands) {
       return { statusCode: 500 };
     }
+    process.env.EXPORT_FORMAT = format;
     let message = '';
     if (format === 'adoc') {
       message = await this.commands?.exportCmd.exportToADoc(
@@ -436,6 +437,7 @@ export class Commands {
         parentCardKey,
       );
     }
+    process.env.EXPORT_FORMAT = '';
     return { statusCode: 200, message: message };
   }
 

--- a/tools/data-handler/src/commands/calculate.ts
+++ b/tools/data-handler/src/commands/calculate.ts
@@ -17,6 +17,7 @@ import { fileURLToPath } from 'node:url';
 import { readFile, rm } from 'node:fs/promises';
 import { readFileSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
+import { sanitizeSvgBase64 } from '../utils/sanitize-svg.js';
 
 import {
   BaseResult,
@@ -548,7 +549,7 @@ export class Calculate {
 
     const clingGraphArgs = [
       '--out=render',
-      '--format=png',
+      '--format=svg',
       '--type=digraph',
       `--name-format=${randomId}`,
       `--dir=${this.project.paths.tempFolder}`,
@@ -580,17 +581,18 @@ export class Calculate {
 
     let fileData;
     try {
-      fileData = await readFile(filePath + '.png');
+      fileData = await readFile(filePath + '.svg');
     } catch (e) {
       throw new Error(
         `Graph: Failed to read image file after generating graph: ${e}`,
       );
     } finally {
       await rm(filePath, { force: true });
-      await rm(filePath + '.png', { force: true });
+      await rm(filePath + '.svg', { force: true });
     }
 
-    return fileData.toString('base64');
+    // Sanitizing SVG before returning it
+    return sanitizeSvgBase64(fileData);
   }
 
   /**

--- a/tools/data-handler/src/macros/index.ts
+++ b/tools/data-handler/src/macros/index.ts
@@ -273,5 +273,14 @@ export function createAdmonition(
  * @returns valid asciidoc with the image
  */
 export function createImage(image: string) {
-  return `image::data:image/png;base64,${image}[]\n`;
+  if (process.env.EXPORT_FORMAT) {
+    return `image::data:image/svg+xml;base64,${image}[]\n`;
+  } else {
+    return `++++
+<div class="cyberismo-svg-wrapper" data-type="cyberismo-svg-wrapper">
+${Buffer.from(image, 'base64').toString('utf-8')}
+</div>
+++++
+`;
+  }
 }

--- a/tools/data-handler/src/utils/sanitize-svg.ts
+++ b/tools/data-handler/src/utils/sanitize-svg.ts
@@ -1,0 +1,46 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2024
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import createDOMPurify, { type WindowLike } from 'dompurify';
+import { Buffer } from 'buffer';
+import { JSDOM } from 'jsdom';
+
+const window = new JSDOM('').window as unknown as Window;
+
+// Remove SVG size to make it scale in the application properly
+const removeSvgWidthAndHeight = (node: Element) => {
+  if (node.nodeName === 'svg') {
+    node.removeAttribute('width');
+    node.removeAttribute('height');
+  }
+};
+
+/**
+ * Sanitize an SVG Buffer and return a base64-encoded string
+ * @param buffer - SVG content as a Buffer
+ * @returns base64-encoded sanitized SVG string
+ */
+export function sanitizeSvgBase64(buffer: Buffer): string {
+  const DOMPurify = createDOMPurify(window as unknown as WindowLike);
+
+  const dirty = buffer.toString('utf-8');
+
+  DOMPurify.setConfig({ USE_PROFILES: { svg: true } });
+  DOMPurify.addHook('afterSanitizeAttributes', removeSvgWidthAndHeight);
+
+  let cleaned = DOMPurify.sanitize(dirty);
+
+  // Remove link titles, quick fix for Clingraph/Graphviz generated titles for links that are quite strange
+  cleaned = cleaned.replace(/\s*xlink:title=(["']).*?\1/g, '');
+
+  return Buffer.from(cleaned, 'utf-8').toString('base64');
+}


### PR DESCRIPTION
- Clingraph images are now SVG format
- New open full screen and download buttons added to every graph
- New modal to view the SVG
  - Modal supports mouse move, zoom, backpedal, etc. basic functionalities
- Export support kept with environment variable that will:
  - Import sanitized regular adoc svg image for exports
  - Import sanitized raw SVG for gui

OPEN THINGS:
- Name of the SVG when downloaded is Diagram.svg, how we make this better?