### PR TITLE
INTDEV-955, INTDEV-933 C++ code formatting and analysis

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,42 @@
+# Clang-Format configuration for Cyberismo C++ code
+#
+# Note: clang-format is optional for CI builds - if not available, formatting checks are skipped
+# Developers should install clang-format for automatic code formatting.
+
+# Use LLVM; try to avoid any exceptions.
+BasedOnStyle: LLVM
+Language: Cpp
+ColumnLimit: 120
+
+# Indentation
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+NamespaceIndentation: All
+IndentCaseLabels: true
+PenaltyBreakComment: 1000
+ReflowComments: false
+
+# Braces
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterStruct: true
+  AfterFunction: true
+  AfterNamespace: true
+  BeforeElse: true
+  BeforeCatch: true
+
+# Enforce parameters on own rows, function return value on same row
+AllowAllParametersOfDeclarationOnNextLine: false
+AlwaysBreakAfterReturnType: None
+PenaltyReturnTypeOnItsOwnLine: 1000
+BinPackArguments: false
+BinPackParameters: false
+
+# Put pointers and references to types
+PointerAlignment: Left
+
+# When bracket opens, align arguments to new lines
+AlignAfterOpenBracket: AlwaysBreak

--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 # Clang-Format configuration for Cyberismo C++ code
 #
-# Note: clang-format is optional for CI builds - if not available, formatting checks are skipped
+# Note that formatting checks for CI builds are skipped if clang-format cannot be found.
 # Developers should install clang-format for automatic code formatting.
 
 # Use LLVM; try to avoid any exceptions.

--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,2 +1,3 @@
-paths-excluded:
-  - resources/**
+# Use security and quality queries for comprehensive analysis
+queries:
+  - uses: security-and-quality

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,11 +4,6 @@
 # You may wish to alter this file to override the set of languages analyzed,
 # or to provide custom queries or build logic.
 #
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL Advanced"
 
 on:
@@ -47,6 +42,8 @@ jobs:
           build-mode: none
         - language: javascript-typescript
           build-mode: none
+        - language: c-cpp
+          build-mode: manual
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -59,40 +56,53 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    # Add any setup steps before running the `github/codeql-action/init` action.
-    # This includes steps like installing compilers or runtimes (`actions/setup-node`
-    # or others). This is typically only required for manual builds.
-    # - name: Setup runtime (example)
-    #   uses: actions/setup-example@v1
+    - name: Setup Node.js
+      if: matrix.language == 'c-cpp'
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
 
-    # Initializes the CodeQL tools for scanning.
+    - name: Setup Python
+      if: matrix.language == 'c-cpp'
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+
+    - name: Install build dependencies
+      if: matrix.language == 'c-cpp'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential python3-dev
+        # Install clingo for node-clingo compilation
+        sudo apt-get install -y gringo || echo "Could not install gringo, continuing..."
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
+        config-file: .github/codeql-config.yml
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
 
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
 
     # If the analyze step fails for one of the languages you are analyzing with
     # "We were unable to automatically build your code", modify the matrix above
     # to set the build mode to "manual" for that language. Then modify this step
     # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - if: matrix.build-mode == 'manual'
+    # Command-line programs to run using the OS shell.
+    # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+    # Manual build for C++ (node-clingo native addon)
+    - name: Build C++ code
+      if: matrix.build-mode == 'manual'
       shell: bash
       run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
+        echo "Building node-clingo C++ native addon for CodeQL analysis..."
+        cd tools/node-clingo
+        npm install
+        echo "C++ compilation completed for CodeQL analysis"
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/cpp-quality.yml
+++ b/.github/workflows/cpp-quality.yml
@@ -67,37 +67,3 @@ jobs:
         fi
 
         echo "All C++ files are properly formatted"
-
-  build-test:
-    name: Build and Test C++ Code
-    runs-on: ubuntu-latest
-    needs: format-check
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '18'
-
-    - name: Setup Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
-
-    - name: Install system dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y build-essential python3-dev
-        # Try to install clingo
-        sudo apt-get install -y clingo libclingo-dev || \
-        sudo apt-get install -y gringo clasp || \
-        echo "Warning: Could not install clingo from apt"
-
-    - name: Build C++ native addon
-      run: |
-        cd tools/node-clingo
-        npm install
-        echo "C++ compilation successful"

--- a/.github/workflows/cpp-quality.yml
+++ b/.github/workflows/cpp-quality.yml
@@ -1,0 +1,103 @@
+# CodeQL analysis for C++ files.
+name: "C++ Code Quality"
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'tools/node-clingo/src/**'
+      - '.clang-format'
+      - '.github/workflows/cpp-quality.yml'
+  pull_request:
+    branches: [ "main", "temp-main" ]
+    paths:
+      - 'tools/node-clingo/src/**'
+      - '.clang-format'
+      - '.github/workflows/cpp-quality.yml'
+
+jobs:
+  format-check:
+    name: Check C++ Formatting
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install clang-format
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-format
+        clang-format --version
+
+    - name: Check C++ code formatting
+      run: |
+        echo "Checking C++ code formatting..."
+        cd tools/node-clingo
+
+        # Check if any C++ files need formatting
+        NEEDS_FORMAT=false
+        for file in src/*.cc src/*.h; do
+          if [ -f "$file" ]; then
+            echo "Checking $file..."
+            if ! clang-format --dry-run --Werror "$file" >/dev/null 2>&1; then
+              echo "$file is not properly formatted"
+              echo "Expected format:"
+              clang-format "$file" | head -20
+              echo "..."
+              NEEDS_FORMAT=true
+            else
+              echo "$file is properly formatted"
+            fi
+          fi
+        done
+
+        if [ "$NEEDS_FORMAT" = true ]; then
+          echo ""
+          echo "Some C++ files are not properly formatted!"
+          echo ""
+          echo "To fix the formatting, run:"
+          echo "  cd tools/node-clingo && npm run format:cpp"
+          echo ""
+          echo "Or format individual files:"
+          echo "  clang-format -i <filename>"
+          exit 1
+        fi
+
+        echo "All C++ files are properly formatted"
+
+  build-test:
+    name: Build and Test C++ Code
+    runs-on: ubuntu-latest
+    needs: format-check
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential python3-dev
+        # Try to install clingo
+        sudo apt-get install -y clingo libclingo-dev || \
+        sudo apt-get install -y gringo clasp || \
+        echo "Warning: Could not install clingo from apt"
+
+    - name: Build C++ native addon
+      run: |
+        cd tools/node-clingo
+        npm install
+        echo "C++ compilation successful"

--- a/scripts/pre-commit.sample.txt
+++ b/scripts/pre-commit.sample.txt
@@ -1,0 +1,64 @@
+#!/bin/sh
+#
+# Sample pre-commit hook for enforcing clang-format on C++ files
+# This hook prevents commits that contain unformatted C++ code in tools/node-clingo
+#
+# To install this hook, copy it to .git/hooks/pre-commit and make it executable:
+#   cp scripts/pre-commit.sample .git/hooks/pre-commit
+#   chmod +x .git/hooks/pre-commit
+#
+
+# Check if clang-format is available
+if ! command -v clang-format >/dev/null 2>&1; then
+    echo "⚠️  clang-format is not installed or not in PATH"
+    echo "⚠️  Skipping C++ format check"
+    echo ""
+    echo "To enable C++ format checking, install clang-format:"
+    echo "  macOS: brew install clang-format"
+    echo "  Ubuntu: sudo apt-get install clang-format"
+    echo "  Windows: choco install llvm"
+    echo ""
+    # Skip format check but allow commit
+    exit 0
+fi
+
+# Get list of staged C++ files in tools/node-clingo
+CPP_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E "tools/node-clingo/src/.*\.(cc|cpp|cxx|h|hpp)$")
+
+if [ -z "$CPP_FILES" ]; then
+    # No C++ files to check
+    exit 0
+fi
+
+echo "Checking C++ code formatting with clang-format..."
+
+# Check if any C++ files need formatting
+NEEDS_FORMAT=false
+for file in $CPP_FILES; do
+    if [ -f "$file" ]; then
+        # Check if file needs formatting (compare with clang-format output)
+        if ! clang-format --dry-run --Werror "$file" >/dev/null 2>&1; then
+            echo "❌ $file is not properly formatted"
+            NEEDS_FORMAT=true
+        else
+            echo "✅ $file"
+        fi
+    fi
+done
+
+if [ "$NEEDS_FORMAT" = true ]; then
+    echo ""
+    echo "❌ Some C++ files are not properly formatted!"
+    echo ""
+    echo "To fix the formatting, run:"
+    echo "  cd tools/node-clingo && npm run format:cpp"
+    echo ""
+    echo "Or format individual files:"
+    echo "  clang-format -i <filename>"
+    echo ""
+    echo "Then stage and commit your changes again."
+    exit 1
+fi
+
+echo "✅ All C++ files are properly formatted"
+exit 0

--- a/tools/node-clingo/package.json
+++ b/tools/node-clingo/package.json
@@ -4,16 +4,16 @@
   "description": "Node.js bindings for Clingo answer set solver",
   "scripts": {
     "install": "node scripts/download-prebuild.js || node-gyp-build",
-    "build": "npm run format:cpp:check:optional && tsc -p tsconfig.build.json",
-    "build-prebuildify": "npm run format:cpp:optional && shx rm -rf prebuilds && prebuildify --napi",
+    "build": "pnpm format:cpp:check:optional && tsc -p tsconfig.build.json",
+    "build-prebuildify": "pnpm format:cpp:optional && shx rm -rf prebuilds && prebuildify --napi",
     "dev": "tsc -p tsconfig.build.json --watch",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint .",
     "format:cpp": "clang-format -i src/*.cc src/*.h",
     "format:cpp:check": "clang-format --dry-run --Werror src/*.cc src/*.h",
-    "format:cpp:optional": "command -v clang-format >/dev/null 2>&1 && npm run format:cpp || echo 'clang-format not available, skipping C++ formatting'",
-    "format:cpp:check:optional": "command -v clang-format >/dev/null 2>&1 && npm run format:cpp:check || echo 'clang-format not available, skipping C++ format check'"
+    "format:cpp:optional": "command -v clang-format >/dev/null 2>&1 && pnpm format:cpp || echo 'clang-format not available, skipping C++ formatting'",
+    "format:cpp:check:optional": "command -v clang-format >/dev/null 2>&1 && pnpm format:cpp:check || echo 'clang-format not available, skipping C++ format check'"
   },
   "keywords": [],
   "author": "",

--- a/tools/node-clingo/package.json
+++ b/tools/node-clingo/package.json
@@ -4,12 +4,16 @@
   "description": "Node.js bindings for Clingo answer set solver",
   "scripts": {
     "install": "node scripts/download-prebuild.js || node-gyp-build",
-    "build": "tsc -p tsconfig.build.json",
-    "build-prebuildify": "shx rm -rf prebuilds && prebuildify --napi",
+    "build": "npm run format:cpp:check:optional && tsc -p tsconfig.build.json",
+    "build-prebuildify": "npm run format:cpp:optional && shx rm -rf prebuilds && prebuildify --napi",
     "dev": "tsc -p tsconfig.build.json --watch",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "format:cpp": "clang-format -i src/*.cc src/*.h",
+    "format:cpp:check": "clang-format --dry-run --Werror src/*.cc src/*.h",
+    "format:cpp:optional": "command -v clang-format >/dev/null 2>&1 && npm run format:cpp || echo 'clang-format not available, skipping C++ formatting'",
+    "format:cpp:check:optional": "command -v clang-format >/dev/null 2>&1 && npm run format:cpp:check || echo 'clang-format not available, skipping C++ format check'"
   },
   "keywords": [],
   "author": "",

--- a/tools/node-clingo/src/function_handlers.cc
+++ b/tools/node-clingo/src/function_handlers.cc
@@ -1,13 +1,14 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2025
-
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2025
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 #include "function_handlers.h"
 #include "helpers.h"
@@ -24,8 +25,8 @@
 
 #if USE_FORMAT_FALLBACK
 #include <ctime>
-#include <time.h>
 #include <iomanip>
+#include <time.h>
 #else
 #include <format>
 #endif
@@ -34,10 +35,10 @@ namespace node_clingo
 {
 
     bool handle_concatenate(
-        clingo_symbol_t const *arguments,
+        clingo_symbol_t const* arguments,
         size_t arguments_size,
         clingo_symbol_callback_t symbol_callback,
-        void *symbol_callback_data)
+        void* symbol_callback_data)
     {
         std::string result;
 
@@ -47,7 +48,7 @@ namespace node_clingo
 
             if (type == clingo_symbol_type_string)
             {
-                const char *str;
+                const char* str;
                 if (!clingo_symbol_string(arguments[i], &str))
                 {
                     return false;
@@ -73,10 +74,10 @@ namespace node_clingo
     }
 
     bool handle_days_since(
-        clingo_symbol_t const *arguments,
+        clingo_symbol_t const* arguments,
         size_t arguments_size,
         clingo_symbol_callback_t symbol_callback,
-        void *symbol_callback_data)
+        void* symbol_callback_data)
     {
         if (arguments_size != 1)
         {
@@ -92,7 +93,7 @@ namespace node_clingo
             return symbol_callback(&sym, 1, symbol_callback_data);
         }
 
-        const char *date_str;
+        const char* date_str;
         if (!clingo_symbol_string(arguments[0], &date_str))
         {
             return false;
@@ -123,10 +124,10 @@ namespace node_clingo
     }
 
     bool handle_today(
-        clingo_symbol_t const *arguments,
+        clingo_symbol_t const* arguments,
         size_t arguments_size,
         clingo_symbol_callback_t symbol_callback,
-        void *symbol_callback_data)
+        void* symbol_callback_data)
     {
         if (arguments_size != 0)
         {
@@ -151,10 +152,10 @@ namespace node_clingo
     }
 
     bool handle_wrap(
-        clingo_symbol_t const *arguments,
+        clingo_symbol_t const* arguments,
         size_t arguments_size,
         clingo_symbol_callback_t symbol_callback,
-        void *symbol_callback_data)
+        void* symbol_callback_data)
     {
         if (arguments_size != 1)
         {
@@ -166,7 +167,7 @@ namespace node_clingo
 
         if (arg_type == clingo_symbol_type_string || arg_type == clingo_symbol_type_function)
         {
-            const char *text;
+            const char* text;
             if (!clingo_symbol_string(arguments[0], &text))
             {
                 return false;
@@ -204,33 +205,36 @@ namespace node_clingo
     }
 
     bool handle_resource_prefix(
-        clingo_symbol_t const *arguments,
+        clingo_symbol_t const* arguments,
         size_t arguments_size,
         clingo_symbol_callback_t symbol_callback,
-        void *symbol_callback_data)
+        void* symbol_callback_data)
     {
-        return extract_resource_part(arguments, arguments_size, symbol_callback, symbol_callback_data, ResourcePart::PREFIX);
+        return extract_resource_part(
+            arguments, arguments_size, symbol_callback, symbol_callback_data, ResourcePart::PREFIX);
     }
 
     bool handle_resource_type(
-        clingo_symbol_t const *arguments,
+        clingo_symbol_t const* arguments,
         size_t arguments_size,
         clingo_symbol_callback_t symbol_callback,
-        void *symbol_callback_data)
+        void* symbol_callback_data)
     {
-        return extract_resource_part(arguments, arguments_size, symbol_callback, symbol_callback_data, ResourcePart::TYPE);
+        return extract_resource_part(
+            arguments, arguments_size, symbol_callback, symbol_callback_data, ResourcePart::TYPE);
     }
 
     bool handle_resource_identifier(
-        clingo_symbol_t const *arguments,
+        clingo_symbol_t const* arguments,
         size_t arguments_size,
         clingo_symbol_callback_t symbol_callback,
-        void *symbol_callback_data)
+        void* symbol_callback_data)
     {
-        return extract_resource_part(arguments, arguments_size, symbol_callback, symbol_callback_data, ResourcePart::IDENTIFIER);
+        return extract_resource_part(
+            arguments, arguments_size, symbol_callback, symbol_callback_data, ResourcePart::IDENTIFIER);
     }
 
-    const std::unordered_map<std::string, FunctionHandler> &get_function_handlers()
+    const std::unordered_map<std::string, FunctionHandler>& get_function_handlers()
     {
         static const std::unordered_map<std::string, FunctionHandler> handlers = {
             {"concatenate", handle_concatenate},

--- a/tools/node-clingo/src/function_handlers.h
+++ b/tools/node-clingo/src/function_handlers.h
@@ -1,13 +1,14 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2025
-
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2025
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 #ifndef NODE_CLINGO_FUNCTION_HANDLERS_H
 #define NODE_CLINGO_FUNCTION_HANDLERS_H
@@ -21,10 +22,10 @@ namespace node_clingo
 {
 
     using FunctionHandler = std::function<bool(
-        clingo_symbol_t const *arguments,
+        clingo_symbol_t const* arguments,
         size_t arguments_size,
         clingo_symbol_callback_t symbol_callback,
-        void *symbol_callback_data)>;
+        void* symbol_callback_data)>;
 
     /**
      * Handler for the @concatenate function.
@@ -36,10 +37,10 @@ namespace node_clingo
      * @returns True on success, false on error.
      */
     bool handle_concatenate(
-        clingo_symbol_t const *arguments,
+        clingo_symbol_t const* arguments,
         size_t arguments_size,
         clingo_symbol_callback_t symbol_callback,
-        void *symbol_callback_data);
+        void* symbol_callback_data);
 
     /**
      * Handler for the @days_since function.
@@ -51,10 +52,10 @@ namespace node_clingo
      * @returns True on success, false on error.
      */
     bool handle_days_since(
-        clingo_symbol_t const *arguments,
+        clingo_symbol_t const* arguments,
         size_t arguments_size,
         clingo_symbol_callback_t symbol_callback,
-        void *symbol_callback_data);
+        void* symbol_callback_data);
 
     /**
      * Handler for the @today function.
@@ -66,10 +67,10 @@ namespace node_clingo
      * @returns True on success, false on error.
      */
     bool handle_today(
-        clingo_symbol_t const *arguments,
+        clingo_symbol_t const* arguments,
         size_t arguments_size,
         clingo_symbol_callback_t symbol_callback,
-        void *symbol_callback_data);
+        void* symbol_callback_data);
 
     /**
      * Handler for the @wrap function.
@@ -81,10 +82,10 @@ namespace node_clingo
      * @returns True on success, false on error.
      */
     bool handle_wrap(
-        clingo_symbol_t const *arguments,
+        clingo_symbol_t const* arguments,
         size_t arguments_size,
         clingo_symbol_callback_t symbol_callback,
-        void *symbol_callback_data);
+        void* symbol_callback_data);
 
     /**
      * Handler for the @resourcePrefix function.
@@ -96,10 +97,10 @@ namespace node_clingo
      * @returns True on success, false on error.
      */
     bool handle_resource_prefix(
-        clingo_symbol_t const *arguments,
+        clingo_symbol_t const* arguments,
         size_t arguments_size,
         clingo_symbol_callback_t symbol_callback,
-        void *symbol_callback_data);
+        void* symbol_callback_data);
 
     /**
      * Handler for the @resourceType function.
@@ -111,10 +112,10 @@ namespace node_clingo
      * @returns True on success, false on error.
      */
     bool handle_resource_type(
-        clingo_symbol_t const *arguments,
+        clingo_symbol_t const* arguments,
         size_t arguments_size,
         clingo_symbol_callback_t symbol_callback,
-        void *symbol_callback_data);
+        void* symbol_callback_data);
 
     /**
      * Handler for the @resourceIdentifier function.
@@ -126,17 +127,17 @@ namespace node_clingo
      * @returns True on success, false on error.
      */
     bool handle_resource_identifier(
-        clingo_symbol_t const *arguments,
+        clingo_symbol_t const* arguments,
         size_t arguments_size,
         clingo_symbol_callback_t symbol_callback,
-        void *symbol_callback_data);
+        void* symbol_callback_data);
 
     /**
      * Get the map of function names to their handlers.
      * @returns A constant reference to the unordered map containing function handlers.
      */
-    const std::unordered_map<std::string, FunctionHandler> &get_function_handlers();
+    const std::unordered_map<std::string, FunctionHandler>& get_function_handlers();
 
-}
+} // namespace node_clingo
 
 #endif // NODE_CLINGO_FUNCTION_HANDLERS_H

--- a/tools/node-clingo/src/helpers.cc
+++ b/tools/node-clingo/src/helpers.cc
@@ -1,13 +1,14 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2025
-
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2025
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 #include "helpers.h"
 
@@ -25,8 +26,8 @@
 #endif
 
 #if USE_CHRONO_FROM_STREAM_FALLBACK
-#include <iomanip>
 #include <ctime>
+#include <iomanip>
 #endif
 
 namespace node_clingo
@@ -34,7 +35,7 @@ namespace node_clingo
 
     std::string get_symbol_string(clingo_symbol_t symbol)
     {
-        char *string = nullptr;
+        char* string = nullptr;
         size_t n;
         // determine size of the string representation of the next symbol in the model
         if (!clingo_symbol_to_string_size(symbol, &n))
@@ -43,7 +44,7 @@ namespace node_clingo
         }
 
         // allocate memory for the symbol's string
-        string = (char *)malloc(n);
+        string = (char*)malloc(n);
         if (!string)
         {
             return "";
@@ -60,7 +61,7 @@ namespace node_clingo
         return result;
     }
 
-    std::string html_escape(const std::string &input)
+    std::string html_escape(const std::string& input)
     {
         std::string result;
         result.reserve(input.size());
@@ -75,25 +76,25 @@ namespace node_clingo
         {
             switch (c)
             {
-            case '&':
-                result += amp;
-                break;
-            case '<':
-                result += lt;
-                break;
-            case '>':
-                result += gt;
-                break;
-            default:
-                result += c;
-                break;
+                case '&':
+                    result += amp;
+                    break;
+                case '<':
+                    result += lt;
+                    break;
+                case '>':
+                    result += gt;
+                    break;
+                default:
+                    result += c;
+                    break;
             }
         }
 
         return result;
     }
 
-    std::vector<std::string> text_wrap(const std::string &text, size_t line_width)
+    std::vector<std::string> text_wrap(const std::string& text, size_t line_width)
     {
         std::vector<std::string> result;
         std::string line;
@@ -140,7 +141,7 @@ namespace node_clingo
         return result;
     }
 
-    std::chrono::system_clock::time_point parse_iso_date(const std::string &iso_date)
+    std::chrono::system_clock::time_point parse_iso_date(const std::string& iso_date)
     {
         std::istringstream ss(iso_date);
         std::chrono::system_clock::time_point date_point;
@@ -161,7 +162,7 @@ namespace node_clingo
         };
 #endif
 
-        for (const auto &fmt : date_formats)
+        for (const auto& fmt : date_formats)
         {
             // Reset the stringstream state for each attempt
             ss.clear();
@@ -195,10 +196,7 @@ namespace node_clingo
         return std::chrono::system_clock::time_point{};
     }
 
-    bool return_string(
-        const char *str,
-        clingo_symbol_callback_t symbol_callback,
-        void *symbol_callback_data)
+    bool return_string(const char* str, clingo_symbol_callback_t symbol_callback, void* symbol_callback_data)
     {
         clingo_symbol_t sym;
         if (!clingo_symbol_create_string(str, &sym))
@@ -208,18 +206,16 @@ namespace node_clingo
         return symbol_callback(&sym, 1, symbol_callback_data);
     }
 
-    bool return_empty_string(
-        clingo_symbol_callback_t symbol_callback,
-        void *symbol_callback_data)
+    bool return_empty_string(clingo_symbol_callback_t symbol_callback, void* symbol_callback_data)
     {
         return return_string("", symbol_callback, symbol_callback_data);
     }
 
     bool extract_resource_part(
-        clingo_symbol_t const *arguments,
+        clingo_symbol_t const* arguments,
         size_t arguments_size,
         clingo_symbol_callback_t symbol_callback,
-        void *symbol_callback_data,
+        void* symbol_callback_data,
         ResourcePart part)
     {
         if (arguments_size != 1)
@@ -234,33 +230,33 @@ namespace node_clingo
             return return_empty_string(symbol_callback, symbol_callback_data);
         }
 
-        const char *resource_name;
+        const char* resource_name;
         if (!clingo_symbol_string(arguments[0], &resource_name))
         {
             return false;
         }
 
         std::string resource_str(resource_name);
-        
+
         if (resource_str.empty())
         {
             return return_empty_string(symbol_callback, symbol_callback_data);
         }
-        
+
         size_t first_slash = resource_str.find('/');
         if (first_slash == std::string::npos)
         {
             // No slashes - invalid format
             return return_empty_string(symbol_callback, symbol_callback_data);
         }
-        
+
         size_t second_slash = resource_str.find('/', first_slash + 1);
         if (second_slash == std::string::npos)
         {
             // Only 1 slash - invalid format
             return return_empty_string(symbol_callback, symbol_callback_data);
         }
-        
+
         size_t third_slash = resource_str.find('/', second_slash + 1);
         if (third_slash != std::string::npos)
         {

--- a/tools/node-clingo/src/helpers.h
+++ b/tools/node-clingo/src/helpers.h
@@ -1,24 +1,25 @@
 /**
-    Cyberismo
-    Copyright © Cyberismo Ltd and contributors 2025
-
-    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public
-    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2025
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 #ifndef NODE_CLINGO_HELPERS_H
 #define NODE_CLINGO_HELPERS_H
 
+#include <chrono>
 #include <clingo.h>
 #include <ctime>
 #include <iomanip>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <chrono>
 
 namespace node_clingo
 {
@@ -28,9 +29,9 @@ namespace node_clingo
      */
     enum class ResourcePart
     {
-        PREFIX = 0,     // Module prefix (e.g., "base")
-        TYPE = 1,       // Resource type (e.g., "fieldTypes") 
-        IDENTIFIER = 2  // Resource identifier (e.g., "owner")
+        PREFIX = 0,    // Module prefix (e.g., "base")
+        TYPE = 1,      // Resource type (e.g., "fieldTypes")
+        IDENTIFIER = 2 // Resource identifier (e.g., "owner")
     };
 
     /**
@@ -46,22 +47,24 @@ namespace node_clingo
      * @param input The input string.
      * @returns The HTML-escaped string.
      */
-    std::string html_escape(const std::string &input);
+    std::string html_escape(const std::string& input);
 
     /**
      * Wraps text to a specified line width, similar to Python's textwrap.
      * @param text The text to wrap.
      * @param line_width The maximum width of each line.
-     * @returns A vector of strings, each representing a line of the wrapped text.
+     * @returns A vector of strings, each representing a line of the wrapped
+     * text.
      */
-    std::vector<std::string> text_wrap(const std::string &text, size_t line_width);
+    std::vector<std::string> text_wrap(const std::string& text, size_t line_width);
 
     /**
-     * Parses an ISO 8601 date string into a time_point. Returns epoch on failure.
+     * Parses an ISO 8601 date string into a time_point. Returns epoch on
+     * failure.
      * @param iso_date The date string in ISO 8601 format (YYYY-MM-DD).
      * @returns The time_point value representing the date, or epoch on error.
      */
-    std::chrono::system_clock::time_point parse_iso_date(const std::string &iso_date);
+    std::chrono::system_clock::time_point parse_iso_date(const std::string& iso_date);
 
     /**
      * Helper function to return a string symbol via callback.
@@ -70,11 +73,7 @@ namespace node_clingo
      * @param symbol_callback_data User data for the callback.
      * @returns True on success, false on error.
      */
-    bool return_string(
-        const char *str,
-        clingo_symbol_callback_t symbol_callback,
-        void *symbol_callback_data);
-
+    bool return_string(const char* str, clingo_symbol_callback_t symbol_callback, void* symbol_callback_data);
 
     /**
      * Helper function to return an empty string symbol via callback.
@@ -82,9 +81,7 @@ namespace node_clingo
      * @param symbol_callback_data User data for the callback.
      * @returns True on success, false on error.
      */
-    bool return_empty_string(
-        clingo_symbol_callback_t symbol_callback,
-        void *symbol_callback_data);
+    bool return_empty_string(clingo_symbol_callback_t symbol_callback, void* symbol_callback_data);
 
     /**
      * Helper function to validate and extract part of resource name format.
@@ -93,15 +90,16 @@ namespace node_clingo
      * @param symbol_callback Callback function to return the result symbol.
      * @param symbol_callback_data User data for the callback.
      * @param part Resource part to extract (PREFIX, TYPE, or IDENTIFIER)
-     * @returns True on success, false on error. Calls symbol_callback with result.
+     * @returns True on success, false on error. Calls symbol_callback with
+     * result.
      */
     bool extract_resource_part(
-        clingo_symbol_t const *arguments,
+        clingo_symbol_t const* arguments,
         size_t arguments_size,
         clingo_symbol_callback_t symbol_callback,
-        void *symbol_callback_data,
+        void* symbol_callback_data,
         ResourcePart part);
 
-}
+} // namespace node_clingo
 
 #endif // NODE_CLINGO_HELPERS_H


### PR DESCRIPTION
### C++ code analysis ###

C++ code in `tools/node-clingo` is now analysed by the GitHub. It also checks that code is formatted. 

### C++ code formatting ###

C++ code formatting is now using Clang formatter. The rules are supporting older version of Clang formatter, to make the installation simpler for all platforms. 

I tried to avoid formatting the existing code as little as possible.
The base C++ style is now based on LLVM (I think it was closest for existing code base).

#### Deviations ####
However I made two small styling decisions : 

1) Pointer and reference are part of the type, and not name
E.g.  `int* pointer;` instead of `int *pointer;`
IMHO it makes no sense to attach the information to the variable name,

2) Enforced whitespace before a control command (`if`, `switch`, `for` ...)
E.g.  `if (test)` instead of `if(test)`
IMHO improves code readability. 

On other cases, even if I had thought that something else is my preference, I opted to keep the existing code.

There were some inconsistencies in the current code, so multiple ways of doing certain code style couldn't be supported (for example, how `switch-case` is intended). I just made the call which way is now auto-formatted.

### New PNPM tasks ###

The new tasks for `tools/node-clingo` are: 
 * `format:cpp` - Format C++ files in place using Clang-formatter
 * `format:cpp:check` - Check formatting - used by developers
 * `format:cpp:optional` - Optional formatting - used by prebuildify
 * `format:cpp:check:optional` - Optional format check - used by build

The optional tasks are to avoid making the clang-format required by the builds.


### Additionally ### 

Suggesting developers to install precommit hook to auto-format C++ code. Then it should be harder to push non-formatted code to git (and then get an error from C++ code check). Additionally, recommend to install the clang-formatter to your favourite editor. 


FYI: Pre-commit sample that enforces that formatting needs be correct before a commit:
```
#!/bin/sh
#
# Sample pre-commit hook for enforcing clang-format on C++ files
# This hook prevents commits that contain unformatted C++ code in tools/node-clingo
#
# To install this hook, copy it to .git/hooks/pre-commit and make it executable:
#   cp <source location>/pre-commit.sample .git/hooks/pre-commit
#   chmod +x .git/hooks/pre-commit
#

# Check if clang-format is available
if ! command -v clang-format >/dev/null 2>&1; then
    echo "⚠️  clang-format is not installed or not in PATH"
    echo "⚠️  Skipping C++ format check"
    echo ""
    echo "To enable C++ format checking, install clang-format:"
    echo "  macOS: brew install clang-format"
    echo "  Ubuntu: sudo apt-get install clang-format"
    echo "  Windows: choco install llvm"
    echo ""
    # Skip format check but allow commit
    exit 0
fi

# Get list of staged C++ files in tools/node-clingo
CPP_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E "tools/node-clingo/src/.*\.(cc|cpp|cxx|h|hpp)$")

if [ -z "$CPP_FILES" ]; then
    # No C++ files to check
    exit 0
fi

echo "Checking C++ code formatting with clang-format..."

# Check if any C++ files need formatting
NEEDS_FORMAT=false
for file in $CPP_FILES; do
    if [ -f "$file" ]; then
        # Check if file needs formatting (compare with clang-format output)
        if ! clang-format --dry-run --Werror "$file" >/dev/null 2>&1; then
            echo "❌ $file is not properly formatted"
            NEEDS_FORMAT=true
        else
            echo "✅ $file"
        fi
    fi
done

if [ "$NEEDS_FORMAT" = true ]; then
    echo ""
    echo "❌ Some C++ files are not properly formatted!"
    echo ""
    echo "To fix the formatting, run:"
    echo "  cd tools/node-clingo && npm run format:cpp"
    echo ""
    echo "Or format individual files:"
    echo "  clang-format -i <filename>"
    echo ""
    echo "Then stage and commit your changes again."
    exit 1
fi

echo "✅ All C++ files are properly formatted"
exit 0
```
