### PR TITLE
Do not lint coverage test results

### DIFF
--- a/tools/app/eslint.config.mjs
+++ b/tools/app/eslint.config.mjs
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint';
 import eslintConfigPrettier from 'eslint-config-prettier';
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  { ignores: ['dist', 'coverage'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],


### PR DESCRIPTION
Linting through coverage test results causes unwanted lint warnings:

<img width="1013" alt="Screenshot 2025-06-02 at 10 26 41" src="https://github.com/user-attachments/assets/baa753d4-f087-4d91-8e22-c5824e39c428" />

