### PR TITLE
SECURITY FIX: Pin actions to specific commit SHAs instead of labels

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -49,7 +49,7 @@ jobs:
         registry-url: 'https://npm.pkg.github.com'
         scope: '@cyberismo'
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@829114fc20da43a41d27359103ec7a63020954d4 # v1
       with:
         ruby-version: '3.2'
     - name: Install asciidoctor-pdf

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -25,14 +25,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Check for changes in node-clingo
-      uses: dorny/paths-filter@v3
+      uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
       id: changes
       with:
         filters: |
           node_clingo:
             - 'tools/node-clingo/**'
     - name: Setup Miniconda
-      uses: conda-incubator/setup-miniconda@v3
+      uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830 # v3
       if: steps.changes.outputs.node_clingo == 'true'
       with:
         python-version: 3.12
@@ -51,7 +51,7 @@ jobs:
         registry-url: 'https://npm.pkg.github.com'
         scope: '@cyberismo'
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@829114fc20da43a41d27359103ec7a63020954d4 # v1
       with:
         ruby-version: '3.2'
     - name: Install asciidoctor-pdf

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,7 +43,7 @@ jobs:
         registry-url: 'https://npm.pkg.github.com'
         scope: '@cyberismo'
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@829114fc20da43a41d27359103ec7a63020954d4 # v1
       with:
         ruby-version: '3.2'
     - name: Install asciidoctor-pdf

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
         with:
           version: 9
 

--- a/.github/workflows/test-pr-docker.yml
+++ b/.github/workflows/test-pr-docker.yml
@@ -24,12 +24,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
         with:
           install: true
 
       - name: Build and push multi-arch Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
         with:
           context: .
           file: Dockerfile
@@ -38,7 +38,7 @@ jobs:
           load: true
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
         with:
           version: 9
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
All actions are now pinned to specific commit SHAs, which prevents supply chain attacks where malicious actors could potentially:
 * Move version tags to point to compromised code 
 * Inject backdoors or malicious code into popular GitHub Actions

The original version is still kept in a comment for human readers. 

This fixes issues 116-124 from https://github.com/CyberismoCom/cyberismo/security/code-scanning