### PR TITLE
INTDEV-839 adjust notification hiding

### DIFF
--- a/tools/app/src/lib/slices/notifications.ts
+++ b/tools/app/src/lib/slices/notifications.ts
@@ -17,9 +17,13 @@ export interface Notification {
   message: string;
   type: 'success' | 'error';
   closed: boolean;
+  createdAt: number;
 }
 
-export type NotificationMessage = Omit<Notification, 'id' | 'closed'>;
+export type NotificationMessage = Omit<
+  Notification,
+  'id' | 'closed' | 'createdAt'
+>;
 
 export interface NotificationsState {
   notifications: Notification[];
@@ -54,6 +58,7 @@ export const notificationsSlice = createSlice({
         type: action.payload.type,
         id: ++state.prevId,
         closed: false,
+        createdAt: Date.now(),
       });
     },
   },

--- a/tools/app/src/lib/swr.ts
+++ b/tools/app/src/lib/swr.ts
@@ -28,7 +28,15 @@ export class ApiCallError extends Error {
 export async function createApiCallError(
   response: Response,
 ): Promise<ApiCallError> {
-  return new ApiCallError(response, await response.text());
+  // If the response is a text, return the text as the reason
+  // Otherwise, it should be in json format, where the reason is the 'error' field
+  const text = await response.text();
+  try {
+    const json = JSON.parse(text);
+    return new ApiCallError(response, json.error);
+  } catch (e) {
+    return new ApiCallError(response, text);
+  }
 }
 
 async function handleResponse<T>(response: Response): Promise<T> {

--- a/tools/app/src/pages/card-view.tsx
+++ b/tools/app/src/pages/card-view.tsx
@@ -152,7 +152,7 @@ export default function Page() {
               } catch (error) {
                 dispatch(
                   addNotification({
-                    message: `Failed to handle link operation: ${error instanceof Error ? error.message : 'Unknown error'}`,
+                    message: error instanceof Error ? error.message : '',
                     type: 'error',
                   }),
                 );
@@ -172,7 +172,7 @@ export default function Page() {
               } catch (error) {
                 dispatch(
                   addNotification({
-                    message: `Failed to delete link: ${error instanceof Error ? error.message : 'Unknown error'}`,
+                    message: error instanceof Error ? error.message : '',
                     type: 'error',
                   }),
                 );

--- a/tools/app/src/pages/layout.tsx
+++ b/tools/app/src/pages/layout.tsx
@@ -145,11 +145,18 @@ function AppLayout({ children }: Readonly<{ children: ReactNode }>) {
           sx={{
             marginBottom: index * 9,
           }}
-          autoHideDuration={4000}
+          autoHideDuration={notification.type === 'error' ? 10000 : 4000}
           color={notification.type === 'error' ? 'danger' : 'success'}
           variant="solid"
           onClose={(_, reason) => {
-            if (reason === 'clickaway') return;
+            // If the notification has been closed by clicking away, and it has been less than 2 seconds, don't close it
+            if (
+              reason === 'clickaway' &&
+              notification.createdAt + 2000 >= Date.now()
+            ) {
+              return;
+            }
+
             dispatch(closeNotification(notification.id));
           }}
           onUnmount={() => {


### PR DESCRIPTION
Now for errors, autohide duration is 10 seconds. If you click anywhere(after at least 2 seconds), it will simply hide the error.

Also errors will be shown as is from DH