### PR TITLE
Use fallback with 'import.meta.dirname'

### DIFF
--- a/tools/node-clingo/lib/index.ts
+++ b/tools/node-clingo/lib/index.ts
@@ -23,11 +23,13 @@ interface ClingoBinding {
 }
 
 let binding: ClingoBinding;
+// Use import.meta.dirname when available, fallback to __dirname for compatibility
+const currentDirname = import.meta.dirname || __dirname;
 try {
-  binding = build(resolve(import.meta.dirname, '..')) as ClingoBinding;
+  binding = build(resolve(currentDirname, '..')) as ClingoBinding;
 } catch (error) {
   console.error('Error building clingo:', error);
-  binding = build(import.meta.dirname) as ClingoBinding;
+  binding = build(currentDirname) as ClingoBinding;
 }
 
 /**


### PR DESCRIPTION
In tests `import.meta.dirname` is not defined when Mocha runs tests as CommonJS. 
Fortunately, when using CommonJS we can use `__dirname`. 

Thus set the value either with `import.meta.dirname` or with `__dirname`. 