### PR TITLE
Build docker on version change and version containers

### DIFF
--- a/.github/workflows/build-cyberismo-app-image.yml
+++ b/.github/workflows/build-cyberismo-app-image.yml
@@ -6,25 +6,69 @@ on:
       - main
 
 jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    outputs:
+      version-changed: ${{ steps.check.outputs.changed }}
+      version: ${{ steps.check.outputs.version }}
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2  # Fetch last 2 commits to compare
+
+      - name: Check if CLI version changed
+        id: check
+        run: |
+          # Get current version from CLI package.json
+          current_version=$(node -p 'require("./tools/cli/package.json").version')
+          
+          # Get previous version (from HEAD~1)
+          git checkout HEAD~1 -- tools/cli/package.json 2>/dev/null || echo "No previous commit"
+          previous_version=$(node -p 'require("./tools/cli/package.json").version' 2>/dev/null || echo "none")
+          
+          # Restore current package.json
+          git checkout HEAD -- tools/cli/package.json
+          
+          echo "Current CLI version: $current_version"
+          echo "Previous CLI version: $previous_version"
+          
+          if [ "$current_version" != "$previous_version" ]; then
+            echo "CLI version changed from $previous_version to $current_version"
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "version=$current_version" >> $GITHUB_OUTPUT
+          else
+            echo "CLI version unchanged: $current_version"
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "version=$current_version" >> $GITHUB_OUTPUT
+          fi
+
   build-and-publish:
+    needs: version-check
+    if: needs.version-check.outputs.version-changed == 'true'
     runs-on: cyberismo_ubuntu_x64
 
     permissions:
       contents: read
-      packages: read
 
     steps:
       - name: Check out code
         uses: actions/checkout@v3
 
-      - name: Read version from package.json
-        id: version
+      - name: Parse version for multi-level tags
+        id: parse
         run: |
-          ver=$(node -p 'require("./package.json").version')
-          echo "VERSION=$ver" >> $GITHUB_ENV
-
-      - name: Short commit SHA
-        run: echo "SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
+          VERSION="${{ needs.version-check.outputs.version }}"
+          MAJOR=$(echo $VERSION | cut -d. -f1)
+          MINOR=$(echo $VERSION | cut -d. -f1-2)
+          echo "major=$MAJOR" >> $GITHUB_OUTPUT
+          echo "minor=$MINOR" >> $GITHUB_OUTPUT
+          echo "Full version: $VERSION"
+          echo "Major version: $MAJOR"
+          echo "Minor version: $MINOR"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -38,13 +82,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          
       - name: Build and push multi-arch Docker image
         uses: docker/build-push-action@v6
         with:
@@ -54,3 +91,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             docker.io/${{ secrets.DOCKERHUB_USERNAME }}/cyberismo:latest
+            docker.io/${{ secrets.DOCKERHUB_USERNAME }}/cyberismo:${{ needs.version-check.outputs.version }}
+            docker.io/${{ secrets.DOCKERHUB_USERNAME }}/cyberismo:${{ steps.parse.outputs.minor }}
+            docker.io/${{ secrets.DOCKERHUB_USERNAME }}/cyberismo:${{ steps.parse.outputs.major }}


### PR DESCRIPTION
It simply checks if the commit before had a different version. If yes, triggers docker build(on main). Version tags have also been added in addition to having the latest tag:
`latest`=most recent version
`x`=receive all updates for major versions(i.e. cyberismo:1 will not update to version 2)
`x.y`=receive all updates for a specific minor version(in other words patches)
`x.y.z`=use a specific version.