### PR TITLE
Skip git module cloning test on CI/Windows due to fluctuation

### DIFF
--- a/tools/data-handler/test/module-manager.test.ts
+++ b/tools/data-handler/test/module-manager.test.ts
@@ -5,6 +5,8 @@ import { describe, it } from 'mocha';
 // node
 import { mkdirSync, rmSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import { skip } from 'node:test';
+import * as os from 'node:os';
 
 import { copyDir } from '../src/utils/file-utils.js';
 import { fileURLToPath } from 'node:url';
@@ -43,6 +45,11 @@ describe('module-manager', () => {
     expect(modules.length).equals(1);
   }).timeout(10000);
   it('import git module using credentials', async () => {
+    const skipTest = process.env.GITHUB_ACTIONS && os.platform() === 'win32';
+    if (skipTest)
+      skip(
+        `Importing a module causes action to jam from time to time on CI/Windows`,
+      );
     const gitModule = 'https://github.com/CyberismoCom/module-base.git';
     await commands.importCmd.importModule(
       gitModule,


### PR DESCRIPTION
Let's turn the test off on CI/Windows since it seems to be rather troublesome.