### PR TITLE
INTDEV-859 Move logs under project

### DIFF
--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -12,7 +12,7 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Argument, Command } from 'commander';
+import { Argument, Command, Option } from 'commander';
 import confirm from '@inquirer/confirm';
 import {
   type CardsOptions,
@@ -172,7 +172,12 @@ const additionalHelpForRemove = `Sub-command help:
 program
   .name('cyberismo')
   .description(packageDef.description)
-  .version(packageDef.version);
+  .version(packageDef.version)
+  .addOption(
+    new Option('-L, --log-level <level>', 'Set the log level')
+      .choices(['trace', 'debug', 'info', 'warn', 'error', 'fatal'])
+      .default('fatal'),
+  );
 
 // Add card to a template
 program
@@ -199,7 +204,7 @@ program
       const result = await commandHandler.command(
         Cmd.add,
         [template, cardType, cardKey],
-        options,
+        Object.assign({}, options, program.opts()),
       );
       handleResponse(result);
     },
@@ -229,7 +234,7 @@ calculate
     const result = await commandHandler.command(
       Cmd.calc,
       ['run', filePath],
-      options,
+      Object.assign({}, options, program.opts()),
     );
     handleResponse(result);
   });
@@ -334,7 +339,7 @@ program
       const result = await commandHandler.command(
         Cmd.create,
         [type, target, parameter1, parameter2, parameter3],
-        options,
+        Object.assign({}, options, program.opts()),
       );
       handleResponse(result);
     },
@@ -347,7 +352,11 @@ program
   .argument('<cardKey>', 'Card key of card')
   .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (cardKey: string, options: CardsOptions) => {
-    const result = await commandHandler.command(Cmd.edit, [cardKey], options);
+    const result = await commandHandler.command(
+      Cmd.edit,
+      [cardKey],
+      Object.assign({}, options, program.opts()),
+    );
     handleResponse(result);
   });
 
@@ -376,7 +385,7 @@ program
       const result = await commandHandler.command(
         Cmd.export,
         [format, output, cardKey],
-        options,
+        Object.assign({}, options, program.opts()),
       );
       handleResponse(result);
     },
@@ -407,7 +416,7 @@ importCmd
       const result = await commandHandler.command(
         Cmd.import,
         ['module', source, branch, String(useCredentials)],
-        options,
+        Object.assign({}, options, program.opts()),
       );
       handleResponse(result);
     },
@@ -427,7 +436,7 @@ importCmd
     const result = await commandHandler.command(
       Cmd.import,
       ['csv', csvFile, cardKey],
-      options,
+      Object.assign({}, options, program.opts()),
     );
     handleResponse(result);
   });
@@ -449,7 +458,7 @@ program
       const result = await commandHandler.command(
         Cmd.move,
         [source, destination],
-        options,
+        Object.assign({}, options, program.opts()),
       );
       handleResponse(result);
     },
@@ -473,7 +482,7 @@ rank
       const result = await commandHandler.command(
         Cmd.rank,
         ['card', cardKey, afterCardKey],
-        options,
+        Object.assign({}, options, program.opts()),
       );
       handleResponse(result);
     },
@@ -493,7 +502,7 @@ rank
     const result = await commandHandler.command(
       Cmd.rank,
       ['rebalance', cardKey],
-      options,
+      Object.assign({}, options, program.opts()),
     );
     handleResponse(result);
   });
@@ -555,7 +564,7 @@ program
         const result = await commandHandler.command(
           Cmd.remove,
           [type, parameter1, parameter2, parameter3],
-          options,
+          Object.assign({}, options, program.opts()),
         );
         handleResponse(result);
       }
@@ -571,7 +580,11 @@ program
   .argument('<to>', 'New project prefix')
   .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (to: string, options: CardsOptions) => {
-    const result = await commandHandler.command(Cmd.rename, [to], options);
+    const result = await commandHandler.command(
+      Cmd.rename,
+      [to],
+      Object.assign({}, options, program.opts()),
+    );
     handleResponse(result);
   });
 
@@ -592,7 +605,7 @@ program
     const result = await commandHandler.command(
       Cmd.report,
       [parameters, output],
-      options,
+      Object.assign({}, options, program.opts()),
     );
     handleResponse(result);
   });
@@ -624,7 +637,7 @@ program
       const result = await commandHandler.command(
         Cmd.show,
         [type, typeDetail],
-        options,
+        Object.assign({}, options, program.opts()),
       );
       handleResponse(result);
     }
@@ -645,7 +658,7 @@ program
       const result = await commandHandler.command(
         Cmd.transition,
         [cardKey, transition],
-        options,
+        Object.assign({}, options, program.opts()),
       );
       handleResponse(result);
     },
@@ -678,7 +691,7 @@ program
       const result = await commandHandler.command(
         Cmd.update,
         [resourceName, key, operation, value, newValue],
-        options,
+        Object.assign({}, options, program.opts()),
       );
       handleResponse(result);
     },
@@ -690,7 +703,11 @@ program
   .description('Updates all imported modules with latest versions')
   .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (options: CardsOptions) => {
-    const result = await commandHandler.command(Cmd.updateModules, [], options);
+    const result = await commandHandler.command(
+      Cmd.updateModules,
+      [],
+      Object.assign({}, options, program.opts()),
+    );
     handleResponse(result);
   });
 
@@ -700,7 +717,11 @@ program
   .description('Validate project structure')
   .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (options: CardsOptions) => {
-    const result = await commandHandler.command(Cmd.validate, [], options);
+    const result = await commandHandler.command(
+      Cmd.validate,
+      [],
+      Object.assign({}, options, program.opts()),
+    );
     handleResponse(result);
   });
 
@@ -717,7 +738,11 @@ program
   .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (options: CardsOptions) => {
     // validate project
-    const result = await commandHandler.command(Cmd.validate, [], options);
+    const result = await commandHandler.command(
+      Cmd.validate,
+      [],
+      Object.assign({}, options, program.opts()),
+    );
     if (!result.message) {
       program.error('Expected validation result, but got none');
       return;

--- a/tools/data-handler/src/card-metadata-updater.ts
+++ b/tools/data-handler/src/card-metadata-updater.ts
@@ -15,7 +15,7 @@
 import type { CardMetadata } from './interfaces/project-interfaces.js';
 import type { FieldType } from './interfaces/resource-interfaces.js';
 import { FieldTypeResource } from './resources/field-type-resource.js';
-import { logger } from './utils/log-utils.js';
+import { getChildLogger } from './utils/log-utils.js';
 import type { Project } from './containers/project.js';
 import type { UpdateField } from './types/queries.js';
 
@@ -34,6 +34,11 @@ interface CardUpdateResult {
  *       can be incorporated there and this class can be removed.
  */
 export class CardMetadataUpdater {
+  private static get logger() {
+    return getChildLogger({
+      module: 'cardMetadataUpdater',
+    });
+  }
   /**
    * Applies a given array of changes to card(s).
    * @param project Current project.
@@ -136,7 +141,7 @@ export class CardMetadataUpdater {
 
     if (allErrors.length > 0) {
       allErrors.push('On transition change to card(s) can not be applied.');
-      logger.error(allErrors.join('\n'));
+      this.logger.error(allErrors.join('\n'));
     }
   }
 

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -43,6 +43,8 @@ import { errorFunction } from './utils/log-utils.js';
 import { readJsonFile } from './utils/json.js';
 import { resourceName } from './utils/resource-utils.js';
 
+import { type Level } from 'pino';
+
 // Generic options interface
 export interface CardsOptions {
   details?: boolean;
@@ -50,6 +52,7 @@ export interface CardsOptions {
   projectPath?: string;
   repeat?: number;
   showUse?: boolean;
+  logLevel?: Level;
 }
 
 // Commands that this class supports.
@@ -90,6 +93,7 @@ export class Commands {
   private commands?: CommandManager;
   private projectPath: string;
   private validateCmd: Validate;
+  private level?: Level;
 
   constructor() {
     this.projectPath = '';
@@ -117,7 +121,7 @@ export class Commands {
     const creatingNewProject = command === Cmd.create && args[0] === 'project';
     if (!creatingNewProject) {
       try {
-        await this.doSetProject(options.projectPath || '');
+        await this.doSetProject(options.projectPath || '', options.logLevel);
       } catch (error) {
         return { statusCode: 400, message: errorFunction(error) };
       }
@@ -143,7 +147,7 @@ export class Commands {
   }
 
   // Handles initializing the project so that it can be used in the class.
-  private async doSetProject(path: string) {
+  private async doSetProject(path: string, level?: Level) {
     this.projectPath = resolveTilde(await this.setProjectPath(path));
     if (!Validate.validateFolder(this.projectPath)) {
       let errorMessage = '';
@@ -159,7 +163,7 @@ export class Commands {
       throw new Error(`Input validation error: cannot find project '${path}'`);
     }
 
-    this.commands = await CommandManager.getInstance(this.projectPath);
+    this.commands = await CommandManager.getInstance(this.projectPath, level);
     if (!this.commands) {
       throw new Error('Cannot get instance of CommandManager');
     }

--- a/tools/data-handler/src/commands/calculate.ts
+++ b/tools/data-handler/src/commands/calculate.ts
@@ -30,7 +30,7 @@ import { Mutex } from 'async-mutex';
 import Handlebars from 'handlebars';
 import { type Project, ResourcesFrom } from '../containers/project.js';
 import { flattenCardArray } from '../utils/card-utils.js';
-import { logger } from '../utils/log-utils.js';
+import { getChildLogger } from '../utils/log-utils.js';
 import {
   createCardFacts,
   createCardTypeFacts,
@@ -61,6 +61,11 @@ const QUERY_LANGUAGE_KEY = 'queryLanguage';
 
 // Class that calculates with logic program card / project level calculations.
 export class Calculate {
+  private get logger() {
+    return getChildLogger({
+      module: 'calculate',
+    });
+  }
   private static mutex = new Mutex();
 
   constructor(private project: Project) {}
@@ -78,7 +83,7 @@ export class Calculate {
       const modules = await this.generateModules();
       this.modules = modules; // Store initial modules in logicProgram
     } catch (error) {
-      logger.error(`Failed to initialize modules: ${error}`);
+      this.logger.error(error, 'Failed to initialize modules');
     }
   }
 
@@ -200,8 +205,9 @@ export class Calculate {
             content += `${moduleContent}\n`;
             content += `% SECTION: MODULE_${calculationFile.name}_END\n\n`;
           } catch (error) {
-            logger.warn(
-              `Failed to read module ${calculationFile.name}: ${error}`,
+            this.logger.warn(
+              error,
+              `Failed to read module ${calculationFile.name}`,
             );
           }
         }
@@ -296,21 +302,18 @@ export class Calculate {
       // For queries, use both base and queryLanguage
       const basePrograms = [BASE_PROGRAM_KEY, QUERY_LANGUAGE_KEY];
 
+      this.logger.trace(
+        {
+          clingo: true,
+        },
+        'Solving',
+      );
+
       // Then solve with the program - need to pass the program as parameter
       return solve(query, basePrograms);
     });
 
-    logger.trace(
-      {
-        query,
-      },
-      `Ran Clingo solve command`,
-    );
-
     if (res && res.answers && res.answers.length > 0) {
-      logger.trace({
-        result: res.answers,
-      });
       return res.answers;
     }
 
@@ -323,6 +326,14 @@ export class Calculate {
    */
   public async generate(cardKey?: string) {
     await Calculate.mutex.runExclusive(async () => {
+      this.logger.trace(
+        {
+          clingo: true,
+          cardKey,
+        },
+        'Generating logic program',
+      );
+
       if (!this.modulesInitialized) {
         await this.initializeModules();
         this.modulesInitialized = true;
@@ -383,6 +394,13 @@ export class Calculate {
 
       // Also store the base program (without query language) for updates
       this.logicProgram = baseProgram;
+      this.logger.trace(
+        {
+          clingo: true,
+          cardKey,
+        },
+        'Logic program set',
+      );
     });
   }
 
@@ -476,6 +494,14 @@ export class Calculate {
    * @returns a base64 encoded image as a string
    */
   public async runGraph(model: string, view: string) {
+    this.logger.trace(
+      {
+        model,
+        view,
+      },
+      'Running graph',
+    );
+
     // Let's run the clingraph query
     const result = await generateReportContent({
       calculate: this,
@@ -522,6 +548,7 @@ export class Calculate {
       throw new Error(`Query file ${queryName} not found`);
     }
 
+    this.logger.trace({ queryName }, 'Running query');
     const clingoOutput = await this.run(content);
 
     const result = await this.parseClingoResult(clingoOutput);

--- a/tools/data-handler/src/containers/project/project-paths.ts
+++ b/tools/data-handler/src/containers/project/project-paths.ts
@@ -81,7 +81,7 @@ export class ProjectPaths {
   }
 
   public get logPath(): string {
-    return join(this.resourcesFolder, 'dh.log');
+    return join(this.path, '.logs', 'cyberismo_data-handler.log');
   }
 
   public get modulesFolder(): string {

--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -37,7 +37,7 @@ import {
   getRankAfter,
   sortItems,
 } from '../utils/lexorank.js';
-import { logger } from '../utils/log-utils.js';
+import { getChildLogger } from '../utils/log-utils.js';
 import { readJsonFile } from '../utils/json.js';
 import { Project } from './project.js';
 import { resourceName } from '../utils/resource-utils.js';
@@ -47,6 +47,11 @@ export class Template extends CardContainer {
   private templatePath: string;
   private templateCardsPath: string;
   private project: Project;
+  private get logger() {
+    return getChildLogger({
+      module: 'template',
+    });
+  }
 
   constructor(project: Project, template: Resource) {
     // Templates might come from modules. Remove module name from template name.
@@ -465,7 +470,7 @@ export class Template extends CardContainer {
     details?: FetchCardDetails,
   ): Promise<Card[]> {
     if (placeHolderPath) {
-      logger.warn('A non-used variable was used in the cards method');
+      this.logger.warn('A non-used variable was used in the cards method');
     }
     const cardDetails = details
       ? details

--- a/tools/data-handler/src/macros/graph/index.ts
+++ b/tools/data-handler/src/macros/graph/index.ts
@@ -18,7 +18,7 @@ import type { MacroOptions } from '../index.js';
 import { createImage, validateMacroContent } from '../index.js';
 import Handlebars from 'handlebars';
 import { join } from 'node:path';
-import { logger } from '../../utils/log-utils.js';
+import { getChildLogger } from '../../utils/log-utils.js';
 import type { MacroGenerationContext } from '../../interfaces/macros.js';
 import macroMetadata from './metadata.js';
 import { pathExists } from '../../utils/file-utils.js';
@@ -35,6 +35,11 @@ export interface GraphOptions extends MacroOptions {
 }
 
 class ReportMacro extends BaseMacro {
+  private get logger() {
+    return getChildLogger({
+      module: 'graphMacro',
+    });
+  }
   constructor(tasksQueue: TaskQueue) {
     super(macroMetadata, tasksQueue);
   }
@@ -76,7 +81,7 @@ class ReportMacro extends BaseMacro {
         ),
       );
     } catch (err) {
-      logger.trace(
+      this.logger.trace(
         err,
         'Graph schema not found or failed to read, skipping validation',
       );

--- a/tools/data-handler/src/utils/clingo-fact-builder.ts
+++ b/tools/data-handler/src/utils/clingo-fact-builder.ts
@@ -1,5 +1,5 @@
 import { INT32_MAX } from './constants.js';
-import { logger } from './log-utils.js';
+import { getChildLogger } from './log-utils.js';
 
 /**
     Cyberismo
@@ -40,6 +40,11 @@ export class ClingoFactBuilder {
   protected predicate: string;
   private end: string;
   private arguments: ClingoArgumentInternal[] = [];
+  private get logger() {
+    return getChildLogger({
+      module: 'clingoFactBuilder',
+    });
+  }
 
   constructor(predicate: string, end: string = '.') {
     this.predicate = predicate;
@@ -120,7 +125,7 @@ export class ClingoFactBuilder {
     } else if (typeof value === 'number') {
       let floored = Math.floor(value);
       if (floored !== value) {
-        logger.warn(
+        this.logger.warn(
           {
             value,
           },
@@ -130,7 +135,7 @@ export class ClingoFactBuilder {
 
       const exceedsInt32Max = floored > INT32_MAX;
       if (exceedsInt32Max || floored < -INT32_MAX) {
-        logger.warn(
+        this.logger.warn(
           {
             value,
           },

--- a/tools/data-handler/src/utils/log-utils.ts
+++ b/tools/data-handler/src/utils/log-utils.ts
@@ -9,54 +9,33 @@
     You should have received a copy of the GNU Affero General Public
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
+import pino, { type ChildLoggerOptions, type Logger } from 'pino';
 
-import { join } from 'path';
-import pino, { type TransportTargetOptions } from 'pino';
-import { fileURLToPath } from 'url';
-const LOG_FILE_LOCATION: string = join(
-  fileURLToPath(import.meta.url),
-  '../../../../../logs/data-handler.trace',
-);
+// This could be also a more generic interface, but since we use pino and this is an internal package, let's keep it simple
+// silent logger as default
+let _logger: Logger = pino.default({ level: 'silent' });
 
-function getLogger() {
-  const all: TransportTargetOptions[] = [
-    {
-      target: 'pino/file',
-      options: { destination: LOG_FILE_LOCATION, mkdir: true }, // trace file
-      level: 'trace',
-    },
-    {
-      target: 'pino-pretty',
-      level: process.env.LOG_LEVEL || 'debug',
-    },
-  ];
-
-  const [file, stdout] = all;
-
-  if (process.env.NODE_ENV === 'test') {
-    // While testing, we simply use stdout and info level by default
-    return pino.default({
-      level: process.env.LOG_LEVEL || 'info',
-      transport: stdout,
-    });
-  }
-  if (process.env.NODE_ENV === 'development') {
-    // In dev mode, only stdout and debug logs by default
-    return pino.default({
-      level: 'trace',
-      transport: {
-        targets: all,
-      },
-    });
-  }
-  return pino.default({
-    level: 'trace',
-    transport: file,
-  });
+export function setLogger(logger: Logger) {
+  _logger = logger;
 }
-
-export const logger = getLogger();
-
+/**
+ * Returns the logger instance.
+ */
+export function getLogger(): Logger {
+  return _logger;
+}
+/**
+ * Returns a child logger instance.
+ * @param context Context to add to the logger.
+ * @param options Options to pass to the logger.
+ * @returns Child logger instance.
+ */
+export function getChildLogger(
+  context: { module: string } & Record<string, unknown>,
+  options?: ChildLoggerOptions,
+): Logger {
+  return _logger.child(context, options);
+}
 /**
  * Returns error message string from an Error object.
  * @param error Error object


### PR DESCRIPTION
Moved logs under the project to `<project_path>/.logs/dh.log`
By default, DH won't log to stdout, but the logs can be enabled with `-L debug|info|trace etc...`. Regardless of configuration, all logs(including trace) are logged to the file. The logs are in pino's json format, but they can be viewed like so: `cyberismo app -L trace | npx pino-pretty`

Also made a few small improvements to logging, but nothing major. Now we should start simply using the logger more. I removed the countless clingo traces, as there is no benefit to logging every single query / response given by clingo if there are no errors.