### PR TITLE
INTDEV-848 - Use 'import type' when type import is enough

### DIFF
--- a/tools/cli/eslint.config.js
+++ b/tools/cli/eslint.config.js
@@ -11,4 +11,9 @@ export default [
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   eslintConfigPrettier,
+  {
+    rules: {
+      '@typescript-eslint/consistent-type-imports': 'error',
+    },
+  },
 ];

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -15,12 +15,12 @@
 import { Argument, Command } from 'commander';
 import confirm from '@inquirer/confirm';
 import {
-  CardsOptions,
+  type CardsOptions,
   Cmd,
   Commands,
   ExportFormats,
-  requestStatus,
-  UpdateOperations,
+  type requestStatus,
+  type UpdateOperations,
 } from '@cyberismocom/data-handler';
 import { ResourceTypeParser as Parser } from './resource-type-parser.js';
 import { startServer } from '@cyberismocom/backend';

--- a/tools/data-handler/eslint.config.js
+++ b/tools/data-handler/eslint.config.js
@@ -11,4 +11,9 @@ export default [
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   eslintConfigPrettier,
+  {
+    rules: {
+      '@typescript-eslint/consistent-type-imports': 'error',
+    },
+  },
 ];

--- a/tools/data-handler/src/card-metadata-updater.ts
+++ b/tools/data-handler/src/card-metadata-updater.ts
@@ -12,12 +12,12 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { CardMetadata } from './interfaces/project-interfaces.js';
-import { FieldType } from './interfaces/resource-interfaces.js';
+import type { CardMetadata } from './interfaces/project-interfaces.js';
+import type { FieldType } from './interfaces/resource-interfaces.js';
 import { FieldTypeResource } from './resources/field-type-resource.js';
 import { logger } from './utils/log-utils.js';
-import { Project } from './containers/project.js';
-import { UpdateField } from './types/queries.js';
+import type { Project } from './containers/project.js';
+import type { UpdateField } from './types/queries.js';
 
 /**
  * Card metadata update result.

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -15,7 +15,8 @@ import { dirname, join, resolve } from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { readFileSync } from 'node:fs';
-import {
+
+import type {
   Card,
   CardAttachment,
   CardListContainer,
@@ -25,13 +26,16 @@ import {
   RemovableResourceTypes,
   ResourceTypes,
 } from './interfaces/project-interfaces.js';
-import { DataType, ResourceContent } from './interfaces/resource-interfaces.js';
+import type {
+  DataType,
+  ResourceContent,
+} from './interfaces/resource-interfaces.js';
 
-import { requestStatus } from './interfaces/request-status-interfaces.js';
+import type { requestStatus } from './interfaces/request-status-interfaces.js';
 
 import { Create, Validate } from './commands/index.js';
 import { CommandManager } from './command-manager.js';
-import { UpdateOperations } from './resources/resource-object.js';
+import type { UpdateOperations } from './resources/resource-object.js';
 import { Project } from './containers/project.js';
 
 import { pathExists, resolveTilde } from './utils/file-utils.js';

--- a/tools/data-handler/src/commands/calculate.ts
+++ b/tools/data-handler/src/commands/calculate.ts
@@ -18,18 +18,18 @@ import { readFile, rm } from 'node:fs/promises';
 import { readFileSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 
-import {
+import type {
   BaseResult,
   ParseResult,
   QueryName,
   QueryResult,
 } from '../types/queries.js';
-import { Card } from '../interfaces/project-interfaces.js';
+import type { Card } from '../interfaces/project-interfaces.js';
 import ClingoParser from '../utils/clingo-parser.js';
 import { pathExists } from '../utils/file-utils.js';
 import { Mutex } from 'async-mutex';
 import Handlebars from 'handlebars';
-import { Project, ResourcesFrom } from '../containers/project.js';
+import { type Project, ResourcesFrom } from '../containers/project.js';
 import { flattenCardArray } from '../utils/card-utils.js';
 import { logger } from '../utils/log-utils.js';
 import {
@@ -45,7 +45,7 @@ import {
 } from '../utils/clingo-facts.js';
 import { CardMetadataUpdater } from '../card-metadata-updater.js';
 import { generateRandomString } from '../utils/random.js';
-import {
+import type {
   CardType,
   FieldType,
   LinkType,

--- a/tools/data-handler/src/commands/create.ts
+++ b/tools/data-handler/src/commands/create.ts
@@ -20,13 +20,17 @@ import {
   writeFile,
 } from 'node:fs/promises';
 
-import { Calculate, Validate } from './index.js';
+import { type Calculate, Validate } from './index.js';
 import { errorFunction } from '../utils/log-utils.js';
 import { Project } from '../containers/project.js';
 import { EMPTY_RANK, sortItems } from '../utils/lexorank.js';
-import { DataType, Link, LinkType } from '../interfaces/resource-interfaces.js';
+import type {
+  DataType,
+  Link,
+  LinkType,
+} from '../interfaces/resource-interfaces.js';
 import { pathExists } from '../utils/file-utils.js';
-import { ProjectFile } from '../interfaces/project-interfaces.js';
+import type { ProjectFile } from '../interfaces/project-interfaces.js';
 import { resourceName, resourceNameToString } from '../utils/resource-utils.js';
 import { writeJsonFile } from '../utils/json.js';
 

--- a/tools/data-handler/src/commands/edit.ts
+++ b/tools/data-handler/src/commands/edit.ts
@@ -16,7 +16,7 @@ import { homedir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 
 import { ActionGuard } from '../permissions/action-guard.js';
-import { Calculate } from './index.js';
+import type { Calculate } from './index.js';
 import type { MetadataContent } from '../interfaces/project-interfaces.js';
 import { Project } from '../containers/project.js';
 import { UserPreferences } from '../utils/user-preferences.js';

--- a/tools/data-handler/src/commands/export-site.ts
+++ b/tools/data-handler/src/commands/export-site.ts
@@ -24,11 +24,11 @@ import { fileURLToPath } from 'node:url';
 import git from 'isomorphic-git';
 import { dump } from 'js-yaml';
 
-import { Calculate, Export, Show } from './index.js';
-import { Card } from '../interfaces/project-interfaces.js';
-import { CardType } from '../interfaces/resource-interfaces.js';
+import { type Calculate, Export, type Show } from './index.js';
+import type { Card } from '../interfaces/project-interfaces.js';
+import type { CardType } from '../interfaces/resource-interfaces.js';
 import { errorFunction } from '../utils/log-utils.js';
-import { Project } from '../containers/project.js';
+import type { Project } from '../containers/project.js';
 import { sortItems } from '../utils/lexorank.js';
 
 interface ExportOptions {

--- a/tools/data-handler/src/commands/export.ts
+++ b/tools/data-handler/src/commands/export.ts
@@ -18,11 +18,14 @@ import { dirname, join } from 'node:path';
 
 // asciidoctor
 import Processor from '@asciidoctor/core';
-import { Calculate, Show } from './index.js';
-import { Card, FetchCardDetails } from '../interfaces/project-interfaces.js';
-import { CardType } from '../interfaces/resource-interfaces.js';
+import type { Calculate, Show } from './index.js';
+import type {
+  Card,
+  FetchCardDetails,
+} from '../interfaces/project-interfaces.js';
+import type { CardType } from '../interfaces/resource-interfaces.js';
 import { Project } from '../containers/project.js';
-import { QueryResult } from '../types/queries.js';
+import type { QueryResult } from '../types/queries.js';
 import { sortItems } from '../utils/lexorank.js';
 
 const attachmentFolder: string = 'a';

--- a/tools/data-handler/src/commands/import.ts
+++ b/tools/data-handler/src/commands/import.ts
@@ -11,10 +11,10 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { CardType } from '../interfaces/resource-interfaces.js';
-import { Create, Validate } from './index.js';
+import type { CardType } from '../interfaces/resource-interfaces.js';
+import { type Create, Validate } from './index.js';
 import { ModuleManager } from '../module-manager.js';
-import { Project } from '../containers/project.js';
+import type { Project } from '../containers/project.js';
 import { readCsvFile } from '../utils/csv.js';
 import { resourceName } from '../utils/resource-utils.js';
 import { TemplateResource } from '../resources/template-resource.js';

--- a/tools/data-handler/src/commands/move.ts
+++ b/tools/data-handler/src/commands/move.ts
@@ -15,9 +15,12 @@ import { join, sep } from 'node:path';
 
 import { ActionGuard } from '../permissions/action-guard.js';
 import { copyDir, deleteDir } from '../utils/file-utils.js';
-import { Calculate } from './index.js';
-import { Card, FetchCardDetails } from '../interfaces/project-interfaces.js';
-import { Project, ResourcesFrom } from '../containers/project.js';
+import type { Calculate } from './index.js';
+import type {
+  Card,
+  FetchCardDetails,
+} from '../interfaces/project-interfaces.js';
+import { type Project, ResourcesFrom } from '../containers/project.js';
 import {
   EMPTY_RANK,
   FIRST_RANK,

--- a/tools/data-handler/src/commands/remove.ts
+++ b/tools/data-handler/src/commands/remove.ts
@@ -15,10 +15,10 @@
 import { join, sep } from 'node:path';
 
 import { ActionGuard } from '../permissions/action-guard.js';
-import { Calculate } from './index.js';
+import type { Calculate } from './index.js';
 import { deleteDir, deleteFile } from '../utils/file-utils.js';
 import { Project } from '../containers/project.js';
-import { RemovableResourceTypes } from '../interfaces/project-interfaces.js';
+import type { RemovableResourceTypes } from '../interfaces/project-interfaces.js';
 import { resourceName } from '../utils/resource-utils.js';
 
 const MODULES_PATH = `${sep}modules${sep}`;

--- a/tools/data-handler/src/commands/rename.ts
+++ b/tools/data-handler/src/commands/rename.ts
@@ -16,10 +16,10 @@ import { assert } from 'node:console';
 import { join } from 'node:path';
 import { rename, readdir, readFile, writeFile } from 'node:fs/promises';
 
-import { Calculate } from './index.js';
-import { Card } from '../interfaces/project-interfaces.js';
+import type { Calculate } from './index.js';
+import type { Card } from '../interfaces/project-interfaces.js';
 import { isTemplateCard } from '../utils/card-utils.js';
-import { Project, ResourcesFrom } from '../containers/project.js';
+import { type Project, ResourcesFrom } from '../containers/project.js';
 import { resourceName } from '../utils/resource-utils.js';
 import { Template } from '../containers/template.js';
 

--- a/tools/data-handler/src/commands/show.ts
+++ b/tools/data-handler/src/commands/show.ts
@@ -19,8 +19,8 @@ import { spawn } from 'node:child_process';
 
 import mime from 'mime-types';
 
-import { attachmentPayload } from '../interfaces/request-status-interfaces.js';
-import {
+import type { attachmentPayload } from '../interfaces/request-status-interfaces.js';
+import type {
   CardAttachment,
   Card,
   CardListContainer,
@@ -29,13 +29,13 @@ import {
   ProjectMetadata,
   Resource,
 } from '../interfaces/project-interfaces.js';
-import {
+import type {
   CardType,
   ResourceContent,
   TemplateConfiguration,
   Workflow,
 } from '../interfaces/resource-interfaces.js';
-import { Project, ResourcesFrom } from '../containers/project.js';
+import { Project, type ResourcesFrom } from '../containers/project.js';
 import { resourceName } from '../utils/resource-utils.js';
 import { TemplateResource } from '../resources/template-resource.js';
 import { UserPreferences } from '../utils/user-preferences.js';

--- a/tools/data-handler/src/commands/transition.ts
+++ b/tools/data-handler/src/commands/transition.ts
@@ -12,14 +12,14 @@
 */
 
 import { ActionGuard } from '../permissions/action-guard.js';
-import { Calculate } from './calculate.js';
-import {
+import type { Calculate } from './calculate.js';
+import type {
   CardType,
   Workflow,
   WorkflowState,
 } from '../interfaces/resource-interfaces.js';
 import { CardMetadataUpdater } from '../card-metadata-updater.js';
-import { Project } from '../containers/project.js';
+import type { Project } from '../containers/project.js';
 
 export class Transition {
   constructor(

--- a/tools/data-handler/src/commands/update.ts
+++ b/tools/data-handler/src/commands/update.ts
@@ -10,7 +10,7 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import {
+import type {
   AddOperation,
   ChangeOperation,
   Operation,

--- a/tools/data-handler/src/commands/validate.ts
+++ b/tools/data-handler/src/commands/validate.ts
@@ -12,24 +12,24 @@
 */
 
 // node
-import { Dirent } from 'node:fs';
+import { type Dirent } from 'node:fs';
 import { basename, dirname, extname, join, parse, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readdir } from 'node:fs/promises';
 
 // dependencies
-import { Validator as JSONValidator, Schema } from 'jsonschema';
+import { Validator as JSONValidator, type Schema } from 'jsonschema';
 import { Validator as DirectoryValidator } from 'directory-schema-validator';
 import { parentSchema, schemas } from '../utils/schemas.js';
 
 // data-handler
-import {
+import type {
   Card,
   DotSchemaContent,
   ProjectSettings,
   ResourceTypes,
 } from '../interfaces/project-interfaces.js';
-import {
+import type {
   CardType,
   CustomField,
   FieldType,

--- a/tools/data-handler/src/containers/card-container.ts
+++ b/tools/data-handler/src/containers/card-container.ts
@@ -14,7 +14,7 @@
 
 // node
 import { basename, join, sep } from 'node:path';
-import { Dirent } from 'node:fs';
+import type { Dirent } from 'node:fs';
 import { readdir, readFile, writeFile } from 'node:fs/promises';
 
 import { writeJsonFile } from '../utils/json.js';
@@ -22,10 +22,10 @@ import { getFilesSync } from '../utils/file-utils.js';
 
 // interfaces
 import {
-  CardAttachment,
-  Card,
+  type CardAttachment,
+  type Card,
   CardNameRegEx,
-  FetchCardDetails,
+  type FetchCardDetails,
 } from '../interfaces/project-interfaces.js';
 
 // asciidoctor

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -13,28 +13,28 @@
 */
 
 // node
-import { Dirent } from 'node:fs';
+import { type Dirent } from 'node:fs';
 import { dirname, join, resolve, sep } from 'node:path';
 import { readdir } from 'node:fs/promises';
 
 import { CardContainer } from './card-container.js'; // base class
 
 import {
-  Card,
-  CardAttachment,
+  type Card,
+  type CardAttachment,
   CardLocation,
-  CardListContainer,
-  CardMetadata,
+  type CardListContainer,
+  type CardMetadata,
   CardNameRegEx,
-  FetchCardDetails,
-  MetadataContent,
-  ModuleContent,
-  ModuleSetting,
-  ProjectFetchCardDetails,
-  ProjectMetadata,
-  ProjectSettings,
-  Resource,
-  ResourceFolderType,
+  type FetchCardDetails,
+  type MetadataContent,
+  type ModuleContent,
+  type ModuleSetting,
+  type ProjectFetchCardDetails,
+  type ProjectMetadata,
+  type ProjectSettings,
+  type Resource,
+  type ResourceFolderType,
 } from '../interfaces/project-interfaces.js';
 import { findParentPath } from '../utils/card-utils.js';
 import { getFilesSync, pathExists } from '../utils/file-utils.js';
@@ -45,14 +45,14 @@ import { ProjectPaths } from './project/project-paths.js';
 import { readJsonFile } from '../utils/json.js';
 import {
   resourceName,
-  ResourceName,
+  type ResourceName,
   resourceNameToString,
 } from '../utils/resource-utils.js';
 import {
   ResourcesFrom,
   ResourceCollector,
 } from './project/resource-collector.js';
-import { Template } from './template.js';
+import type { Template } from './template.js';
 import { Validate } from '../commands/validate.js';
 
 import { CardTypeResource } from '../resources/card-type-resource.js';

--- a/tools/data-handler/src/containers/project/project-paths.ts
+++ b/tools/data-handler/src/containers/project/project-paths.ts
@@ -13,7 +13,7 @@
 
 import { join } from 'node:path';
 
-import { ResourceFolderType } from '../../interfaces/project-interfaces.js';
+import type { ResourceFolderType } from '../../interfaces/project-interfaces.js';
 
 /**
  * Handles paths for a project.

--- a/tools/data-handler/src/containers/project/resource-collector.ts
+++ b/tools/data-handler/src/containers/project/resource-collector.ts
@@ -12,14 +12,14 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Dirent, readdirSync } from 'node:fs';
+import { type Dirent, readdirSync } from 'node:fs';
 import { readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { CardContainer } from '../card-container.js';
-import { Project } from '../project.js';
-import { ProjectPaths } from './project-paths.js';
-import {
+import type { Project } from '../project.js';
+import type { ProjectPaths } from './project-paths.js';
+import type {
   Resource,
   ResourceFolderType,
 } from '../../interfaces/project-interfaces.js';

--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -14,20 +14,20 @@
 // node
 import { basename, join, resolve, sep } from 'node:path';
 import { copyFile, mkdir, readdir, rm, writeFile } from 'node:fs/promises';
-import { Dirent, readdirSync } from 'node:fs';
+import { type Dirent, readdirSync } from 'node:fs';
 
 // Base class
 import { CardContainer } from './card-container.js';
 
 import {
-  Card,
-  CardAttachment,
+  type Card,
+  type CardAttachment,
   CardNameRegEx,
-  FetchCardDetails,
-  FileContentType,
-  Resource,
+  type FetchCardDetails,
+  type FileContentType,
+  type Resource,
 } from '../interfaces/project-interfaces.js';
-import { CardType, Workflow } from '../interfaces/resource-interfaces.js';
+import type { CardType, Workflow } from '../interfaces/resource-interfaces.js';
 import { pathExists, stripExtension } from '../utils/file-utils.js';
 import { DefaultContent } from '../resources/create-defaults.js';
 

--- a/tools/data-handler/src/exceptions/index.ts
+++ b/tools/data-handler/src/exceptions/index.ts
@@ -10,7 +10,7 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { ValidationError } from 'json-schema';
+import type { ValidationError } from 'json-schema';
 
 export class DHValidationError extends Error {
   public errors?: ValidationError[];

--- a/tools/data-handler/src/interfaces/macros.ts
+++ b/tools/data-handler/src/interfaces/macros.ts
@@ -10,7 +10,7 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { macroMetadata } from '../macros/common.js';
+import type { macroMetadata } from '../macros/common.js';
 
 type Mode = 'validate' | 'static' | 'inject';
 

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -10,7 +10,7 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Link, type TemplateConfiguration } from './resource-interfaces.js';
+import type { Link, TemplateConfiguration } from './resource-interfaces.js';
 
 // Single card; either in project or in template.
 export interface Card {

--- a/tools/data-handler/src/interfaces/resource-interfaces.ts
+++ b/tools/data-handler/src/interfaces/resource-interfaces.ts
@@ -10,7 +10,7 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Schema } from 'jsonschema';
+import type { Schema } from 'jsonschema';
 
 /**
  * Each resource represents a file (or a folder in some cases) with metadata stored

--- a/tools/data-handler/src/macros/base-macro.ts
+++ b/tools/data-handler/src/macros/base-macro.ts
@@ -10,7 +10,7 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import {
+import type {
   HandlebarsOptions,
   MacroGenerationContext,
   MacroMetadata,
@@ -18,7 +18,7 @@ import {
 } from '../interfaces/macros.js';
 import { generateRandomString } from '../utils/random.js';
 import { handleMacroError } from './index.js';
-import TaskQueue from './task-queue.js';
+import type TaskQueue from './task-queue.js';
 
 abstract class BaseMacro {
   private globalId: string;

--- a/tools/data-handler/src/macros/createCards/index.ts
+++ b/tools/data-handler/src/macros/createCards/index.ts
@@ -12,10 +12,10 @@
 
 import { createHtmlPlaceholder, validateMacroContent } from '../index.js';
 
-import { MacroGenerationContext } from '../../interfaces/macros.js';
+import type { MacroGenerationContext } from '../../interfaces/macros.js';
 import macroMetadata from './metadata.js';
 import BaseMacro from '../base-macro.js';
-import TaskQueue from '../task-queue.js';
+import type TaskQueue from '../task-queue.js';
 
 export interface CreateCardsOptions {
   buttonLabel: string;

--- a/tools/data-handler/src/macros/createCards/metadata.ts
+++ b/tools/data-handler/src/macros/createCards/metadata.ts
@@ -10,7 +10,7 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { MacroMetadata } from '../../interfaces/macros.js';
+import type { MacroMetadata } from '../../interfaces/macros.js';
 
 const macroMetadata: MacroMetadata = {
   name: 'createCards',

--- a/tools/data-handler/src/macros/graph/index.ts
+++ b/tools/data-handler/src/macros/graph/index.ts
@@ -18,15 +18,15 @@ import { createImage, validateMacroContent } from '../index.js';
 import Handlebars from 'handlebars';
 import { join } from 'node:path';
 import { logger } from '../../utils/log-utils.js';
-import { MacroGenerationContext } from '../../interfaces/macros.js';
+import type { MacroGenerationContext } from '../../interfaces/macros.js';
 import macroMetadata from './metadata.js';
 import { pathExists } from '../../utils/file-utils.js';
 import { Project } from '../../containers/project.js';
 import { readFile } from 'node:fs/promises';
 import { resourceName } from '../../utils/resource-utils.js';
-import { Schema } from 'jsonschema';
+import type { Schema } from 'jsonschema';
 import { validateJson } from '../../utils/validate.js';
-import TaskQueue from '../task-queue.js';
+import type TaskQueue from '../task-queue.js';
 
 export interface GraphOptions extends Record<string, string> {
   model: string;

--- a/tools/data-handler/src/macros/graph/metadata.ts
+++ b/tools/data-handler/src/macros/graph/metadata.ts
@@ -10,7 +10,7 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { MacroMetadata } from '../../interfaces/macros.js';
+import type { MacroMetadata } from '../../interfaces/macros.js';
 
 const macroMetadata: MacroMetadata = {
   name: 'graph',

--- a/tools/data-handler/src/macros/index.ts
+++ b/tools/data-handler/src/macros/index.ts
@@ -19,14 +19,14 @@ import scoreCard from './scoreCard/index.js';
 
 import { validateJson } from '../utils/validate.js';
 import { DHValidationError } from '../exceptions/index.js';
-import { AdmonitionType } from '../interfaces/adoc.js';
-import { Validator } from 'jsonschema';
-import {
+import type { AdmonitionType } from '../interfaces/adoc.js';
+import type { Validator } from 'jsonschema';
+import type {
   MacroGenerationContext,
   MacroMetadata,
   MacroName,
 } from '../interfaces/macros.js';
-import BaseMacro from './base-macro.js';
+import type BaseMacro from './base-macro.js';
 import TaskQueue from './task-queue.js';
 
 const CURLY_LEFT = '&#123;';

--- a/tools/data-handler/src/macros/report/index.ts
+++ b/tools/data-handler/src/macros/report/index.ts
@@ -12,14 +12,14 @@
 
 import { registerEmptyMacros, validateMacroContent } from '../index.js';
 
-import { MacroGenerationContext } from '../../interfaces/macros.js';
+import type { MacroGenerationContext } from '../../interfaces/macros.js';
 import macroMetadata from './metadata.js';
 import { Project } from '../../containers/project.js';
 import { Calculate } from '../../commands/index.js';
 import Handlebars from 'handlebars';
 import BaseMacro from '../base-macro.js';
 import { validateJson } from '../../utils/validate.js';
-import TaskQueue from '../task-queue.js';
+import type TaskQueue from '../task-queue.js';
 import { ReportResource } from '../../resources/report-resource.js';
 import { resourceName } from '../../utils/resource-utils.js';
 

--- a/tools/data-handler/src/macros/report/metadata.ts
+++ b/tools/data-handler/src/macros/report/metadata.ts
@@ -10,7 +10,7 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { MacroMetadata } from '../../interfaces/macros.js';
+import type { MacroMetadata } from '../../interfaces/macros.js';
 
 const macroMetadata: MacroMetadata = {
   name: 'report',

--- a/tools/data-handler/src/macros/scoreCard/index.ts
+++ b/tools/data-handler/src/macros/scoreCard/index.ts
@@ -12,10 +12,10 @@
 
 import { createHtmlPlaceholder, validateMacroContent } from '../index.js';
 
-import { MacroGenerationContext } from '../../interfaces/macros.js';
+import type { MacroGenerationContext } from '../../interfaces/macros.js';
 import macroMetadata from './metadata.js';
 import BaseMacro from '../base-macro.js';
-import TaskQueue from '../task-queue.js';
+import type TaskQueue from '../task-queue.js';
 
 export interface ScoreCardOptions {
   title?: string;

--- a/tools/data-handler/src/macros/scoreCard/metadata.ts
+++ b/tools/data-handler/src/macros/scoreCard/metadata.ts
@@ -10,7 +10,7 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { MacroMetadata } from '../../interfaces/macros.js';
+import type { MacroMetadata } from '../../interfaces/macros.js';
 
 const macroMetadata: MacroMetadata = {
   name: 'scoreCard',

--- a/tools/data-handler/src/macros/task-queue.ts
+++ b/tools/data-handler/src/macros/task-queue.ts
@@ -10,7 +10,7 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { MacroTaskState } from '../interfaces/macros.js';
+import type { MacroTaskState } from '../interfaces/macros.js';
 
 export default class TaskQueue {
   private tasks: MacroTaskState[] = [];

--- a/tools/data-handler/src/module-manager.ts
+++ b/tools/data-handler/src/module-manager.ts
@@ -19,10 +19,10 @@ import git from 'isomorphic-git';
 import http from 'isomorphic-git/http/node/index.js';
 
 import { copyDir, deleteDir, pathExists } from './utils/file-utils.js';
-import { Import } from './commands/index.js';
-import { ModuleSetting } from './interfaces/project-interfaces.js';
+import type { Import } from './commands/index.js';
+import type { ModuleSetting } from './interfaces/project-interfaces.js';
 import { Project } from './containers/project.js';
-import { ProjectConfiguration } from './project-settings.js';
+import type { ProjectConfiguration } from './project-settings.js';
 import { ProjectPaths } from './containers/project/project-paths.js';
 import { readJsonFile } from './utils/json.js';
 import { Validate } from './commands/index.js';

--- a/tools/data-handler/src/permissions/action-guard.ts
+++ b/tools/data-handler/src/permissions/action-guard.ts
@@ -10,8 +10,8 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Calculate } from '../commands/index.js';
-import { DeniedOperationCollection } from '../types/queries.js';
+import type { Calculate } from '../commands/index.js';
+import type { DeniedOperationCollection } from '../types/queries.js';
 
 export type Action = keyof DeniedOperationCollection;
 

--- a/tools/data-handler/src/project-settings.ts
+++ b/tools/data-handler/src/project-settings.ts
@@ -13,7 +13,7 @@
 
 import { writeJsonFile as atomicWrite } from 'write-json-file';
 
-import {
+import type {
   ModuleSetting,
   ProjectSettings,
 } from './interfaces/project-interfaces.js';

--- a/tools/data-handler/src/resources/array-handler.ts
+++ b/tools/data-handler/src/resources/array-handler.ts
@@ -12,7 +12,7 @@
 
 import { deepCompare } from '../utils/common-utils.js';
 
-import {
+import type {
   AddOperation,
   ChangeOperation,
   Operation,

--- a/tools/data-handler/src/resources/card-type-resource.ts
+++ b/tools/data-handler/src/resources/card-type-resource.ts
@@ -9,23 +9,23 @@
     You should have received a copy of the GNU Affero General Public
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-import {
+import type {
   CardType,
   CustomField,
   LinkType,
 } from '../interfaces/resource-interfaces.js';
 import { FieldTypeResource } from './field-type-resource.js';
 import {
-  AddOperation,
-  Card,
-  ChangeOperation,
+  type AddOperation,
+  type Card,
+  type ChangeOperation,
   DefaultContent,
   FileResource,
-  Operation,
-  Project,
-  RemoveOperation,
+  type Operation,
+  type Project,
+  type RemoveOperation,
   ResourcesFrom,
-  ResourceName,
+  type ResourceName,
   resourceName,
   resourceNameToString,
   sortCards,

--- a/tools/data-handler/src/resources/create-defaults.ts
+++ b/tools/data-handler/src/resources/create-defaults.ts
@@ -10,8 +10,8 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Card } from '../interfaces/project-interfaces.js';
-import {
+import type { Card } from '../interfaces/project-interfaces.js';
+import type {
   CardType,
   DataType,
   FieldType,
@@ -21,9 +21,9 @@ import {
   LinkType,
   ReportMetadata,
   TemplateMetadata,
-  WorkflowCategory,
   Workflow,
 } from '../interfaces/resource-interfaces.js';
+import { WorkflowCategory } from '../interfaces/resource-interfaces.js';
 import { FIRST_RANK, getRankAfter, sortItems } from '../utils/lexorank.js';
 
 // Helper function to get latest card rank from a set of cards.

--- a/tools/data-handler/src/resources/field-type-resource.ts
+++ b/tools/data-handler/src/resources/field-type-resource.ts
@@ -11,21 +11,24 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import {
+import type {
   Card,
   ChangeOperation,
-  DefaultContent,
-  FileResource,
   Operation,
   Project,
   RemoveOperation,
+  ResourceName,
+} from './file-resource.js';
+import {
+  DefaultContent,
+  FileResource,
   ResourcesFrom,
   resourceName,
   resourceNameToString,
-  ResourceName,
   sortCards,
 } from './file-resource.js';
-import {
+
+import type {
   CardType,
   DataType,
   EnumDefinition,

--- a/tools/data-handler/src/resources/file-resource.ts
+++ b/tools/data-handler/src/resources/file-resource.ts
@@ -13,12 +13,12 @@
 */
 
 // node
-import { basename, join } from 'node:path';
+import { basename, join, sep } from 'node:path';
 import { mkdir, rename } from 'node:fs/promises';
 import { readFile } from 'node:fs/promises';
 
-import {
-  type Card,
+import type {
+  Card,
   ResourceFolderType,
 } from '../interfaces/project-interfaces.js';
 import {
@@ -36,7 +36,7 @@ import {
   readJsonFileSync,
   writeJsonFile,
 } from '../utils/json.js';
-import {
+import type {
   ResourceBaseMetadata,
   ResourceContent,
 } from '../interfaces/resource-interfaces.js';
@@ -45,8 +45,8 @@ import {
   resourceName,
   resourceNameToPath,
   resourceNameToString,
-  resourceObjectToResource,
 } from '../utils/resource-utils.js';
+import type { Resource } from '../interfaces/project-interfaces.js';
 import { sortCards } from '../utils/card-utils.js';
 import { Validate } from '../commands/index.js';
 
@@ -85,6 +85,14 @@ export class FileResource extends ResourceObject {
   // Type of resource.
   private resourceType(): ResourceFolderType {
     return this.type as ResourceFolderType;
+  }
+
+  // Converts resource name to Resource object.
+  private resourceObjectToResource(object: FileResource): Resource {
+    return {
+      name: object.data ? object.data.name : '',
+      path: object.fileName.substring(0, object.fileName.lastIndexOf(sep)),
+    };
   }
 
   private toCache() {
@@ -164,7 +172,7 @@ export class FileResource extends ResourceObject {
 
     // Notify project & collector
     this.project.addResource(
-      resourceObjectToResource(this),
+      this.resourceObjectToResource(this),
       this.content as unknown as JSON,
     );
   }
@@ -234,7 +242,7 @@ export class FileResource extends ResourceObject {
       );
     }
     await deleteFile(this.fileName);
-    this.project.removeResource(resourceObjectToResource(this));
+    this.project.removeResource(this.resourceObjectToResource(this));
     this.fileName = '';
   }
 

--- a/tools/data-handler/src/resources/folder-resource.ts
+++ b/tools/data-handler/src/resources/folder-resource.ts
@@ -13,7 +13,7 @@
 import { basename, join } from 'node:path';
 import { mkdir, rename, rm } from 'node:fs/promises';
 
-import { ResourceFolderType } from '../interfaces/project-interfaces.js';
+import type { ResourceFolderType } from '../interfaces/project-interfaces.js';
 import {
   type Card,
   DefaultContent,
@@ -25,7 +25,7 @@ import {
   resourceNameToString,
   sortCards,
 } from './file-resource.js';
-import { ResourceContent } from '../interfaces/resource-interfaces.js';
+import type { ResourceContent } from '../interfaces/resource-interfaces.js';
 
 export {
   type Card,

--- a/tools/data-handler/src/resources/graph-model-resource.ts
+++ b/tools/data-handler/src/resources/graph-model-resource.ts
@@ -15,17 +15,19 @@
 import { readdir } from 'node:fs/promises';
 import { extname, join } from 'node:path';
 
-import {
+import type {
   Card,
-  DefaultContent,
-  FolderResource,
   Operation,
   Project,
   ResourceName,
+} from './folder-resource.js';
+import {
+  DefaultContent,
+  FolderResource,
   resourceNameToString,
   sortCards,
 } from './folder-resource.js';
-import {
+import type {
   GraphModel,
   GraphModelMetadata,
 } from '../interfaces/resource-interfaces.js';

--- a/tools/data-handler/src/resources/graph-view-resource.ts
+++ b/tools/data-handler/src/resources/graph-view-resource.ts
@@ -15,17 +15,19 @@
 import { readdir } from 'node:fs/promises';
 import { extname, join } from 'node:path';
 
-import {
+import type {
   Card,
-  DefaultContent,
-  FolderResource,
   Operation,
   Project,
   ResourceName,
+} from './folder-resource.js';
+import {
+  DefaultContent,
+  FolderResource,
   resourceNameToString,
   sortCards,
 } from './folder-resource.js';
-import {
+import type {
   GraphView,
   GraphViewMetadata,
 } from '../interfaces/resource-interfaces.js';

--- a/tools/data-handler/src/resources/link-type-resource.ts
+++ b/tools/data-handler/src/resources/link-type-resource.ts
@@ -10,17 +10,19 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import {
+import type {
   Card,
-  DefaultContent,
-  FileResource,
   Operation,
   Project,
   ResourceName,
+} from './file-resource.js';
+import {
+  DefaultContent,
+  FileResource,
   resourceNameToString,
   sortCards,
-} from './file-resource.js';
-import { LinkType } from '../interfaces/resource-interfaces.js';
+} from './folder-resource.js';
+import type { LinkType } from '../interfaces/resource-interfaces.js';
 
 /**
  * Link Type resource class.

--- a/tools/data-handler/src/resources/report-resource.ts
+++ b/tools/data-handler/src/resources/report-resource.ts
@@ -18,18 +18,23 @@ import { extname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { copyDir } from '../utils/file-utils.js';
-import {
+import type {
   Card,
-  DefaultContent,
-  FolderResource,
   Operation,
   Project,
   ResourceName,
+} from './folder-resource.js';
+import {
+  DefaultContent,
+  FolderResource,
   resourceNameToString,
   sortCards,
 } from './folder-resource.js';
-import { Report, ReportMetadata } from '../interfaces/resource-interfaces.js';
-import { Schema } from 'jsonschema';
+import type {
+  Report,
+  ReportMetadata,
+} from '../interfaces/resource-interfaces.js';
+import type { Schema } from 'jsonschema';
 
 const CARD_CONTENT_HANDLEBAR_FILE = 'index.adoc.hbs';
 const QUERY_HANDLEBAR_FILE = 'query.lp.hbs';

--- a/tools/data-handler/src/resources/resource-object.ts
+++ b/tools/data-handler/src/resources/resource-object.ts
@@ -17,13 +17,13 @@ import { readFile, writeFile } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 
 import { ArrayHandler } from './array-handler.js';
-import {
-  type Card,
+import type {
+  Card,
   ResourceFolderType,
 } from '../interfaces/project-interfaces.js';
-import { Project, ResourcesFrom } from '../containers/project.js';
-import { ResourceContent } from '../interfaces/resource-interfaces.js';
-import { ResourceName } from '../utils/resource-utils.js';
+import { type Project, ResourcesFrom } from '../containers/project.js';
+import type { ResourceContent } from '../interfaces/resource-interfaces.js';
+import type { ResourceName } from '../utils/resource-utils.js';
 
 // Possible operations to perform when doing "update"
 export type UpdateOperations = 'add' | 'change' | 'rank' | 'remove';

--- a/tools/data-handler/src/resources/template-resource.ts
+++ b/tools/data-handler/src/resources/template-resource.ts
@@ -15,17 +15,19 @@
 import { basename, dirname, join } from 'node:path';
 import { mkdir } from 'node:fs/promises';
 
-import {
+import type {
   Card,
-  DefaultContent,
-  FolderResource,
   Operation,
   Project,
   ResourceName,
+} from './folder-resource.js';
+import {
+  DefaultContent,
+  FolderResource,
   resourceNameToString,
   sortCards,
 } from './folder-resource.js';
-import {
+import type {
   TemplateConfiguration,
   TemplateMetadata,
 } from '../interfaces/resource-interfaces.js';

--- a/tools/data-handler/src/resources/workflow-resource.ts
+++ b/tools/data-handler/src/resources/workflow-resource.ts
@@ -10,26 +10,28 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import {
+import type {
   CardType,
   Workflow,
   WorkflowState,
   WorkflowTransition,
 } from '../interfaces/resource-interfaces.js';
 import { CardTypeResource } from './card-type-resource.js';
-import {
+import type {
   Card,
   ChangeOperation,
-  DefaultContent,
-  FileResource,
   Operation,
   Project,
-  ResourcesFrom,
   ResourceName,
-  resourceName,
+} from './file-resource.js';
+import {
+  DefaultContent,
+  FileResource,
   resourceNameToString,
   sortCards,
-} from './file-resource.js';
+} from './folder-resource.js';
+import { ResourcesFrom } from '../containers/project.js';
+import { resourceName } from './file-resource.js';
 
 /**
  * Workflow resource class.

--- a/tools/data-handler/src/types/queries.ts
+++ b/tools/data-handler/src/types/queries.ts
@@ -14,7 +14,7 @@
  * Types for query result
  */
 
-import {
+import type {
   DataType,
   WorkflowCategory,
 } from '../interfaces/resource-interfaces.js';

--- a/tools/data-handler/src/utils/card-utils.ts
+++ b/tools/data-handler/src/utils/card-utils.ts
@@ -12,7 +12,7 @@
 
 import { sep } from 'node:path';
 
-import { Card } from '../interfaces/project-interfaces.js';
+import type { Card } from '../interfaces/project-interfaces.js';
 
 // Helper function to find the parent path from a card path
 export const findParentPath = (cardPath: string): string | null => {

--- a/tools/data-handler/src/utils/clingo-facts.ts
+++ b/tools/data-handler/src/utils/clingo-facts.ts
@@ -11,9 +11,12 @@
 */
 import { sep } from 'node:path';
 
-import { AllowedClingoType, ClingoFactBuilder } from './clingo-fact-builder.js';
-import { Card, ModuleContent } from '../interfaces/project-interfaces.js';
 import {
+  type AllowedClingoType,
+  ClingoFactBuilder,
+} from './clingo-fact-builder.js';
+import type { Card, ModuleContent } from '../interfaces/project-interfaces.js';
+import type {
   CardType,
   FieldType,
   Link,
@@ -25,7 +28,7 @@ import {
 import { ClingoProgramBuilder } from './clingo-program-builder.js';
 import { isPredefinedField } from './constants.js';
 import { isTemplateCard } from '../utils/card-utils.js';
-import { Project } from '../containers/project.js';
+import type { Project } from '../containers/project.js';
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace Facts {

--- a/tools/data-handler/src/utils/clingo-parser.ts
+++ b/tools/data-handler/src/utils/clingo-parser.ts
@@ -10,8 +10,12 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { DataType } from '../interfaces/resource-interfaces.js';
-import { BaseResult, LinkDirection, ParseResult } from '../types/queries.js';
+import type { DataType } from '../interfaces/resource-interfaces.js';
+import type {
+  BaseResult,
+  LinkDirection,
+  ParseResult,
+} from '../types/queries.js';
 
 /**
  * This function reverses the encoding made by the "encodeClingoValue" function

--- a/tools/data-handler/src/utils/clingo-program-builder.ts
+++ b/tools/data-handler/src/utils/clingo-program-builder.ts
@@ -9,7 +9,10 @@
     You should have received a copy of the GNU Affero General Public
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-import { ClingoArgument, ClingoFactBuilder } from './clingo-fact-builder.js';
+import {
+  type ClingoArgument,
+  ClingoFactBuilder,
+} from './clingo-fact-builder.js';
 
 interface IBuilder {
   build(): string;

--- a/tools/data-handler/src/utils/constants.ts
+++ b/tools/data-handler/src/utils/constants.ts
@@ -1,4 +1,4 @@
-import { PredefinedCardMetadata } from '../interfaces/project-interfaces.js';
+import type { PredefinedCardMetadata } from '../interfaces/project-interfaces.js';
 
 export const INT32_MAX = 2147483647; // 2^31-1
 /**

--- a/tools/data-handler/src/utils/csv.ts
+++ b/tools/data-handler/src/utils/csv.ts
@@ -12,7 +12,7 @@
 
 import { readFile } from 'fs/promises';
 import { parse } from 'csv-parse/sync';
-import { CSVRowRaw } from '../interfaces/project-interfaces.js';
+import type { CSVRowRaw } from '../interfaces/project-interfaces.js';
 
 /**
  * Reads a CSV file and returns its content as an array of objects.

--- a/tools/data-handler/src/utils/json.ts
+++ b/tools/data-handler/src/utils/json.ts
@@ -13,7 +13,7 @@
 */
 
 import { readFileSync } from 'node:fs';
-import { FileHandle, readFile, writeFile } from 'node:fs/promises';
+import { type FileHandle, readFile, writeFile } from 'node:fs/promises';
 
 /**
  * Handles reading of a JSON file.

--- a/tools/data-handler/src/utils/log-utils.ts
+++ b/tools/data-handler/src/utils/log-utils.ts
@@ -11,7 +11,7 @@
 */
 
 import { join } from 'path';
-import pino, { TransportTargetOptions } from 'pino';
+import pino, { type TransportTargetOptions } from 'pino';
 import { fileURLToPath } from 'url';
 const LOG_FILE_LOCATION: string = join(
   fileURLToPath(import.meta.url),

--- a/tools/data-handler/src/utils/resource-utils.ts
+++ b/tools/data-handler/src/utils/resource-utils.ts
@@ -10,9 +10,7 @@
 // node
 import { join, parse, sep } from 'node:path';
 
-import { FileResource } from '../resources/file-resource.js';
-import { Project } from '../containers/project.js';
-import { Resource } from '../interfaces/project-interfaces.js';
+import type { Project } from '../containers/project.js';
 import { stripExtension } from './file-utils.js';
 
 // Resource name parts are:
@@ -31,12 +29,6 @@ const TYPE_INDEX = 1;
 const IDENTIFIER_INDEX = 2;
 // Valid resource name has three parts
 const RESOURCE_NAME_PARTS = 3;
-
-const EMPTY_NAME = {
-  prefix: '',
-  type: '',
-  identifier: '',
-};
 
 // Checks if name is valid (3 parts, separated by '/').
 export function isResourceName(name: string): boolean {
@@ -185,27 +177,4 @@ export function resourceNameToString(resourceName: ResourceName): string {
   return resourceName.prefix && resourceName.type && resourceName.prefix
     ? `${resourceName.prefix}/${resourceName.type}/${resourceName.identifier}`
     : `${resourceName.identifier}`;
-}
-
-/**
- * Converts resource object to Resource. Resource is basically path + file for certain name.
- * @param object Resource object of any type.
- * @returns Resource information (file name and path)
- */
-export function resourceObjectToResource(object: FileResource): Resource {
-  return {
-    name: object.data ? object.data.name : '',
-    path: object.fileName.substring(0, object.fileName.lastIndexOf(sep)),
-  };
-}
-
-/**
- * Converts resource object to ResourceName.
- * @param object Resource object of any type.
- * @returns ResourceName information (prefix, type and identifier).
- */
-export function resourceObjectToResourceName(
-  object: FileResource,
-): ResourceName {
-  return object.data ? resourceName(object.data.name) : EMPTY_NAME;
 }

--- a/tools/data-handler/src/utils/validate.ts
+++ b/tools/data-handler/src/utils/validate.ts
@@ -9,7 +9,7 @@
     You should have received a copy of the GNU Affero General Public
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-import { Schema, Validator } from 'jsonschema';
+import { type Schema, Validator } from 'jsonschema';
 import { DHValidationError, SchemaNotFound } from '../exceptions/index.js';
 import { schemas } from './schemas.js';
 

--- a/tools/data-handler/src/utils/value-utils.ts
+++ b/tools/data-handler/src/utils/value-utils.ts
@@ -11,7 +11,7 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { DataType } from '../interfaces/resource-interfaces.js';
+import type { DataType } from '../interfaces/resource-interfaces.js';
 import { isBigInt } from '../utils/common-utils.js';
 import * as EmailValidator from 'email-validator';
 

--- a/tools/data-handler/test/0_validate.test.ts
+++ b/tools/data-handler/test/0_validate.test.ts
@@ -12,7 +12,7 @@ import { readJsonFile } from '../src/utils/json.js';
 import { Validate } from '../src/commands/index.js';
 import { Project } from '../src/containers/project.js';
 import { errorFunction } from '../src/utils/log-utils.js';
-import { ResourceTypes } from '../src/interfaces/project-interfaces.js';
+import type { ResourceTypes } from '../src/interfaces/project-interfaces.js';
 
 describe('validate cmd tests', () => {
   const baseDir = dirname(fileURLToPath(import.meta.url));

--- a/tools/data-handler/test/calculate.test.ts
+++ b/tools/data-handler/test/calculate.test.ts
@@ -7,7 +7,7 @@ import { Calculate } from '../src/commands/index.js';
 import { copyDir } from '../src/utils/file-utils.js';
 import { fileURLToPath } from 'node:url';
 import { Project } from '../src/containers/project.js';
-import { QueryResult } from '../src/types/queries.js';
+import type { QueryResult } from '../src/types/queries.js';
 
 use(chaiAsPromised);
 

--- a/tools/data-handler/test/command-handler-add.test.ts
+++ b/tools/data-handler/test/command-handler-add.test.ts
@@ -7,7 +7,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 // cyberismo
-import { CardsOptions, Cmd, Commands } from '../src/command-handler.js';
+import { type CardsOptions, Cmd, Commands } from '../src/command-handler.js';
 import { copyDir } from '../src/utils/file-utils.js';
 
 // Create test artifacts in a temp folder.

--- a/tools/data-handler/test/command-handler-create.test.ts
+++ b/tools/data-handler/test/command-handler-create.test.ts
@@ -9,11 +9,11 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 // cyberismo
-import { CardsOptions, Cmd, Commands } from '../src/command-handler.js';
+import { type CardsOptions, Cmd, Commands } from '../src/command-handler.js';
 import { copyDir, deleteDir, resolveTilde } from '../src/utils/file-utils.js';
 import { Calculate } from '../src/commands/index.js';
 import { DefaultContent } from '../src/resources/create-defaults.js';
-import {
+import type {
   Card,
   CardListContainer,
 } from '../src/interfaces/project-interfaces.js';

--- a/tools/data-handler/test/command-handler-import.test.ts
+++ b/tools/data-handler/test/command-handler-import.test.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'node:url';
 
 // cyberismo
 import { copyDir } from '../src/utils/file-utils.js';
-import { CardsOptions, Cmd, Commands } from '../src/command-handler.js';
+import { type CardsOptions, Cmd, Commands } from '../src/command-handler.js';
 import { Project } from '../src/containers/project.js';
 import { Show } from '../src/commands/index.js';
 

--- a/tools/data-handler/test/command-handler-move.test.ts
+++ b/tools/data-handler/test/command-handler-move.test.ts
@@ -7,7 +7,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 // cyberismo
-import { CardsOptions, Cmd, Commands } from '../src/command-handler.js';
+import { type CardsOptions, Cmd, Commands } from '../src/command-handler.js';
 import { copyDir } from '../src/utils/file-utils.js';
 import { Project } from '../src/containers/project.js';
 import { Show } from '../src/commands/index.js';

--- a/tools/data-handler/test/command-handler-rank.test.ts
+++ b/tools/data-handler/test/command-handler-rank.test.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'node:url';
 // cyberismo
 import { Calculate, Show } from '../src/commands/index.js';
 import { copyDir } from '../src/utils/file-utils.js';
-import { CardsOptions, Cmd, Commands } from '../src/command-handler.js';
+import { type CardsOptions, Cmd, Commands } from '../src/command-handler.js';
 import { Project } from '../src/containers/project.js';
 
 // Create test artifacts in a temp folder.

--- a/tools/data-handler/test/command-handler-remove.test.ts
+++ b/tools/data-handler/test/command-handler-remove.test.ts
@@ -8,11 +8,11 @@ import { fileURLToPath } from 'node:url';
 
 // cyberismo
 import { Calculate, Remove } from '../src/commands/index.js';
-import { CardsOptions, Cmd, Commands } from '../src/command-handler.js';
-import { Card } from '../src/interfaces/project-interfaces.js';
+import { type CardsOptions, Cmd, Commands } from '../src/command-handler.js';
+import { type Card } from '../src/interfaces/project-interfaces.js';
 import { copyDir } from '../src/utils/file-utils.js';
 import { Project } from '../src/containers/project.js';
-import { requestStatus } from '../src/interfaces/request-status-interfaces.js';
+import { type requestStatus } from '../src/interfaces/request-status-interfaces.js';
 
 // Create test artifacts in a temp folder.
 const baseDir = dirname(fileURLToPath(import.meta.url));

--- a/tools/data-handler/test/command-handler-rename.test.ts
+++ b/tools/data-handler/test/command-handler-rename.test.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'node:url';
 
 // cyberismo
 import { copyDir } from '../src/utils/file-utils.js';
-import { CardsOptions, Cmd, Commands } from '../src/command-handler.js';
+import { type CardsOptions, Cmd, Commands } from '../src/command-handler.js';
 import { errorFunction } from '../src/utils/log-utils.js';
 
 // Create test artifacts in a temp folder.

--- a/tools/data-handler/test/command-handler-show.test.ts
+++ b/tools/data-handler/test/command-handler-show.test.ts
@@ -7,10 +7,10 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 // cyberismo
-import { CardsOptions, Cmd, Commands } from '../src/command-handler.js';
+import { type CardsOptions, Cmd, Commands } from '../src/command-handler.js';
 import { copyDir } from '../src/utils/file-utils.js';
 import { errorFunction } from '../src/utils/log-utils.js';
-import { ModuleContent } from '../src/interfaces/project-interfaces.js';
+import { type ModuleContent } from '../src/interfaces/project-interfaces.js';
 import { Project } from '../src/containers/project.js';
 import { Show } from '../src/commands/index.js';
 

--- a/tools/data-handler/test/command-handler-transition.test.ts
+++ b/tools/data-handler/test/command-handler-transition.test.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'node:url';
 
 // cyberismo
 import { copyDir } from '../src/utils/file-utils.js';
-import { CardsOptions, Cmd, Commands } from '../src/command-handler.js';
+import { type CardsOptions, Cmd, Commands } from '../src/command-handler.js';
 import { Project } from '../src/containers/project.js';
 import { Show } from '../src/commands/index.js';
 

--- a/tools/data-handler/test/command-handler-update.test.ts
+++ b/tools/data-handler/test/command-handler-update.test.ts
@@ -6,7 +6,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { mkdirSync, rmSync } from 'node:fs';
 
-import { CardType } from '../src/interfaces/resource-interfaces.js';
+import { type CardType } from '../src/interfaces/resource-interfaces.js';
 import { copyDir } from '../src/utils/file-utils.js';
 import { Project } from '../src/containers/project.js';
 import { ResourceCollector } from '../src/containers/project/resource-collector.js';

--- a/tools/data-handler/test/command-handler-validate.test.ts
+++ b/tools/data-handler/test/command-handler-validate.test.ts
@@ -7,7 +7,7 @@ import { join } from 'node:path';
 
 // cyberismo
 import { Cmd, Commands } from '../src/command-handler.js';
-import { requestStatus } from '../src/interfaces/request-status-interfaces.js';
+import { type requestStatus } from '../src/interfaces/request-status-interfaces.js';
 
 const commandHandler: Commands = new Commands();
 

--- a/tools/data-handler/test/edit.test.ts
+++ b/tools/data-handler/test/edit.test.ts
@@ -4,7 +4,7 @@ import { mkdirSync, rmSync } from 'node:fs';
 
 import { copyDir } from '../src/utils/file-utils.js';
 import { CommandManager } from '../src/command-manager.js';
-import { Edit } from '../src/commands/index.js';
+import { type Edit } from '../src/commands/index.js';
 import { fileURLToPath } from 'node:url';
 
 describe('edit card', () => {

--- a/tools/data-handler/test/export.test.ts
+++ b/tools/data-handler/test/export.test.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { mkdirSync, rmSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
-import { CardsOptions, Cmd, Commands } from '../src/command-handler.js';
+import { type CardsOptions, Cmd, Commands } from '../src/command-handler.js';
 import { CommandManager } from '../src/command-manager.js';
 import { copyDir } from '../src/utils/file-utils.js';
 import { ExportSite } from '../src/commands/index.js';

--- a/tools/data-handler/test/macros/index.test.ts
+++ b/tools/data-handler/test/macros/index.test.ts
@@ -12,7 +12,7 @@ import {
 import { Validator } from 'jsonschema';
 import Handlebars from 'handlebars';
 import BaseMacro from '../../src/macros/base-macro.js';
-import { MacroGenerationContext } from '../../src/interfaces/macros.js';
+import type { MacroGenerationContext } from '../../src/interfaces/macros.js';
 import TaskQueue from '../../src/macros/task-queue.js';
 
 class TestMacro extends BaseMacro {

--- a/tools/data-handler/test/project.test.ts
+++ b/tools/data-handler/test/project.test.ts
@@ -10,9 +10,9 @@ import { fileURLToPath } from 'node:url';
 import { copyDir } from '../src/utils/file-utils.js';
 import {
   CardLocation,
-  FileContentType,
+  type FileContentType,
 } from '../src/interfaces/project-interfaces.js';
-import {
+import type {
   CardType,
   TemplateMetadata,
   Workflow,
@@ -23,11 +23,11 @@ import { Project } from '../src/containers/project.js';
 import { ProjectConfiguration } from '../src/project-settings.js';
 import { resourceName } from '../src/utils/resource-utils.js';
 
-import { CardTypeResource } from '../src/resources/card-type-resource.js';
-import { FieldTypeResource } from '../src/resources/field-type-resource.js';
-import { LinkTypeResource } from '../src/resources/link-type-resource.js';
+import type { CardTypeResource } from '../src/resources/card-type-resource.js';
+import type { FieldTypeResource } from '../src/resources/field-type-resource.js';
+import type { LinkTypeResource } from '../src/resources/link-type-resource.js';
 import { TemplateResource } from '../src/resources/template-resource.js';
-import { WorkflowResource } from '../src/resources/workflow-resource.js';
+import type { WorkflowResource } from '../src/resources/workflow-resource.js';
 
 describe('project', () => {
   // Create test artifacts in a temp folder.

--- a/tools/data-handler/test/resources.test.ts
+++ b/tools/data-handler/test/resources.test.ts
@@ -12,7 +12,7 @@ import { Calculate, Create, Import, Remove } from '../src/commands/index.js';
 import { Project } from '../src/containers/project.js';
 import { ResourceCollector } from '../src/containers/project/resource-collector.js';
 import { resourceName } from '../src/utils/resource-utils.js';
-import {
+import type {
   RemovableResourceTypes,
   ResourceFolderType,
 } from '../src/interfaces/project-interfaces.js';
@@ -26,7 +26,7 @@ import { ReportResource } from '../src/resources/report-resource.js';
 import { TemplateResource } from '../src/resources/template-resource.js';
 import { WorkflowResource } from '../src/resources/workflow-resource.js';
 
-import {
+import type {
   CardType,
   CustomField,
   EnumDefinition,
@@ -41,7 +41,7 @@ import {
   WorkflowTransition,
 } from '../src/interfaces/resource-interfaces.js';
 
-import {
+import type {
   AddOperation,
   ChangeOperation,
   RemoveOperation,

--- a/tools/data-handler/test/show.test.ts
+++ b/tools/data-handler/test/show.test.ts
@@ -5,9 +5,9 @@ import { dirname, join } from 'node:path';
 import { CommandManager } from '../src/command-manager.js';
 import { copyDir, writeFileSafe } from '../src/utils/file-utils.js';
 import { errorFunction } from '../src/utils/log-utils.js';
-import { FetchCardDetails } from '../src/interfaces/project-interfaces.js';
+import type { FetchCardDetails } from '../src/interfaces/project-interfaces.js';
 import { fileURLToPath } from 'node:url';
-import { Show } from '../src/commands/index.js';
+import type { Show } from '../src/commands/index.js';
 import { writeJsonFile } from '../src/utils/json.js';
 
 describe('show', () => {

--- a/tools/data-handler/test/template.test.ts
+++ b/tools/data-handler/test/template.test.ts
@@ -7,7 +7,10 @@ import { mkdirSync, rmSync } from 'node:fs';
 import { dirname, join, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { Card, FileContentType } from '../src/interfaces/project-interfaces.js';
+import type {
+  Card,
+  FileContentType,
+} from '../src/interfaces/project-interfaces.js';
 import { copyDir } from '../src/utils/file-utils.js';
 import { Project } from '../src/containers/project.js';
 import { resourceName } from '../src/utils/resource-utils.js';

--- a/tools/data-handler/test/utils/resource-utils.test.ts
+++ b/tools/data-handler/test/utils/resource-utils.test.ts
@@ -8,16 +8,13 @@ import { fileURLToPath } from 'node:url';
 
 import {
   pathToResourceName,
-  ResourceName,
+  type ResourceName,
   resourceNameToPath,
   resourceName,
   resourceNameToString,
-  resourceObjectToResource,
-  resourceObjectToResourceName,
 } from '../../src/utils/resource-utils.js';
 
 import { Project } from '../../src/containers/project.js';
-import { WorkflowResource } from '../../src/resources/workflow-resource.js';
 
 describe('resource utils', () => {
   it('resourceName with valid resource name (success)', () => {
@@ -217,28 +214,5 @@ describe('resource utils with Project instance', () => {
         }
       }
     }
-  });
-  it('resourceObjectToResource with valid values', () => {
-    const resourceFullName = 'decision/workflows/decision';
-    const workflow = new WorkflowResource(
-      project,
-      resourceName(resourceFullName),
-    );
-    const resource = resourceObjectToResource(workflow);
-    expect(resource.name).to.equal(resourceFullName);
-    expect(resource.path).to.equal(
-      `${project.paths.resourcesFolder}${sep}workflows`,
-    );
-  });
-  it('resourceObjectToResourceName with valid values', () => {
-    const resourceFullName = 'decision/workflows/decision';
-    const workflow = new WorkflowResource(
-      project,
-      resourceName(resourceFullName),
-    );
-    const name = resourceObjectToResourceName(workflow);
-    expect(name.prefix).to.equal('decision');
-    expect(name.type).to.equal('workflows');
-    expect(name.identifier).to.equal('decision');
   });
 });

--- a/tools/data-handler/test/utils/value-utils.test.ts
+++ b/tools/data-handler/test/utils/value-utils.test.ts
@@ -7,7 +7,7 @@ import {
   fromNumber,
   fromString,
 } from '../../src/utils/value-utils.js';
-import { DataType } from '../../src/interfaces/resource-interfaces.js';
+import type { DataType } from '../../src/interfaces/resource-interfaces.js';
 
 describe('data type conversions', () => {
   const dataTypes: DataType[] = [


### PR DESCRIPTION
I decided to re-create the PR and not reorder the imports to make the change a smaller one.

Additionally, removed one circular dependency between resource-utils and file-resource files.
There were two methods that used `FileResource` and thus it was imported to `resource-utils` and `file-resource` imported these methods. Fixed it so that other method was removed (not used anywhere) and the other was moved inside the `file-resource` itself. 