### PR TITLE
INTDEV-320 Validate module after importing it

### DIFF
--- a/tools/data-handler/src/commands/import.ts
+++ b/tools/data-handler/src/commands/import.ts
@@ -134,6 +134,9 @@ export class Import {
     destination?: string,
     options?: ModuleSettingOptions,
   ) {
+    const beforeImportValidateErrors = await Validate.getInstance().validate(
+      this.project.basePath,
+    );
     const gitModule = source.startsWith('https') || source.startsWith('git@');
     const modulePrefix = gitModule
       ? await this.moduleManager.importGitModule(source, options)
@@ -156,7 +159,17 @@ export class Import {
     await this.moduleManager.updateModule(moduleSettings, options?.credentials);
 
     // Add module as a dependency.
-    return this.project.importModule(moduleSettings);
+    await this.project.importModule(moduleSettings);
+
+    // Validate the project after module has been imported
+    const afterImportValidateErrors = await Validate.getInstance().validate(
+      this.project.basePath,
+    );
+    if (afterImportValidateErrors.length > beforeImportValidateErrors.length) {
+      console.error(
+        `There are new validations errors after importing the module. Check the project`,
+      );
+    }
   }
 
   /**

--- a/tools/data-handler/src/module-manager.ts
+++ b/tools/data-handler/src/module-manager.ts
@@ -257,14 +257,15 @@ export class ModuleManager {
   private async handleFileModule(module: ModuleSetting) {
     this.stripProtocolFromLocation(module);
     await this.remove(module);
-    await this.importFromFolder(module);
+    await this.importFromFolder(module.location, module.name);
   }
 
   // Updates one module that is received from Git.
   private async handleGitModule(module: ModuleSetting) {
     await this.clone(module);
+    const tempLocation = join(this.tempModulesDir, module.name);
     await this.remove(module);
-    await this.importFromTemp(module);
+    await this.importFromFolder(tempLocation, module.name);
   }
 
   // Updates one module.
@@ -274,19 +275,11 @@ export class ModuleManager {
       : this.handleFileModule(module);
   }
 
-  // Handles importing a module from module settings 'location'
-  private async importFromFolder(module: ModuleSetting) {
-    await this.importFileModule(module.location);
+  // Imports from a given folder. Is used both for .temp/<module name> and file locations.
+  private async importFromFolder(path: string, name: string) {
+    await this.importFileModule(path);
     console.log(
-      `... Imported module '${module.name}' to '${this.project.configuration.name}'`,
-    );
-  }
-
-  // Handles importing a module from '.temp' folder
-  private async importFromTemp(module: ModuleSetting) {
-    await this.importFileModule(join(this.tempModulesDir, module.name));
-    console.log(
-      `... Imported module '${module.name}' to '${this.project.configuration.name}'`,
+      `... Imported module '${name}' to '${this.project.configuration.name}'`,
     );
   }
 


### PR DESCRIPTION
Changed the implementation so that validation occurs automatically after `import module`.
It only gives indication that there are new validation errors after import that weren't there before. 

Also, combined `importFromFolder` and `importFromTemp` to a single function.