### PR TITLE
INTDEV-730 Resources have displayName and optional description

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -37,7 +37,7 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         brew install clingo --ignore-dependencies
-  
+
     - name: Install pnpm
       uses: pnpm/action-setup@v4
       with:

--- a/.github/workflows/test-pr-docker.yml
+++ b/.github/workflows/test-pr-docker.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
 
-      
+
 
 jobs:
   test-image:
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu-latest, ubuntu-24.04-arm]
         node-version: [22.x]
     runs-on: ${{ matrix.os }}
-    
+
     permissions:
       contents: read
 
@@ -26,7 +26,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           install: true
-          
+
       - name: Build and push multi-arch Docker image
         uses: docker/build-push-action@v6
         with:
@@ -72,10 +72,10 @@ jobs:
         run: |
           chmod +x scripts/cyberismo
           echo "$(pwd)/scripts" >> $GITHUB_PATH
-      
+
       - name: Run CLI tests
         run: |
           cd tools/cli
           pnpm test
 
-          
+

--- a/tools/app/__tests__/components.test.tsx
+++ b/tools/app/__tests__/components.test.tsx
@@ -107,6 +107,7 @@ const testProject: Project = {
   workflows: [
     {
       name: 'test/workflows/controlledDocument',
+      displayName: '',
       states: [
         {
           name: 'Draft',
@@ -146,6 +147,7 @@ const testProject: Project = {
     },
     {
       name: 'test/workflows/internalControl',
+      displayName: '',
       states: [
         {
           name: 'Open',
@@ -194,6 +196,7 @@ const testProject: Project = {
     },
     {
       name: 'test/workflows/simple',
+      displayName: '',
       states: [
         {
           name: 'Created',
@@ -212,6 +215,7 @@ const testProject: Project = {
   cardTypes: [
     {
       name: 'test/cardTypes/controlledDocument',
+      displayName: '',
       workflow: 'test/workflows/controlledDocument',
       customFields: [],
       alwaysVisibleFields: [],
@@ -219,6 +223,7 @@ const testProject: Project = {
     },
     {
       name: 'test/cardTypes/internalControl',
+      displayName: '',
       workflow: 'test/workflows/internalControl',
       customFields: [],
       alwaysVisibleFields: [],
@@ -226,6 +231,7 @@ const testProject: Project = {
     },
     {
       name: 'test/cardTypes/simplePage',
+      displayName: '',
       workflow: 'test/workflows/simple',
       customFields: [],
       alwaysVisibleFields: [],

--- a/tools/app/__tests__/utils.test.ts
+++ b/tools/app/__tests__/utils.test.ts
@@ -141,6 +141,7 @@ const testProject: Project = {
   workflows: [
     {
       name: 'test/workflows/controlledDocument',
+      displayName: '',
       states: [
         {
           name: 'Draft',
@@ -177,6 +178,7 @@ const testProject: Project = {
     },
     {
       name: 'test/workflows/internalControl',
+      displayName: '',
       states: [
         {
           name: 'Open',
@@ -221,6 +223,7 @@ const testProject: Project = {
     },
     {
       name: 'test/workflows/simple',
+      displayName: '',
       states: [
         {
           name: 'Created',
@@ -238,6 +241,7 @@ const testProject: Project = {
   cardTypes: [
     {
       name: 'test/cardTypes/controlledDocument',
+      displayName: '',
       workflow: 'test/workflows/controlledDocument',
       customFields: [],
       alwaysVisibleFields: [],
@@ -245,6 +249,7 @@ const testProject: Project = {
     },
     {
       name: 'test/cardTypes/internalControl',
+      displayName: '',
       workflow: 'test/workflows/internalControl',
       customFields: [],
       alwaysVisibleFields: [],
@@ -252,6 +257,7 @@ const testProject: Project = {
     },
     {
       name: 'test/cardTypes/simplePage',
+      displayName: '',
       workflow: 'test/workflows/simple',
       customFields: [],
       alwaysVisibleFields: [],
@@ -492,6 +498,7 @@ const treeQueryResult: QueryResult<'tree'>[] = [
 // Test data for link-related functions
 const mockExpandedLinkType: ExpandedLinkType = {
   name: 'testLink',
+  displayName: '',
   outboundDisplayName: 'Test Link Out',
   inboundDisplayName: 'Test Link In',
   enableLinkDescription: false,
@@ -766,6 +773,7 @@ describe('canCreateLinkToCard', () => {
   test('returns true if all conditions are met (linkable)', () => {
     const linkableLinkType: ExpandedLinkType = {
       name: 'testLink',
+      displayName: '',
       outboundDisplayName: 'Test Link Out',
       inboundDisplayName: 'Test Link In',
       enableLinkDescription: false,

--- a/tools/app/src/components/MetadataView.tsx
+++ b/tools/app/src/components/MetadataView.tsx
@@ -204,7 +204,7 @@ function MetadataView({
             dataType,
             enumValues,
             fieldDisplayName,
-            fieldDescription,
+            description,
             visibility,
             isCalculated,
             value,
@@ -223,7 +223,7 @@ function MetadataView({
                 .map((field) => field.fieldName)
                 .includes(key)}
               context={context}
-              description={fieldDescription}
+              description={description}
               editableFieldProps={{
                 dataType,
                 label: fieldDisplayName || key,

--- a/tools/assets/src/schema/resources/cardTypeSchema.json
+++ b/tools/assets/src/schema/resources/cardTypeSchema.json
@@ -11,6 +11,14 @@
       "minLength": 1,
       "pattern": "^[A-Za-z0-9]*/?[A-Za-z]*/?[A-Za-z-_]+[.json]*$"
     },
+    "description": {
+      "description": "A description that describes the card type",
+      "type": "string"
+    },
+    "displayName": {
+      "description": "A name by which the card type is referred to in the user interface",
+      "type": "string"
+    },
     "workflow": {
       "description": "The name of the workflow",
       "type": "string",
@@ -53,5 +61,5 @@
       }
     }
   },
-  "required": ["name", "workflow"]
+  "required": ["displayName", "name", "workflow"]
 }

--- a/tools/assets/src/schema/resources/fieldTypeSchema.json
+++ b/tools/assets/src/schema/resources/fieldTypeSchema.json
@@ -13,9 +13,9 @@
       "type": "string",
       "description": "A name by which the field is referred to in the user interface."
     },
-    "fieldDescription": {
+    "description": {
       "type": "string",
-      "description": ""
+      "description": "A description that describes the field type"
     },
     "dataType": {
       "type": "string",
@@ -43,5 +43,5 @@
       }
     }
   },
-  "required": ["name", "dataType"]
+  "required": ["displayName", "name", "dataType"]
 }

--- a/tools/assets/src/schema/resources/graphModelSchema.json
+++ b/tools/assets/src/schema/resources/graphModelSchema.json
@@ -23,6 +23,6 @@
       "type": "string"
     }
   },
-  "required": ["name", "displayName"],
+  "required": ["displayName", "name", "displayName"],
   "additionalProperties": false
 }

--- a/tools/assets/src/schema/resources/graphViewSchema.json
+++ b/tools/assets/src/schema/resources/graphViewSchema.json
@@ -23,6 +23,6 @@
       "type": "string"
     }
   },
-  "required": ["name", "displayName"],
+  "required": ["displayName", "name", "displayName"],
   "additionalProperties": false
 }

--- a/tools/assets/src/schema/resources/linkTypeSchema.json
+++ b/tools/assets/src/schema/resources/linkTypeSchema.json
@@ -5,6 +5,14 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "description": {
+      "description": "A description that describes the link type",
+      "type": "string"
+    },
+    "displayName": {
+      "description": "A name by which the link type is referred to in the user interface",
+      "type": "string"
+    },
     "name": {
       "type": "string",
       "description": "The technical name by which the field is referred to in JSON files."
@@ -37,6 +45,7 @@
     }
   },
   "required": [
+    "displayName",
     "name",
     "outboundDisplayName",
     "inboundDisplayName",

--- a/tools/assets/src/schema/resources/reportSchema.json
+++ b/tools/assets/src/schema/resources/reportSchema.json
@@ -23,6 +23,6 @@
       "type": "string"
     }
   },
-  "required": ["name", "displayName", "description", "category"],
+  "required": ["name", "displayName", "category"],
   "additionalProperties": false
 }

--- a/tools/assets/src/schema/resources/templateSchema.json
+++ b/tools/assets/src/schema/resources/templateSchema.json
@@ -24,5 +24,5 @@
       "type": "string"
     }
   },
-  "required": ["name"]
+  "required": ["displayName", "name"]
 }

--- a/tools/assets/src/schema/resources/workflowSchema.json
+++ b/tools/assets/src/schema/resources/workflowSchema.json
@@ -5,6 +5,14 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "description": {
+      "description": "A description that describes the workflow",
+      "type": "string"
+    },
+    "displayName": {
+      "description": "A name by which the workflow is referred to in the user interface",
+      "type": "string"
+    },
     "name": {
       "description": "The name of this workflow",
       "type": "string",
@@ -63,5 +71,5 @@
       }
     }
   },
-  "required": ["name", "states", "transitions"]
+  "required": ["displayName", "name", "states", "transitions"]
 }

--- a/tools/backend/test/api.test.ts
+++ b/tools/backend/test/api.test.ts
@@ -88,7 +88,7 @@ test('fieldTypes endpoint returns proper data', async () => {
   expect(result.length).toBe(9);
   expect(result[0].name).toBe('decision/fieldTypes/admins');
   expect(result[0].displayName).toBe('Administrators');
-  expect(result[0].fieldDescription).toBe('List of admin persons');
+  expect(result[0].description).toBe('List of admin persons');
   expect(result[0].dataType).toBe('list');
 });
 

--- a/tools/data-handler/src/interfaces/resource-interfaces.ts
+++ b/tools/data-handler/src/interfaces/resource-interfaces.ts
@@ -1,13 +1,14 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
-
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 import type { Schema } from 'jsonschema';
@@ -30,6 +31,7 @@ export interface CardType extends ResourceBaseMetadata {
 }
 
 // Custom field
+// todo: merge with FieldType.
 export interface CustomField {
   name: string;
   description?: string;
@@ -59,8 +61,6 @@ export interface EnumDefinition {
 
 // Field type content.
 export interface FieldType extends ResourceBaseMetadata {
-  displayName?: string;
-  fieldDescription?: string;
   dataType: DataType;
   enumValues?: Array<EnumDefinition>;
 }
@@ -68,8 +68,6 @@ export interface FieldType extends ResourceBaseMetadata {
 // Graph model content.
 export interface GraphModelMetadata extends ResourceBaseMetadata {
   category?: string;
-  description?: string;
-  displayName: string;
 }
 
 export interface GraphModel extends GraphModelMetadata {
@@ -79,8 +77,6 @@ export interface GraphModel extends GraphModelMetadata {
 // Graph view content.
 export interface GraphViewMetadata extends ResourceBaseMetadata {
   category?: string;
-  description?: string;
-  displayName: string;
 }
 
 export interface GraphView extends GraphViewMetadata {
@@ -104,7 +100,7 @@ export interface LinkType extends ResourceBaseMetadata {
 }
 
 // Report resource.
-export interface Report {
+export interface Report extends ResourceBaseMetadata {
   name: string;
   metadata: ReportMetadata;
   contentTemplate: string;
@@ -114,14 +110,14 @@ export interface Report {
 
 // Metadata for report
 export interface ReportMetadata extends ResourceBaseMetadata {
-  displayName: string;
-  description: string;
   category: string;
 }
 
 // Base interface for all resources.
 export interface ResourceBaseMetadata {
   name: string;
+  description?: string;
+  displayName: string;
   usedIn?: string[];
 }
 
@@ -137,8 +133,7 @@ export type ResourceContent =
   | Workflow;
 
 // Template configuration details.
-export interface TemplateConfiguration {
-  name: string;
+export interface TemplateConfiguration extends ResourceBaseMetadata {
   path: string;
   numberOfCards: number;
   metadata: TemplateMetadata;
@@ -146,8 +141,6 @@ export interface TemplateConfiguration {
 
 // Template configuration content details.
 export interface TemplateMetadata extends ResourceBaseMetadata {
-  displayName?: string;
-  description?: string;
   category?: string;
 }
 

--- a/tools/data-handler/src/resources/create-defaults.ts
+++ b/tools/data-handler/src/resources/create-defaults.ts
@@ -1,13 +1,14 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
-
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 import type { Card } from '../interfaces/project-interfaces.js';
@@ -78,6 +79,7 @@ export abstract class DefaultContent {
   static cardType(cardTypeName: string, workflowName: string): CardType {
     return {
       name: cardTypeName,
+      displayName: '',
       workflow: workflowName,
       customFields: [],
       alwaysVisibleFields: [],
@@ -94,6 +96,7 @@ export abstract class DefaultContent {
   static fieldType(fieldTypeName: string, dataType: DataType): FieldType {
     const value = {
       name: fieldTypeName,
+      displayName: '',
       dataType: dataType,
     } as FieldType;
     if (dataType === 'enum') {
@@ -111,7 +114,6 @@ export abstract class DefaultContent {
     return {
       name: graphModelName,
       displayName: '',
-      description: '',
     };
   }
 
@@ -124,7 +126,6 @@ export abstract class DefaultContent {
     return {
       name: graphViewName,
       displayName: '',
-      description: '',
     };
   }
 
@@ -149,6 +150,7 @@ export abstract class DefaultContent {
   static linkType(linkTypeName: string): LinkType {
     return {
       name: linkTypeName,
+      displayName: '',
       outboundDisplayName: linkTypeName,
       inboundDisplayName: linkTypeName,
       sourceCardTypes: [],
@@ -166,7 +168,6 @@ export abstract class DefaultContent {
     return {
       name: reportName,
       displayName: '',
-      description: '',
       category: 'Uncategorised report',
     };
   }
@@ -178,6 +179,7 @@ export abstract class DefaultContent {
   public static template(templateName: string): TemplateMetadata {
     return {
       name: templateName,
+      displayName: '',
     };
   }
 
@@ -189,6 +191,7 @@ export abstract class DefaultContent {
   public static workflow(workflowName: string): Workflow {
     return {
       name: workflowName,
+      displayName: '',
       states: [
         { name: 'Draft', category: WorkflowCategory.initial },
         { name: 'Approved', category: WorkflowCategory.closed },

--- a/tools/data-handler/src/resources/field-type-resource.ts
+++ b/tools/data-handler/src/resources/field-type-resource.ts
@@ -462,8 +462,8 @@ export class FieldTypeResource extends FileResource {
         key,
         content.enumValues as Type[],
       ) as EnumDefinition[];
-    } else if (key === 'fieldDescription') {
-      content.fieldDescription = super.handleScalar(op) as string;
+    } else if (key === 'description') {
+      content.description = super.handleScalar(op) as string;
     } else {
       throw new Error(`Unknown property '${key}' for FieldType`);
     }

--- a/tools/data-handler/src/resources/file-resource.ts
+++ b/tools/data-handler/src/resources/file-resource.ts
@@ -1,14 +1,13 @@
 /**
   Cyberismo
   Copyright © Cyberismo Ltd and contributors 2024
-
   This program is free software: you can redistribute it and/or modify it under
   the terms of the GNU Affero General Public License version 3 as published by
-  the Free Software Foundation. This program is distributed in the hope that it
-  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
-  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  See the GNU Affero General Public License for more details.
-  You should have received a copy of the GNU Affero General Public
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
@@ -72,7 +71,10 @@ export {
  */
 export class FileResource extends ResourceObject {
   public fileName: string = '';
-  protected content: ResourceBaseMetadata = { name: '' };
+  protected content: ResourceBaseMetadata = {
+    name: '',
+    displayName: '',
+  };
   private cache: Map<string, JSON>;
 
   constructor(
@@ -196,8 +198,11 @@ export class FileResource extends ResourceObject {
 
     let validContent = {} as ResourceContent;
     if (newContent) {
-      validContent = newContent as unknown as ResourceContent;
+      validContent = newContent;
       validContent.name = validName;
+    } else {
+      validContent.description = '';
+      validContent.displayName = '';
     }
 
     this.content = validContent;

--- a/tools/data-handler/src/resources/folder-resource.ts
+++ b/tools/data-handler/src/resources/folder-resource.ts
@@ -1,13 +1,14 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
-
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { basename, join } from 'node:path';
@@ -94,7 +95,7 @@ export class FolderResource extends FileResource {
    * @returns resource type's metadata.
    */
   protected async show(): Promise<ResourceContent> {
-    return super.show() as Promise<ResourceContent>;
+    return super.show();
   }
 
   /**

--- a/tools/data-handler/src/resources/report-resource.ts
+++ b/tools/data-handler/src/resources/report-resource.ts
@@ -1,14 +1,13 @@
 /**
   Cyberismo
   Copyright © Cyberismo Ltd and contributors 2024
-
   This program is free software: you can redistribute it and/or modify it under
   the terms of the GNU Affero General Public License version 3 as published by
-  the Free Software Foundation. This program is distributed in the hope that it
-  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
-  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  See the GNU Affero General Public License for more details.
-  You should have received a copy of the GNU Affero General Public
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
@@ -155,6 +154,8 @@ export class ReportResource extends FolderResource {
     const reportMetadata = (await super.show()) as ReportMetadata;
     return {
       name: resourceNameToString(this.resourceName),
+      displayName: reportMetadata.displayName,
+      description: reportMetadata.description,
       metadata: reportMetadata,
       contentTemplate: (
         await readFile(join(this.internalFolder, CARD_CONTENT_HANDLEBAR_FILE))

--- a/tools/data-handler/src/resources/template-resource.ts
+++ b/tools/data-handler/src/resources/template-resource.ts
@@ -1,14 +1,13 @@
 /**
   Cyberismo
   Copyright © Cyberismo Ltd and contributors 2024
-
   This program is free software: you can redistribute it and/or modify it under
   the terms of the GNU Affero General Public License version 3 as published by
-  the Free Software Foundation. This program is distributed in the hope that it
-  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
-  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  See the GNU Affero General Public License for more details.
-  You should have received a copy of the GNU Affero General Public
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
@@ -120,6 +119,8 @@ export class TemplateResource extends FolderResource {
     return {
       metadata: templateMetadata,
       name: resourceNameToString(this.resourceName),
+      displayName: templateMetadata.displayName,
+      description: templateMetadata.description,
       path: this.fileName,
       numberOfCards: (await container.listCards()).length,
     };

--- a/tools/data-handler/src/types/queries.ts
+++ b/tools/data-handler/src/types/queries.ts
@@ -1,13 +1,14 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
-
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 /**
@@ -134,7 +135,7 @@ interface CardQueryField extends BaseResult {
   visibility: 'always' | 'optional';
   index: number;
   fieldDisplayName: string;
-  fieldDescription: string;
+  description: string;
   dataType: DataType;
   isCalculated: boolean;
   value: string | number | boolean | null | EnumValue | ListValueItem[];

--- a/tools/data-handler/src/utils/clingo-facts.ts
+++ b/tools/data-handler/src/utils/clingo-facts.ts
@@ -1,13 +1,14 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
-
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 import { sep } from 'node:path';
 
@@ -270,12 +271,12 @@ export const createFieldTypeFacts = (fieldType: FieldType) => {
       fieldType.displayName,
     );
 
-  if (fieldType.fieldDescription)
+  if (fieldType.description)
     builder.addFact(
       Facts.Common.FIELD,
       fieldType.name,
-      'fieldDescription',
-      fieldType.fieldDescription,
+      'description',
+      fieldType.description,
     );
 
   builder.addFact(

--- a/tools/data-handler/test/command-handler-create.test.ts
+++ b/tools/data-handler/test/command-handler-create.test.ts
@@ -856,6 +856,7 @@ describe('create command', () => {
     const content = `
         {
           "name": "${workflowName}",
+          "displayName": "",
           "states": [
               { "name": "Open", "category": "initial" },
               { "name": "In Progress", "category": "active" },
@@ -970,9 +971,8 @@ describe('create command', () => {
   });
   it('access default parameters for template (success)', () => {
     const defaultContent = DefaultContent.template('testName');
-    expect(defaultContent.displayName).to.equal(undefined);
+    expect(defaultContent.displayName).to.equal('');
     expect(defaultContent.category).to.equal(undefined);
-    expect(defaultContent.description).to.equal(undefined);
   });
   it('access default parameters for workflow (success)', () => {
     const defaultContent = DefaultContent.workflow('test');

--- a/tools/data-handler/test/resources.test.ts
+++ b/tools/data-handler/test/resources.test.ts
@@ -458,6 +458,7 @@ describe('resources', function () {
       expect(found).to.equal(undefined);
       const linkTypeData = {
         name: name,
+        displayName: name,
         inboundDisplayName: 'in',
         outboundDisplayName: 'out',
         destinationCardTypes: ['decision/cardTypes/decision'],
@@ -479,6 +480,7 @@ describe('resources', function () {
         // missing mandatory value 'enableLinkDescription'
         // note that interface should be such that property is mandatory.
         name: name,
+        displayName: name,
         inboundDisplayName: 'in',
         outboundDisplayName: 'out',
         destinationCardTypes: ['decision/cardTypes/decision'],
@@ -590,6 +592,7 @@ describe('resources', function () {
       expect(found).to.equal(undefined);
       const workflowData = {
         name: name,
+        displayName: name,
         states: [],
         transitions: [],
       } as Workflow;
@@ -920,6 +923,7 @@ describe('resources', function () {
       expect(JSON.stringify(res.data)).to.equal(
         JSON.stringify({
           name: 'decision/cardTypes/newCT',
+          displayName: '',
           workflow: 'decision/workflows/decision',
           customFields: [],
           alwaysVisibleFields: [],
@@ -935,6 +939,7 @@ describe('resources', function () {
       expect(JSON.stringify(res.data)).to.equal(
         JSON.stringify({
           name: 'decision/fieldTypes/newFT',
+          displayName: '',
           dataType: 'shortText',
         }),
       );
@@ -948,7 +953,6 @@ describe('resources', function () {
         JSON.stringify({
           name: 'decision/graphModels/newGM',
           displayName: '',
-          description: '',
         }),
       );
     });
@@ -961,7 +965,6 @@ describe('resources', function () {
         JSON.stringify({
           name: 'decision/graphViews/newGV',
           displayName: '',
-          description: '',
         }),
       );
     });
@@ -973,6 +976,7 @@ describe('resources', function () {
       expect(JSON.stringify(res.data)).to.equal(
         JSON.stringify({
           name: 'decision/linkTypes/newLT',
+          displayName: '',
           outboundDisplayName: 'decision/linkTypes/newLT',
           inboundDisplayName: 'decision/linkTypes/newLT',
           sourceCardTypes: [],
@@ -990,7 +994,6 @@ describe('resources', function () {
         JSON.stringify({
           name: 'decision/reports/newREP',
           displayName: '',
-          description: '',
           category: 'Uncategorised report',
         }),
       );
@@ -1003,6 +1006,7 @@ describe('resources', function () {
       expect(JSON.stringify(res.data)).to.equal(
         JSON.stringify({
           name: 'decision/templates/newTEMP',
+          displayName: '',
         }),
       );
     });
@@ -1014,6 +1018,7 @@ describe('resources', function () {
       expect(JSON.stringify(res.data)).to.equal(
         JSON.stringify({
           name: 'decision/workflows/newWF',
+          displayName: '',
           states: [
             { name: 'Draft', category: 'initial' },
             { name: 'Approved', category: 'closed' },
@@ -1037,6 +1042,7 @@ describe('resources', function () {
       expect(JSON.stringify(data)).to.equal(
         JSON.stringify({
           name: 'decision/cardTypes/newCT',
+          displayName: '',
           workflow: 'decision/workflows/decision',
           customFields: [],
           alwaysVisibleFields: [],
@@ -1053,6 +1059,7 @@ describe('resources', function () {
       expect(JSON.stringify(data)).to.equal(
         JSON.stringify({
           name: 'decision/fieldTypes/newFT',
+          displayName: '',
           dataType: 'shortText',
         }),
       );
@@ -1067,7 +1074,6 @@ describe('resources', function () {
         JSON.stringify({
           name: 'decision/graphModels/newGM',
           displayName: '',
-          description: '',
           calculationFile: 'model.lp',
         }),
       );
@@ -1082,7 +1088,6 @@ describe('resources', function () {
         JSON.stringify({
           name: 'decision/graphViews/newGV',
           displayName: '',
-          description: '',
           handleBarFile: 'view.lp.hbs',
         }),
       );
@@ -1096,6 +1101,7 @@ describe('resources', function () {
       expect(JSON.stringify(data)).to.equal(
         JSON.stringify({
           name: 'decision/linkTypes/newLT',
+          displayName: '',
           outboundDisplayName: 'decision/linkTypes/newLT',
           inboundDisplayName: 'decision/linkTypes/newLT',
           sourceCardTypes: [],
@@ -1115,10 +1121,10 @@ describe('resources', function () {
       expect(JSON.stringify(others)).to.equal(
         JSON.stringify({
           name: 'decision/reports/newREP',
+          displayName: '',
           metadata: {
             name: 'decision/reports/newREP',
             displayName: '',
-            description: '',
             category: 'Uncategorised report',
           },
           schema: {
@@ -1164,10 +1170,10 @@ describe('resources', function () {
       expect(JSON.stringify(others)).to.equal(
         JSON.stringify({
           name: 'decision/reports/newREP',
+          displayName: '',
           metadata: {
             name: 'decision/reports/newREP',
             displayName: '',
-            description: '',
             category: 'Uncategorised report',
           },
           schema: {
@@ -1201,8 +1207,12 @@ describe('resources', function () {
       const { path, ...others } = data;
       expect(JSON.stringify(others)).to.equal(
         JSON.stringify({
-          metadata: { name: 'decision/templates/newTEMP' },
+          metadata: {
+            name: 'decision/templates/newTEMP',
+            displayName: '',
+          },
           name: 'decision/templates/newTEMP',
+          displayName: '',
           numberOfCards: 0,
         }),
       );
@@ -1216,6 +1226,7 @@ describe('resources', function () {
       expect(JSON.stringify(data)).to.equal(
         JSON.stringify({
           name: 'decision/workflows/newWF',
+          displayName: '',
           states: [
             { name: 'Draft', category: 'initial' },
             { name: 'Approved', category: 'closed' },
@@ -1840,7 +1851,7 @@ describe('resources', function () {
         expect(false).equals(true);
       }
     });
-    it('update field type - change displayName and fieldDescription', async () => {
+    it('update field type - change displayName and description', async () => {
       const res = new FieldTypeResource(
         project,
         resourceName('decision/fieldTypes/dateFieldType'),
@@ -1850,15 +1861,13 @@ describe('resources', function () {
         target: '',
         to: 'Field for dates',
       });
-      await res.update('fieldDescription', {
+      await res.update('description', {
         name: 'change',
         target: '',
         to: 'Field description',
       });
       expect((res.data as FieldType).displayName).to.equal('Field for dates');
-      expect((res.data as FieldType).fieldDescription).to.equal(
-        'Field description',
-      );
+      expect((res.data as FieldType).description).to.equal('Field description');
     });
     it('update field type - change enumValues', async () => {
       const res = new FieldTypeResource(

--- a/tools/data-handler/test/test-data/invalid/invalid-wrong-resource-names/.cards/local/cardTypes/decision.json
+++ b/tools/data-handler/test/test-data/invalid/invalid-wrong-resource-names/.cards/local/cardTypes/decision.json
@@ -1,5 +1,6 @@
 {
     "name": "wrong/cardTypesWrong/decisionWrong",
+    "displayName": "",
     "workflow": "decision/workflows/decision",
     "customFields": [
     ]

--- a/tools/data-handler/test/test-data/invalid/invalid-wrong-resource-names/.cards/local/templates/decision.json
+++ b/tools/data-handler/test/test-data/invalid/invalid-wrong-resource-names/.cards/local/templates/decision.json
@@ -1,3 +1,4 @@
 {
-    "name": "wrong/templates/decision"
+    "name": "wrong/templates/decision",
+    "displayName": ""
 }

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/cardTypes/decision.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/cardTypes/decision.json
@@ -1,5 +1,6 @@
 {
     "name": "decision/cardTypes/decision",
+    "displayName": "Decision card type",
     "workflow": "decision/workflows/decision",
     "customFields": [
         {

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/cardTypes/simplepage.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/cardTypes/simplepage.json
@@ -1,4 +1,5 @@
 {
     "name": "decision/cardTypes/simplepage",
+    "displayName": "Simple card type",
     "workflow": "decision/workflows/simple"
 }

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldTypes/admins.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldTypes/admins.json
@@ -1,6 +1,6 @@
 {
     "name": "decision/fieldTypes/admins",
     "displayName": "Administrators",
-    "fieldDescription": "List of admin persons",
+    "description": "List of admin persons",
     "dataType": "list"
 }

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldTypes/commitDescription.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldTypes/commitDescription.json
@@ -1,6 +1,6 @@
 {
     "name": "decision/fieldTypes/commitDescription",
     "displayName": "Commit Description",
-    "fieldDescription": "In long format describe how source code was changed",
+    "description": "In long format describe how source code was changed",
     "dataType": "longText"
 }

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldTypes/finished.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldTypes/finished.json
@@ -1,6 +1,6 @@
 {
     "name": "decision/fieldTypes/finished",
     "displayName": "Finished",
-    "fieldDescription": "True, if the task is ready; false otherwise",
+    "description": "True, if the task is ready; false otherwise",
     "dataType": "boolean"
 }

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldTypes/lastChangedDate.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldTypes/lastChangedDate.json
@@ -1,6 +1,6 @@
 {
     "name": "decision/fieldTypes/lastChangedDate",
     "displayName": "Last changed date",
-    "fieldDescription": "Date when the task was last updated",
+    "description": "Date when the task was last updated",
     "dataType": "date"
 }

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldTypes/lastChangedTimestamp.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldTypes/lastChangedTimestamp.json
@@ -1,6 +1,6 @@
 {
     "name": "decision/fieldTypes/lastChangedTimestamp",
     "displayName": "Last changed timestamp",
-    "fieldDescription": "Date and time when the task was last time updated",
+    "description": "Date and time when the task was last time updated",
     "dataType": "dateTime"
 }

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldTypes/numberOfCommits.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldTypes/numberOfCommits.json
@@ -1,6 +1,6 @@
 {
     "name": "decision/fieldTypes/numberOfCommits",
     "displayName": "Number of commits",
-    "fieldDescription": "How many commits have been done related to this task",
+    "description": "How many commits have been done related to this task",
     "dataType": "number"
 }

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldTypes/obsoletedBy.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldTypes/obsoletedBy.json
@@ -1,6 +1,6 @@
 {
     "name": "decision/fieldTypes/obsoletedBy",
     "displayName": "Obsoleted by (from field type)",
-    "fieldDescription": "Card is obsolete (from field type)",
+    "description": "Card is obsolete (from field type)",
     "dataType": "shortText"
 }

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldTypes/percentageReady.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldTypes/percentageReady.json
@@ -1,6 +1,6 @@
 {
     "name": "decision/fieldTypes/percentageReady",
     "displayName": "Percentage ready",
-    "fieldDescription": "How complete (in %) the task is",
+    "description": "How complete (in %) the task is",
     "dataType": "number"
 }

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldTypes/responsible.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/fieldTypes/responsible.json
@@ -1,6 +1,6 @@
 {
     "name": "decision/fieldTypes/responsible",
     "displayName": "Responsible",
-    "fieldDescription": "Who is responsible for the task",
+    "description": "Who is responsible for the task",
     "dataType": "person"
 }

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/linkTypes/test.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/linkTypes/test.json
@@ -1,5 +1,6 @@
 {
     "name": "decision/linkTypes/test",
+    "displayName": "Text link type",
     "outboundDisplayName": "test",
     "inboundDisplayName": "test",
     "sourceCardTypes": [],

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/linkTypes/testTypes.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/linkTypes/testTypes.json
@@ -1,5 +1,6 @@
 {
     "name": "decision/linkTypes/testTypes",
+    "displayName": "Another link type test",
     "outboundDisplayName": "test",
     "inboundDisplayName": "test",
     "sourceCardTypes": ["decision/cardTypes/decision"],

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/templates/empty.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/templates/empty.json
@@ -1,3 +1,4 @@
 {
-  "name": "decision/templates/empty"
+  "name": "decision/templates/empty",
+  "displayName": "Empty page"
 }

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/templates/simplepage.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/templates/simplepage.json
@@ -1,3 +1,4 @@
 {
-  "name": "decision/templates/simplepage"
+  "name": "decision/templates/simplepage",
+  "displayName": "Simple page template"
 }

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/workflows/decision.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/workflows/decision.json
@@ -1,5 +1,6 @@
 {
     "name": "decision/workflows/decision",
+    "displayName": "Decision based workflow",
     "states": [
         { "name": "Draft", "category": "initial" },
         { "name": "Approved", "category": "closed" },

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/workflows/simple.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/workflows/simple.json
@@ -1,5 +1,6 @@
 {
     "name": "decision/workflows/simple",
+    "displayName": "Simple workflow",
     "states": [
         { "name": "Created", "category": "initial" },
         { "name": "Approved", "category": "closed" },

--- a/tools/data-handler/test/test-data/valid/minimal/.cards/local/cardTypes/myCardtype.json
+++ b/tools/data-handler/test/test-data/valid/minimal/.cards/local/cardTypes/myCardtype.json
@@ -1,4 +1,5 @@
 {
   "name": "mini/cardTypes/myCardtype",
+  "displayName": "Test card type",
   "workflow": "mini/workflows/minimal"
 }

--- a/tools/data-handler/test/test-data/valid/minimal/.cards/local/templates/test-template.json
+++ b/tools/data-handler/test/test-data/valid/minimal/.cards/local/templates/test-template.json
@@ -1,3 +1,4 @@
 {
-  "name": "mini/templates/test-template"
+  "name": "mini/templates/test-template",
+  "displayName": "Test template"
 }

--- a/tools/data-handler/test/test-data/valid/minimal/.cards/local/workflows/default.json
+++ b/tools/data-handler/test/test-data/valid/minimal/.cards/local/workflows/default.json
@@ -1,5 +1,6 @@
 {
     "name":"mini/workflows/default",
+    "displayName": "Default workflow",
     "states":[
         { "name": "Open", "category": "initial" },
         { "name": "In Progress", "category": "active" },

--- a/tools/data-handler/test/test-data/valid/minimal/.cards/local/workflows/minimal.json
+++ b/tools/data-handler/test/test-data/valid/minimal/.cards/local/workflows/minimal.json
@@ -1,5 +1,6 @@
 {
     "name": "mini/workflows/minimal",
+    "displayName": "Minimal workflow",
     "states": [ { "name": "Created", "category": "initial" } ],
     "transitions": [
         {


### PR DESCRIPTION
Change schemas and implementations so that each resource type have `displayName` and `description`. 
The changes are highlighted in the JIRA issue.

CLI test is temporarily using feature for the tests until PR for the `module-base` related to this change has been merged.
Each content repo needs to have a data structure changes. These will be done in separate PRs for each repository.

There is a migrator application available, if somebody needs to upgrade repositories that we cannot access.
[migrate_resources_display_name_and_description.zip](https://github.com/user-attachments/files/20367388/migrate_resources_display_name_and_description.zip)

This PR will build correctly after https://github.com/CyberismoCom/module-base/pull/19 has been merged.
