### PR TITLE
INTDEV-850 Support both private and public repos with modules

### DIFF
--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -395,15 +395,26 @@ importCmd
   )
   .argument('<source>', 'Path to import from')
   .argument('[branch]', 'When using git URL defines the branch. Default: main')
+  .argument(
+    '[useCredentials]',
+    'When using git URL uses credentials for cloning. Default: false',
+  )
   .option('-p, --project-path [path]', `${pathGuideline}`)
-  .action(async (source: string, branch: string, options: CardsOptions) => {
-    const result = await commandHandler.command(
-      Cmd.import,
-      ['module', source, branch],
-      options,
-    );
-    handleResponse(result);
-  });
+  .action(
+    async (
+      source: string,
+      branch: string,
+      useCredentials: boolean,
+      options: CardsOptions,
+    ) => {
+      const result = await commandHandler.command(
+        Cmd.import,
+        ['module', source, branch, String(useCredentials)],
+        options,
+      );
+      handleResponse(result);
+    },
+  );
 
 // import csv
 importCmd

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -258,8 +258,12 @@ export class Commands {
       } else if (command === Cmd.import) {
         const target = args.splice(0, 1)[0];
         if (target === 'module') {
-          const [source, branch] = args;
-          await this.import(source, branch);
+          const [source, branch, useCredentials] = args;
+          await this.import(
+            source,
+            branch,
+            useCredentials && useCredentials === 'true' ? true : false,
+          );
         }
         if (target === 'csv') {
           const [csvFile, cardKey] = args;
@@ -466,12 +470,15 @@ export class Commands {
   }
 
   // Imports another project to the 'destination' project as a module.
-  private async import(source: string, branch?: string) {
-    return this.commands?.importCmd.importModule(
-      source,
-      this.projectPath,
-      branch,
-    );
+  private async import(
+    source: string,
+    branch?: string,
+    useCredentials?: boolean,
+  ) {
+    return this.commands?.importCmd.importModule(source, this.projectPath, {
+      branch: branch,
+      private: useCredentials,
+    });
   }
 
   // Imports cards from a CSV file to a project.

--- a/tools/data-handler/src/commands/import.ts
+++ b/tools/data-handler/src/commands/import.ts
@@ -14,6 +14,7 @@
 import type { CardType } from '../interfaces/resource-interfaces.js';
 import { type Create, Validate } from './index.js';
 import { ModuleManager } from '../module-manager.js';
+import type { ModuleSettingOptions } from '../interfaces/project-interfaces.js';
 import type { Project } from '../containers/project.js';
 import { readCsvFile } from '../utils/csv.js';
 import { resourceName } from '../utils/resource-utils.js';
@@ -121,16 +122,18 @@ export class Import {
    *
    * @param source Path to module that will be imported
    * @param destination Path to project that will receive the imported module
-   * @param branch Git branch for module from Git. Optional.
+   * @param options Additional options for module import. Optional.
+   *        branch: Git branch for module from Git.
+   *        private: If true, uses credentials to clone the repository
    */
   public async importModule(
     source: string,
     destination?: string,
-    branch?: string,
+    options?: ModuleSettingOptions,
   ) {
     const gitModule = source.startsWith('https');
     const modulePrefix = gitModule
-      ? await this.moduleManager.importGitModule(source)
+      ? await this.moduleManager.importGitModule(source, options)
       : await this.moduleManager.importFileModule(source, destination);
 
     if (!modulePrefix) {
@@ -142,7 +145,8 @@ export class Import {
     // Add module as a dependency.
     return this.project.importModule({
       name: modulePrefix,
-      branch: branch,
+      branch: options ? options.branch : undefined,
+      private: options ? options.private : undefined,
       location: gitModule ? source : `file:${source}`,
     });
   }

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -142,10 +142,14 @@ export interface ProjectSettings {
 }
 
 // Module configuration.
-export interface ModuleSetting {
+export interface ModuleSetting extends ModuleSettingOptions {
   name: string;
   location: string;
+}
+
+export interface ModuleSettingOptions {
   branch?: string;
+  private?: boolean;
 }
 
 // Resources that are possible to remove.

--- a/tools/data-handler/test/module-manager.test.ts
+++ b/tools/data-handler/test/module-manager.test.ts
@@ -86,9 +86,26 @@ describe('module-manager', () => {
   });
   it('try to import from incorrect git path', async () => {
     const gitModule = 'https://github.com/CyberismoCom/i-do-not-exist.git';
-    const expectedHttpCode = process.env.CYBERISMO_GIT_USER ? 404 : 401;
+    const expectedHttpCode = 401;
     await commands.importCmd
       .importModule(gitModule, commands.project.basePath)
+      .then(() => expect(false).to.equal(true))
+      .catch((error) => {
+        if (error instanceof Errors.HttpError) {
+          expect(error).to.have.property('data');
+          expect(error.data).to.have.property('statusCode');
+          expect(error.data.statusCode).to.equal(expectedHttpCode);
+        } else {
+          expect(false).to.equal(true);
+        }
+      });
+  }).timeout(10000);
+  it('try to import from incorrect private git path', async () => {
+    const gitModule = 'https://github.com/CyberismoCom/i-do-not-exist.git';
+    const expectedHttpCode = process.env.CYBERISMO_GIT_USER ? 404 : 401;
+    const options = { private: true };
+    await commands.importCmd
+      .importModule(gitModule, commands.project.basePath, options)
       .then(() => expect(false).to.equal(true))
       .catch((error) => {
         if (error instanceof Errors.HttpError) {

--- a/tools/schema/cardsConfigSchema.json
+++ b/tools/schema/cardsConfigSchema.json
@@ -35,6 +35,10 @@
           "branch": {
             "description": "If using git URL in 'location' defines git branch. If empty, assumed to be 'main'. ",
             "type": "string"
+          },
+          "private": {
+            "description": "If true, the module is private and requires credentials (CYBERISMO_GIT_USER / CYBERISMO_GIT_TOKEN)",
+            "type": "boolean"
           }
         },
         "required": ["name", "location"]


### PR DESCRIPTION
Implementation now supports both public and private repositories for modules. 

It is assumed that module is public; if there is need for private repository access, then the project importing that modules needs to defined in `cardsConfig.json` that module is private with `"private": true`.
Credentials need to be provided through `.env` or with environmental variables.

Additionally, clarified the output from `update modules` command so that it is clear which repository is being used. 

Finally, added a possibility to add private repo directly (no need to manually edit `cardsConfig.json`) with 
`cyberismo import module <https> [useCredentials]` option.

**Note** that multiple private repository locations are not currently supported. 