### PR TITLE
INTDEV-949 Fix: raw macro does not work for handlebars helpers / syntax

### DIFF
--- a/tools/data-handler/test/macros/index.test.ts
+++ b/tools/data-handler/test/macros/index.test.ts
@@ -200,6 +200,45 @@ describe('macros', () => {
           '{{#scoreCard}}"title": "Open issues", "value": 0 {{/scoreCard}}',
         );
       });
+      it('raw macro with handlebars helpers (success)', async () => {
+        const handlebarsContent = `{{#each results}}
+
+* {{this.title}}
+{{/each}}`;
+        const withRaw = `{{#raw}}${handlebarsContent}{{/raw}}`;
+        const result = await evaluateMacros(
+          withRaw,
+          {
+            mode: 'static',
+            project: project,
+            cardKey: '',
+          },
+          calculate,
+        );
+        expect(result).to.equal(handlebarsContent);
+      });
+      it('raw macro with mixed content (success)', async () => {
+        const mixedContent = `{{#each results}}
+* {{this.title}}
+{{/each}}
+
+{{#scoreCard}}"title": "Test", "value": 42{{/scoreCard}}
+
+{{#if condition}}
+  This is conditional
+{{/if}}`;
+        const withRaw = `{{#raw}}${mixedContent}{{/raw}}`;
+        const result = await evaluateMacros(
+          withRaw,
+          {
+            mode: 'static',
+            project: project,
+            cardKey: '',
+          },
+          calculate,
+        );
+        expect(result).to.equal(mixedContent);
+      });
     });
   });
   describe('validate macros', () => {

--- a/tools/data-handler/test/macros/index.test.ts
+++ b/tools/data-handler/test/macros/index.test.ts
@@ -239,6 +239,32 @@ describe('macros', () => {
         );
         expect(result).to.equal(mixedContent);
       });
+      it('nested raw macros should preserve inner raw tags as literal text', async () => {
+        const nestedContent = `{{#raw}}
+Outer content
+{{#raw}}
+Inner content
+{{/raw}}
+More outer content
+{{/raw}}`;
+        const expectedResult = `
+Outer content
+{{#raw}}
+Inner content
+{{/raw}}
+More outer content
+`;
+        const result = await evaluateMacros(
+          nestedContent,
+          {
+            mode: 'static',
+            project: project,
+            cardKey: '',
+          },
+          calculate,
+        );
+        expect(result).to.equal(expectedResult);
+      });
     });
   });
   describe('validate macros', () => {


### PR DESCRIPTION
Only macros were being escaped. Instead of trying to implement raw macro within handlebars, I used a regex to process the content before passing it forward. Thus, anything inside raw macros will be rendered as is