### PR TITLE
INTDEV-919 Fix indentation of .gitignore and add folders to it

### DIFF
--- a/tools/data-handler/src/commands/create.ts
+++ b/tools/data-handler/src/commands/create.ts
@@ -72,15 +72,20 @@ export class Create {
     },
   ];
 
-  static gitIgnoreContent: string = `.calc\n
-        .asciidoctor\n
-        .vscode\n
-        *.html\n
-        *.pdf\n
-        *.puml\n
-        **/.DS_Store\n
-        *-debug.log\n
-        *-error.log\n`;
+  static gitIgnoreContent: string[] = [
+    '.calc',
+    '.asciidoctor',
+    '.vscode',
+    '*.html',
+    '*.pdf',
+    '*.puml',
+    '**/.DS_Store',
+    '*-debug.log',
+    '*-error.log',
+    '.temp',
+    '.logs',
+    '.cache',
+  ];
 
   /**
    * Adds new cards to a template.
@@ -510,7 +515,10 @@ export class Create {
     });
 
     try {
-      await writeFile(join(projectPath, '.gitignore'), this.gitIgnoreContent);
+      await writeFile(
+        join(projectPath, '.gitignore'),
+        this.gitIgnoreContent.join('\n') + '\n',
+      );
     } catch {
       console.error('Failed to create project');
     }


### PR DESCRIPTION
Because the string was a multi-line string, the indentation was also visible on the generated `.gitignore`. Added also `.temp`, `.cache` and `.logs` folders. Unsure what creates the `.cache` folder, but let's add it for now. Might be also useful in the future.