### PR TITLE
Fix the logic program rule for ancestor

### DIFF
--- a/resources/calculations/common/base.lp
+++ b/resources/calculations/common/base.lp
@@ -11,8 +11,10 @@
 %
 
 % parent and ancestor
-ancestor(A, C) :- parent(A, C), card(A), card(B).
+ancestor(A, C) :- parent(A, C), card(A), card(C).
+ancestor(A, C) :- parent(A, C), card(A), template(C).
 ancestor(A, C) :- parent(A, B), ancestor (B, C), card(A), card(B), card(C).
+ancestor(A, C) :- parent(A, B), ancestor (B, C), card(A), card(B), template(C).
 
 % if the card type is given, then it's a card
 card(C) :- field(C, "cardType", _).


### PR DESCRIPTION
- Fix a bug in the existing ancestor rule
- Add ancestor rules for templates, where the highest level parent is the template itself