### PR TITLE
INTDEV-849 Use the imported schemas instead of reading them from disk

### DIFF
--- a/tools/data-handler/src/commands/validate.ts
+++ b/tools/data-handler/src/commands/validate.ts
@@ -12,7 +12,7 @@
 */
 
 // node
-import { Dirent, readdirSync } from 'node:fs';
+import { Dirent } from 'node:fs';
 import { basename, dirname, extname, join, parse, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readdir } from 'node:fs/promises';
@@ -20,6 +20,7 @@ import { readdir } from 'node:fs/promises';
 // dependencies
 import { Validator as JSONValidator, Schema } from 'jsonschema';
 import { Validator as DirectoryValidator } from 'directory-schema-validator';
+import { parentSchema, schemas } from '../utils/schemas.js';
 
 // data-handler
 import {
@@ -40,7 +41,7 @@ import { errorFunction } from '../utils/log-utils.js';
 import { isTemplateCard } from '../utils/card-utils.js';
 import { pathExists } from '../utils/file-utils.js';
 import { Project } from '../containers/project.js';
-import { readJsonFile, readJsonFileSync } from '../utils/json.js';
+import { readJsonFile } from '../utils/json.js';
 import { resourceName } from '../utils/resource-utils.js';
 
 const invalidNames = new RegExp(
@@ -95,7 +96,7 @@ export class Validate {
     );
     this.validator = new JSONValidator();
     this.directoryValidator = new DirectoryValidator();
-    this.parentSchema = readJsonFileSync(Validate.parentSchemaFile) as Schema;
+    this.parentSchema = parentSchema;
     this.addChildSchemas();
     this.validatedFieldTypes = new Map();
     this.validatedWorkflows = new Map();
@@ -109,13 +110,9 @@ export class Validate {
 
   // Loads child schemas to validator.
   private addChildSchemas() {
-    readdirSync(Validate.baseFolder, { withFileTypes: true, recursive: true })
-      .filter((dirent) => dirent.name !== Validate.parentSchemaFile)
-      .filter((dirent) => dirent.isFile())
-      .forEach((file) => {
-        const schema = readJsonFileSync(this.fullPath(file)) as Schema;
-        this.validator.addSchema(schema, schema.$id);
-      });
+    schemas.forEach((schema) => {
+      this.validator.addSchema(schema, schema.$id);
+    });
   }
 
   // Validates that 'name' in resources matches filename, location and project prefix.

--- a/tools/data-handler/src/utils/schemas.ts
+++ b/tools/data-handler/src/utils/schemas.ts
@@ -25,6 +25,8 @@ import scoreCardMacroSchema from '../../../schema/macros/scoreCardMacroSchema.js
 // resources
 import cardTypeSchema from '../../../schema/resources/cardTypeSchema.json' with { type: 'json' };
 import fieldTypeSchema from '../../../schema/resources/fieldTypeSchema.json' with { type: 'json' };
+import graphModelSchema from '../../../schema/resources/graphModelSchema.json' with { type: 'json' };
+import graphViewSchema from '../../../schema/resources/graphViewSchema.json' with { type: 'json' };
 import linkTypeSchema from '../../../schema/resources/linkTypeSchema.json' with { type: 'json' };
 import reportSchema from '../../../schema/resources/reportSchema.json' with { type: 'json' };
 import templateSchema from '../../../schema/resources/templateSchema.json' with { type: 'json' };
@@ -39,6 +41,8 @@ export const schemas = [
   dotSchema,
   fieldTypeSchema,
   graphMacroBaseSchema,
+  graphModelSchema,
+  graphViewSchema,
   linkTypeSchema,
   reportMacroBaseSchema,
   reportSchema,

--- a/tools/data-handler/test/0_validate.test.ts
+++ b/tools/data-handler/test/0_validate.test.ts
@@ -22,6 +22,7 @@ describe('validate cmd tests', () => {
   it('validate() - decision-records (success)', async () => {
     const path = join(testDir, 'valid/decision-records');
     const valid = await validateCmd.validate(path);
+    expect(valid).to.equal('');
     expect(valid.length).to.equal(0);
   });
   it('validate() - minimal (success)', async () => {


### PR DESCRIPTION
As suggested in https://github.com/CyberismoCom/cyberismo/pull/619 by @samutoljamo-pareto , we should use the imported schemas instead of reading them (again!) from disk. 

Noticed that few of the schemas were missing from imports --> added those.
Also made the first validate test such that it shows what is wrong with validation in test results.