### PR TITLE
Add access public to publish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "dev-export": "pnpm prepare-export && cross-env VITE_CYBERISMO_EXPORT=true pnpm --filter app dev",
     "build-docker": "docker build -t cyberismo .",
     "install-dev-packages": "node scripts/install-dev-packages.js",
-    "ci:publish": "pnpm --filter !app publish"
+    "ci:publish": "pnpm --filter !app publish --access public"
   }
 }


### PR DESCRIPTION
npm / pnpm wants us to specify public so that we do not accidentally publish private packages