### PR TITLE
INTDEV-911 Show display name of card type on the app

### DIFF
--- a/tools/app/cypress/e2e/app.cy.ts
+++ b/tools/app/cypress/e2e/app.cy.ts
@@ -113,7 +113,7 @@ describe('Navigation', () => {
     cy.get('[data-cy="metadataView"]').contains(t['cardKey']);
     cy.get('[data-cy="metadataView"]').contains(t['cardType']);
     cy.get('[data-cy="metadataView"]').contains(t['lastUpdated']);
-    cy.get('[data-cy="metadataView"]').contains('base/cardTypes/decision');
+    cy.get('[data-cy="metadataView"]').contains('Decision');
 
     // Check that edit element is visible and clicks it
     cy.get('[data-cy="editButton"]').contains(t['edit']).click(); // Clicks Edit button

--- a/tools/app/src/components/MetadataView.tsx
+++ b/tools/app/src/components/MetadataView.tsx
@@ -168,7 +168,7 @@ function MetadataView({
         />
         <FieldItem
           name="__cardtype__"
-          forceValue={card.cardType}
+          forceValue={card.cardTypeDisplayName || card.cardType}
           expanded={true}
           editableFieldProps={{
             label: t('cardType'),

--- a/tools/assets/src/calculations/queries/card.lp
+++ b/tools/assets/src/calculations/queries/card.lp
@@ -92,8 +92,15 @@ field((Card, Field), "value", Value) :-
     childResult(Card, (Card, Field), "fields"),
     field(Card, Field, Value).
 
+% add cardTypeDisplayName
+field(Card, "cardTypeDisplayName", DisplayName, "shortText") :-
+    result(Card),
+    field(Card, "cardType", CardType),
+    field(CardType, "displayName", DisplayName).
+
 % select only non-custom fields
 select(1, "cardType").
+select(1, "cardTypeDisplayName").
 select(1, "title").
 select(1, "key").
 select(1, "lastUpdated").

--- a/tools/backend/test/api.test.ts
+++ b/tools/backend/test/api.test.ts
@@ -45,6 +45,8 @@ test('/api/cards/decision_5 returns a card object', async () => {
   expect(result.policyChecks).not.toBe(null);
   expect(result.deniedOperations).not.toBe(null);
   expect(result.fields).not.toBe(null);
+  expect(result.cardTypeDisplayName).toBe('Simple card type');
+  expect(result.cardType).toBe('decision/cardTypes/simplepage');
 });
 
 test('/api/cards/decision_1/a/the-needle.heic returns an attachment file', async () => {

--- a/tools/data-handler/src/types/queries.ts
+++ b/tools/data-handler/src/types/queries.ts
@@ -92,6 +92,7 @@ interface CardQueryResult extends BaseResult {
   rank: string;
   title: string;
   cardType: string;
+  cardTypeDisplayName: string;
   workflowState: string;
   lastUpdated: string;
   fields: CardQueryField[];


### PR DESCRIPTION
Display name of card type is shown rather than the "id" name