### PR TITLE
INTDEV-579 Allow renaming or removing workflow states with update

### DIFF
--- a/tools/data-handler/src/resources/array-handler.ts
+++ b/tools/data-handler/src/resources/array-handler.ts
@@ -83,15 +83,20 @@ export class ArrayHandler<T> {
     if (targetIndex === -1) {
       throw new Error(`Item '${JSON.stringify(target)}' not found`);
     }
+    const actualTarget = array[targetIndex];
     const parsedTo = this.tryParseJSON(to);
 
     if (typeof to === 'string' && (to.startsWith('[') || to.startsWith('{'))) {
       return parsedTo as T[];
     }
 
-    return array.map((item) =>
-      deepCompare(item as object, target as object) ? parsedTo : item,
+    const updatedArray = array.map((item) =>
+      deepCompare(item as object, actualTarget as object) ? parsedTo : item,
     );
+    if (deepCompare(updatedArray, array)) {
+      throw new Error('Cannot change value. Target was not found.');
+    }
+    return updatedArray;
   }
 
   private handleRank(operation: RankOperation<T>, array: T[]): T[] {

--- a/tools/data-handler/src/resources/field-type-resource.ts
+++ b/tools/data-handler/src/resources/field-type-resource.ts
@@ -71,21 +71,6 @@ export class FieldTypeResource extends FileResource {
       .map((card) => card.key);
   }
 
-  // Collects affected cards.
-  private async collectCards(cardContent: object, cardTypeName: string) {
-    async function filteredCards(
-      cardSource: Promise<Card[]>,
-      cardTypeName: string,
-    ): Promise<Card[]> {
-      const cards = await cardSource;
-      return cards.filter((card) => card.metadata?.cardType === cardTypeName);
-    }
-    return filteredCards(
-      this.project.cards(this.project.paths.cardRootFolder, cardContent),
-      cardTypeName,
-    );
-  }
-
   // Converts values.
   // The allowed conversions are:
   // - shortText/longText --> person, if valid email


### PR DESCRIPTION
This change enables operations like: 

State rename:
`cyberismo update cisms/workflows/page change states "{\"name\": \"Approved\", \"category\":\"closed\"}" "{\"name\": \"ApprovedNew\", \"category\":\"closed\"}"` 
--> Renames 'Approved' state to 'ApprovedNew' and updates all cards using the state.

State removal: 
`cyberismo update cisms/workflows/page remove states "Approved"`
--> Removes 'Approved' state. Cards using the state are not updated, as there is no replacement value given. It is assumed that the user knows what he/she is doing. User needs to update cards him/herself with valid value(s).

or with replacement value: 
`cyberismo update cisms/workflows/page remove states "Approved" "{\"name\": \"Deprecated\", \"category\": \"closed\"}"`
--> Removes 'Approved' state and replaces workflow state value in cards from 'Approved' to 'Deprecated'

Using the escaped JSON is a bit clumsy, but CLI use case is not very important. 
Programmatically the last operation is for example:
```
      const op = {
        name: 'change',
        target: { name: 'Approved', category: 'closed' },
        to: { name: 'Deprecated', category: 'closed' },
      } as RemoveOperation<WorkflowState>;
      workflow.update('states', op);
```

