### PR TITLE
INTDEV-851 Remove copyright comment blocks from .lp

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -687,3 +687,16 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+# Additional notes on content file licensing
+
+All Answer Set Programming (ASP) assets (file extensions .lp and .lp.hbs) and
+AsciiDoc assets (file extensions .adoc and adoc.hbs) in this repository are
+licensed as follows:
+
+Copyright © Cyberismo Ltd and contributors 2024
+
+The use of the Cyberismo trademark: https://cyberismo.com/trademark-policy/
+This content is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.

--- a/resources/calculations/common/base.lp
+++ b/resources/calculations/common/base.lp
@@ -1,11 +1,3 @@
-% Copyright © Cyberismo Ltd and contributors 2025
-%
-% License: https://github.com/CyberismoCom/cyberismo/blob/main/LICENSE
-% The use of the Cyberismo trademark: https://cyberismo.com/trademark-policy/
-% This content is distributed in the hope that it will be useful, but
-% WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-% FITNESS FOR A PARTICULAR PURPOSE.
-
 %
 % Common definitions for all Cards projects
 %

--- a/resources/calculations/common/main.lp
+++ b/resources/calculations/common/main.lp
@@ -1,11 +1,3 @@
-% Copyright © Cyberismo Ltd and contributors 2025
-%
-% License: https://github.com/CyberismoCom/cyberismo/blob/main/LICENSE
-% The use of the Cyberismo trademark: https://cyberismo.com/trademark-policy/
-% This content is distributed in the hope that it will be useful, but
-% WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-% FITNESS FOR A PARTICULAR PURPOSE.
-
 #include "base.lp".
 #include "cardTree.lp".
 #include "resourceImports.lp".

--- a/resources/calculations/common/pythonFunctions.lp
+++ b/resources/calculations/common/pythonFunctions.lp
@@ -1,11 +1,3 @@
-% Copyright © Cyberismo Ltd and contributors 2025
-%
-% License: https://github.com/CyberismoCom/cyberismo/blob/main/LICENSE
-% The use of the Cyberismo trademark: https://cyberismo.com/trademark-policy/
-% This content is distributed in the hope that it will be useful, but
-% WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-% FITNESS FOR A PARTICULAR PURPOSE.
-
 % python functions
 
 #script (python)

--- a/resources/calculations/common/queryLanguage.lp
+++ b/resources/calculations/common/queryLanguage.lp
@@ -1,11 +1,3 @@
-% Copyright © Cyberismo Ltd and contributors 2025
-%
-% License: https://github.com/CyberismoCom/cyberismo/blob/main/LICENSE
-% The use of the Cyberismo trademark: https://cyberismo.com/trademark-policy/
-% This content is distributed in the hope that it will be useful, but
-% WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-% FITNESS FOR A PARTICULAR PURPOSE.
-
 % Cyberismo query language
 
 % select(n, collection, field): on result level n and for "collection", "field" should be returned

--- a/resources/calculations/queries/card.lp
+++ b/resources/calculations/queries/card.lp
@@ -1,11 +1,3 @@
-% Copyright © Cyberismo Ltd and contributors 2025
-%
-% License: https://github.com/CyberismoCom/cyberismo/blob/main/LICENSE
-% The use of the Cyberismo trademark: https://cyberismo.com/trademark-policy/
-% This content is distributed in the hope that it will be useful, but
-% WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-% FITNESS FOR A PARTICULAR PURPOSE.
-
 result({{cardKey}}).
 
 % a helper term for display names

--- a/resources/calculations/queries/onCreation.lp
+++ b/resources/calculations/queries/onCreation.lp
@@ -1,11 +1,3 @@
-% Copyright © Cyberismo Ltd and contributors 2025
-%
-% License: https://github.com/CyberismoCom/cyberismo/blob/main/LICENSE
-% The use of the Cyberismo trademark: https://cyberismo.com/trademark-policy/
-% This content is distributed in the hope that it will be useful, but
-% WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-% FITNESS FOR A PARTICULAR PURPOSE.
-
 {{#each cardKeys}}
 createdCard({{this}}).
 {{/each}}

--- a/resources/calculations/queries/onTransition.lp
+++ b/resources/calculations/queries/onTransition.lp
@@ -1,11 +1,3 @@
-% Copyright © Cyberismo Ltd and contributors 2025
-%
-% License: https://github.com/CyberismoCom/cyberismo/blob/main/LICENSE
-% The use of the Cyberismo trademark: https://cyberismo.com/trademark-policy/
-% This content is distributed in the hope that it will be useful, but
-% WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-% FITNESS FOR A PARTICULAR PURPOSE.
-
 selectAll.
 
 result(transitionSideEffects).

--- a/resources/calculations/queries/tree.lp
+++ b/resources/calculations/queries/tree.lp
@@ -1,11 +1,3 @@
-% Copyright © Cyberismo Ltd and contributors 2025
-%
-% License: https://github.com/CyberismoCom/cyberismo/blob/main/LICENSE
-% The use of the Cyberismo trademark: https://cyberismo.com/trademark-policy/
-% This content is distributed in the hope that it will be useful, but
-% WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-% FITNESS FOR A PARTICULAR PURPOSE.
-
 select("title";"statusIndicator";"progress";"rank";"cardType").
 result(Card) :- card(Card), not parent(Card, _), not hiddenInTreeView(Card).
 childResult(Parent, Card, "children") :- card(Card), parent(Card, Parent), not hiddenInTreeView(Card).


### PR DESCRIPTION
Remove the previously added copyright blocks.
Extend license to cover the files with additional note instead.