### PR TITLE
Use local variable value instead of parsing again

### DIFF
--- a/tools/data-handler/src/macros/include/index.ts
+++ b/tools/data-handler/src/macros/include/index.ts
@@ -81,12 +81,7 @@ export default class IncludeMacro extends BaseMacro {
 
     const adjustedContent = this.adjustTitles(
       content,
-      options.levelOffset
-        ? Math.min(
-            Math.max(parseInt(options.levelOffset, 10), -MAX_LEVEL_OFFSET),
-            MAX_LEVEL_OFFSET,
-          )
-        : 0,
+      levelOffset,
       options.pageTitles === 'discrete',
     );
     return adjustedContent;


### PR DESCRIPTION
This fixes codeQL scanning finding: https://github.com/CyberismoCom/cyberismo/security/code-scanning/125
The local variable value was not used, but parsed again. As a fix, use the local variable value.
