### PR TITLE
INTDEV-901 Update specific module

### DIFF
--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -768,15 +768,18 @@ program
     },
   );
 
-// Updates all modules in the project.
+// Updates all modules, or specific named module in the project.
 program
   .command('update-modules')
-  .description('Updates all imported modules with latest versions')
+  .description(
+    'Updates to latest versions either all modules or a specific module',
+  )
+  .argument('[moduleName]', 'Module name')
   .option('-p, --project-path [path]', `${pathGuideline}`)
-  .action(async (options: CardsOptions) => {
+  .action(async (moduleName, options: CardsOptions) => {
     const result = await commandHandler.command(
       Cmd.updateModules,
-      [],
+      [moduleName],
       Object.assign({}, options, program.opts()),
       credentials(),
     );

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -352,7 +352,12 @@ export class Commands {
           newValue ? JSON.parse(newValue) : undefined,
         );
       } else if (command === Cmd.updateModules) {
-        await this.commands?.importCmd.updateAllModules(credentials);
+        const [module] = args;
+        if (module) {
+          await this.commands?.importCmd.updateModule(module, credentials);
+        } else {
+          await this.commands?.importCmd.updateAllModules(credentials);
+        }
       } else if (command === Cmd.validate) {
         return this.validate();
       } else {

--- a/tools/data-handler/src/commands/import.ts
+++ b/tools/data-handler/src/commands/import.ts
@@ -173,6 +173,22 @@ export class Import {
   }
 
   /**
+   * Updates a specific imported module.
+   * @param moduleName Name (prefix) of module to update.
+   * @param credentials Optional credentials for a private module.
+   * @throws if module is not part of the project
+   */
+  public async updateModule(moduleName: string, credentials?: Credentials) {
+    const module = this.project.configuration.modules.find(
+      (item) => item.name === moduleName,
+    );
+    if (!module) {
+      throw new Error(`Module '${moduleName}' is not part of the project`);
+    }
+    return this.moduleManager.updateModule(module, credentials);
+  }
+
+  /**
    * Updates all imported modules.
    * @param credentials Optional credentials for private modules.
    */

--- a/tools/data-handler/test/module-manager.test.ts
+++ b/tools/data-handler/test/module-manager.test.ts
@@ -149,4 +149,32 @@ describe('module-manager', () => {
     modules = await commands.showCmd.showModules();
     expect(modules.length).equals(2);
   }).timeout(60000);
+  it('update a specific module', async () => {
+    let modules = await commands.showCmd.showModules();
+    expect(modules.length).equals(0);
+    const localModule = join(testDir, 'valid/minimal');
+    await commands.importCmd.importModule(
+      localModule,
+      commands.project.basePath,
+    );
+
+    const gitModule = 'https://github.com/CyberismoCom/module-base.git';
+    await commands.importCmd.importModule(
+      gitModule,
+      commands.project.basePath,
+      {
+        credentials: {
+          username: process.env.CYBERISMO_GIT_USER,
+          token: process.env.CYBERISMO_GIT_TOKEN,
+        },
+      },
+    );
+
+    modules = await commands.showCmd.showModules();
+    expect(modules.length).equals(2);
+
+    await commands.importCmd.updateModule('base');
+    modules = await commands.showCmd.showModules();
+    expect(modules.length).equals(2);
+  }).timeout(60000);
 });


### PR DESCRIPTION
Add possibility to update just one specific module.
Similarly to updating all modules, it also fetches the dependencies and updates them too. 

Implementation re-uses `update modules` command by having an optional string parameter for it. 
It is not ideal, but I think updating all modules is the normal use case (and thus, should be as easy as possible) and updating a specific module is a bit rarer. Thus, I didn't want to change the update command so that you'd need to use a flag / option for updating all modules (e.g. "cyberismo update-module --all"), even though the command in CLI is now a bit semantically funny ("cyberismo update-modules base").