### PR TITLE
INTDEV-952 Fix edge handling in Graphviz query

### DIFF
--- a/tools/assets/src/graphvizReport/query.lp.hbs
+++ b/tools/assets/src/graphvizReport/query.lp.hbs
@@ -100,6 +100,7 @@ field(((node, Node), Field), "value", Value) :-
     attr(node, Node, Field, Value),
     not labelAttribute(Field).
 
+% default graph
 graph(default) :-
     node(_).
 
@@ -112,8 +113,8 @@ node(X, default) :-
 edge((XR, YR), default) :-
     edge((XR, YR)).
 
-edge((XR, YR, ""), Graph) :-
-    edge((XR, YR), Graph).
+edge((XR, YR, Identifier), default) :-
+    edge((XR, YR, Identifier)).
 
 % edges
 childResult(Graph, (edge, (XR, YR, Description)), "edges") :-
@@ -137,5 +138,12 @@ field((edge, (XR, YR, Description)), "source", XR) :-
 
 field((edge, (XR, YR, Description)), "destination", YR) :-
     edge((XR, YR, Description), _).
+
+% edges without a separate identifier use "" as their identifier
+edge((XR, YR, ""), Graph) :-
+    edge((XR, YR), Graph).
+
+attr(edge, (Source, Destination, ""), Attribute, Value) :-
+  attr(edge, (Source, Destination), Attribute, Value).
 
 order(N, Collection, 1, "rank", "ASC") :- resultLevel(_, N, Collection).


### PR DESCRIPTION
Two rules were missing in the Graphviz query:

- There was no rule to put edges that did not specify a graph to the `default`graph, if the edge had an identifier (3-tuple edge)
- Attributes of edges that do not have an identifier (2-tuple edges) did not work, as we did not have a rule to yield the same attribute for a 3-type edge with `""` as its identifier 