### PR TITLE
Fix release CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,5 +38,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Build
+        run: pnpm build
+
       - name: Publish packages
         run: pnpm ci:publish

--- a/tools/assets/package.json
+++ b/tools/assets/package.json
@@ -7,8 +7,7 @@
   "scripts": {
     "build": "shx rm -rf dist && shx mkdir -p dist && pnpm script:schemas && node scripts/build.js && tsc && shx cp -r src/static dist/",
     "dev": "chokidar 'src/**/*' -c 'pnpm build'",
-    "script:schemas": "node scripts/generateSchemaImports && prettier --write src/schemas.ts",
-    "prepublishOnly": "pnpm build"
+    "script:schemas": "node scripts/generateSchemaImports && prettier --write src/schemas.ts"
   },
   "keywords": [],
   "author": "sami.merila@cyberismo.com",

--- a/tools/backend/package.json
+++ b/tools/backend/package.json
@@ -9,8 +9,7 @@
     "dev": "tsx watch src/main.ts",
     "export": "pnpm build && node dist/main.js --export",
     "build": "tsc -p tsconfig.build.json && shx rm -rf ./dist/public && shx cp -r ../app/dist ./dist/public",
-    "test": "vitest run",
-    "prepublishOnly": "pnpm --filter app build && pnpm build"
+    "test": "vitest run"
   },
   "keywords": [],
   "author": "",

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -16,8 +16,7 @@
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf node_modules",
     "lint": "eslint .",
-    "test": "mocha --require mocha-suppress-logs --disable-warning=ExperimentalWarning --forbid-only \"./test/**/*.test.ts\"",
-    "prepublishOnly": "pnpm build"
+    "test": "mocha --require mocha-suppress-logs --disable-warning=ExperimentalWarning --forbid-only \"./test/**/*.test.ts\""
   },
   "keywords": [],
   "author": "",

--- a/tools/data-handler/package.json
+++ b/tools/data-handler/package.json
@@ -19,8 +19,7 @@
     "test": "mocha --require mocha-suppress-logs --disable-warning=ExperimentalWarning --forbid-only \"./test/**/*.test.ts\"",
     "test-coverage": "c8 pnpm test",
     "dev": "tsc --watch -p tsconfig.build.json",
-    "watch": "pnpm dev",
-    "prepublishOnly": "pnpm build"
+    "watch": "pnpm dev"
   },
   "exports": {
     ".": "./dist/index.js",

--- a/tools/node-clingo/package.json
+++ b/tools/node-clingo/package.json
@@ -7,8 +7,7 @@
     "build": "tsc -p tsconfig.build.json",
     "build-prebuildify": "shx rm -rf prebuilds && prebuildify --napi",
     "test": "vitest run",
-    "test:watch": "vitest",
-    "prepublishOnly": "pnpm build"
+    "test:watch": "vitest"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Allthough pnpm determines that package A is a dependency of package B and thus knows to build A before B, it does not work when we use build in a prepublish script if we only publish B instead of A.