### PR TITLE
INTDEV-845 Update cache values when data changes

### DIFF
--- a/tools/backend/src/export.ts
+++ b/tools/backend/src/export.ts
@@ -94,7 +94,9 @@ export async function exportSite(
     JSON.stringify(configJson),
   );
 
-  const commands = await CommandManager.getInstance(projectPath, level);
+  const commands = await CommandManager.getInstance(projectPath, {
+    logLevel: level,
+  });
   await toSsg(app, commands, exportDir, onProgress);
 }
 

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -797,6 +797,10 @@ program
   .description(
     'Starts the cyberismo app, accessible with a web browser at http://localhost:3000',
   )
+  .option(
+    '-w, --watch-resource-changes',
+    'Project watches changes in .cards folder resources',
+  )
   .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (options: CardsOptions) => {
     // validate project

--- a/tools/data-handler/src/containers/project/project-content-watcher.ts
+++ b/tools/data-handler/src/containers/project/project-content-watcher.ts
@@ -1,0 +1,65 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2025
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { watch } from 'node:fs';
+
+import { getChildLogger } from '../../utils/log-utils.js';
+
+/**
+ * Class that starts watching certain path for changes.
+ * Generally we are not interested for file renames, as they are handled
+ * through rename command, thus there is an option to ignore those.
+ */
+export class ContentWatcher {
+  private watcher;
+  private abortController = new AbortController();
+
+  constructor(
+    ignoreRenames: boolean,
+    private watchPath: string,
+    callback: (fileName: string) => void,
+  ) {
+    this.watcher = watch(
+      this.watchPath,
+      {
+        persistent: true,
+        recursive: true,
+        signal: this.abortController.signal,
+      },
+      (eventType, filename) => {
+        if ((ignoreRenames && eventType === 'rename') || !filename) {
+          return;
+        }
+        callback(filename);
+      },
+    ).on('error', (error) => {
+      ContentWatcher.logger.error(error, 'Watch error');
+      this.close();
+    });
+    this.watcher.unref();
+  }
+
+  // Returns instance of logger.
+  private static get logger() {
+    return getChildLogger({
+      module: 'contentWatcher',
+    });
+  }
+
+  /**
+   * Close content watcher. Removes watcher.
+   */
+  public close() {
+    this.abortController.abort();
+  }
+}

--- a/tools/data-handler/src/resources/card-type-resource.ts
+++ b/tools/data-handler/src/resources/card-type-resource.ts
@@ -16,6 +16,7 @@ import type {
   CardType,
   CustomField,
   LinkType,
+  Workflow,
 } from '../interfaces/resource-interfaces.js';
 import { FieldTypeResource } from './field-type-resource.js';
 import {
@@ -329,7 +330,7 @@ export class CardTypeResource extends FileResource {
       resourceNameToString(resourceName(workflowName)),
       await this.project.projectPrefixes(),
     );
-    const workflow = await this.project.resource(workflowName);
+    const workflow = await this.project.resource<Workflow>(workflowName);
     if (!workflow) {
       throw new Error(
         `Workflow '${workflowName}' does not exist in the project`,

--- a/tools/data-handler/src/utils/resource-utils.ts
+++ b/tools/data-handler/src/utils/resource-utils.ts
@@ -140,6 +140,10 @@ export function pathToResourceName(
   if (!identifier || !type || !prefix) {
     throw new Error(`invalid path: ${path}`);
   }
+  if (identifierIndex + 1 !== parts.length) {
+    throw new Error(`not a resource path: ${path}`);
+  }
+
   return {
     prefix: prefix,
     type: type,

--- a/tools/data-handler/test/utils/resource-utils.test.ts
+++ b/tools/data-handler/test/utils/resource-utils.test.ts
@@ -178,39 +178,26 @@ describe('resource utils with Project instance', () => {
     }
   });
   it('pathToResourceName with invalid values', () => {
-    const validNames: Map<string, ResourceName> = new Map([
+    const invalidNames: Map<string, string> = new Map([
       [
         `${project.paths.resourcesFolder}${sep}cardTypes${sep}`,
-        {
-          prefix: project.projectPrefix,
-          type: 'cardTypes',
-          identifier: 'test',
-        },
+        `invalid path:`,
       ],
       [
         `${sep}path${sep}to${sep}somewhere${sep}that${sep}is${sep}not${sep}a${sep}project${sep}path`,
-        {
-          prefix: project.projectPrefix,
-          type: 'workflows',
-          identifier: 'decision',
-        },
+        `invalid path:`,
       ],
       [
         `${project.paths.resourcesFolder}${sep}base${sep}workflows${sep}decision.json`,
-        {
-          prefix: 'base',
-          type: 'workflows',
-          identifier: 'decision',
-        },
+        'not a resource path:',
       ],
     ]);
-    for (const name of validNames) {
+    for (const name of invalidNames) {
       try {
         pathToResourceName(project, name[0]);
       } catch (e) {
         if (e instanceof Error) {
-          expect(e.message).to.contain(`invalid path`);
-          expect(e.message).to.contain(`${name[0]}`);
+          expect(e.message).to.equal(`${name[1]} ${name[0]}`);
         }
       }
     }


### PR DESCRIPTION
Added a file watcher for running concurrent instances of a project on same machine. 
This will not work in Docker and is not intended to.

To avoid watching the filesystem unnecessarily (normal case), there is an additional flag for `cyberismo app` `--concurrent-apps` which causes the instance to watch changes in `.cards/local`. Module changes are not watched, as they should not be modified. File renames are ignored. 

When a file change is noticed, it is checked if a resource file was changed. If so, then resource is removed from cache and recreated. Then pushed into cache again.