### PR TITLE
INTDEV-870 Update workflow's 'transitions' values

### DIFF
--- a/tools/data-handler/src/resources/file-resource.ts
+++ b/tools/data-handler/src/resources/file-resource.ts
@@ -301,9 +301,9 @@ export class FileResource extends ResourceObject {
   ) {
     function toValue(op: Operation<Type>) {
       if (op.name === 'rank') return op.newIndex;
-      if (op.name === 'add') return op.target;
-      if (op.name === 'remove') return op.target;
-      if (op.name === 'change') return op.to;
+      if (op.name === 'add') return JSON.stringify(op.target);
+      if (op.name === 'remove') return JSON.stringify(op.target);
+      if (op.name === 'change') return JSON.stringify(op.to);
     }
 
     // Check that new name is valid.
@@ -320,7 +320,9 @@ export class FileResource extends ResourceObject {
     } catch (error) {
       if (error instanceof Error) {
         const errorValue = typeof op === 'object' ? toValue(op) : op;
-        throw new Error(`Cannot ${op.name} '${key}' --> '${errorValue}'`);
+        throw new Error(
+          `Cannot ${op.name} '${key}' --> '${errorValue}: ${error.message}'`,
+        );
       }
     }
 

--- a/tools/data-handler/src/resources/workflow-resource.ts
+++ b/tools/data-handler/src/resources/workflow-resource.ts
@@ -83,11 +83,7 @@ export class WorkflowResource extends FileResource {
   // Handle change of workflow state.
   private async handleStateChange(op: ChangeOperation<WorkflowState>) {
     const content = { ...(this.content as Workflow) };
-    const stateName = (
-      (op.target as WorkflowState).name
-        ? (op.target as WorkflowState).name
-        : op.target
-    ) as string;
+    const stateName = this.targetName(op);
     // Check that state can be changed to
     content.transitions = content.transitions.filter(
       (t) => t.toState !== stateName,
@@ -112,11 +108,7 @@ export class WorkflowResource extends FileResource {
   // State can be removed with or without replacement.
   private async handleStateRemoval(op: RemoveOperation<WorkflowState>) {
     const content = { ...(this.content as Workflow) };
-    const stateName = (
-      (op.target as WorkflowState).name
-        ? (op.target as WorkflowState).name
-        : op.target
-    ) as string;
+    const stateName = this.targetName(op);
 
     // If there is no replacement value, remove all transitions "to" and "from" this state.
     if (!op.replacementValue) {
@@ -152,6 +144,42 @@ export class WorkflowResource extends FileResource {
       // Update all cards that use this state.
       await this.updateCardStates(stateName, replacementState.name);
     }
+  }
+
+  // Returns target name irregardless of the type
+  private targetName(op: Operation<WorkflowState | WorkflowTransition>) {
+    const name = (op.target.name ? op.target.name : op.target) as string;
+    return name;
+  }
+
+  // Potentially updates the changed transition with current properties.
+  private async transitionObject(op: ChangeOperation<WorkflowTransition>) {
+    const content = { ...(this.content as Workflow) };
+    const targetTransitionName = this.targetName(op);
+    const currentTransition = content.transitions.filter(
+      (item) => item.name === targetTransitionName,
+    )[0];
+
+    if (currentTransition) {
+      op.to.fromState =
+        op.to.fromState.length === 0
+          ? currentTransition.fromState
+          : op.to.fromState;
+      op.to.toState = op.to.toState ?? currentTransition.toState;
+    }
+
+    if (
+      op.to.name === undefined ||
+      op.to.toState === undefined ||
+      op.to.fromState == undefined ||
+      op.to.fromState.length === 0
+    ) {
+      throw new Error(
+        `Cannot change transition '${targetTransitionName}' for workflow '${this.content.name}'.
+         Updated transition must have 'name', 'toState' and 'fromState' properties.`,
+      );
+    }
+    return op.to;
   }
 
   // Check if operation is a string operation.
@@ -268,6 +296,33 @@ export class WorkflowResource extends FileResource {
       ) as WorkflowTransition[];
     } else {
       throw new Error(`Unknown property '${key}' for Workflow`);
+    }
+
+    // If workflow transition is removed, then above call to 'handleArray' is all that is needed.
+
+    if (key === 'transitions' && op.name === 'change') {
+      // If workflow transition is changed, update to full object and change the content.
+      let changeOp: ChangeOperation<WorkflowTransition>;
+      if (this.isStringOperation(op)) {
+        const targetTransition = (this.content as Workflow).transitions.find(
+          (transition) => transition.name === op.target,
+        )!;
+        changeOp = {
+          name: 'change',
+          target: targetTransition as WorkflowTransition,
+          to: {
+            name: op.to,
+            toState: targetTransition.toState,
+            fromState: targetTransition.fromState,
+          },
+        };
+      } else {
+        changeOp = op as ChangeOperation<WorkflowTransition>;
+      }
+      const newTransition = await this.transitionObject(changeOp);
+      content.transitions = content.transitions.map((item) =>
+        item.name == newTransition.name ? newTransition : item,
+      );
     }
 
     if (key === 'states' && op.name === 'remove') {


### PR DESCRIPTION
Implement updating 'transitions' for workflows. 

If transition is removed, there is no further actions needed (the object is removed from the `transitions` array), as cards not other resources do not work directly with transitions.

If transition is changed (renamed, or the `toState` value, or `fromStates` array value change), just fetch the full object after making the change to ensure that no partial objects are updated. 

Noticed while implementing this thet workflows are not currently completely validated. So, it is for example possible to update a transition name to already existing one. Once https://cyberismo.atlassian.net/browse/INTDEV-325 has been implemented, this should not be possible. 