### PR TITLE
INTDEV-908 trigger scroll only after tab changes or during the initial load in edit view

### DIFF
--- a/tools/app/src/pages/cards/card-edit.tsx
+++ b/tools/app/src/pages/cards/card-edit.tsx
@@ -392,7 +392,7 @@ function Page() {
       }),
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [card, editor, view]);
+  }, [tab, editor, view]);
 
   // save the last title when user scrolls
   const handleScroll = () => {


### PR DESCRIPTION
Scroll was triggered also after each time a card had loaded. Also checked whether this bug was present in normal view, but it was not.