### PR TITLE
Remove unused method from Validation

### DIFF
--- a/tools/data-handler/src/commands/validate.ts
+++ b/tools/data-handler/src/commands/validate.ts
@@ -705,41 +705,6 @@ export class Validate {
   }
 
   /**
-   * Validate schema that matches schemaId from path.
-   * @param projectPath path to schema
-   * @param schemaId schema's id
-   * @returns string containing all validation errors
-   * @todo - unused; remove?
-   */
-  public async validateSchema(
-    projectPath: string,
-    schemaId: string,
-  ): Promise<string> {
-    const validationErrors: string[] = [];
-    if (!schemaId.startsWith('/')) {
-      schemaId = '/' + schemaId;
-    }
-    const activeJsonSchema = this.validator.schemas[schemaId];
-    if (activeJsonSchema === undefined) {
-      throw new Error(`Unknown schema '${schemaId}'`);
-    } else {
-      let contentFile = '';
-      try {
-        contentFile = await readJsonFile(projectPath);
-      } catch {
-        throw new Error(`Path is not valid ${projectPath}`);
-      }
-
-      const result = this.validator.validate(contentFile, activeJsonSchema);
-      for (const error of result.errors) {
-        const msg = `Schema '${schemaId}' validation Error: ${error.message}\n`;
-        validationErrors.push(msg);
-      }
-    }
-    return validationErrors.join('\n');
-  }
-
-  /**
    * Validates that card's custom fields are according to schema and have correct data in them.
    * @param project currently used Project
    * @param card specific card

--- a/tools/data-handler/test/0_validate.test.ts
+++ b/tools/data-handler/test/0_validate.test.ts
@@ -150,54 +150,6 @@ describe('validate cmd tests', () => {
     const valid = validateCmd.validateJson(jsonSchema, schemaId);
     expect(valid.length).to.be.greaterThan(0);
   });
-  it('validateSchema() - cardsConfig', async () => {
-    const path =
-      'test/test-data/valid/decision-records/.cards/local/cardsConfig.json';
-    const schemaId = 'cardsConfigSchema';
-    const valid = await validateCmd.validateSchema(path, schemaId);
-    expect(valid.length).to.equal(0);
-  });
-  it('validateSchema() - card type', async () => {
-    const path =
-      'test/test-data/valid/decision-records/.cards/local/cardTypes/decision.json';
-    const schemaId = 'cardTypeSchema';
-    const valid = await validateCmd.validateSchema(path, schemaId);
-    expect(valid.length).to.equal(0);
-  });
-  it('validateSchema() - template', async () => {
-    const path =
-      'test/test-data/valid/decision-records/.cards/local/templates/decision.json';
-    const schemaId = 'templateSchema';
-    const valid = await validateCmd.validateSchema(path, schemaId);
-    expect(valid.length).to.equal(0);
-  });
-  it('validateSchema() - workflow', async () => {
-    const path =
-      'test/test-data/valid/decision-records/.cards/local/workflows/decision.json';
-    const schemaId = 'workflowSchema';
-    const valid = await validateCmd.validateSchema(path, schemaId);
-    expect(valid.length).to.equal(0);
-  });
-  it('try to validateSchema() - invalid JSON', async () => {
-    const schemaId = 'workflowSchema';
-    await validateCmd
-      .validateSchema('', schemaId)
-      .catch((error) =>
-        expect(errorFunction(error)).to.equal('Path is not valid '),
-      );
-  });
-  it('try to validateSchema() - invalid schemaId', async () => {
-    const path =
-      'test/test-data/valid/decision-records/.cards/local/workflows/decision';
-    const schemaId = 'i-do-not-exists';
-    await validateCmd
-      .validateSchema(path, schemaId)
-      .catch((error) =>
-        expect(errorFunction(error)).to.equal(
-          "Unknown schema '/i-do-not-exists'",
-        ),
-      );
-  });
 
   it('validateWorkflowState (success)', async () => {
     const project = new Project('test/test-data/valid/decision-records/');


### PR DESCRIPTION
There was an unused method `validateSchema` in `Validation`. 
The `Validation-utils` method `validateJson<T>` basically does the same thing.

Removing the function.