### PR TITLE
Turn off 'safe-directory' for CI/Windows build action

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -57,12 +57,14 @@ jobs:
         repository: CyberismoCom/module-base
         path: .tmp/module-base
         ref: main
+        set-safe-directory: false
     - name: Checkout cyberismo-docs repository for testing purposes
       uses: actions/checkout@v4
       with:
         repository: CyberismoCom/cyberismo-docs
         path: .tmp/cyberismo-docs
         ref: main
+        set-safe-directory: false
     - run: pnpm install
     - run: pnpm --filter=app exec cypress install
     - run: pnpm build


### PR DESCRIPTION
Turn off `safe-directory` for GitHub Windows build action.
The configuration value for git is described here: https://git-scm.com/docs/git-config
In short, it ensures that used directory can be used by any user. 

Why the setting makes cloning directory "slow" in CI/Windows is uncertain. However, it seems to be rather common fix for these kinds of issues in Windows builds in GitHub.