### PR TITLE
INTDEV-857 Resolve module path to the project settings

### DIFF
--- a/tools/data-handler/src/project-settings.ts
+++ b/tools/data-handler/src/project-settings.ts
@@ -13,6 +13,8 @@
 
 import { writeJsonFile as atomicWrite } from 'write-json-file';
 
+import { resolve } from 'path';
+
 import type {
   ModuleSetting,
   ProjectSettings,
@@ -102,6 +104,11 @@ export class ProjectConfiguration implements ProjectSettings {
     const exists = this.modules.find((item) => item.name === module.name);
     if (exists) {
       throw new Error(`Module '${module.name}' already imported`);
+    }
+    // Ensure that module file location is absolute
+    if (module.location && module.location.startsWith('file:')) {
+      const filePath = module.location.substring(5, module.location.length);
+      module.location = `file:${resolve(filePath)}`;
     }
     this.modules.push(module);
     return this.save();

--- a/tools/data-handler/test/command-handler-import.test.ts
+++ b/tools/data-handler/test/command-handler-import.test.ts
@@ -155,6 +155,10 @@ describe('import module', () => {
       );
       expect(result.statusCode).to.equal(200);
 
+      // Ensure that module can be updated.
+      result = await commandHandler.command(Cmd.updateModules, [], optionsMini);
+      expect(result.statusCode).to.equal(200);
+
       // Remove the module so that it won't affect other tests
       await commandHandler.command(
         Cmd.remove,
@@ -180,6 +184,12 @@ describe('import module', () => {
           result = await commandHandler.command(
             Cmd.import,
             ['module', minimalPath],
+            testOptions,
+          );
+          expect(result.statusCode).to.equal(200);
+          result = await commandHandler.command(
+            Cmd.updateModules,
+            [],
             testOptions,
           );
           expect(result.statusCode).to.equal(200);


### PR DESCRIPTION
When module was imported from local filesystem and was using relative path, the actual path in the original import command was stored to be module location. 

E.g. calling from `/user/home` with command: `cyberismo import module ./module-own` would have stored module `location` to be `./module-own`. This would then have failed all module related commands (e.g. `update-modules`) when they are run from any other directory. 

Modified the import unit tests to run `update-modules` after tests have performed import command. 