### PR TITLE
Improve unit tests

### DIFF
--- a/tools/data-handler/test/command-handler-import.test.ts
+++ b/tools/data-handler/test/command-handler-import.test.ts
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'node:url';
 import { copyDir } from '../src/utils/file-utils.js';
 import { type CardsOptions, Cmd, Commands } from '../src/command-handler.js';
 import { Project } from '../src/containers/project.js';
-import { Show } from '../src/commands/index.js';
+import { Calculate, Show } from '../src/commands/index.js';
 
 // Create test artifacts in a temp folder.
 const baseDir = dirname(fileURLToPath(import.meta.url));
@@ -45,7 +45,8 @@ describe('import csv command', () => {
     const [key1, key2] = result.payload as string[];
 
     const project = new Project(decisionRecordsPath);
-    const show = new Show(project);
+    const calculate = new Calculate(project);
+    const show = new Show(project, calculate);
     const card1 = await show.showCardDetails(
       { metadata: true, content: true },
       key1,
@@ -83,7 +84,8 @@ describe('import csv command', () => {
 
     const createdKeys = result.payload as string[];
     const project = new Project(decisionRecordsPath);
-    const show = new Show(project);
+    const calculate = new Calculate(project);
+    const show = new Show(project, calculate);
 
     const parentCard = await show.showCardDetails(
       { metadata: true, content: true, children: true },

--- a/tools/data-handler/test/command-handler-move.test.ts
+++ b/tools/data-handler/test/command-handler-move.test.ts
@@ -10,7 +10,7 @@ import { fileURLToPath } from 'node:url';
 import { type CardsOptions, Cmd, Commands } from '../src/command-handler.js';
 import { copyDir } from '../src/utils/file-utils.js';
 import { Project } from '../src/containers/project.js';
-import { Show } from '../src/commands/index.js';
+import { Calculate, Show } from '../src/commands/index.js';
 
 // Create test artifacts in a temp folder.
 const baseDir = dirname(fileURLToPath(import.meta.url));
@@ -53,7 +53,8 @@ describe('move command', () => {
   });
   it('move card to another card (success)', async () => {
     const project = new Project(options.projectPath!);
-    const cards = await new Show(project).showProjectCards();
+    const calculate = new Calculate(project);
+    const cards = await new Show(project, calculate).showProjectCards();
     expect(cards.length).to.be.greaterThanOrEqual(2);
 
     const sourceId = cards[cards.length - 1].key;
@@ -67,7 +68,8 @@ describe('move command', () => {
   });
   it('move child card to another card (success)', async () => {
     const project = new Project(options.projectPath!);
-    const cards = await new Show(project).showProjectCards();
+    const calculate = new Calculate(project);
+    const cards = await new Show(project, calculate).showProjectCards();
 
     const sourceId = 'decision_6';
     const destination = cards[cards.length - 1].key;

--- a/tools/data-handler/test/command-handler-rank.test.ts
+++ b/tools/data-handler/test/command-handler-rank.test.ts
@@ -79,7 +79,8 @@ describe('rank command', () => {
       expect(result.statusCode).to.equal(200);
 
       const project = new Project(options.projectPath!);
-      const details = await new Show(project).showCardDetails(
+      const calculate = new Calculate(project);
+      const details = await new Show(project, calculate).showCardDetails(
         { metadata: true },
         rankBefore,
       );
@@ -98,7 +99,8 @@ describe('rank command', () => {
       expect(result.statusCode).to.equal(200);
 
       const project = new Project(options.projectPath!);
-      const details = await new Show(project).showCardDetails(
+      const calculate = new Calculate(project);
+      const details = await new Show(project, calculate).showCardDetails(
         { metadata: true, content: true },
         rankBefore,
       );
@@ -115,7 +117,8 @@ describe('rank command', () => {
       expect(result.statusCode).to.equal(200);
 
       const project = new Project(options.projectPath!);
-      const details = await new Show(project).showCardDetails(
+      const calculate = new Calculate(project);
+      const details = await new Show(project, calculate).showCardDetails(
         { metadata: true, content: true },
         key,
       );
@@ -135,7 +138,8 @@ describe('rank command', () => {
 
       expect(result.statusCode).to.equal(200);
 
-      const details = await new Show(project).showCardDetails(
+      const calculate = new Calculate(project);
+      const details = await new Show(project, calculate).showCardDetails(
         { metadata: true },
         rankBefore,
       );
@@ -150,7 +154,8 @@ describe('rank command', () => {
       );
       expect(result.statusCode).to.equal(200);
       const project = new Project(options.projectPath!);
-      const details = await new Show(project).showCardDetails(
+      const calculate = new Calculate(project);
+      const details = await new Show(project, calculate).showCardDetails(
         { metadata: true, content: true },
         key,
       );

--- a/tools/data-handler/test/command-handler-show.test.ts
+++ b/tools/data-handler/test/command-handler-show.test.ts
@@ -12,7 +12,7 @@ import { copyDir } from '../src/utils/file-utils.js';
 import { errorFunction } from '../src/utils/log-utils.js';
 import { type ModuleContent } from '../src/interfaces/project-interfaces.js';
 import { Project } from '../src/containers/project.js';
-import { Show } from '../src/commands/index.js';
+import { Calculate, Show } from '../src/commands/index.js';
 
 // validation tests do not modify the content - so they can use the original files
 const baseDir = dirname(fileURLToPath(import.meta.url));
@@ -47,7 +47,8 @@ describe('shows command', () => {
     it('show attachment file', async () => {
       // No commandHandler command for getting attachment files, so using Show directly
       const project = new Project(decisionRecordsPath);
-      const showCommand = new Show(project);
+      const calculate = new Calculate(project);
+      const showCommand = new Show(project, calculate);
       const result = await showCommand.showAttachment(
         'decision_1',
         'the-needle.heic',
@@ -59,7 +60,8 @@ describe('shows command', () => {
     it('show attachment file, card not found', async () => {
       // No commandHandler command for getting attachment files, so using Show directly
       const project = new Project(decisionRecordsPath);
-      const showCommand = new Show(project);
+      const calculate = new Calculate(project);
+      const showCommand = new Show(project, calculate);
       await showCommand
         .showAttachment('invalid_key', 'does-not-exist.png')
         .catch((error) =>
@@ -71,7 +73,8 @@ describe('shows command', () => {
     it('show attachment file, file not found', async () => {
       // No commandHandler command for getting attachment files, so using Show directly
       const project = new Project(decisionRecordsPath);
-      const showCommand = new Show(project);
+      const calculate = new Calculate(project);
+      const showCommand = new Show(project, calculate);
       await showCommand
         .showAttachment('decision_1', 'does-not-exist.png')
         .catch((error) =>

--- a/tools/data-handler/test/command-handler-transition.test.ts
+++ b/tools/data-handler/test/command-handler-transition.test.ts
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'node:url';
 import { copyDir } from '../src/utils/file-utils.js';
 import { type CardsOptions, Cmd, Commands } from '../src/command-handler.js';
 import { Project } from '../src/containers/project.js';
-import { Show } from '../src/commands/index.js';
+import { Calculate, Show } from '../src/commands/index.js';
 
 // Create test artifacts in a temp folder.
 const baseDir = dirname(fileURLToPath(import.meta.url));
@@ -33,7 +33,8 @@ describe('transition command', () => {
 
   it('transition to new state - success()', async () => {
     const project = new Project(decisionRecordsPath);
-    const show = new Show(project);
+    const calculate = new Calculate(project);
+    const show = new Show(project, calculate);
     const card = await show.showCardDetails({ metadata: true }, 'decision_5');
 
     const result = await commandHandler.command(

--- a/tools/data-handler/test/command-handler-update.test.ts
+++ b/tools/data-handler/test/command-handler-update.test.ts
@@ -10,7 +10,7 @@ import { type CardType } from '../src/interfaces/resource-interfaces.js';
 import { copyDir } from '../src/utils/file-utils.js';
 import { Project } from '../src/containers/project.js';
 import { ResourceCollector } from '../src/containers/project/resource-collector.js';
-import { Show, Update } from '../src/commands/index.js';
+import { Calculate, Show, Update } from '../src/commands/index.js';
 
 describe('Update command tests', async () => {
   const baseDir = dirname(fileURLToPath(import.meta.url));
@@ -21,7 +21,8 @@ describe('Update command tests', async () => {
 
   const project = new Project(decisionRecordsPath);
   const update = new Update(project);
-  const show = new Show(project);
+  const calculate = new Calculate(project);
+  const show = new Show(project, calculate);
   const collector = new ResourceCollector(project);
   collector.collectLocalResources();
 

--- a/tools/data-handler/test/module-manager.test.ts
+++ b/tools/data-handler/test/module-manager.test.ts
@@ -41,7 +41,7 @@ describe('module-manager', () => {
     await commands.importCmd.importModule(gitModule, commands.project.basePath);
     const modules = await commands.showCmd.showModules();
     expect(modules.length).equals(1);
-  });
+  }).timeout(10000);
   it('import git module using credentials', async () => {
     const gitModule = 'https://github.com/CyberismoCom/module-base.git';
     await commands.importCmd.importModule(
@@ -57,7 +57,7 @@ describe('module-manager', () => {
     );
     const modules = await commands.showCmd.showModules();
     expect(modules.length).equals(1);
-  });
+  }).timeout(10000);
   it('try to import duplicate local modules', async () => {
     const localModule = join(testDir, 'valid/minimal');
     await commands.importCmd.importModule(


### PR DESCRIPTION
When `Show` was changed to have two parameters for class construction, tests were not adjusted. Adding the missing `Calculate` parameter to all cases where `Show` is created.

Also, increase timeout for two git-related tests as these failed for me locally at least once.