### PR TITLE
INTDEV-868 Avoid creating a new instance of Project in macros

### DIFF
--- a/tools/backend/src/routes/cards.ts
+++ b/tools/backend/src/routes/cards.ts
@@ -101,7 +101,7 @@ async function getCardDetails(
       cardDetailsResponse.content || '',
       {
         mode: 'inject',
-        projectPath: commands.project.basePath || '',
+        project: commands.project,
         cardKey: key,
       },
       commands.calculateCmd,
@@ -571,7 +571,7 @@ router.post('/:key/parse', async (c) => {
         content,
         {
           mode: 'inject',
-          projectPath: commands.project.basePath || '',
+          project: commands.project,
           cardKey: key,
         },
         commands.calculateCmd,

--- a/tools/data-handler/src/commands/export.ts
+++ b/tools/data-handler/src/commands/export.ts
@@ -196,14 +196,14 @@ export class Export {
     );
 
     let asciiDocContent = '';
-    const projectPath = this.project.basePath;
+    const project = this.project;
     try {
       const { evaluateMacros } = await import('../macros/index.js');
       asciiDocContent = await evaluateMacros(
         cardDetailsResponse.content || '',
         {
           mode: 'static',
-          projectPath,
+          project,
           cardKey: card.key,
         },
         this.calculateCmd,

--- a/tools/data-handler/src/commands/show.ts
+++ b/tools/data-handler/src/commands/show.ts
@@ -358,7 +358,7 @@ export class Show {
     const reportMacro = new ReportMacro(new TaskQueue(), this.calculate);
     const result = await reportMacro.handleInject(
       {
-        projectPath: this.project.basePath,
+        project: this.project,
         cardKey: cardKey,
         mode: 'static',
       },

--- a/tools/data-handler/src/commands/validate.ts
+++ b/tools/data-handler/src/commands/validate.ts
@@ -595,7 +595,7 @@ export class Validate {
               card.content,
               {
                 mode: 'validate',
-                projectPath,
+                project,
                 cardKey: card.key,
               },
               calculate,

--- a/tools/data-handler/src/interfaces/macros.ts
+++ b/tools/data-handler/src/interfaces/macros.ts
@@ -11,11 +11,12 @@
 */
 
 import type { macroMetadata } from '../macros/common.js';
+import type { Project } from '../containers/project.js';
 
 type Mode = 'validate' | 'static' | 'inject';
 
 export interface MacroGenerationContext {
-  projectPath: string;
+  project: Project;
   mode: Mode;
   cardKey: string;
 }

--- a/tools/data-handler/src/macros/graph/index.ts
+++ b/tools/data-handler/src/macros/graph/index.ts
@@ -1,7 +1,6 @@
 /**
   Cyberismo
   Copyright © Cyberismo Ltd and contributors 2024
-
   This program is free software: you can redistribute it and/or modify it under
   the terms of the GNU Affero General Public License version 3 as published by
   the Free Software Foundation. This program is distributed in the hope that it
@@ -22,7 +21,6 @@ import { logger } from '../../utils/log-utils.js';
 import type { MacroGenerationContext } from '../../interfaces/macros.js';
 import macroMetadata from './metadata.js';
 import { pathExists } from '../../utils/file-utils.js';
-import { Project } from '../../containers/project.js';
 import { readFile } from 'node:fs/promises';
 import { resourceName } from '../../utils/resource-utils.js';
 import type { Schema } from 'jsonschema';
@@ -48,16 +46,20 @@ class ReportMacro extends BaseMacro {
   };
 
   handleInject = async (context: MacroGenerationContext, input: unknown) => {
-    const project = new Project(context.projectPath);
-    const calculate = new Calculate(project);
+    const calculate = new Calculate(context.project);
 
     const resourceNameToPath = (name: string, fileName: string) => {
       const { identifier, prefix, type } = resourceName(name);
-      if (prefix === project.projectPrefix) {
-        return join(project.paths.resourcesFolder, type, identifier, fileName);
+      if (prefix === context.project.projectPrefix) {
+        return join(
+          context.project.paths.resourcesFolder,
+          type,
+          identifier,
+          fileName,
+        );
       }
       return join(
-        project.paths.modulesFolder,
+        context.project.paths.modulesFolder,
         prefix,
         type,
         identifier,

--- a/tools/data-handler/src/macros/report/index.ts
+++ b/tools/data-handler/src/macros/report/index.ts
@@ -1,13 +1,14 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
-
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { validateMacroContent } from '../index.js';
@@ -15,7 +16,6 @@ import type { MacroOptions } from '../index.js';
 
 import type { MacroGenerationContext } from '../../interfaces/macros.js';
 import macroMetadata from './metadata.js';
-import { Project } from '../../containers/project.js';
 import type { Calculate } from '../../commands/index.js';
 import BaseMacro from '../base-macro.js';
 import { validateJson } from '../../utils/validate.js';
@@ -45,8 +45,10 @@ class ReportMacro extends BaseMacro {
 
   handleInject = async (context: MacroGenerationContext, data: unknown) => {
     const options = this.validate(data);
-    const project = new Project(context.projectPath);
-    const resource = new ReportResource(project, resourceName(options.name));
+    const resource = new ReportResource(
+      context.project,
+      resourceName(options.name),
+    );
     const report = await resource.show();
 
     if (!report) throw new Error(`Report ${options.name} does not exist`);


### PR DESCRIPTION
Instead of creating the `Project` in each macro instance, pass the existing `Project` to macros. 

(This could have been also fixed by adding prefix to the context and creating a `ProjectPaths` class in macros; as paths and prefix are the only things that macros use from `Project`)