### PR TITLE
INTDEV-897 Smarter 'removeModule' support

### DIFF
--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -824,15 +824,6 @@ export class Project extends CardContainer {
   }
 
   /**
-   * Removes a module from project.
-   * @param moduleName Name of the module
-   */
-  public async removeModule(moduleName: string) {
-    await this.configuration.removeModule(moduleName);
-    await this.collectModuleResources();
-  }
-
-  /**
    * Array of reports in the project.
    * @param from Defines where resources are collected from.
    * @returns array of all reports in the project.

--- a/tools/data-handler/test/command-handler-import.test.ts
+++ b/tools/data-handler/test/command-handler-import.test.ts
@@ -117,27 +117,13 @@ describe('import csv command', () => {
 });
 
 describe('import module', () => {
-  const type = 'module';
-  const miniModule = 'mini';
-  const decisionModule = 'decision';
-
-  before(async () => {
+  beforeEach(async () => {
     mkdirSync(testDir, { recursive: true });
     await copyDir('test/test-data', testDir);
   });
 
-  after(() => {
+  afterEach(() => {
     rmSync(testDir, { recursive: true, force: true });
-  });
-
-  beforeEach(async () => {
-    // Ensure that previous imports are removed.
-    await commandHandler.command(Cmd.remove, [type, miniModule], options);
-    await commandHandler.command(
-      Cmd.remove,
-      [type, decisionModule],
-      optionsMini,
-    );
   });
 
   describe('import module command', () => {


### PR DESCRIPTION
Two new mini-features:

1) If a removed module is still used by other modules, it is only removed from project configuration (`cardsConfig.json`). The files are left on `.cards/modules` as long as they are still used by other modules.
2) If removing a module would lead to a situation where another module would become orphaned (= it is no longer needed by any other module), it is removed as well.

Implementation builds a dependency graph of module-dependencies when one is tried to be removed. Since there are always rather limited amount of modules (some dozens at max), the dependency graph can be built whenever the operation starts; it won't take that long (maybe few ms if you have slow disk). 

Then using the graph, it deduces if it can remove the module and are there any orphans left behind.

Additionally, moved all of the remove-module related code from `Remove` command and `Project` to `ModuleManager` as it was sort of spread allover. Didn't do in this PR; but should do the same for import-module related code.