### PR TITLE
INTDEV-954 Enable linting for 'backend' and 'node-clingo'

### DIFF
--- a/tools/backend/eslint.config.js
+++ b/tools/backend/eslint.config.js
@@ -1,0 +1,19 @@
+// @ts-check
+
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import eslintConfigPrettier from 'eslint-config-prettier';
+
+export default [
+  {
+    ignores: ['**/dist/*', '**/init.js'],
+  },
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  eslintConfigPrettier,
+  {
+    rules: {
+      '@typescript-eslint/consistent-type-imports': 'error',
+    },
+  },
+];

--- a/tools/backend/package.json
+++ b/tools/backend/package.json
@@ -10,7 +10,8 @@
     "debug": "tsx --inspect-brk src/main.ts",
     "export": "pnpm build && node dist/main.js --export",
     "build": "tsc -p tsconfig.build.json && shx rm -rf ./dist/public && shx cp -r ../app/dist ./dist/public",
-    "test": "vitest run"
+    "test": "vitest run",
+    "lint": "eslint ."
   },
   "keywords": [],
   "author": "",

--- a/tools/backend/src/domain/cards/index.ts
+++ b/tools/backend/src/domain/cards/index.ts
@@ -11,8 +11,8 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Context, Hono } from 'hono';
-import { ContentfulStatusCode } from 'hono/utils/http-status';
+import { type Context, Hono } from 'hono';
+import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { ssgParams, isSSGContext } from '../../export.js';
 import { getCardDetails } from './lib.js';
 import * as cardService from './service.js';
@@ -604,6 +604,7 @@ router.get(
         key,
         filename,
       );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const payload = attachmentResponse as any;
 
       return new Response(payload.fileBuffer, {

--- a/tools/backend/src/domain/cards/lib.ts
+++ b/tools/backend/src/domain/cards/lib.ts
@@ -13,18 +13,24 @@
 
 import Processor from '@asciidoctor/core';
 import {
-  Card,
+  type Card,
   CardLocation,
-  ProjectFetchCardDetails,
+  type ProjectFetchCardDetails,
 } from '@cyberismo/data-handler/interfaces/project-interfaces';
-import { CommandManager, evaluateMacros } from '@cyberismo/data-handler';
+import { type CommandManager, evaluateMacros } from '@cyberismo/data-handler';
 import { getCardQueryResult } from '../../export.js';
+
+interface result {
+  status: number;
+  message?: string;
+  data?: object;
+}
 
 export async function getCardDetails(
   commands: CommandManager,
   key: string,
   staticMode?: boolean,
-): Promise<any> {
+): Promise<result> {
   const fetchCardDetails: ProjectFetchCardDetails = {
     attachments: true,
     children: false,

--- a/tools/backend/src/domain/cards/service.ts
+++ b/tools/backend/src/domain/cards/service.ts
@@ -14,9 +14,9 @@
 import Processor from '@asciidoctor/core';
 import {
   CardLocation,
-  MetadataContent,
+  type MetadataContent,
 } from '@cyberismo/data-handler/interfaces/project-interfaces';
-import { CommandManager, evaluateMacros } from '@cyberismo/data-handler';
+import { type CommandManager, evaluateMacros } from '@cyberismo/data-handler';
 import { getCardDetails } from './lib.js';
 
 export async function getProjectInfo(commands: CommandManager) {
@@ -43,15 +43,14 @@ export async function getProjectInfo(commands: CommandManager) {
 export async function updateCard(
   commands: CommandManager,
   key: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   body: any,
 ) {
-  let successes = 0;
   const errors = [];
 
   if (body.state) {
     try {
       await commands.transitionCmd.cardTransition(key, body.state);
-      successes++;
     } catch (error) {
       if (error instanceof Error) errors.push(error.message);
     }
@@ -60,7 +59,6 @@ export async function updateCard(
   if (body.content != null) {
     try {
       await commands.editCmd.editCardContent(key, body.content);
-      successes++;
     } catch (error) {
       if (error instanceof Error) errors.push(error.message);
     }
@@ -72,7 +70,6 @@ export async function updateCard(
 
       try {
         await commands.editCmd.editCardMetadata(key, metadataKey, value);
-        successes++;
       } catch (error) {
         if (error instanceof Error) errors.push(error.message);
       }
@@ -82,7 +79,6 @@ export async function updateCard(
   if (body.parent) {
     try {
       await commands.moveCmd.moveCard(key, body.parent);
-      successes++;
     } catch (error) {
       if (error instanceof Error) errors.push(error.message);
     }
@@ -90,7 +86,6 @@ export async function updateCard(
   if (body.index != null) {
     try {
       await commands.moveCmd.rankByIndex(key, body.index);
-      successes++;
     } catch (error) {
       if (error instanceof Error) errors.push(error.message);
     }

--- a/tools/backend/src/domain/fieldTypes/service.ts
+++ b/tools/backend/src/domain/fieldTypes/service.ts
@@ -11,7 +11,7 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { CommandManager } from '@cyberismo/data-handler';
+import type { CommandManager } from '@cyberismo/data-handler';
 
 export async function getFieldTypes(commands: CommandManager) {
   const response = await commands.showCmd.showResources('fieldTypes');

--- a/tools/backend/src/domain/linkTypes/service.ts
+++ b/tools/backend/src/domain/linkTypes/service.ts
@@ -11,7 +11,7 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { CommandManager } from '@cyberismo/data-handler';
+import type { CommandManager } from '@cyberismo/data-handler';
 
 export async function getLinkTypes(commands: CommandManager) {
   const response = await commands.showCmd.showResources('linkTypes');

--- a/tools/backend/src/domain/resources/service.ts
+++ b/tools/backend/src/domain/resources/service.ts
@@ -12,18 +12,19 @@
 */
 
 import type { ResourceContent } from '@cyberismo/data-handler/interfaces/resource-interfaces';
-import {
-  type Card,
-  type ResourceFolderType,
+import type {
+  Card,
+  ResourceFolderType,
   RemovableResourceTypes,
 } from '@cyberismo/data-handler/interfaces/project-interfaces';
-import { CommandManager, resourceNameToString } from '@cyberismo/data-handler';
 import {
+  type CommandManager,
   isResourceFolderType,
   moduleNameFromCardKey,
   resourceName,
+  resourceNameToString,
 } from '@cyberismo/data-handler';
-import { ResourceParams } from './schema.js';
+import type { ResourceParams } from './schema.js';
 
 const resourceTypes: ResourceFolderType[] = [
   'calculations',
@@ -39,14 +40,15 @@ const resourceTypes: ResourceFolderType[] = [
 
 export async function buildResourceTree(commands: CommandManager) {
   const project = await commands.showCmd.showProject();
-  const tree: any[] = [];
-  const allModuleResources: { [prefix: string]: { [type: string]: any[] } } =
-    {};
+  const tree: unknown[] = [];
+  const allModuleResources: {
+    [prefix: string]: { [type: string]: unknown[] };
+  } = {};
 
   // Process each resource type
   for (const resourceType of resourceTypes) {
-    let rootResources: any[];
-    let moduleResources: { [prefix: string]: any[] };
+    let rootResources: unknown[];
+    let moduleResources: { [prefix: string]: unknown[] };
 
     if (resourceType === 'templates') {
       ({ rootResources, moduleResources } = await processTemplates(
@@ -129,13 +131,13 @@ async function createResourceNode(
   resourceType: ResourceFolderType,
   name: string,
   projectPrefix: string,
-  children?: any[],
+  children?: unknown[],
 ): Promise<{
   id: string;
   type: ResourceFolderType;
   name: string;
   data: ResourceContent | undefined;
-  children?: any[];
+  children?: unknown[];
   readOnly?: boolean;
 }> {
   const resourceData = await commands.showCmd.showResource(name);
@@ -144,7 +146,7 @@ async function createResourceNode(
     type: ResourceFolderType;
     name: string;
     data: ResourceContent | undefined;
-    children?: any[];
+    children?: unknown[];
     readOnly?: boolean;
   } = {
     id: `${resourceType}-${name}`,
@@ -184,15 +186,23 @@ function createCardNode(
   card: Card,
   module: string,
   projectPrefix: string,
-): any {
+): unknown {
   // Destructure to separate children from other card data
   const { children, ...cardData } = card;
 
-  const cardNode: any = {
+  const cardNode: {
+    id: string;
+    type: string;
+    name: string;
+    data: Omit<Card, 'children'>;
+    children: unknown[];
+    readOnly: boolean;
+  } = {
     id: `${card.key}`,
     type: 'card',
     name: `${module}/cards/${card.key}`,
     data: cardData,
+    children: [],
     readOnly: moduleNameFromCardKey(card.key) !== projectPrefix,
   };
 
@@ -214,9 +224,9 @@ async function processTemplates(
   const templates = await commands.showCmd.showResources('templates');
   const templateTree = await commands.showCmd.showAllTemplateCards();
 
-  const rootTemplates: { [templateName: string]: any[] } = {};
+  const rootTemplates: { [templateName: string]: unknown[] } = {};
   const moduleTemplates: {
-    [prefix: string]: { [templateName: string]: any[] };
+    [prefix: string]: { [templateName: string]: unknown[] };
   } = {};
 
   for (const { name, cards } of templateTree) {
@@ -255,7 +265,7 @@ async function processTemplates(
     ),
   );
 
-  const moduleResources: { [prefix: string]: any[] } = {};
+  const moduleResources: { [prefix: string]: unknown[] } = {};
   for (const [prefix, templates] of Object.entries(moduleTemplates)) {
     moduleResources[prefix] = await Promise.all(
       Object.entries(templates).map(([templateName, cards]) =>
@@ -308,7 +318,7 @@ async function processTemplates(
 
 // Helper function to group regular resources by prefix
 async function groupResourcesByPrefix(
-  commands: any,
+  commands: CommandManager,
   resourceType: ResourceFolderType,
   projectPrefix: string,
 ) {
@@ -319,8 +329,8 @@ async function groupResourcesByPrefix(
     ),
   );
 
-  const rootResources: any[] = [];
-  const moduleResources: { [prefix: string]: any[] } = {};
+  const rootResources: unknown[] = [];
+  const moduleResources: { [prefix: string]: unknown[] } = {};
 
   resources.forEach((resource) => {
     const { prefix } = parseResourcePrefix(resource.name);

--- a/tools/backend/src/domain/resources/service.ts
+++ b/tools/backend/src/domain/resources/service.ts
@@ -299,7 +299,9 @@ async function processTemplates(
         moduleResources[prefix] = [];
       }
       if (
-        !moduleResources[prefix].find((resource) => resource.name === template)
+        !moduleResources[prefix].find(
+          (resource) => (resource as { name: string }).name === template,
+        )
       ) {
         moduleResources[prefix].push(
           await createResourceNode(

--- a/tools/backend/src/domain/templates/service.ts
+++ b/tools/backend/src/domain/templates/service.ts
@@ -11,7 +11,7 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { CommandManager } from '@cyberismo/data-handler';
+import type { CommandManager } from '@cyberismo/data-handler';
 
 export async function getTemplatesWithDetails(commands: CommandManager) {
   const response = await commands.showCmd.showTemplatesWithDetails();

--- a/tools/backend/src/domain/tree/service.ts
+++ b/tools/backend/src/domain/tree/service.ts
@@ -11,7 +11,7 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { CommandManager } from '@cyberismo/data-handler';
+import type { CommandManager } from '@cyberismo/data-handler';
 
 export async function getCardTree(commands: CommandManager, isSsg: boolean) {
   await commands.calculateCmd.generate();

--- a/tools/backend/src/export.ts
+++ b/tools/backend/src/export.ts
@@ -23,8 +23,8 @@ import {
   runInParallel,
   staticFrontendDirRelative,
 } from './utils.js';
-import { QueryResult } from '@cyberismo/data-handler/types/queries';
-import { Context, Hono, MiddlewareHandler } from 'hono';
+import type { QueryResult } from '@cyberismo/data-handler/types/queries';
+import type { Context, Hono, MiddlewareHandler } from 'hono';
 import mime from 'mime-types';
 
 let _cardQueryPromise: Promise<QueryResult<'card'>[]> | null = null;
@@ -156,7 +156,7 @@ async function toSsg(
 
   let processedFiles = 0;
   let failed = false;
-  let errors: Error[] = [];
+  const errors: Error[] = [];
   const done = async (error?: Error) => {
     if (error) {
       failed = true;

--- a/tools/backend/src/middleware/commandManager.ts
+++ b/tools/backend/src/middleware/commandManager.ts
@@ -10,7 +10,7 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Context, MiddlewareHandler } from 'hono';
+import type { Context, MiddlewareHandler } from 'hono';
 import { CommandManager } from '@cyberismo/data-handler';
 
 // Extend Hono Context type to include our custom properties

--- a/tools/backend/src/utils.ts
+++ b/tools/backend/src/utils.ts
@@ -19,7 +19,7 @@ import { createServer } from 'node:net';
  * @param maxConcurrent - Maximum number of promises to run at a time
  * @returns - Promise that resolves when all promises have resolved
  */
-export async function runInParallel<T>(
+export async function runInParallel(
   promises: (() => Promise<unknown>)[],
   maxConcurrent: number = 2,
 ) {
@@ -47,7 +47,9 @@ export async function runCbSafely<T>(
 ): Promise<T | undefined> {
   try {
     return await cb();
-  } catch {}
+  } catch {
+    // All exceptions are ignored.
+  }
 }
 
 /**

--- a/tools/backend/test/api.test.ts
+++ b/tools/backend/test/api.test.ts
@@ -24,7 +24,7 @@ test('/api/cards returns a project with a list of cards', async () => {
   const response = await app.request('/api/cards');
   expect(response).not.toBe(null);
 
-  const result: any = await response.json();
+  const result = await response.json();
   expect(response.status).toBe(200);
   expect(result.name).toBe('decision');
   expect(result.workflows.length).toBeGreaterThan(0);
@@ -35,7 +35,7 @@ test('/api/cards/decision_5 returns a card object', async () => {
   const response = await app.request('/api/cards/decision_5');
   expect(response).not.toBe(null);
 
-  const result: any = await response.json();
+  const result = await response.json();
   expect(response.status).toBe(200);
   expect(result.title).toBe('Decision Records');
   expect(result.rawContent).not.toBe(null);
@@ -79,7 +79,7 @@ test('fieldTypes endpoint returns proper data', async () => {
   const response = await app.request('/api/fieldTypes');
   expect(response).not.toBe(null);
 
-  const result = (await response.json()) as any[];
+  const result = await response.json();
   expect(response.status).toBe(200);
   expect(result.length).toBe(9);
   expect(result[0].name).toBe('decision/fieldTypes/admins');
@@ -92,7 +92,7 @@ test('linkTypes endpoint returns proper data', async () => {
   const response = await app.request('/api/linkTypes');
   expect(response).not.toBe(null);
 
-  const result = (await response.json()) as any[];
+  const result = await response.json();
   expect(response.status).toBe(200);
   expect(result.length).toBe(2);
   expect(result[1].name).toBe('decision/linkTypes/testTypes');
@@ -106,7 +106,7 @@ test('templates endpoint returns proper data', async () => {
   const response = await app.request('/api/templates');
   expect(response).not.toBe(null);
 
-  const result = (await response.json()) as any[];
+  const result = await response.json();
   expect(response.status).toBe(200);
   expect(result.length).toBe(3);
   expect(result[0].name).toBe('decision/templates/decision');
@@ -119,7 +119,7 @@ test('tree endpoint returns proper data', async () => {
   const response = await app.request('/api/tree');
   expect(response).not.toBe(null);
 
-  const result = (await response.json()) as any[];
+  const result = await response.json();
   expect(response.status).toBe(200);
   expect(result[0].key).toBe('decision_5');
   expect(result[0].title).toBe('Decision Records');

--- a/tools/backend/test/export.test.ts
+++ b/tools/backend/test/export.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { Context } from 'hono';
+import type { Context, Hono } from 'hono';
 import {
   getCardQueryResult,
   exportSite,
@@ -18,7 +18,7 @@ vi.mock('../src/app.js');
 vi.mock('node:fs/promises');
 vi.mock('../src/utils.js', () => ({
   runCbSafely: vi.fn((fn) => fn()),
-  runInParallel: vi.fn(async (promises, _concurrency) => {
+  runInParallel: vi.fn(async (promises) => {
     for (const promiseFn of promises) {
       await promiseFn();
     }
@@ -52,7 +52,7 @@ describe('export module', () => {
       };
 
       vi.mocked(CommandManager.getInstance).mockResolvedValue(
-        mockCommands as any,
+        mockCommands as unknown as CommandManager,
       );
 
       const result = await getCardQueryResult('/test/project');
@@ -78,7 +78,7 @@ describe('export module', () => {
       };
 
       vi.mocked(CommandManager.getInstance).mockResolvedValue(
-        mockCommands as any,
+        mockCommands as unknown as CommandManager,
       );
 
       const result = await getCardQueryResult('/test/project', 'card1');
@@ -98,7 +98,7 @@ describe('export module', () => {
       };
 
       vi.mocked(CommandManager.getInstance).mockResolvedValue(
-        mockCommands as any,
+        mockCommands as unknown as CommandManager,
       );
 
       await expect(
@@ -118,7 +118,7 @@ describe('export module', () => {
       };
 
       vi.mocked(CommandManager.getInstance).mockResolvedValue(
-        mockCommands as any,
+        mockCommands as unknown as CommandManager,
       );
 
       // First call
@@ -160,9 +160,9 @@ describe('export module', () => {
         },
       };
 
-      vi.mocked(createApp).mockReturnValue(mockApp as any);
+      vi.mocked(createApp).mockReturnValue(mockApp as unknown as Hono);
       vi.mocked(CommandManager.getInstance).mockResolvedValue(
-        mockCommands as any,
+        mockCommands as unknown as CommandManager,
       );
       vi.mocked(cp).mockResolvedValue(undefined);
       vi.mocked(readFile).mockResolvedValue('{"staticMode": false}');
@@ -218,9 +218,9 @@ describe('export module', () => {
         },
       };
 
-      vi.mocked(createApp).mockReturnValue(mockApp as any);
+      vi.mocked(createApp).mockReturnValue(mockApp as unknown as Hono);
       vi.mocked(CommandManager.getInstance).mockResolvedValue(
-        mockCommands as any,
+        mockCommands as unknown as CommandManager,
       );
       vi.mocked(cp).mockResolvedValue(undefined);
       vi.mocked(readFile).mockResolvedValue('{"staticMode": false}');
@@ -258,9 +258,9 @@ describe('export module', () => {
         },
       };
 
-      vi.mocked(createApp).mockReturnValue(mockApp as any);
+      vi.mocked(createApp).mockReturnValue(mockApp as unknown as Hono);
       vi.mocked(CommandManager.getInstance).mockResolvedValue(
-        mockCommands as any,
+        mockCommands as unknown as CommandManager,
       );
       vi.mocked(cp).mockResolvedValue(undefined);
       vi.mocked(readFile).mockResolvedValue('{"staticMode": false}');
@@ -295,9 +295,9 @@ describe('export module', () => {
         },
       };
 
-      vi.mocked(createApp).mockReturnValue(mockApp as any);
+      vi.mocked(createApp).mockReturnValue(mockApp as unknown as Hono);
       vi.mocked(CommandManager.getInstance).mockResolvedValue(
-        mockCommands as any,
+        mockCommands as unknown as CommandManager,
       );
       vi.mocked(cp).mockResolvedValue(undefined);
       vi.mocked(readFile).mockResolvedValue('{"staticMode": false}');
@@ -315,7 +315,7 @@ describe('export module', () => {
         req: {
           header: vi.fn().mockReturnValue('true'),
         },
-      } as any as Context;
+      } as unknown as Context;
 
       const result = isSSGContext(mockContext);
 
@@ -328,7 +328,7 @@ describe('export module', () => {
         req: {
           header: vi.fn().mockReturnValue('false'),
         },
-      } as any as Context;
+      } as unknown as Context;
 
       const result = isSSGContext(mockContext);
 
@@ -340,7 +340,7 @@ describe('export module', () => {
         req: {
           header: vi.fn().mockReturnValue(undefined),
         },
-      } as any as Context;
+      } as unknown as Context;
 
       const result = isSSGContext(mockContext);
 
@@ -355,7 +355,7 @@ describe('export module', () => {
           header: vi.fn().mockReturnValue('true'),
         },
         json: vi.fn().mockReturnValue('json-response'),
-      } as any as Context;
+      } as unknown as Context;
 
       const mockFn = vi.fn().mockResolvedValue([{ id: 1 }, { id: 2 }]);
       const middleware = ssgParams(mockFn);
@@ -374,7 +374,7 @@ describe('export module', () => {
           header: vi.fn().mockReturnValue('true'),
         },
         json: vi.fn().mockReturnValue('empty-json-response'),
-      } as any as Context;
+      } as unknown as Context;
 
       const middleware = ssgParams();
 
@@ -389,7 +389,7 @@ describe('export module', () => {
         req: {
           header: vi.fn().mockReturnValue('false'),
         },
-      } as any as Context;
+      } as unknown as Context;
 
       const mockNext = vi.fn().mockReturnValue('next-response');
       const middleware = ssgParams(vi.fn());
@@ -406,7 +406,7 @@ describe('export module', () => {
           header: vi.fn().mockReturnValue('true'),
         },
         json: vi.fn(),
-      } as any as Context;
+      } as unknown as Context;
 
       const mockFn = vi.fn().mockRejectedValue(new Error('Function error'));
       const middleware = ssgParams(mockFn);

--- a/tools/backend/test/resources.service.test.ts
+++ b/tools/backend/test/resources.service.test.ts
@@ -3,6 +3,23 @@ import { buildResourceTree } from '../src/domain/resources/service.js';
 import type { CommandManager } from '@cyberismo/data-handler';
 import type { Card } from '@cyberismo/data-handler/interfaces/project-interfaces';
 
+// Helper interface for tests.
+interface testDataNode {
+  name: string;
+  displayName: string;
+  description: string;
+  dataType: string;
+}
+
+// Helper interface for tests.
+interface testObjectNode {
+  name: string;
+  id: string;
+  type: string;
+  data: testDataNode;
+  children: testObjectNode[];
+}
+
 // Create mock CommandManager
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const createMockCommandManager = (overrides: any = {}) => {
@@ -97,7 +114,9 @@ describe('Resources Service', () => {
         },
       });
 
-      const result = await buildResourceTree(mockCommands);
+      const result = (await buildResourceTree(
+        mockCommands,
+      )) as testObjectNode[];
 
       expect(result).toHaveLength(2); // fieldTypes and templates groups
       expect(result[0].name).toBe('fieldTypes');
@@ -136,7 +155,9 @@ describe('Resources Service', () => {
         },
       });
 
-      const result = await buildResourceTree(mockCommands);
+      const result = (await buildResourceTree(
+        mockCommands,
+      )) as testObjectNode[];
 
       expect(result).toHaveLength(2); // fieldTypes group and modules group
 
@@ -176,7 +197,9 @@ describe('Resources Service', () => {
         },
       });
 
-      const result = await buildResourceTree(mockCommands);
+      const result = (await buildResourceTree(
+        mockCommands,
+      )) as testObjectNode[];
 
       expect(result).toHaveLength(1); // templates group only
       expect(result[0].name).toBe('templates');
@@ -215,7 +238,9 @@ describe('Resources Service', () => {
         },
       });
 
-      const result = await buildResourceTree(mockCommands);
+      const result = (await buildResourceTree(
+        mockCommands,
+      )) as testObjectNode[];
 
       expect(result).toHaveLength(2); // templates group and modules group
 
@@ -278,7 +303,9 @@ describe('Resources Service', () => {
         },
       });
 
-      const result = await buildResourceTree(mockCommands);
+      const result = (await buildResourceTree(
+        mockCommands,
+      )) as testObjectNode[];
 
       expect(result).toHaveLength(resourceTypes.length); // One group per resource type
 
@@ -310,7 +337,9 @@ describe('Resources Service', () => {
         },
       });
 
-      const result = await buildResourceTree(mockCommands);
+      const result = (await buildResourceTree(
+        mockCommands,
+      )) as testObjectNode[];
 
       // Check resource group IDs and types
       expect(result[0].id).toBe('fieldTypes');

--- a/tools/backend/test/resources.service.test.ts
+++ b/tools/backend/test/resources.service.test.ts
@@ -4,6 +4,7 @@ import type { CommandManager } from '@cyberismo/data-handler';
 import type { Card } from '@cyberismo/data-handler/interfaces/project-interfaces';
 
 // Create mock CommandManager
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const createMockCommandManager = (overrides: any = {}) => {
   return {
     showCmd: {
@@ -14,7 +15,7 @@ const createMockCommandManager = (overrides: any = {}) => {
       ...overrides.showCmd,
     },
     ...overrides,
-  } as any as CommandManager;
+  } as unknown as CommandManager;
 };
 
 // Mock resource data

--- a/tools/node-clingo/eslint.config.js
+++ b/tools/node-clingo/eslint.config.js
@@ -1,0 +1,19 @@
+// @ts-check
+
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import eslintConfigPrettier from 'eslint-config-prettier';
+
+export default [
+  {
+    ignores: ['**/dist/*', '**/init.js'],
+  },
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  eslintConfigPrettier,
+  {
+    rules: {
+      '@typescript-eslint/consistent-type-imports': 'error',
+    },
+  },
+];

--- a/tools/node-clingo/lib/index.ts
+++ b/tools/node-clingo/lib/index.ts
@@ -12,12 +12,22 @@
 import build from 'node-gyp-build';
 import { resolve } from 'node:path';
 
-let binding: any;
+// Interface for clingo bindings.
+// Should match the functions in this file.
+interface ClingoBinding {
+  setProgram(key: string, program: string, categories?: string[]): void;
+  removeProgram(key: string): boolean;
+  removeProgramsByCategory(category: string): number;
+  removeAllPrograms(): void;
+  solve(program: string, categories: string[]): ClingoResult;
+}
+
+let binding: ClingoBinding;
 try {
-  binding = build(resolve(import.meta.dirname, '..'));
+  binding = build(resolve(import.meta.dirname, '..')) as ClingoBinding;
 } catch (error) {
   console.error('Error building clingo:', error);
-  binding = build(import.meta.dirname);
+  binding = build(import.meta.dirname) as ClingoBinding;
 }
 
 /**

--- a/tools/node-clingo/lib/node-gyp-build.d.ts
+++ b/tools/node-clingo/lib/node-gyp-build.d.ts
@@ -20,7 +20,7 @@ declare module 'node-gyp-build' {
    * @param directory The directory containing the compiled addon
    * @returns The native addon module
    */
-  function build(directory: string): any;
+  function build(directory: string): unknown;
 
   export default build;
 }

--- a/tools/node-clingo/package.json
+++ b/tools/node-clingo/package.json
@@ -8,7 +8,8 @@
     "build-prebuildify": "shx rm -rf prebuilds && prebuildify --napi",
     "dev": "tsc -p tsconfig.build.json --watch",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "lint": "eslint ."
   },
   "keywords": [],
   "author": "",

--- a/tools/node-clingo/scripts/collect-prebuilds.js
+++ b/tools/node-clingo/scripts/collect-prebuilds.js
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+/* eslint-env node */
+/* globals console */
+
 /**
     Cyberismo
     Copyright © Cyberismo Ltd and contributors 2025

--- a/tools/node-clingo/scripts/download-prebuild.js
+++ b/tools/node-clingo/scripts/download-prebuild.js
@@ -1,3 +1,6 @@
+/* eslint-env node */
+/* globals console, process, fetch */
+
 /**
     Cyberismo
     Copyright © Cyberismo Ltd and contributors 2025
@@ -107,7 +110,7 @@ try {
   const extractor = extract();
 
   extractor.on('entry', (header, stream, next) => {
-    const nameParts = header.name.split(/[\/]/).filter((part) => part);
+    const nameParts = header.name.split(/[/]/).filter((part) => part);
     const strippedName = nameParts.slice(1).join(sep);
 
     if (header.type !== 'file' || !strippedName) {


### PR DESCRIPTION
Enable listing for 'node-clingo' and 'backend' sub-projects.

It might be good idea to define the interfaces for the backend methods instead of using `unknown`. 