### PR TITLE
Mock does not define a function; causes error in tests

### DIFF
--- a/tools/backend/test/resources.service.test.ts
+++ b/tools/backend/test/resources.service.test.ts
@@ -29,6 +29,7 @@ const createMockCommandManager = (overrides: any = {}) => {
       showResources: vi.fn(),
       showResource: vi.fn(),
       showAllTemplateCards: vi.fn(),
+      showFileNames: vi.fn().mockResolvedValue([]),
       ...overrides.showCmd,
     },
     ...overrides,
@@ -300,6 +301,7 @@ describe('Resources Service', () => {
             name,
           })),
           showAllTemplateCards: vi.fn().mockResolvedValue([]),
+          showFileNames: vi.fn().mockResolvedValue([]),
         },
       });
 


### PR DESCRIPTION
`showFileNames` was missing from mock object.
Add the function so that tests do not cause an error. 

Interestingly, this was not seen as tests failing...