### PR TITLE
INTDEV-866 Fetch dependencies when importing a module

### DIFF
--- a/tools/data-handler/src/commands/import.ts
+++ b/tools/data-handler/src/commands/import.ts
@@ -29,7 +29,7 @@ export class Import {
     private project: Project,
     private createCmd: Create,
   ) {
-    this.moduleManager = new ModuleManager(this.project, this);
+    this.moduleManager = new ModuleManager(this.project);
   }
 
   /**
@@ -145,28 +145,25 @@ export class Import {
       );
     }
 
-    // Add module as a dependency.
-    return this.project.importModule({
+    const moduleSettings = {
       name: modulePrefix,
       branch: options ? options.branch : undefined,
       private: options ? options.private : undefined,
       location: gitModule ? source : `file:${source}`,
-    });
+    };
+
+    // Fetch module dependencies.
+    await this.moduleManager.updateModule(moduleSettings, options?.credentials);
+
+    // Add module as a dependency.
+    return this.project.importModule(moduleSettings);
   }
 
   /**
    * Updates all imported modules.
+   * @param credentials Optional credentials for private modules.
    */
   public async updateAllModules(credentials?: Credentials) {
-    return this.moduleManager.update(credentials);
-  }
-
-  /**
-   * Updates 'moduleName' module from its source.
-   * Modules using gitUrl, are first copied to .temp
-   * @param moduleName module name (prefix) to update
-   */
-  public async updateExistingModule(moduleName: string) {
-    await this.moduleManager.importFileModule(moduleName);
+    return this.moduleManager.updateModules(credentials);
   }
 }

--- a/tools/data-handler/src/commands/remove.ts
+++ b/tools/data-handler/src/commands/remove.ts
@@ -188,8 +188,8 @@ export class Remove {
     if (!module) {
       throw new Error(`Module '${moduleName}' not found`);
     }
-    await deleteDir(module.path);
     await this.project.removeModule(moduleName);
+    await deleteDir(module.path);
   }
 
   /**


### PR DESCRIPTION
Earlier when a user imported a module, user needed to execute `cyberismo update-modules` to get all the dependencies for the imported module.

Now, once user imports a module, it automatically fetches dependencies for this module. 
There are two limitations:
  1) The automatic fetch is not done for modules that were imported from file locations. This limitation was already in place before this commit. If file-based dependencies are seen as important, we could check their `cardsConfig.json` and try to look for their dependencies as well. For now, this is seen as low priority.
  2) The dependencies of the new module might clash with existing modules. This is not checked during an import operation, but only validated during `update-modules`. 

Additionally noticed few strange issues in the current implementation:
`show modules` lists all dependencies, not just direct dependencies.
`remove module` can make a non-direct dependency to be removed; it logs about the operation.
`remove module` leaves behind non-direct dependencies to the project. 

Second issue was fixed in this PR.
Third issue will be handled with https://cyberismo.atlassian.net/browse/INTDEV-897

Additionally noticed that method `isFileModule` is a bit unreliable, as it looks for `file:` protocol, and in some cases the protocol is removed during operations. Thus, implemented `isGitModule` which now relies on `https:` protocol (and in future both the `https:` and `git:`).