### PR TITLE
INTDEV-922 implement SVG score card generation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,6 +310,9 @@ importers:
       simple-git:
         specifier: ^3.2.0
         version: 3.27.0
+      string-pixel-width:
+        specifier: ^1.11.0
+        version: 1.11.0
       tslib:
         specifier: ^2.6.2
         version: 2.8.1
@@ -2955,6 +2958,9 @@ packages:
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
+  lodash.deburr@4.1.0:
+    resolution: {integrity: sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ==}
+
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
     deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
@@ -3870,6 +3876,9 @@ packages:
 
   streamx@2.22.0:
     resolution: {integrity: sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==}
+
+  string-pixel-width@1.11.0:
+    resolution: {integrity: sha512-GeKuNcCza7Gf3tlMJiZY8SF1LtbFGeMUEpHifncgJn+ZcUpnoPyE69HEyb0rXrJ3bejY/M/kBylu7IDlPJD9Ng==}
 
   string-width@3.1.0:
     resolution: {integrity: sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==}
@@ -7097,6 +7106,8 @@ snapshots:
 
   lodash.debounce@4.0.8: {}
 
+  lodash.deburr@4.1.0: {}
+
   lodash.get@4.4.2: {}
 
   lodash.merge@4.6.2: {}
@@ -8037,6 +8048,10 @@ snapshots:
       text-decoder: 1.2.3
     optionalDependencies:
       bare-events: 2.5.4
+
+  string-pixel-width@1.11.0:
+    dependencies:
+      lodash.deburr: 4.1.0
 
   string-width@3.1.0:
     dependencies:

--- a/tools/data-handler/package.json
+++ b/tools/data-handler/package.json
@@ -38,8 +38,8 @@
   },
   "dependencies": {
     "@asciidoctor/core": "^3.0.4",
-    "@cyberismo/node-clingo": "workspace:*",
     "@cyberismo/assets": "workspace:*",
+    "@cyberismo/node-clingo": "workspace:*",
     "@viz-js/viz": "^3.12.0",
     "async-mutex": "^0.5.0",
     "csv-parse": "^5.6.0",
@@ -54,6 +54,7 @@
     "mime-types": "^3.0.1",
     "pino": "^9.7.0",
     "simple-git": "^3.2.0",
+    "string-pixel-width": "^1.11.0",
     "tslib": "^2.6.2",
     "write-json-file": "^6.0.0"
   },

--- a/tools/data-handler/src/macros/index.ts
+++ b/tools/data-handler/src/macros/index.ts
@@ -1,13 +1,15 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
 
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 import Handlebars from 'handlebars';
@@ -422,15 +424,15 @@ export function createCodeBlock(content: string) {
  * @param image base64 encoded image
  * @returns valid asciidoc with the image
  */
-export function createImage(image: string) {
+export function createImage(image: string, controls: boolean = true) {
   if (process.env.EXPORT_FORMAT) {
     return `image::data:image/svg+xml;base64,${image}[]\n`;
   } else {
-    return `++++
-<div class="cyberismo-svg-wrapper" data-type="cyberismo-svg-wrapper">
-${Buffer.from(image, 'base64').toString('utf-8')}
-</div>
-++++
-`;
+    const svg = Buffer.from(image, 'base64').toString('utf-8');
+    if (controls) {
+      return `++++\n<div class="cyberismo-svg-wrapper" data-type="cyberismo-svg-wrapper">\n${svg}\n</div>\n++++\n`;
+    } else {
+      return `++++\n${svg}\n++++\n`;
+    }
   }
 }

--- a/tools/data-handler/src/macros/scoreCard/index.ts
+++ b/tools/data-handler/src/macros/scoreCard/index.ts
@@ -1,22 +1,25 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2024
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
 
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 import type { MacroOptions } from '../index.js';
-import { createHtmlPlaceholder, validateMacroContent } from '../index.js';
+import { createImage, validateMacroContent } from '../index.js';
 
 import type { MacroGenerationContext } from '../../interfaces/macros.js';
 import macroMetadata from './metadata.js';
 import BaseMacro from '../base-macro.js';
 import type TaskQueue from '../task-queue.js';
+import { scoreCard } from '../../svg/index.js';
 
 export interface ScoreCardOptions extends MacroOptions {
   title?: string;
@@ -33,22 +36,20 @@ class ScoreCardMacro extends BaseMacro {
     this.validate(data);
   };
 
-  handleStatic = async (context: MacroGenerationContext, input: unknown) => {
+  handleStatic = async (_: MacroGenerationContext, input: unknown) => {
     const options = this.validate(input);
-    return this.createAsciidocElement(options);
+    return createImage(
+      Buffer.from(scoreCard(options)).toString('base64'),
+      false,
+    );
   };
 
-  handleInject = async (_: MacroGenerationContext, input: unknown) => {
-    const options = this.validate(input);
-    return createHtmlPlaceholder(this.metadata, options);
+  handleInject = async (context: MacroGenerationContext, input: unknown) => {
+    return this.handleStatic(context, input);
   };
 
   private validate(input: unknown): ScoreCardOptions {
     return validateMacroContent<ScoreCardOptions>(this.metadata, input);
-  }
-
-  private createAsciidocElement(options: ScoreCardOptions) {
-    return `\n----\n${options.title}: ${options.value} ${options.unit ?? ''} ${options.legend ?? ''}\n----\n`;
   }
 }
 

--- a/tools/data-handler/src/svg/index.ts
+++ b/tools/data-handler/src/svg/index.ts
@@ -1,0 +1,14 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2025
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+export * from './scoreCard.js';

--- a/tools/data-handler/src/svg/lib.ts
+++ b/tools/data-handler/src/svg/lib.ts
@@ -1,0 +1,23 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2025
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+import pixelWidth from 'string-pixel-width';
+
+export function measureTextWidth(
+  text: string,
+  font: string,
+  size: number,
+  bold = false,
+): number {
+  return pixelWidth(text, { font, size, bold });
+}

--- a/tools/data-handler/src/svg/lib.ts
+++ b/tools/data-handler/src/svg/lib.ts
@@ -13,6 +13,14 @@
 */
 import pixelWidth from 'string-pixel-width';
 
+/**
+ * Measures the width of a text string
+ * @param text - The text to measure
+ * @param font - The font to use
+ * @param size - The size of the font
+ * @param bold - Whether the text is bold
+ * @returns The width of the text
+ */
 export function measureTextWidth(
   text: string,
   font: string,

--- a/tools/data-handler/src/svg/scoreCard.ts
+++ b/tools/data-handler/src/svg/scoreCard.ts
@@ -78,9 +78,9 @@ export function scoreCard(options: ScoreCardOptions): string {
   const svgContent = `<svg class="card" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg">
     <rect rx="8" ry="8" fill="#fff" stroke="#dfe4ea" stroke-width="3" width="${width}" height="${height}"/>
     <g text-anchor="middle">
-      <text class="title" x="${width / 2}" y="${TITLE_SIZE / 2 + PADDING}" font-family="${FONT_FAMILY}" font-size="${TITLE_SIZE}" font-weight="400" fill="#001829" dominant-baseline="middle">${title}</text>
-      <text class="value" x="${width / 2}" y="${titleHeight + VALUE_SIZE / 2 + PADDING}" font-family="${FONT_FAMILY}" font-size="${VALUE_SIZE}" font-weight="700" fill="#333" dominant-baseline="middle">${value}<tspan class="unit" font-size="${UNIT_SIZE}" font-weight="400" dx="${UNIT_OFFSET}">${unit}</tspan></text>
-      <text class="caption" x="${width / 2}" y="${titleHeight + valueHeight + LINE_GAP_CAPTION + CAPTION_SIZE / 2 + PADDING}" font-family="${FONT_FAMILY}" font-size="${CAPTION_SIZE}" font-weight="400" fill="#999" dominant-baseline="middle">${legend}</text>
+      <text class="title" x="${width / 2}" y="${TITLE_SIZE / 2 + PADDING}" font-size="${TITLE_SIZE}" font-weight="400" fill="#001829" dominant-baseline="middle">${title}</text>
+      <text class="value" x="${width / 2}" y="${titleHeight + VALUE_SIZE / 2 + PADDING}" font-size="${VALUE_SIZE}" font-weight="700" fill="#333" dominant-baseline="middle">${value}<tspan class="unit" font-size="${UNIT_SIZE}" font-weight="400" dx="${UNIT_OFFSET}">${unit}</tspan></text>
+      <text class="caption" x="${width / 2}" y="${titleHeight + valueHeight + LINE_GAP_CAPTION + CAPTION_SIZE / 2 + PADDING}" font-size="${CAPTION_SIZE}" font-weight="400" fill="#999" dominant-baseline="middle">${legend}</text>
     </g>
   </svg>`;
 

--- a/tools/data-handler/src/svg/scoreCard.ts
+++ b/tools/data-handler/src/svg/scoreCard.ts
@@ -25,6 +25,13 @@ const UNIT_OFFSET = 3;
 const LINE_GAP_TITLE = 16;
 const LINE_GAP_CAPTION = 16;
 
+/**
+ * Options for the score card
+ * @param title - The title of the score card
+ * @param value - The value of the score card
+ * @param unit - The unit of the score card
+ * @param legend - The legend of the score card
+ */
 export interface ScoreCardOptions {
   title?: string;
   value: number;

--- a/tools/data-handler/src/svg/scoreCard.ts
+++ b/tools/data-handler/src/svg/scoreCard.ts
@@ -1,0 +1,81 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2025
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+import { measureTextWidth } from './lib.js';
+
+// Padding on y-axis
+const PADDING = 24;
+// font used to estimate text width
+const FONT_FAMILY = 'Helvetica';
+const TITLE_SIZE = 16;
+const VALUE_SIZE = 48;
+const UNIT_SIZE = 24;
+const CAPTION_SIZE = 14;
+const UNIT_OFFSET = 3;
+const LINE_GAP_TITLE = 16;
+const LINE_GAP_CAPTION = 16;
+
+export interface ScoreCardOptions {
+  title?: string;
+  value: number;
+  unit?: string;
+  legend?: string;
+}
+
+/**
+ * Creates an SVG score card
+ * @param options - The options for the score card
+ * @returns The SVG score card
+ */
+export function scoreCard(options: ScoreCardOptions): string {
+  const { title = '', value, unit = '', legend = '' } = options;
+
+  const titleWidth = measureTextWidth(title, FONT_FAMILY, TITLE_SIZE, false);
+  const valueWidth = measureTextWidth(
+    String(value),
+    FONT_FAMILY,
+    VALUE_SIZE,
+    true,
+  );
+  const unitWidth = measureTextWidth(unit, FONT_FAMILY, UNIT_SIZE, false);
+  const captionWidth = measureTextWidth(
+    legend,
+    FONT_FAMILY,
+    CAPTION_SIZE,
+    false,
+  );
+
+  const valueLineWidth = valueWidth + unitWidth + UNIT_OFFSET;
+  const maxTextWidth = Math.max(titleWidth, valueLineWidth, captionWidth);
+
+  const width = Math.ceil(maxTextWidth + PADDING * 2);
+
+  const titleHeight = title.length > 0 ? TITLE_SIZE + LINE_GAP_TITLE : 0;
+  const valueHeight = VALUE_SIZE;
+  const captionHeight = legend.length > 0 ? CAPTION_SIZE + LINE_GAP_CAPTION : 0;
+
+  const textBlockHeight = titleHeight + valueHeight + captionHeight;
+
+  const height = Math.ceil(textBlockHeight + PADDING * 2);
+
+  const svgContent = `<svg class="card" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg">
+    <rect rx="8" ry="8" fill="#fff" stroke="#dfe4ea" stroke-width="3" width="${width}" height="${height}"/>
+    <g text-anchor="middle">
+      <text class="title" x="${width / 2}" y="${TITLE_SIZE / 2 + PADDING}" font-family="${FONT_FAMILY}" font-size="${TITLE_SIZE}" font-weight="400" fill="#001829" dominant-baseline="middle">${title}</text>
+      <text class="value" x="${width / 2}" y="${titleHeight + VALUE_SIZE / 2 + PADDING}" font-family="${FONT_FAMILY}" font-size="${VALUE_SIZE}" font-weight="700" fill="#333" dominant-baseline="middle">${value}<tspan class="unit" font-size="${UNIT_SIZE}" font-weight="400" dx="${UNIT_OFFSET}">${unit}</tspan></text>
+      <text class="caption" x="${width / 2}" y="${titleHeight + valueHeight + LINE_GAP_CAPTION + CAPTION_SIZE / 2 + PADDING}" font-family="${FONT_FAMILY}" font-size="${CAPTION_SIZE}" font-weight="400" fill="#999" dominant-baseline="middle">${legend}</text>
+    </g>
+  </svg>`;
+
+  return svgContent;
+}

--- a/tools/data-handler/src/types/string-pixel-width.d.ts
+++ b/tools/data-handler/src/types/string-pixel-width.d.ts
@@ -1,0 +1,23 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2025
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+declare module 'string-pixel-width' {
+  interface PixelWidthOptions {
+    font?: string;
+    size?: number;
+    bold?: boolean;
+    italic?: boolean;
+  }
+  function pixelWidth(text: string, options?: PixelWidthOptions): number;
+  export default pixelWidth;
+}

--- a/tools/data-handler/test/macros/index.test.ts
+++ b/tools/data-handler/test/macros/index.test.ts
@@ -285,7 +285,7 @@ Some content here`;
           },
           calculate,
         );
-        expect(result).to.contain('<score-card');
+        expect(result).to.contain('<svg');
       });
       it('scoreCard static (success)', async () => {
         const macro = `{{#scoreCard}}"title": "Open issues", "value": 0 {{/scoreCard}}`;
@@ -298,7 +298,7 @@ Some content here`;
           },
           calculate,
         );
-        expect(result).to.contain('----');
+        expect(result).to.contain('<svg');
       });
     });
     describe('includeMacro', () => {


### PR DESCRIPTION
Score cards were using html syntax and as part of wanting to use `asciidoctor-pdf`, we cannot use html based components or we need have 2 separate implementations. In this case, I used svg for implementing the score card. Some restrictions:
* Rendering now happens in DH instead of App. Generally this is a bad idea. Might be smart to create some kind of common package that shared between DH and App, which would allow the app to render it. Development would be nicer if we used e.g. react to make the template instead of actually string(it can still be rendered on the server)
* Layout depends on estimating size of text(we could get a more accurate estimation by actually rendering the svg and checking its size, but I don't think that's needed)
* The svg is not responsive, but app does not work on mobile anyway
* No good way to go around these issues, unless we either:
1. Utilize web technologies for the pdf and use html(no straightforward tool exists, since we did not want to use `asciidoctor-web-pdf`, since it has stopped  receiving updates)
2. Use svg for exports but html for the site / exported site: results in small differences in the pdf version.

I think we can for now go with the svg version and use a separate implementation for app if needed later. 

<img width="331" height="748" alt="image" src="https://github.com/user-attachments/assets/abba040f-2dec-48f5-aecf-d1c7e4e1d81e" />
