### PR TITLE
INTDEV-924 Add context to logic programs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,8 +348,8 @@ importers:
   tools/node-clingo:
     dependencies:
       node-addon-api:
-        specifier: ^7.1.0
-        version: 7.1.1
+        specifier: ^8.5.0
+        version: 8.5.0
       node-gyp-build:
         specifier: ^4.8.4
         version: 4.8.4
@@ -3163,8 +3163,9 @@ packages:
     resolution: {integrity: sha512-c5XK0MjkGBrQPGYG24GBADZud0NCbznxNx0ZkS+ebUTrmV1qTDxPxSL8zEAPURXSbLRWVexxmP4986BziahL5w==}
     engines: {node: '>=10'}
 
-  node-addon-api@7.1.1:
-    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+  node-addon-api@8.5.0:
+    resolution: {integrity: sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==}
+    engines: {node: ^18 || ^20 || >= 21}
 
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
@@ -7306,7 +7307,7 @@ snapshots:
     dependencies:
       semver: 7.7.2
 
-  node-addon-api@7.1.1: {}
+  node-addon-api@8.5.0: {}
 
   node-gyp-build@4.8.4: {}
 

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -199,7 +199,7 @@ export class Commands {
           return this.runLogicProgram(cardKey, options.context || 'localApp');
         }
         if (command === 'generate') {
-          return this.generateLogicProgram(cardKey);
+          return this.generateLogicProgram();
         }
       } else if (command === Cmd.create) {
         const [type, ...rest] = args;
@@ -465,9 +465,9 @@ export class Commands {
   }
 
   // Generates logic program for a card.
-  private async generateLogicProgram(cardKey?: string): Promise<requestStatus> {
+  private async generateLogicProgram(): Promise<requestStatus> {
     try {
-      await this.commands?.calculateCmd.generate(cardKey);
+      await this.commands?.calculateCmd.generate();
       return { statusCode: 200 };
     } catch (e) {
       return { statusCode: 500, message: errorFunction(e) };

--- a/tools/data-handler/src/commands/calculate.ts
+++ b/tools/data-handler/src/commands/calculate.ts
@@ -29,7 +29,6 @@ import { pathExists } from '../utils/file-utils.js';
 import { Mutex } from 'async-mutex';
 import Handlebars from 'handlebars';
 import { type Project, ResourcesFrom } from '../containers/project.js';
-import { flattenCardArray } from '../utils/card-utils.js';
 import { getChildLogger } from '../utils/log-utils.js';
 import {
   createCardFacts,
@@ -52,15 +51,17 @@ import type {
   TemplateMetadata,
   Workflow,
 } from '../interfaces/resource-interfaces.js';
-import { solve, setBaseProgram } from '@cyberismo/node-clingo';
+import {
+  removeAllPrograms,
+  solve,
+  setProgram,
+  removeProgram,
+} from '@cyberismo/node-clingo';
 import { generateReportContent } from '../utils/report.js';
 import { lpFiles, graphvizReport } from '@cyberismo/assets';
 
-// Define names for the base programs
-const BASE_PROGRAM_KEY = 'base';
-const QUERY_LANGUAGE_KEY = 'queryLanguage';
-const UTILS_PROGRAM_KEY = 'utils';
-const CONTEXT_PROGRAM_KEY = 'context';
+// Define the main flag that will be used for all programs
+const MAIN_FLAG = 'main';
 
 // Class that calculates with logic program card / project level calculations.
 export class Calculate {
@@ -99,72 +100,17 @@ export class Calculate {
   }
 
   // Generate card tree content
-  private async generateCardTreeContent(parentCard: Card | undefined) {
-    const cards = await this.getCards(parentCard);
-
-    let content = '% SECTION: CARDS_START\n';
+  private async setCardTreeContent() {
+    const cards = await this.getCards(undefined);
 
     for (const card of cards) {
-      const cardContent = await createCardFacts(card, this.project);
-      content += `% SECTION: CARD_${card.key}_START\n`;
-      content += `% Card ${card.key}\n`;
-      content += `${cardContent}\n`;
-      content += `% SECTION: CARD_${card.key}_END\n\n`;
+      await this.setCardContent(card);
     }
-
-    content += '% SECTION: CARDS_END';
-
-    return content;
   }
 
-  //
-  private async generateCardTypes() {
-    const cardTypes = await this.project.cardTypes();
-    let content = '';
-
-    for (const cardType of await Promise.all(
-      cardTypes.map((c) => this.project.resource<CardType>(c.name)),
-    )) {
-      if (!cardType) continue;
-
-      const cardTypeContent = createCardTypeFacts(cardType);
-      content += `% CardType ${cardType.name}\n${cardTypeContent}\n\n`;
-    }
-
-    return content;
-  }
-
-  //
-  private async generateFieldTypes() {
-    const fieldTypes = await this.project.fieldTypes();
-    let content = '';
-
-    for (const fieldType of await Promise.all(
-      fieldTypes.map((m) => this.project.resource<FieldType>(m.name)),
-    )) {
-      if (!fieldType) continue;
-
-      const fieldTypeContent = createFieldTypeFacts(fieldType);
-      content += `% FieldType ${fieldType.name}\n${fieldTypeContent}\n\n`;
-    }
-    return content;
-  }
-
-  // Collects all linkTypes from the project
-  private async generateLinkTypes() {
-    const linkTypes = await this.project.linkTypes();
-    let content = '';
-
-    for (const linkType of await Promise.all(
-      linkTypes.map((c) => this.project.resource<LinkType>(c.name)),
-    )) {
-      if (!linkType) continue;
-
-      const linkTypeContent = createLinkTypeFacts(linkType);
-      content += `% LinkType ${linkType.name}\n${linkTypeContent}\n\n`;
-    }
-
-    return content;
+  private async setCardContent(card: Card) {
+    const cardContent = await createCardFacts(card, this.project);
+    setProgram(card.key, cardContent, [MAIN_FLAG]);
   }
 
   // Generates logic programs related to modules (and project itself).
@@ -183,13 +129,99 @@ export class Calculate {
     return content;
   }
 
-  // Collects all logic calculation files from project (local and imported modules)
-  private async generateCalculations() {
-    // Collect all available calculations
-    const calculations = await this.project.calculations(ResourcesFrom.all);
-    let content = '% SECTION: MODULES_START\n';
+  // Sets individual CardType programs
+  private async setCardTypesPrograms() {
+    const cardTypes = await this.project.cardTypes();
 
-    // Process modules content
+    for (const cardType of await Promise.all(
+      cardTypes.map((c) => this.project.resource<CardType>(c.name)),
+    )) {
+      if (!cardType) continue;
+
+      const cardTypeContent = createCardTypeFacts(cardType);
+      setProgram(cardType.name, cardTypeContent, [MAIN_FLAG]);
+    }
+  }
+
+  // Sets individual FieldType programs
+  private async setFieldTypesPrograms() {
+    const fieldTypes = await this.project.fieldTypes();
+
+    for (const fieldType of await Promise.all(
+      fieldTypes.map((m) => this.project.resource<FieldType>(m.name)),
+    )) {
+      if (!fieldType) continue;
+
+      const fieldTypeContent = createFieldTypeFacts(fieldType);
+      setProgram(fieldType.name, fieldTypeContent, [MAIN_FLAG]);
+    }
+  }
+
+  // Sets individual LinkType programs
+  private async setLinkTypesPrograms() {
+    const linkTypes = await this.project.linkTypes();
+
+    for (const linkType of await Promise.all(
+      linkTypes.map((c) => this.project.resource<LinkType>(c.name)),
+    )) {
+      if (!linkType) continue;
+
+      const linkTypeContent = createLinkTypeFacts(linkType);
+      setProgram(linkType.name, linkTypeContent, [MAIN_FLAG]);
+    }
+  }
+
+  // Sets individual Workflow programs
+  private async setWorkflowsPrograms() {
+    const workflows = await this.project.workflows();
+
+    for (const workflow of await Promise.all(
+      workflows.map((m) => this.project.resource<Workflow>(m.name)),
+    )) {
+      if (!workflow) continue;
+
+      const workflowContent = createWorkflowFacts(workflow);
+      setProgram(workflow.name, workflowContent, [MAIN_FLAG]);
+    }
+  }
+
+  // Sets individual Report programs
+  private async setReportsPrograms() {
+    const reports = await this.project.reports();
+
+    for (const report of await Promise.all(
+      reports.map((r) => this.project.resource<ReportMetadata>(r.name)),
+    )) {
+      if (!report) continue;
+
+      const reportContent = createReportFacts(report);
+      setProgram(report.name, reportContent, [MAIN_FLAG]);
+    }
+  }
+
+  // Sets individual Template programs
+  private async setTemplatesPrograms() {
+    const templates = await this.project.templates();
+
+    for (const template of await Promise.all(
+      templates.map((r) => this.project.resource<TemplateMetadata>(r.name)),
+    )) {
+      if (!template) continue;
+
+      const templateContent = createTemplateFacts(template);
+      const cards = await this.getCards(template.name);
+      for (const card of cards) {
+        const cardContent = await createCardFacts(card, this.project);
+        setProgram(card.key, cardContent, [MAIN_FLAG]);
+      }
+      setProgram(template.name, templateContent, [MAIN_FLAG]);
+    }
+  }
+
+  // Sets individual Calculation programs
+  private async setCalculationsPrograms() {
+    const calculations = await this.project.calculations(ResourcesFrom.all);
+
     for (const calculationFile of calculations) {
       if (calculationFile.path) {
         const moduleLogicFile = resolve(
@@ -203,93 +235,23 @@ export class Calculate {
         if (pathExists(filePath)) {
           try {
             const moduleContent = await readFile(filePath, 'utf-8');
-            content += `% SECTION: MODULE_${calculationFile.name}_START\n`;
-            content += `% Module ${calculationFile.name}\n`;
-            content += `${moduleContent}\n`;
-            content += `% SECTION: MODULE_${calculationFile.name}_END\n\n`;
+            setProgram(calculationFile.name, moduleContent, [MAIN_FLAG]);
           } catch (error) {
             this.logger.warn(
               error,
-              `Failed to read module ${calculationFile.name}`,
+              `Failed to read calculation ${calculationFile.name}`,
             );
           }
         }
       }
     }
-    content += '% SECTION: MODULES_END';
-    return content;
-  }
-
-  // Generates logic programs related to reports.
-  private async generateReports() {
-    const reports = await this.project.reports();
-    let content = '';
-
-    for (const report of await Promise.all(
-      reports.map((r) => this.project.resource<ReportMetadata>(r.name)),
-    )) {
-      if (!report) continue;
-      content += createReportFacts(report);
-    }
-    return content;
-  }
-
-  // Generates logic programs related to templates (including their cards).
-  private async generateTemplates() {
-    const templates = await this.project.templates();
-    let content = '';
-
-    for (const template of await Promise.all(
-      templates.map((r) => this.project.resource<TemplateMetadata>(r.name)),
-    )) {
-      if (!template) continue;
-
-      let templateContent = createTemplateFacts(template);
-      const cards = await this.getCards(undefined, template.name);
-      for (const card of cards) {
-        const cardContent = await createCardFacts(card, this.project);
-        templateContent = templateContent.concat(cardContent);
-      }
-      content = content.concat(templateContent);
-    }
-    return content;
-  }
-
-  //
-  private async generateWorkFlows() {
-    const workflows = await this.project.workflows();
-    let content = '';
-
-    // loop through workflows
-    for (const workflow of await Promise.all(
-      workflows.map((m) => this.project.resource<Workflow>(m.name)),
-    )) {
-      if (!workflow) continue;
-
-      const workflowContent = createWorkflowFacts(workflow);
-      content += `% Workflow ${workflow.name}\n${workflowContent}\n\n`;
-    }
-
-    return content;
   }
 
   // Gets either all the cards (no parent), or a subtree.
-  private async getCards(
-    card: Card | undefined,
-    templateName?: string,
-  ): Promise<Card[]> {
-    let cards: Card[] = [];
-    if (!card) {
-      return templateName
-        ? this.project.templateCards(templateName)
-        : this.project.cards();
-    }
-    if (card.children) {
-      cards = flattenCardArray(card.children);
-    }
-    card.children = [];
-    cards.unshift(card);
-    return cards;
+  private async getCards(templateName?: string): Promise<Card[]> {
+    return templateName
+      ? this.project.templateCards(templateName)
+      : this.project.cards();
   }
 
   // Checks that Clingo successfully returned result.
@@ -303,13 +265,8 @@ export class Calculate {
   private async run(query: string, context: Context): Promise<string[]> {
     try {
       const res = await Calculate.mutex.runExclusive(async () => {
-        // For queries, use both base and queryLanguage
-        const basePrograms = [
-          BASE_PROGRAM_KEY,
-          QUERY_LANGUAGE_KEY,
-          UTILS_PROGRAM_KEY,
-          CONTEXT_PROGRAM_KEY,
-        ];
+        // Use the main flag to include all programs
+        const basePrograms = [MAIN_FLAG];
 
         this.logger.trace(
           {
@@ -319,7 +276,7 @@ export class Calculate {
         );
 
         const contextFacts = createContextFacts(context);
-        setBaseProgram(contextFacts, CONTEXT_PROGRAM_KEY);
+        setProgram('context', contextFacts, [MAIN_FLAG]);
         // Then solve with the program - need to pass the program as parameter
         return solve(query, basePrograms);
       });
@@ -344,81 +301,42 @@ export class Calculate {
    * Generates a logic program.
    * @param cardKey Optional, sub-card tree defining card
    */
-  public async generate(cardKey?: string) {
+  public async generate() {
     await Calculate.mutex.runExclusive(async () => {
       this.logger.trace(
         {
           clingo: true,
-          cardKey,
         },
         'Generating logic program',
       );
+      removeAllPrograms();
 
       if (!this.modulesInitialized) {
         await this.initializeModules();
         this.modulesInitialized = true;
       }
+      // Set base common programs with main flag
+      setProgram('base', lpFiles.common.base, [MAIN_FLAG]);
+      setProgram('queryLanguage', lpFiles.common.queryLanguage, [MAIN_FLAG]);
 
-      let card: Card | undefined;
-      if (cardKey) {
-        card = await this.project.findSpecificCard(cardKey, {
-          metadata: true,
-          children: true,
-          content: false,
-          parent: false,
-        });
-        if (!card) {
-          throw new Error(`Card '${cardKey}' not found`);
-        }
-      }
-      const calculations = await this.generateCalculations();
-      const cardTreeContent = await this.generateCardTreeContent(card);
-      const workFlows = await this.generateWorkFlows();
-      const cardTypes = await this.generateCardTypes();
-      const fieldTypes = await this.generateFieldTypes();
-      const linkTypes = await this.generateLinkTypes();
-      const reports = await this.generateReports();
-      const templates = await this.generateTemplates();
+      setProgram('utils', lpFiles.common.utils, [MAIN_FLAG]);
 
-      // Combine all resources
-      const resourcesProgram =
-        '% SECTION: RESOURCES_START\n' +
-        calculations +
-        workFlows +
-        cardTypes +
-        fieldTypes +
-        linkTypes +
-        reports +
-        templates +
-        '% SECTION: RESOURCES_END';
+      // Set modules program
+      setProgram('modules', this.modules, [MAIN_FLAG]);
 
-      // Create base program content
-      const baseProgram =
-        '% SECTION: BASE_START\n' +
-        lpFiles.common.base +
-        '\n% SECTION: BASE_END\n\n' +
-        this.modules +
-        '\n\n' +
-        cardTreeContent +
-        '\n\n' +
-        resourcesProgram;
+      // Set individual resource type programs
+      await this.setCardTreeContent();
+      await this.setCardTypesPrograms();
+      await this.setFieldTypesPrograms();
+      await this.setLinkTypesPrograms();
+      await this.setWorkflowsPrograms();
+      await this.setReportsPrograms();
+      await this.setTemplatesPrograms();
+      await this.setCalculationsPrograms();
 
-      // Set the base programs separately
-      setBaseProgram(baseProgram, BASE_PROGRAM_KEY);
-      setBaseProgram(
-        '% SECTION: QUERY_LANGUAGE_START\n' +
-          lpFiles.common.queryLanguage +
-          '\n% SECTION: QUERY_LANGUAGE_END',
-        QUERY_LANGUAGE_KEY,
-      );
-      setBaseProgram(lpFiles.common.utils, UTILS_PROGRAM_KEY);
-
-      // Also store the base program (without query language) for updates
-      this.logicProgram = baseProgram;
       this.logger.trace(
         {
           clingo: true,
-          cardKey,
         },
         'Logic program set',
       );
@@ -430,7 +348,9 @@ export class Calculate {
    * @param changedCard Card that was changed.
    */
   public async handleCardChanged(changedCard: Card) {
-    await this.generate(changedCard.key);
+    await Calculate.mutex.runExclusive(async () => {
+      await this.setCardContent(changedCard);
+    });
     return { statusCode: 200 };
   }
 
@@ -442,22 +362,15 @@ export class Calculate {
     if (!deletedCard) {
       return;
     }
-
     await Calculate.mutex.runExclusive(async () => {
-      const affectedCards = await this.getCards(deletedCard);
-
-      // Filter out deleted cards' content from the cardsProgram string
-      for (const card of affectedCards) {
-        // Remove card-specific content from the in-memory program using section markers
-        const cardSectionPattern = new RegExp(
-          `% SECTION: CARD_${card.key}_START[\\s\\S]*?% SECTION: CARD_${card.key}_END\\n\\n`,
-          'g',
+      if (!removeProgram(deletedCard.key)) {
+        this.logger.warn(
+          {
+            cardKey: deletedCard.key,
+          },
+          'Tried to remove card program that does not exist',
         );
-        this.logicProgram = this.logicProgram.replace(cardSectionPattern, '');
       }
-
-      // Update the base program after modifying logicProgram
-      setBaseProgram(this.logicProgram, BASE_PROGRAM_KEY);
     });
   }
 
@@ -470,28 +383,10 @@ export class Calculate {
       return;
     }
 
-    // Only proceed if we already have a logic program
-    if (!this.logicProgram) {
-      return;
-    }
-
     await Calculate.mutex.runExclusive(async () => {
-      // Generate content for all cards (including new ones)
-      const cardTreeContent = await this.generateCardTreeContent(undefined);
-
-      // Update the main logic program with the new cards program
-      if (
-        this.logicProgram.includes('% SECTION: CARDS_START') &&
-        this.logicProgram.includes('% SECTION: CARDS_END')
-      ) {
-        this.logicProgram = this.logicProgram.replace(
-          /% SECTION: CARDS_START[\s\S]*?% SECTION: CARDS_END/,
-          cardTreeContent,
-        );
+      for (const card of cards) {
+        await this.setCardContent(card);
       }
-
-      // Update the base program after modifying logicProgram
-      setBaseProgram(this.logicProgram, BASE_PROGRAM_KEY);
     });
 
     const cardKeys = cards.map((item) => item.key);

--- a/tools/data-handler/src/commands/calculate.ts
+++ b/tools/data-handler/src/commands/calculate.ts
@@ -60,8 +60,8 @@ import {
 import { generateReportContent } from '../utils/report.js';
 import { lpFiles, graphvizReport } from '@cyberismo/assets';
 
-// Define the main flag that will be used for all programs
-const MAIN_FLAG = 'main';
+// Define the all category that will be used for all programs
+const ALL_CATEGORY = 'all';
 
 // Class that calculates with logic program card / project level calculations.
 export class Calculate {
@@ -110,7 +110,7 @@ export class Calculate {
 
   private async setCardContent(card: Card) {
     const cardContent = await createCardFacts(card, this.project);
-    setProgram(card.key, cardContent, [MAIN_FLAG]);
+    setProgram(card.key, cardContent, [ALL_CATEGORY]);
   }
 
   // Generates logic programs related to modules (and project itself).
@@ -139,7 +139,7 @@ export class Calculate {
       if (!cardType) continue;
 
       const cardTypeContent = createCardTypeFacts(cardType);
-      setProgram(cardType.name, cardTypeContent, [MAIN_FLAG]);
+      setProgram(cardType.name, cardTypeContent, [ALL_CATEGORY]);
     }
   }
 
@@ -153,7 +153,7 @@ export class Calculate {
       if (!fieldType) continue;
 
       const fieldTypeContent = createFieldTypeFacts(fieldType);
-      setProgram(fieldType.name, fieldTypeContent, [MAIN_FLAG]);
+      setProgram(fieldType.name, fieldTypeContent, [ALL_CATEGORY]);
     }
   }
 
@@ -167,7 +167,7 @@ export class Calculate {
       if (!linkType) continue;
 
       const linkTypeContent = createLinkTypeFacts(linkType);
-      setProgram(linkType.name, linkTypeContent, [MAIN_FLAG]);
+      setProgram(linkType.name, linkTypeContent, [ALL_CATEGORY]);
     }
   }
 
@@ -181,7 +181,7 @@ export class Calculate {
       if (!workflow) continue;
 
       const workflowContent = createWorkflowFacts(workflow);
-      setProgram(workflow.name, workflowContent, [MAIN_FLAG]);
+      setProgram(workflow.name, workflowContent, [ALL_CATEGORY]);
     }
   }
 
@@ -195,7 +195,7 @@ export class Calculate {
       if (!report) continue;
 
       const reportContent = createReportFacts(report);
-      setProgram(report.name, reportContent, [MAIN_FLAG]);
+      setProgram(report.name, reportContent, [ALL_CATEGORY]);
     }
   }
 
@@ -212,9 +212,9 @@ export class Calculate {
       const cards = await this.getCards(template.name);
       for (const card of cards) {
         const cardContent = await createCardFacts(card, this.project);
-        setProgram(card.key, cardContent, [MAIN_FLAG]);
+        setProgram(card.key, cardContent, [ALL_CATEGORY]);
       }
-      setProgram(template.name, templateContent, [MAIN_FLAG]);
+      setProgram(template.name, templateContent, [ALL_CATEGORY]);
     }
   }
 
@@ -235,7 +235,7 @@ export class Calculate {
         if (pathExists(filePath)) {
           try {
             const moduleContent = await readFile(filePath, 'utf-8');
-            setProgram(calculationFile.name, moduleContent, [MAIN_FLAG]);
+            setProgram(calculationFile.name, moduleContent, [ALL_CATEGORY]);
           } catch (error) {
             this.logger.warn(
               error,
@@ -265,8 +265,8 @@ export class Calculate {
   private async run(query: string, context: Context): Promise<string[]> {
     try {
       const res = await Calculate.mutex.runExclusive(async () => {
-        // Use the main flag to include all programs
-        const basePrograms = [MAIN_FLAG];
+        // Use the main category to include all programs
+        const basePrograms = [ALL_CATEGORY];
 
         this.logger.trace(
           {
@@ -276,7 +276,7 @@ export class Calculate {
         );
 
         const contextFacts = createContextFacts(context);
-        setProgram('context', contextFacts, [MAIN_FLAG]);
+        setProgram('context', contextFacts, [ALL_CATEGORY]);
         // Then solve with the program - need to pass the program as parameter
         return solve(query, basePrograms);
       });
@@ -315,14 +315,14 @@ export class Calculate {
         await this.initializeModules();
         this.modulesInitialized = true;
       }
-      // Set base common programs with main flag
-      setProgram('base', lpFiles.common.base, [MAIN_FLAG]);
-      setProgram('queryLanguage', lpFiles.common.queryLanguage, [MAIN_FLAG]);
+      // Set base common programs with main category
+      setProgram('base', lpFiles.common.base, [ALL_CATEGORY]);
+      setProgram('queryLanguage', lpFiles.common.queryLanguage, [ALL_CATEGORY]);
 
-      setProgram('utils', lpFiles.common.utils, [MAIN_FLAG]);
+      setProgram('utils', lpFiles.common.utils, [ALL_CATEGORY]);
 
       // Set modules program
-      setProgram('modules', this.modules, [MAIN_FLAG]);
+      setProgram('modules', this.modules, [ALL_CATEGORY]);
 
       // Set individual resource type programs
       await this.setCardTreeContent();

--- a/tools/node-clingo/README.md
+++ b/tools/node-clingo/README.md
@@ -21,7 +21,7 @@ import {
   setProgram,
   removeProgram,
   removeAllPrograms,
-  removeProgramsByFlag,
+  removeProgramsByCategory,
 } from '@cyberismo/node-clingo';
 
 // Solve a simple logic program
@@ -48,7 +48,7 @@ const result4 = await solve('valid :- color(X), shape(Y), size(Z).', [
   'sizes',
 ]);
 
-// Programs with flags for easier management
+// Programs with categories for easier management
 setProgram('base-facts', 'person(alice). person(bob).', ['facts']);
 setProgram('base-rules', 'friend(X,Y) :- person(X), person(Y), X != Y.', [
   'rules',
@@ -57,7 +57,7 @@ const result5 = await solve('happy(X) :- friend(X,Y).', ['facts', 'rules']);
 
 // Remove programs
 removeProgram('query'); // removes specific program
-removeProgramsByFlag('facts'); // removes all programs with 'facts' flag
+removeProgramsByCategory('facts'); // removes all programs with 'facts' category
 removeAllPrograms(); // clears all programs
 ```
 
@@ -65,9 +65,9 @@ removeAllPrograms(); // clears all programs
 
 ## API
 
-### `async solve(program: string, refs?: string[]): Promise<ClingoResult>`
+### `async solve(program: string, categories?: string[]): Promise<ClingoResult>`
 
-Solves a logic program, optionally combining with one or more stored programs referenced by key or flag. Returns all answer sets, execution time (μs), and any errors/warnings.
+Solves a logic program, optionally combining with one or more stored programs referenced by key or category. Returns all answer sets, execution time (μs), and any errors/warnings.
 
 **Returns:** `ClingoResult` object with:
 
@@ -76,15 +76,15 @@ Solves a logic program, optionally combining with one or more stored programs re
 - `errors: string[]` - Any error messages from Clingo
 - `warnings: string[]` - Any warning messages from Clingo
 
-### `setProgram(key: string, program: string, refs?: string[])`
+### `setProgram(key: string, program: string, categories?: string[])`
 
-Stores a program under a key. Optionally assign flags (refs) for easier program management.
+Stores a program under a key. Optionally assign categories for easier program management.
 
 **Parameters:**
 
 - `key: string` - Unique identifier for this program
 - `program: string` - The logic program content
-- `refs?: string[]` - Optional array of flag names to associate with this program
+- `categories?: string[]` - Optional array of category names to associate with this program
 
 ### `removeProgram(key: string): boolean`
 
@@ -92,9 +92,9 @@ Removes a stored program by key.
 
 **Returns:** `true` if the program was found and removed, `false` if it didn't exist.
 
-### `removeProgramsByFlag(flag: string): number`
+### `removeProgramsByCategory(category: string): number`
 
-Removes all stored programs that have the specified flag.
+Removes all stored programs that have the specified category.
 
 **Returns:** Number of programs removed.
 

--- a/tools/node-clingo/binding.gyp
+++ b/tools/node-clingo/binding.gyp
@@ -6,8 +6,6 @@
   "targets": [
     {
       "target_name": "node-clingo",
-      "cflags!": [ "-fno-exceptions" ],
-      "cflags_cc!": [ "-fno-exceptions" ],
       "cflags_cc": [ "-std=c++20" ],
       "sources": [ 
         "src/binding.cc",
@@ -18,17 +16,14 @@
         "<!@(node -p \"require('node-addon-api').include\")",
         "<(conda_prefix)/Library/include"
       ],
-      "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ],
+      "dependencies": [
+        "<!(node -p \"require('node-addon-api').targets\"):node_addon_api_except_all"
+      ],
       "conditions": [
         ["OS=='win'", {
           "libraries": [
             "<(conda_prefix)/Library/lib/import_clingo.lib"
           ],
-          "msvs_settings": {
-            "VCCLCompilerTool": {
-              "ExceptionHandling": 1
-            }
-          },
           "copies": [
             {
               "destination": "<(PRODUCT_DIR)",
@@ -76,7 +71,6 @@
             }]
           ],
           "xcode_settings": {
-            "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
             "OTHER_LDFLAGS": [
               "-Wl,-rpath,@loader_path"
             ]

--- a/tools/node-clingo/lib/index.ts
+++ b/tools/node-clingo/lib/index.ts
@@ -46,13 +46,13 @@ interface ClingoResult {
 }
 
 /**
- * Sets a program with optional refs
+ * Sets a program with optional categories
  * @param key Name to identify this program
  * @param program The program content
- * @param refs Optional array of reference names
+ * @param categories Optional array of category names
  */
-function setProgram(key: string, program: string, refs?: string[]) {
-  binding.setProgram(key, program, refs);
+function setProgram(key: string, program: string, categories?: string[]) {
+  binding.setProgram(key, program, categories);
 }
 
 /**
@@ -65,27 +65,30 @@ function removeProgram(key: string): boolean {
 }
 
 /**
- * Removes all stored programs that have the specified flag
- * @param flag The flag to match
+ * Removes all stored programs that have the specified category
+ * @param category The category to match
  * @returns The number of programs removed
  */
-function removeProgramsByFlag(flag: string): number {
-  return binding.removeProgramsByFlag(flag);
+function removeProgramsByCategory(category: string): number {
+  return binding.removeProgramsByCategory(category);
 }
 
 /**
  * Solves a logic program
  * @param program The logic program as a string
- * @param refs Optional array of program keys to include
+ * @param categories Optional array of program keys or categories to include
  * @returns Promise resolving to an object containing answers and execution time
  */
-async function solve(program: string, refs?: string[]): Promise<ClingoResult> {
+async function solve(
+  program: string,
+  categories?: string[],
+): Promise<ClingoResult> {
   if (!program) {
     throw new Error('No program provided');
   }
 
   try {
-    const result = binding.solve(program, refs ?? []);
+    const result = binding.solve(program, categories ?? []);
     return result;
   } catch (error) {
     if (
@@ -122,7 +125,7 @@ export {
   solve,
   setProgram,
   removeProgram,
-  removeProgramsByFlag,
+  removeProgramsByCategory,
   removeAllPrograms,
   ClingoResult,
 };
@@ -130,6 +133,6 @@ export default {
   solve,
   setProgram,
   removeProgram,
-  removeProgramsByFlag,
+  removeProgramsByCategory,
   removeAllPrograms,
 };

--- a/tools/node-clingo/package.json
+++ b/tools/node-clingo/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "license": "AGPL-3.0",
   "dependencies": {
-    "node-addon-api": "^7.1.0",
+    "node-addon-api": "^8.5.0",
     "node-gyp-build": "^4.8.4",
     "tar-stream": "^3.1.7"
   },

--- a/tools/node-clingo/package.json
+++ b/tools/node-clingo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyberismo/node-clingo",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Node.js bindings for Clingo answer set solver",
   "scripts": {
     "install": "node scripts/download-prebuild.js || node-gyp-build",

--- a/tools/node-clingo/test/solve.test.ts
+++ b/tools/node-clingo/test/solve.test.ts
@@ -3,7 +3,7 @@ import {
   solve,
   setProgram,
   removeAllPrograms,
-  removeProgramsByFlag,
+  removeProgramsByCategory,
   removeProgram,
 } from '../lib/index.js';
 
@@ -62,7 +62,7 @@ describe('Clingo solver', () => {
       expect(result2.answers[0]).not.toContain('type(query)');
     });
 
-    it('should work with ref ids', async () => {
+    it('should work with category ids', async () => {
       setProgram('query', 'type(query).', ['ref']);
       const result1 = await solve('valid :- type(query).', ['ref']);
       expect(result1.answers[0]).toContain('valid');
@@ -269,33 +269,33 @@ describe('Clingo solver', () => {
     });
   });
 
-  describe('Program management by flag', () => {
-    it('should remove programs by flag and return count', () => {
-      // Set up programs with various flags
+  describe('Program management by category', () => {
+    it('should remove programs by category and return count', () => {
+      // Set up programs with various categories
       setProgram('program1', 'fact(a).', ['base', 'common']);
       setProgram('program2', 'fact(b).', ['base', 'special']);
       setProgram('program3', 'fact(c).', ['advanced']);
       setProgram('program4', 'fact(d).', ['base']);
 
-      // Remove programs with 'base' flag
-      const removedCount = removeProgramsByFlag('base');
+      // Remove programs with 'base' category
+      const removedCount = removeProgramsByCategory('base');
 
       // Should return 3 (program1, program2, program4)
       expect(removedCount).toBe(3);
     });
 
-    it('should not affect programs without the specified flag', async () => {
+    it('should not affect programs without the specified category', async () => {
       // Set up programs
       setProgram('keep1', 'fact(keep1).', ['advanced']);
       setProgram('remove1', 'fact(remove1).', ['base']);
       setProgram('keep2', 'fact(keep2).', ['special']);
       setProgram('remove2', 'fact(remove2).', ['base', 'other']);
 
-      // Remove programs with 'base' flag
-      const removedCount = removeProgramsByFlag('base');
+      // Remove programs with 'base' category
+      const removedCount = removeProgramsByCategory('base');
       expect(removedCount).toBe(2);
 
-      // Programs without 'base' flag should still work
+      // Programs without 'base' category should still work
       const result1 = await solve('test :- fact(keep1).', ['keep1']);
       expect(result1.answers[0]).toContain('test');
       expect(result1.answers[0]).toContain('fact(keep1)');
@@ -304,53 +304,57 @@ describe('Clingo solver', () => {
       expect(result2.answers[0]).toContain('test');
       expect(result2.answers[0]).toContain('fact(keep2)');
 
-      // Programs with 'base' flag should be gone and not affect solving
+      // Programs with 'base' category should be gone and not affect solving
       const result3 = await solve('a.', ['remove1', 'remove2']);
       expect(result3.answers[0]).toBe('a');
     });
 
-    it('should return 0 when no programs have the specified flag', () => {
-      // Set up programs without the target flag
+    it('should return 0 when no programs have the specified category', () => {
+      // Set up programs without the target category
       setProgram('program1', 'fact(a).', ['other']);
       setProgram('program2', 'fact(b).', ['different']);
 
-      // Try to remove programs with non-existent flag
-      const removedCount = removeProgramsByFlag('nonexistent');
+      // Try to remove programs with non-existent category
+      const removedCount = removeProgramsByCategory('nonexistent');
 
       expect(removedCount).toBe(0);
     });
 
     it('should return 0 when no programs are stored', () => {
       // No programs set up
-      const removedCount = removeProgramsByFlag('any_flag');
+      const removedCount = removeProgramsByCategory('any_category');
       expect(removedCount).toBe(0);
     });
 
-    it('should handle programs with multiple flags correctly', () => {
-      // Set up programs with overlapping flags
-      setProgram('multi1', 'fact(m1).', ['flag1', 'flag2', 'flag3']);
-      setProgram('multi2', 'fact(m2).', ['flag2', 'flag4']);
-      setProgram('multi3', 'fact(m3).', ['flag1', 'flag4']);
-      setProgram('single', 'fact(s).', ['flag5']);
+    it('should handle programs with multiple categories correctly', () => {
+      // Set up programs with overlapping categories
+      setProgram('multi1', 'fact(m1).', [
+        'category1',
+        'category2',
+        'category3',
+      ]);
+      setProgram('multi2', 'fact(m2).', ['category2', 'category4']);
+      setProgram('multi3', 'fact(m3).', ['category1', 'category4']);
+      setProgram('single', 'fact(s).', ['category5']);
 
-      // Remove by flag2 - should remove multi1 and multi2
-      const removedCount1 = removeProgramsByFlag('flag2');
+      // Remove by category2 - should remove multi1 and multi2
+      const removedCount1 = removeProgramsByCategory('category2');
       expect(removedCount1).toBe(2);
 
-      // Remove by flag1 - should remove multi3 (multi1 already removed)
-      const removedCount2 = removeProgramsByFlag('flag1');
+      // Remove by category1 - should remove multi3 (multi1 already removed)
+      const removedCount2 = removeProgramsByCategory('category1');
       expect(removedCount2).toBe(1);
 
-      // Remove by flag5 - should remove single
-      const removedCount3 = removeProgramsByFlag('flag5');
+      // Remove by category5 - should remove single
+      const removedCount3 = removeProgramsByCategory('category5');
       expect(removedCount3).toBe(1);
 
-      // No programs should be left with flag4
-      const removedCount4 = removeProgramsByFlag('flag4');
+      // No programs should be left with category4
+      const removedCount4 = removeProgramsByCategory('category4');
       expect(removedCount4).toBe(0);
     });
 
-    it('should work correctly after removing programs by flag', async () => {
+    it('should work correctly after removing programs by category', async () => {
       // Set up test scenario
       setProgram('base_common', 'common(value).', ['base']);
       setProgram('special_logic', 'special(rule).', ['special']);
@@ -364,7 +368,7 @@ describe('Clingo solver', () => {
       expect(initialResult.answers[0]).toContain('test');
 
       // Remove base programs
-      const removedCount = removeProgramsByFlag('base');
+      const removedCount = removeProgramsByCategory('base');
       expect(removedCount).toBe(1);
 
       // Should still be able to use remaining programs
@@ -381,12 +385,12 @@ describe('Clingo solver', () => {
       expect(withoutBase.answers[0]).toBe('a'); // Only the main program result
     });
 
-    it('should handle empty flag string', () => {
+    it('should handle empty category string', () => {
       setProgram('program1', 'fact(a).', ['', 'normal']);
       setProgram('program2', 'fact(b).', ['normal']);
 
-      // Remove programs with empty flag
-      const removedCount = removeProgramsByFlag('');
+      // Remove programs with empty category
+      const removedCount = removeProgramsByCategory('');
       expect(removedCount).toBe(1);
     });
   });
@@ -437,8 +441,8 @@ describe('Clingo solver', () => {
       expect(removed).toBe(false);
     });
 
-    it('should remove program with specific key while keeping others with same flags', async () => {
-      // Set up programs with same flags but different keys
+    it('should remove program with specific key while keeping others with same categories', async () => {
+      // Set up programs with same categories but different keys
       setProgram('base1', 'type(base1).', ['common']);
       setProgram('base2', 'type(base2).', ['common']);
       setProgram('base3', 'type(base3).', ['common']);
@@ -447,7 +451,7 @@ describe('Clingo solver', () => {
       const removed = removeProgram('base2');
       expect(removed).toBe(true);
 
-      // Other programs with same flag should still work
+      // Other programs with same category should still work
       const result = await solve('test :- type(base1), type(base3).', [
         'common',
       ]);
@@ -457,20 +461,22 @@ describe('Clingo solver', () => {
       expect(result.answers[0]).not.toContain('type(base2)');
     });
 
-    it('should work with programs that have no flags', async () => {
-      setProgram('no_flags', 'fact(no_flags).', []);
-      setProgram('with_flags', 'fact(with_flags).', ['flag']);
+    it('should work with programs that have no categories', async () => {
+      setProgram('no_categories', 'fact(no_categories).', []);
+      setProgram('with_categories', 'fact(with_categories).', ['category']);
 
-      // Remove the program without flags
-      const removed = removeProgram('no_flags');
+      // Remove the program without categories
+      const removed = removeProgram('no_categories');
       expect(removed).toBe(true);
 
-      // Program with flags should still work
-      const result = await solve('test :- fact(with_flags).', ['with_flags']);
+      // Program with categories should still work
+      const result = await solve('test :- fact(with_categories).', [
+        'with_categories',
+      ]);
       expect(result.answers[0]).toContain('test');
 
-      // Program without flags should be gone
-      const result2 = await solve('a.', ['no_flags']);
+      // Program without categories should be gone
+      const result2 = await solve('a.', ['no_categories']);
       expect(result2.answers[0]).toBe('a');
     });
 
@@ -524,14 +530,14 @@ describe('Clingo solver', () => {
 
     it('should work after partial removals', async () => {
       // Set up programs
-      setProgram('keep', 'fact(keep).', ['flag']);
-      setProgram('remove1', 'fact(remove1).', ['flag']);
+      setProgram('keep', 'fact(keep).', ['category']);
+      setProgram('remove1', 'fact(remove1).', ['category']);
       setProgram('remove2', 'fact(remove2).', ['other']);
 
       // Remove some programs individually
       const removed1 = removeProgram('remove1');
       expect(removed1).toBe(true);
-      const removed2 = removeProgramsByFlag('other');
+      const removed2 = removeProgramsByCategory('other');
       expect(removed2).toBe(1);
 
       // One program should still be available

--- a/tools/node-clingo/test/solve.test.ts
+++ b/tools/node-clingo/test/solve.test.ts
@@ -1,10 +1,16 @@
 import { describe, it, expect, afterEach, beforeEach } from 'vitest';
-import { solve, setBaseProgram, clearBaseProgram } from '../dist/index.js';
+import {
+  solve,
+  setProgram,
+  removeAllPrograms,
+  removeProgramsByFlag,
+  removeProgram,
+} from '../lib/index.js';
 
 describe('Clingo solver', () => {
   afterEach(() => {
     // Reset all base programs after each test
-    clearBaseProgram();
+    removeAllPrograms();
   });
 
   it('should solve a simple logic program', async () => {
@@ -17,63 +23,66 @@ describe('Clingo solver', () => {
     expect(result.executionTime).toBeGreaterThan(0);
   });
 
-  it('should use the default base program when solving', async () => {
-    // Set up a base program
-    const baseProgram = 'base(1).';
-    setBaseProgram(baseProgram);
-
-    // Solve with additional rules
-    const program = 'derived :- base(X).';
-    const result = await solve(program);
-
-    expect(result.answers.length).toBeGreaterThan(0);
-    expect(result.answers[0]).toContain('derived');
-    expect(result.answers[0]).toContain('base(1)');
-  });
-
   it('should reuse default base program across multiple solves', async () => {
     // Set base program once
     const baseProgram = 'common(value).';
-    setBaseProgram(baseProgram);
+    setProgram('base', baseProgram);
 
     // First solve
-    const result1 = await solve('a.');
+    const result1 = await solve('a.', ['base']);
     expect(result1.answers[0]).toContain('common(value)');
     expect(result1.answers[0]).toContain('a');
 
     // Second solve with different program
-    const result2 = await solve('b.');
+    const result2 = await solve('b.', ['base']);
     expect(result2.answers[0]).toContain('common(value)');
     expect(result2.answers[0]).toContain('b');
 
     // Third solve with different program
-    const result3 = await solve('c.');
+    const result3 = await solve('c.', ['base']);
     expect(result3.answers[0]).toContain('common(value)');
     expect(result3.answers[0]).toContain('c');
   });
 
   describe('Named base programs', () => {
     it('should use a specified named base program', async () => {
-      setBaseProgram('type(query).', 'query');
-      setBaseProgram('type(graph).', 'graph');
+      setProgram('query', 'type(query).');
+      setProgram('graph', 'type(graph).');
 
       // Use query base program
-      const result1 = await solve('valid :- type(query).', 'query');
+      const result1 = await solve('valid :- type(query).', ['query']);
       expect(result1.answers[0]).toContain('valid');
       expect(result1.answers[0]).toContain('type(query)');
       expect(result1.answers[0]).not.toContain('type(graph)');
 
       // Use graph base program
-      const result2 = await solve('valid :- type(graph).', 'graph');
+      const result2 = await solve('valid :- type(graph).', ['graph']);
       expect(result2.answers[0]).toContain('valid');
       expect(result2.answers[0]).toContain('type(graph)');
       expect(result2.answers[0]).not.toContain('type(query)');
     });
 
+    it('should work with ref ids', async () => {
+      setProgram('query', 'type(query).', ['ref']);
+      const result1 = await solve('valid :- type(query).', ['ref']);
+      expect(result1.answers[0]).toContain('valid');
+      expect(result1.answers[0]).toContain('type(query)');
+    });
+
+    it('should work with multiple refs', async () => {
+      setProgram('query', 'type(query).', ['ref']);
+      setProgram('graph', 'type(graph).', ['ref']);
+      setProgram('base', 'base(base).', ['ref']);
+      const result1 = await solve('valid :- type(query), base(base).', ['ref']);
+      expect(result1.answers[0]).toContain('valid');
+      expect(result1.answers[0]).toContain('type(query)');
+      expect(result1.answers[0]).toContain('base(base)');
+    });
+
     it('should combine multiple base programs', async () => {
-      setBaseProgram('color(red).', 'colors');
-      setBaseProgram('shape(circle).', 'shapes');
-      setBaseProgram('size(large).', 'sizes');
+      setProgram('colors', 'color(red).');
+      setProgram('shapes', 'shape(circle).');
+      setProgram('sizes', 'size(large).');
 
       // Combine multiple base programs
       const result = await solve('valid :- color(X), shape(Y), size(Z).', [
@@ -90,14 +99,14 @@ describe('Clingo solver', () => {
 
     it('should handle non-existent base program gracefully', async () => {
       // Solve with non-existent base program
-      const result = await solve('a.', 'non_existent');
+      const result = await solve('a.', ['non_existent']);
 
       // Should still solve normally
       expect(result.answers[0]).toBe('a');
     });
   });
   it('should handle errors', async () => {
-    await expect(solve('not a program', 'non_existent')).rejects.toThrow();
+    await expect(solve('not a program', ['non_existent'])).rejects.toThrow();
   });
   it('should include errors and warnings in the result', async () => {
     try {
@@ -105,7 +114,7 @@ describe('Clingo solver', () => {
       expect.fail('Expected solve to throw an error');
     } catch (error: any) {
       expect(error).toBeDefined();
-      expect(error.message).toBe('parsing failed');
+      expect(error.message).toContain('Parsing failed');
 
       // Verify the error has details with errors and warnings
       expect(error.details).toBeDefined();
@@ -128,7 +137,7 @@ describe('Clingo solver', () => {
         #show result2/1.
         #show result3/1.
       `;
-      setBaseProgram(showResultsProgram, 'show_results');
+      setProgram('show_results', showResultsProgram);
     });
     it('should extract prefix from valid resource names', async () => {
       const program = `
@@ -136,7 +145,7 @@ describe('Clingo solver', () => {
         result2(@resourcePrefix("local/cardTypes/task")).  
         result3(@resourcePrefix("system/workflows/review")).
       `;
-      const result = await solve(program, 'show_results');
+      const result = await solve(program, ['show_results']);
 
       expect(result.answers[0]).toContain('result("base")');
       expect(result.answers[0]).toContain('result2("local")');
@@ -149,7 +158,7 @@ describe('Clingo solver', () => {
         result2(@resourceType("local/cardTypes/task")).
         result3(@resourceType("system/workflows/review")).
       `;
-      const result = await solve(program, 'show_results');
+      const result = await solve(program, ['show_results']);
 
       expect(result.answers[0]).toContain('result("fieldTypes")');
       expect(result.answers[0]).toContain('result2("cardTypes")');
@@ -162,7 +171,7 @@ describe('Clingo solver', () => {
         result2(@resourceIdentifier("local/cardTypes/task")).
         result3(@resourceIdentifier("system/workflows/review")).
       `;
-      const result = await solve(program, 'show_results');
+      const result = await solve(program, ['show_results']);
 
       expect(result.answers[0]).toContain('result("owner")');
       expect(result.answers[0]).toContain('result2("task")');
@@ -175,7 +184,7 @@ describe('Clingo solver', () => {
         result2(@resourceType("invalidname")).
         result3(@resourceIdentifier("invalidname")).
       `;
-      const result = await solve(program, 'show_results');
+      const result = await solve(program, ['show_results']);
 
       expect(result.answers[0]).toContain('result1("")');
       expect(result.answers[0]).toContain('result2("")');
@@ -188,7 +197,7 @@ describe('Clingo solver', () => {
         result2(@resourceType("base/owner")).
         result3(@resourceIdentifier("base/owner")).
       `;
-      const result = await solve(program, 'show_results');
+      const result = await solve(program, ['show_results']);
 
       expect(result.answers[0]).toContain('result1("")');
       expect(result.answers[0]).toContain('result2("")');
@@ -201,7 +210,7 @@ describe('Clingo solver', () => {
         result2(@resourceType("base/fieldTypes/owner/extra")).
         result3(@resourceIdentifier("base/fieldTypes/owner/extra")).
       `;
-      const result = await solve(program, 'show_results');
+      const result = await solve(program, ['show_results']);
 
       expect(result.answers[0]).toContain('result1("")');
       expect(result.answers[0]).toContain('result2("")');
@@ -214,7 +223,7 @@ describe('Clingo solver', () => {
         result2(@resourceType("")).
         result3(@resourceIdentifier("")).
       `;
-      const result = await solve(program, 'show_results');
+      const result = await solve(program, ['show_results']);
 
       expect(result.answers[0]).toContain('result1("")');
       expect(result.answers[0]).toContain('result2("")');
@@ -227,7 +236,7 @@ describe('Clingo solver', () => {
         result2(@resourceType(456)).
         result3(@resourceIdentifier(789)).
       `;
-      const result = await solve(program, 'show_results');
+      const result = await solve(program, ['show_results']);
 
       expect(result.answers[0]).toContain('result1("")');
       expect(result.answers[0]).toContain('result2("")');
@@ -240,7 +249,7 @@ describe('Clingo solver', () => {
         result2(@resourceType("base-123/field_types/owner-name")).
         result3(@resourceIdentifier("base-123/field_types/owner-name")).
       `;
-      const result = await solve(program, 'show_results');
+      const result = await solve(program, ['show_results']);
 
       expect(result.answers[0]).toContain('result1("base-123")');
       expect(result.answers[0]).toContain('result2("field_types")');
@@ -253,10 +262,302 @@ describe('Clingo solver', () => {
         result1(@resourcePrefix(R)) :- resource(R).
         result2(@concatenate(@resourcePrefix("base/fieldTypes/owner"), "/", @resourceType("base/fieldTypes/owner"))).
       `;
-      const result = await solve(program, 'show_results');
+      const result = await solve(program, ['show_results']);
 
       expect(result.answers[0]).toContain('result1("base")');
       expect(result.answers[0]).toContain('result2("base/fieldTypes")');
+    });
+  });
+
+  describe('Program management by flag', () => {
+    it('should remove programs by flag and return count', () => {
+      // Set up programs with various flags
+      setProgram('program1', 'fact(a).', ['base', 'common']);
+      setProgram('program2', 'fact(b).', ['base', 'special']);
+      setProgram('program3', 'fact(c).', ['advanced']);
+      setProgram('program4', 'fact(d).', ['base']);
+
+      // Remove programs with 'base' flag
+      const removedCount = removeProgramsByFlag('base');
+
+      // Should return 3 (program1, program2, program4)
+      expect(removedCount).toBe(3);
+    });
+
+    it('should not affect programs without the specified flag', async () => {
+      // Set up programs
+      setProgram('keep1', 'fact(keep1).', ['advanced']);
+      setProgram('remove1', 'fact(remove1).', ['base']);
+      setProgram('keep2', 'fact(keep2).', ['special']);
+      setProgram('remove2', 'fact(remove2).', ['base', 'other']);
+
+      // Remove programs with 'base' flag
+      const removedCount = removeProgramsByFlag('base');
+      expect(removedCount).toBe(2);
+
+      // Programs without 'base' flag should still work
+      const result1 = await solve('test :- fact(keep1).', ['keep1']);
+      expect(result1.answers[0]).toContain('test');
+      expect(result1.answers[0]).toContain('fact(keep1)');
+
+      const result2 = await solve('test :- fact(keep2).', ['keep2']);
+      expect(result2.answers[0]).toContain('test');
+      expect(result2.answers[0]).toContain('fact(keep2)');
+
+      // Programs with 'base' flag should be gone and not affect solving
+      const result3 = await solve('a.', ['remove1', 'remove2']);
+      expect(result3.answers[0]).toBe('a');
+    });
+
+    it('should return 0 when no programs have the specified flag', () => {
+      // Set up programs without the target flag
+      setProgram('program1', 'fact(a).', ['other']);
+      setProgram('program2', 'fact(b).', ['different']);
+
+      // Try to remove programs with non-existent flag
+      const removedCount = removeProgramsByFlag('nonexistent');
+
+      expect(removedCount).toBe(0);
+    });
+
+    it('should return 0 when no programs are stored', () => {
+      // No programs set up
+      const removedCount = removeProgramsByFlag('any_flag');
+      expect(removedCount).toBe(0);
+    });
+
+    it('should handle programs with multiple flags correctly', () => {
+      // Set up programs with overlapping flags
+      setProgram('multi1', 'fact(m1).', ['flag1', 'flag2', 'flag3']);
+      setProgram('multi2', 'fact(m2).', ['flag2', 'flag4']);
+      setProgram('multi3', 'fact(m3).', ['flag1', 'flag4']);
+      setProgram('single', 'fact(s).', ['flag5']);
+
+      // Remove by flag2 - should remove multi1 and multi2
+      const removedCount1 = removeProgramsByFlag('flag2');
+      expect(removedCount1).toBe(2);
+
+      // Remove by flag1 - should remove multi3 (multi1 already removed)
+      const removedCount2 = removeProgramsByFlag('flag1');
+      expect(removedCount2).toBe(1);
+
+      // Remove by flag5 - should remove single
+      const removedCount3 = removeProgramsByFlag('flag5');
+      expect(removedCount3).toBe(1);
+
+      // No programs should be left with flag4
+      const removedCount4 = removeProgramsByFlag('flag4');
+      expect(removedCount4).toBe(0);
+    });
+
+    it('should work correctly after removing programs by flag', async () => {
+      // Set up test scenario
+      setProgram('base_common', 'common(value).', ['base']);
+      setProgram('special_logic', 'special(rule).', ['special']);
+      setProgram('keep_this', 'keep(this).', ['keep']);
+
+      // Verify initial state works
+      const initialResult = await solve('test :- common(value), keep(this).', [
+        'base',
+        'keep',
+      ]);
+      expect(initialResult.answers[0]).toContain('test');
+
+      // Remove base programs
+      const removedCount = removeProgramsByFlag('base');
+      expect(removedCount).toBe(1);
+
+      // Should still be able to use remaining programs
+      const afterRemoval = await solve('test :- special(rule), keep(this).', [
+        'special',
+        'keep',
+      ]);
+      expect(afterRemoval.answers[0]).toContain('test');
+      expect(afterRemoval.answers[0]).toContain('special(rule)');
+      expect(afterRemoval.answers[0]).toContain('keep(this)');
+
+      // Base program should no longer be available
+      const withoutBase = await solve('a.', ['base']);
+      expect(withoutBase.answers[0]).toBe('a'); // Only the main program result
+    });
+
+    it('should handle empty flag string', () => {
+      setProgram('program1', 'fact(a).', ['', 'normal']);
+      setProgram('program2', 'fact(b).', ['normal']);
+
+      // Remove programs with empty flag
+      const removedCount = removeProgramsByFlag('');
+      expect(removedCount).toBe(1);
+    });
+  });
+
+  describe('Single program removal', () => {
+    it('should remove a specific program by key', async () => {
+      // Set up programs
+      setProgram('remove_me', 'fact(remove).', ['test']);
+      setProgram('keep_me', 'fact(keep).', ['test']);
+
+      // Verify both programs work initially
+      const initialResult = await solve('test :- fact(remove), fact(keep).', [
+        'remove_me',
+        'keep_me',
+      ]);
+      expect(initialResult.answers[0]).toContain('test');
+
+      // Remove one program
+      const removed = removeProgram('remove_me');
+      expect(removed).toBe(true);
+
+      // Verify the kept program still works
+      const afterRemoval = await solve('test :- fact(keep).', ['keep_me']);
+      expect(afterRemoval.answers[0]).toContain('test');
+      expect(afterRemoval.answers[0]).toContain('fact(keep)');
+
+      // Verify the removed program is no longer available
+      const withoutRemoved = await solve('a.', ['remove_me']);
+      expect(withoutRemoved.answers[0]).toBe('a'); // Only main program result
+    });
+
+    it('should handle removing non-existent program gracefully', async () => {
+      // Set up one program
+      setProgram('exists', 'fact(exists).', []);
+
+      // Try to remove non-existent program (should not throw)
+      const removed = removeProgram('does_not_exist');
+      expect(removed).toBe(false);
+
+      // Existing program should still be there
+      const result = await solve('test :- fact(exists).', ['exists']);
+      expect(result.answers[0]).toContain('test');
+    });
+
+    it('should handle removing from empty program store', () => {
+      // No programs set up, try to remove something
+      const removed = removeProgram('anything');
+      expect(removed).toBe(false);
+    });
+
+    it('should remove program with specific key while keeping others with same flags', async () => {
+      // Set up programs with same flags but different keys
+      setProgram('base1', 'type(base1).', ['common']);
+      setProgram('base2', 'type(base2).', ['common']);
+      setProgram('base3', 'type(base3).', ['common']);
+
+      // Remove specific program
+      const removed = removeProgram('base2');
+      expect(removed).toBe(true);
+
+      // Other programs with same flag should still work
+      const result = await solve('test :- type(base1), type(base3).', [
+        'common',
+      ]);
+      expect(result.answers[0]).toContain('test');
+      expect(result.answers[0]).toContain('type(base1)');
+      expect(result.answers[0]).toContain('type(base3)');
+      expect(result.answers[0]).not.toContain('type(base2)');
+    });
+
+    it('should work with programs that have no flags', async () => {
+      setProgram('no_flags', 'fact(no_flags).', []);
+      setProgram('with_flags', 'fact(with_flags).', ['flag']);
+
+      // Remove the program without flags
+      const removed = removeProgram('no_flags');
+      expect(removed).toBe(true);
+
+      // Program with flags should still work
+      const result = await solve('test :- fact(with_flags).', ['with_flags']);
+      expect(result.answers[0]).toContain('test');
+
+      // Program without flags should be gone
+      const result2 = await solve('a.', ['no_flags']);
+      expect(result2.answers[0]).toBe('a');
+    });
+
+    it('should return correct boolean values for removal attempts', () => {
+      setProgram('exists', 'fact(exists).', []);
+
+      // First removal should return true
+      const firstRemove = removeProgram('exists');
+      expect(firstRemove).toBe(true);
+
+      // Second removal of same program should return false
+      const secondRemove = removeProgram('exists');
+      expect(secondRemove).toBe(false);
+
+      // Removing non-existent program should return false
+      const nonExistentRemove = removeProgram('never_existed');
+      expect(nonExistentRemove).toBe(false);
+    });
+  });
+
+  describe('Remove all programs', () => {
+    it('should remove all stored programs', async () => {
+      // Set up multiple programs with different configurations
+      setProgram('program1', 'fact(1).', ['flag1']);
+      setProgram('program2', 'fact(2).', ['flag2', 'flag3']);
+      setProgram('program3', 'fact(3).', []);
+      setProgram('program4', 'fact(4).', ['flag1', 'flag4']);
+
+      // Verify programs work initially
+      const initialResult = await solve('test :- fact(1).', ['program1']);
+      expect(initialResult.answers[0]).toContain('test');
+
+      // Remove all programs
+      removeAllPrograms();
+
+      // All programs should be gone - solve should work with empty refs
+      const afterClear1 = await solve('a.', ['program1']);
+      expect(afterClear1.answers[0]).toBe('a');
+
+      const afterClear2 = await solve('b.', ['flag1']);
+      expect(afterClear2.answers[0]).toBe('b');
+
+      const afterClear3 = await solve('c.', ['program3']);
+      expect(afterClear3.answers[0]).toBe('c');
+    });
+
+    it('should work when no programs are stored', () => {
+      // Call removeAllPrograms when no programs exist
+      removeAllPrograms();
+    });
+
+    it('should work after partial removals', async () => {
+      // Set up programs
+      setProgram('keep', 'fact(keep).', ['flag']);
+      setProgram('remove1', 'fact(remove1).', ['flag']);
+      setProgram('remove2', 'fact(remove2).', ['other']);
+
+      // Remove some programs individually
+      const removed1 = removeProgram('remove1');
+      expect(removed1).toBe(true);
+      const removed2 = removeProgramsByFlag('other');
+      expect(removed2).toBe(1);
+
+      // One program should still be available
+      const beforeClearAll = await solve('test :- fact(keep).', ['keep']);
+      expect(beforeClearAll.answers[0]).toContain('test');
+
+      // Remove all remaining programs
+      removeAllPrograms();
+
+      // Everything should be gone now
+      const afterClearAll = await solve('a.', ['keep']);
+      expect(afterClearAll.answers[0]).toBe('a');
+    });
+
+    it('should return true indicating successful operation', () => {
+      setProgram('test', 'fact(test).', []);
+      removeAllPrograms();
+    });
+
+    it('should be safe to call multiple times', () => {
+      setProgram('test', 'fact(test).', []);
+
+      // Call multiple times
+      removeAllPrograms();
+      removeAllPrograms();
+      removeAllPrograms();
     });
   });
 });


### PR DESCRIPTION
We add context by setting each logic program for each resource separately. To make adding logic program to solves easier, I created a system where:
* Each program has a key(e.g. `base/fieldTypes/myFieldType`
* Each program may have flags(e.g. `resources` or `main`)

When you want to solve something, you may use flags or keys to add logic programs. Currently we only have flag `main`, which adds every single logic program there is.


### Errors
For example, if there is an exception in some calculation:
<img width="1229" height="220" alt="image" src="https://github.com/user-attachments/assets/1ce92207-9039-4ce7-8fe1-20b38b59431d" />




### Exceptions
Our exception handling was quite complex as we had NAPI on no-exception mode while we had c++ exceptions enabled. After upgrading NAPI to a newer version, I started using NAPIs `except_all` target, which catches std exceptions too so we do not have to add the boilerplate try catch for all functions.