### PR TITLE
INTDEV-582 Change 'workflow' in card type

### DIFF
--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -184,6 +184,31 @@ const additionalHelpForRemove = `Sub-command help:
       <identifier> name of a specific resource.
     Note that you cannot remove resources from imported modules.`;
 
+const additionalHelpForUpdate = `Sub-command help:
+  update <resourceName> <operation> <key> <value> [newValue], where
+      <resourceName> Resource name (e.g., myProject/cardTypes/myCard)
+      <operation> Type of change: "add", "change", "rank", or "remove"
+      <key> Property to change in resource
+      <value> Current value (for change/remove) or value to add
+      [newValue] New value when using "change" operation
+
+  Special case - Workflow changes with state mapping:
+    When changing a card type's workflow, you can provide a mapping file
+    to automatically update cards' workflow states:
+
+    cyberismo update myProject/cardTypes/myCard change workflow oldWorkflow newWorkflow --mapping-file mapping.json
+
+    The mapping file should be JSON with this format:
+    {
+      "stateMapping": {
+        "ExistingState1": "NewState1",
+        "ExistingState2": "NewState2"
+      }
+    }
+
+    If there are states that are skipped, a warning is produced.
+    `;
+
 const contextOption = new Option(
   '-c, --context [context]',
   'Context to run the logic programs in.',
@@ -765,18 +790,24 @@ program
     '[newValue]',
     'When using "change" define new value for detail.\nWhen using "remove" provide optional replacement value for removed value',
   )
+  .option(
+    '-m, --mapping-file [path]',
+    'Path to JSON file containing workflow state mapping (only used when changing workflow)',
+  )
+  .option('-p, --project-path [path]', `${pathGuideline}`)
+  .addHelpText('after', additionalHelpForUpdate)
   .action(
     async (
       resourceName: string,
-      key: string,
       operation: UpdateOperations,
+      key: string,
       value: string,
       newValue: string,
       options: CardsOptions,
     ) => {
       const result = await commandHandler.command(
         Cmd.update,
-        [resourceName, key, operation, value, newValue],
+        [resourceName, operation, key, value, newValue],
         Object.assign({}, options, program.opts()),
       );
       handleResponse(result);

--- a/tools/data-handler/src/commands/update.ts
+++ b/tools/data-handler/src/commands/update.ts
@@ -34,6 +34,7 @@ export class Update {
    * @param key Property to change in resource JSON
    * @param value Value for 'key'
    * @param optionalDetail Additional detail needed for some operations. For example, 'update' needs a new value.
+   * @param mappingTable Optional mapping table for workflow state transitions (only used for workflow changes)
    */
   public async updateValue<Type>(
     name: string,
@@ -41,6 +42,7 @@ export class Update {
     key: string,
     value: Type,
     optionalDetail?: Type, // todo: for 'rank' it might be reasonable to accept also 'number'
+    mappingTable?: { stateMapping: Record<string, string> },
   ) {
     const resource = Project.resourceObject(this.project, resourceName(name));
     const op: Operation<Type> = {
@@ -60,6 +62,10 @@ export class Update {
       (op as ChangeOperation<Type>).to = optionalDetail
         ? optionalDetail
         : (value as Type);
+      // Add mapping table if provided (for workflow changes)
+      if (mappingTable) {
+        (op as ChangeOperation<Type>).mappingTable = mappingTable;
+      }
     } else if (operation === 'rank') {
       (op as RankOperation<Type>).newIndex = optionalDetail as number;
       (op as RankOperation<Type>).target = value;

--- a/tools/data-handler/src/resources/card-type-resource.ts
+++ b/tools/data-handler/src/resources/card-type-resource.ts
@@ -12,7 +12,6 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { AbstractResource } from './resource-object.js';
 import type {
   CardType,
   CustomField,
@@ -178,7 +177,7 @@ export class CardTypeResource extends FileResource {
         const newState = stateMapping[currentState];
 
         if (newState && newState !== currentState) {
-          AbstractResource.logger.info(
+          this.logger.info(
             `Updating card '${card.key}': ${currentState} -> ${newState}`,
           );
           card.metadata.workflowState = newState;
@@ -192,7 +191,7 @@ export class CardTypeResource extends FileResource {
     await Promise.all(updatePromises);
 
     if (unmappedStates.length > 0) {
-      AbstractResource.logger.warn(
+      this.logger.warn(
         `Found unmapped states that were not updated: ${unmappedStates.join(', ')}`,
       );
     }

--- a/tools/data-handler/src/resources/file-resource.ts
+++ b/tools/data-handler/src/resources/file-resource.ts
@@ -137,6 +137,16 @@ export class FileResource extends ResourceObject {
     return cards;
   }
 
+  // Get (resource folder) type name
+  protected get getType() {
+    return super.getType;
+  }
+
+  // Get logger instance
+  protected get logger() {
+    return super.getLogger(this.getType);
+  }
+
   // Initialize the resource.
   protected initialize() {
     if (this.resourceName.type === '') {

--- a/tools/data-handler/src/resources/folder-resource.ts
+++ b/tools/data-handler/src/resources/folder-resource.ts
@@ -76,6 +76,15 @@ export class FolderResource extends FileResource {
     await rm(this.internalFolder, { recursive: true, force: true });
   }
 
+  // Get (resource folder) type name
+  protected get getType() {
+    return super.getType;
+  }
+
+  protected get logger() {
+    return super.getLogger(this.getType);
+  }
+
   protected initialize(): void {
     super.initialize();
 

--- a/tools/data-handler/src/resources/resource-object.ts
+++ b/tools/data-handler/src/resources/resource-object.ts
@@ -21,6 +21,7 @@ import type {
   Card,
   ResourceFolderType,
 } from '../interfaces/project-interfaces.js';
+import type { Logger } from 'pino';
 import { type Project, ResourcesFrom } from '../containers/project.js';
 import type { ResourceContent } from '../interfaces/resource-interfaces.js';
 import type { ResourceName } from '../utils/resource-utils.js';
@@ -70,11 +71,6 @@ export type Operation<T> =
  * Abstract class for resources.
  */
 export abstract class AbstractResource {
-  protected static get logger() {
-    return getChildLogger({
-      module: 'resource',
-    });
-  }
   protected abstract calculate(): Promise<void>; // update resource specific calculations
   protected abstract create(content?: ResourceContent): Promise<void>; // create a new with the content (memory)
   protected abstract delete(): Promise<void>; // delete from disk
@@ -88,6 +84,9 @@ export abstract class AbstractResource {
   protected abstract usage(cards?: Card[]): Promise<string[]>; // list of card keys or resource names where this resource is used in
   protected abstract validate(content?: object): Promise<void>; // validate the content
   protected abstract write(): Promise<void>; // write content to disk
+  // Abstract getters
+  protected abstract get getType(): string;
+  protected abstract getLogger(loggerName: string): Logger;
 }
 
 /**
@@ -116,6 +115,14 @@ export class ResourceObject extends AbstractResource {
   protected async rename(_name: ResourceName) {}
   protected async show(): Promise<ResourceContent> {
     return {} as ResourceContent;
+  }
+  protected get getType(): string {
+    return this.type;
+  }
+  protected getLogger(loggerName: string): Logger {
+    return getChildLogger({
+      module: loggerName,
+    });
   }
   protected async update<Type>(_key: string, _op: Operation<Type>) {}
   protected async usage(_cards?: Card[]): Promise<string[]> {

--- a/tools/data-handler/src/resources/resource-object.ts
+++ b/tools/data-handler/src/resources/resource-object.ts
@@ -24,6 +24,7 @@ import type {
 import { type Project, ResourcesFrom } from '../containers/project.js';
 import type { ResourceContent } from '../interfaces/resource-interfaces.js';
 import type { ResourceName } from '../utils/resource-utils.js';
+import { getChildLogger } from '../utils/log-utils.js';
 
 // Possible operations to perform when doing "update"
 export type UpdateOperations = 'add' | 'change' | 'rank' | 'remove';
@@ -44,6 +45,7 @@ export type AddOperation<T> = BaseOperation<T> & {
 export type ChangeOperation<T> = BaseOperation<T> & {
   name: 'change';
   to: T;
+  mappingTable?: { stateMapping: Record<string, string> }; // Optional state mapping for workflow changes
 };
 
 // Move item in an array to new position.
@@ -68,6 +70,11 @@ export type Operation<T> =
  * Abstract class for resources.
  */
 export abstract class AbstractResource {
+  protected static get logger() {
+    return getChildLogger({
+      module: 'resource',
+    });
+  }
   protected abstract calculate(): Promise<void>; // update resource specific calculations
   protected abstract create(content?: ResourceContent): Promise<void>; // create a new with the content (memory)
   protected abstract delete(): Promise<void>; // delete from disk


### PR DESCRIPTION
Allow `update` command to change `workflow` in a card type. 
This causes all cards that are using the card type to be changed to a new state according to the state mapping table provided. 

The implementation uses a new parameter on CLI that is provided with a flagged parameter to a local file. The file should have just single property `stateMapping` object having keys for each current state and value for those to match new states. 
<img width="495" height="137" alt="Screenshot 2025-08-22 at 9 35 25" src="https://github.com/user-attachments/assets/d2219ec8-c9f7-44d2-9540-ef8dc670999b" />

Before changing the `workflow` value, it is checked that all states in the current workflow are mapped to new states, and that there are no invalid new states (that do not exist in the upcoming workflow). 

**Additionally** 

1) Changed `update` implementation so that if not a JSON value is given as `target`, it defaults to string (previously it would have just failed). This allows giving the parameter as name `demo/workflows/test` instead of JSON `{ "name": "demo/workflows/test" }. This makes it a lot smoother to use on CLI (where you additionally need to escape the JSON double quotes).
2) Added `logger` for all resources to the base class. Not sure if it could be aliased, as the current `AbstractResource.logger` looks a bit daft. Using just `Resource.logger` would be better. 
3) Fixed the command handler update tests so that they are not reliant on earlier tests.
