### PR TITLE
INTDEV-852 Cyberismo calc testing

### DIFF
--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -211,16 +211,13 @@ const calculate = program
 
 calculate
   .command('generate')
-  .description('Generate a logic program')
+  .description('DEPRECATED: Generate a logic program')
   .argument('[cardKey]', 'If given, calculates on the subtree of the card')
   .option('-p, --project-path [path]', `${pathGuideline}`)
-  .action(async (filePath: string, options: CardsOptions) => {
-    const result = await commandHandler.command(
-      Cmd.calc,
-      ['generate', filePath],
-      options,
+  .action(async () => {
+    console.warn(
+      'This command is deprecated. Use "cyberismo calc run" directly instead.',
     );
-    handleResponse(result);
   });
 
 calculate

--- a/tools/cli/test/cli.test.ts
+++ b/tools/cli/test/cli.test.ts
@@ -303,15 +303,17 @@ describe('Cli BAT test', function () {
       },
     );
   });
-  it('Generate calculations', function (done) {
+  it('Test calc run with tree query', function (done) {
     exec(
-      `cd ../../.tmp/cyberismo-cli&&cyberismo calc generate&&cyberismo validate`,
+      `cd ../../.tmp/cyberismo-cli&&cyberismo calc run ../../resources/calculations/queries/tree.lp &&cyberismo validate`,
       (error, stdout, _stderr) => {
         if (error != null) {
           log(error);
         }
         expect(error).to.be.null;
-        expect(stdout).to.include('Done');
+        expect(stdout).to.include(decisionCardKey);
+        expect(stdout).to.include(pageCardKey);
+        expect(stdout).to.include(newPageCardKey);
         expect(stdout).to.include('Project structure validated');
         done();
       },


### PR DESCRIPTION
Added a test for `cyberismo calc run`. Tested that it broke without the fix, which is already in main. Also added a deprecated warning to `cyberismo calc generate`, because it should be removed. But it will still provide a 0 exit code so that it does not break existing CIs