### PR TITLE
INTDEV -956 Allow exporting logic programs

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -188,7 +188,6 @@ jobs:
         run: pnpm build-prebuildify
         env:
           PREBUILD_ARCH: ${{ matrix.arch }}
-          MACOSX_DEPLOYMENT_TARGET: 10.13
 
       - name: Upload prebuilds as artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -188,6 +188,7 @@ jobs:
         run: pnpm build-prebuildify
         env:
           PREBUILD_ARCH: ${{ matrix.arch }}
+          MACOSX_DEPLOYMENT_TARGET: 10.13
 
       - name: Upload prebuilds as artifacts
         uses: actions/upload-artifact@v4

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -318,7 +318,10 @@ const calculate = program
 calculate
   .command('generate')
   .description('Generate a logic program')
-  .argument('<destination>', 'Path to the logic program')
+  .argument(
+    '<destination>',
+    'Path to an output file. Command writes the logic program to this file.',
+  )
   .argument('[query]', 'Query to run')
   .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (destination: string, query: string, options: CardsOptions) => {

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -317,13 +317,17 @@ const calculate = program
 
 calculate
   .command('generate')
-  .description('DEPRECATED: Generate a logic program')
-  .argument('[cardKey]', 'If given, calculates on the subtree of the card')
+  .description('Generate a logic program')
+  .argument('<destination>', 'Path to the logic program')
+  .argument('[query]', 'Query to run')
   .option('-p, --project-path [path]', `${pathGuideline}`)
-  .action(async () => {
-    console.warn(
-      'This command is deprecated. Use "cyberismo calc run" directly instead.',
+  .action(async (destination: string, query: string, options: CardsOptions) => {
+    const result = await commandHandler.command(
+      Cmd.calc,
+      ['generate', destination, query],
+      Object.assign({}, options, program.opts()),
     );
+    handleResponse(result);
   });
 
 calculate

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -47,7 +47,7 @@ import { resourceName } from './utils/resource-utils.js';
 
 import { type Level } from 'pino';
 import { type Context } from './interfaces/project-interfaces.js';
-import { QueryName } from './types/queries.js';
+import { type QueryName } from './types/queries.js';
 
 // Generic options interface
 export interface CardsOptions {

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -47,6 +47,7 @@ import { resourceName } from './utils/resource-utils.js';
 
 import { type Level } from 'pino';
 import { type Context } from './interfaces/project-interfaces.js';
+import { QueryName } from './types/queries.js';
 
 // Generic options interface
 export interface CardsOptions {
@@ -207,8 +208,9 @@ export class Commands {
           return await this.addHub(target);
         }
       } else if (command === Cmd.calc) {
-        const [command, cardKey] = args;
+        const [command, ...rest] = args;
         if (command === 'run') {
+          const [cardKey] = rest;
           if (!cardKey) {
             return { statusCode: 400, message: 'File path is missing' };
           }
@@ -216,7 +218,9 @@ export class Commands {
           return this.runLogicProgram(cardKey, options.context || 'localApp');
         }
         if (command === 'generate') {
-          return this.generateLogicProgram();
+          const [destination, query] = rest;
+          await this.generateLogicProgram();
+          return this.exportLogicProgram(destination, query);
         }
       } else if (command === Cmd.create) {
         const [type, ...rest] = args;
@@ -565,6 +569,22 @@ export class Commands {
   private async generateLogicProgram(): Promise<requestStatus> {
     try {
       await this.commands?.calculateCmd.generate();
+      return { statusCode: 200 };
+    } catch (e) {
+      return { statusCode: 500, message: errorFunction(e) };
+    }
+  }
+
+  private async exportLogicProgram(
+    destination: string,
+    query?: string,
+  ): Promise<requestStatus> {
+    try {
+      await this.commands?.calculateCmd.exportLogicProgram(
+        destination,
+        ['all'],
+        query as QueryName, // TODO: validate with zod
+      );
       return { statusCode: 200 };
     } catch (e) {
       return { statusCode: 500, message: errorFunction(e) };

--- a/tools/data-handler/src/commands/calculate.ts
+++ b/tools/data-handler/src/commands/calculate.ts
@@ -20,7 +20,7 @@ export class Calculate {
   constructor(private project: Project) {}
 
   /**
-   * Exports logic program to a given file with given programs and query
+   * Exports logic program to a given file
    * @param destination Destination file path
    * @param programs Programs or categories to export
    * @param query Query to export, if not provided, all programs will be exported

--- a/tools/data-handler/src/commands/calculate.ts
+++ b/tools/data-handler/src/commands/calculate.ts
@@ -58,4 +58,16 @@ export class Calculate {
   ): Promise<QueryResult<T>[]> {
     return this.project.calculationEngine.runQuery(queryName, context, options);
   }
+
+  public async exportLogicProgram(
+    destination: string,
+    programs: string[] = ['all'],
+    query?: QueryName,
+  ) {
+    return this.project.calculationEngine.exportLogicProgram(
+      destination,
+      programs,
+      query,
+    );
+  }
 }

--- a/tools/data-handler/src/commands/calculate.ts
+++ b/tools/data-handler/src/commands/calculate.ts
@@ -20,6 +20,24 @@ export class Calculate {
   constructor(private project: Project) {}
 
   /**
+   * Exports logic program to a given file with given programs and query
+   * @param destination Destination file path
+   * @param programs Programs or categories to export
+   * @param query Query to export, if not provided, all programs will be exported
+   */
+  public async exportLogicProgram(
+    destination: string,
+    programs: string[] = ['all'],
+    query?: QueryName,
+  ) {
+    await this.project.calculationEngine.exportLogicProgram(
+      destination,
+      programs,
+      query,
+    );
+  }
+
+  /**
    * Generates a logic program.
    */
   public async generate() {
@@ -57,17 +75,5 @@ export class Calculate {
     options?: unknown,
   ): Promise<QueryResult<T>[]> {
     return this.project.calculationEngine.runQuery(queryName, context, options);
-  }
-
-  public async exportLogicProgram(
-    destination: string,
-    programs: string[] = ['all'],
-    query?: QueryName,
-  ) {
-    return this.project.calculationEngine.exportLogicProgram(
-      destination,
-      programs,
-      query,
-    );
   }
 }

--- a/tools/data-handler/src/containers/project/calculation-engine.ts
+++ b/tools/data-handler/src/containers/project/calculation-engine.ts
@@ -111,6 +111,12 @@ export class CalculationEngine {
     return createCardFacts(card, this.project);
   }
 
+  /**
+   * Exports logic program to a given file with given programs and query
+   * @param destination Destination file path
+   * @param programs Programs or categories to export
+   * @param query Query to export, if not provided, all programs will be exported
+   */
   public async exportLogicProgram(
     destination: string,
     programs: string[],

--- a/tools/data-handler/src/containers/project/calculation-engine.ts
+++ b/tools/data-handler/src/containers/project/calculation-engine.ts
@@ -112,7 +112,7 @@ export class CalculationEngine {
   }
 
   /**
-   * Exports logic program to a given file with given programs and query
+   * Exports logic program to a given file
    * @param destination Destination file path
    * @param programs Programs or categories to export
    * @param query Query to export, if not provided, all programs will be exported

--- a/tools/data-handler/src/containers/project/calculation-engine.ts
+++ b/tools/data-handler/src/containers/project/calculation-engine.ts
@@ -122,7 +122,7 @@ export class CalculationEngine {
     programs: string[],
     query?: QueryName,
   ) {
-    let logicProgram = query ? this.getQuery(query) : '';
+    let logicProgram = query ? this.queryContent(query) : '';
     logicProgram += await getProgram('', programs);
     await writeFile(destination, logicProgram);
   }
@@ -520,7 +520,7 @@ export class CalculationEngine {
     return this.parseClingoResult(clingoOutput);
   }
 
-  private getQuery(queryName: QueryName, options?: unknown) {
+  private queryContent(queryName: QueryName, options?: unknown) {
     const content = lpFiles.queries[queryName];
     const handlebars = Handlebars.create();
     const compiled = handlebars.compile(content);
@@ -538,7 +538,7 @@ export class CalculationEngine {
     context: Context = 'localApp',
     options?: unknown,
   ): Promise<QueryResult<T>[]> {
-    const content = this.getQuery(queryName, options);
+    const content = this.queryContent(queryName, options);
 
     this.logger.trace({ queryName }, 'Running query');
     const clingoOutput = await this.run(content, context);

--- a/tools/data-handler/src/containers/project/calculation-engine.ts
+++ b/tools/data-handler/src/containers/project/calculation-engine.ts
@@ -57,7 +57,7 @@ import {
   solve,
   setProgram,
   removeProgram,
-  getProgram,
+  buildProgram,
 } from '@cyberismo/node-clingo';
 import { generateReportContent } from '../../utils/report.js';
 import { lpFiles, graphvizReport } from '@cyberismo/assets';
@@ -123,7 +123,7 @@ export class CalculationEngine {
     query?: QueryName,
   ) {
     let logicProgram = query ? this.queryContent(query) : '';
-    logicProgram += await getProgram('', programs);
+    logicProgram += await buildProgram('', programs);
     await writeFile(destination, logicProgram);
   }
 

--- a/tools/data-handler/src/containers/project/calculation-engine.ts
+++ b/tools/data-handler/src/containers/project/calculation-engine.ts
@@ -122,10 +122,7 @@ export class CalculationEngine {
     programs: string[],
     query?: QueryName,
   ) {
-    let logicProgram = '';
-    if (query) {
-      logicProgram += this.getQuery(query);
-    }
+    let logicProgram = query ? this.getQuery(query) : '';
     logicProgram += await getProgram('', programs);
     await writeFile(destination, logicProgram);
   }

--- a/tools/node-clingo/binding.gyp
+++ b/tools/node-clingo/binding.gyp
@@ -6,7 +6,7 @@
   "targets": [
     {
       "target_name": "node-clingo",
-      "cflags_cc": [ "-std=c++20" ],
+      "cflags_cc": [ "-std=c++20", "-mmacosx-version-min=10.13" ],
       "sources": [ 
         "src/binding.cc",
         "src/helpers.cc",

--- a/tools/node-clingo/binding.gyp
+++ b/tools/node-clingo/binding.gyp
@@ -71,6 +71,7 @@
             }]
           ],
           "xcode_settings": {
+            "CLANG_CXX_LANGUAGE_STANDARD": "c++20",
             "OTHER_LDFLAGS": [
               "-Wl,-rpath,@loader_path"
             ]

--- a/tools/node-clingo/binding.gyp
+++ b/tools/node-clingo/binding.gyp
@@ -6,7 +6,7 @@
   "targets": [
     {
       "target_name": "node-clingo",
-      "cflags_cc": [ "-std=c++20", "-mmacosx-version-min=10.13" ],
+      "cflags_cc": [ "-std=c++20" ],
       "sources": [ 
         "src/binding.cc",
         "src/helpers.cc",
@@ -53,6 +53,8 @@
               ]
             }],
             ["target_arch!='arm64'", {
+              "cflags_cc": [ "-mmacosx-version-min=10.13" ],
+              "ldflags": [ "-mmacosx-version-min=10.13" ],
               "libraries": [
                 "-L/usr/local/lib",
                 "-lclingo"

--- a/tools/node-clingo/binding.gyp
+++ b/tools/node-clingo/binding.gyp
@@ -53,8 +53,6 @@
               ]
             }],
             ["target_arch!='arm64'", {
-              "cflags_cc": [ "-mmacosx-version-min=10.13" ],
-              "ldflags": [ "-mmacosx-version-min=10.13" ],
               "libraries": [
                 "-L/usr/local/lib",
                 "-lclingo"

--- a/tools/node-clingo/binding.gyp
+++ b/tools/node-clingo/binding.gyp
@@ -72,6 +72,7 @@
           ],
           "xcode_settings": {
             "CLANG_CXX_LANGUAGE_STANDARD": "c++20",
+            "MACOSX_DEPLOYMENT_TARGET": "10.13",
             "OTHER_LDFLAGS": [
               "-Wl,-rpath,@loader_path"
             ]

--- a/tools/node-clingo/lib/index.ts
+++ b/tools/node-clingo/lib/index.ts
@@ -20,7 +20,7 @@ interface ClingoBinding {
   removeProgramsByCategory(category: string): number;
   removeAllPrograms(): void;
   solve(program: string, categories: string[]): ClingoResult;
-  getProgram(program: string, categories: string[]): string;
+  buildProgram(program: string, categories: string[]): string;
 }
 
 let binding: ClingoBinding;
@@ -140,8 +140,8 @@ function removeAllPrograms() {
  * @param categories Optional array of program keys or categories to include
  * @returns The complete assembled program as a string
  */
-function getProgram(program: string, categories?: string[]): string {
-  return binding.getProgram(program, categories ?? []);
+function buildProgram(program: string, categories?: string[]): string {
+  return binding.buildProgram(program, categories ?? []);
 }
 
 export {
@@ -150,7 +150,7 @@ export {
   removeProgram,
   removeProgramsByCategory,
   removeAllPrograms,
-  getProgram,
+  buildProgram,
   ClingoResult,
 };
 export default {
@@ -159,5 +159,5 @@ export default {
   removeProgram,
   removeProgramsByCategory,
   removeAllPrograms,
-  getProgram,
+  buildProgram,
 };

--- a/tools/node-clingo/lib/index.ts
+++ b/tools/node-clingo/lib/index.ts
@@ -20,6 +20,7 @@ interface ClingoBinding {
   removeProgramsByCategory(category: string): number;
   removeAllPrograms(): void;
   solve(program: string, categories: string[]): ClingoResult;
+  getProgram(program: string, categories: string[]): string;
 }
 
 let binding: ClingoBinding;
@@ -133,12 +134,23 @@ function removeAllPrograms() {
   binding.removeAllPrograms();
 }
 
+/**
+ * Gets the complete assembled logic program as a string
+ * @param program The main logic program as a string
+ * @param categories Optional array of program keys or categories to include
+ * @returns The complete assembled program as a string
+ */
+function getProgram(program: string, categories?: string[]): string {
+  return binding.getProgram(program, categories ?? []);
+}
+
 export {
   solve,
   setProgram,
   removeProgram,
   removeProgramsByCategory,
   removeAllPrograms,
+  getProgram,
   ClingoResult,
 };
 export default {
@@ -147,4 +159,5 @@ export default {
   removeProgram,
   removeProgramsByCategory,
   removeAllPrograms,
+  getProgram,
 };

--- a/tools/node-clingo/package.json
+++ b/tools/node-clingo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyberismo/node-clingo",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "Node.js bindings for Clingo answer set solver",
   "scripts": {
     "install": "node scripts/download-prebuild.js || node-gyp-build",

--- a/tools/node-clingo/src/binding.cc
+++ b/tools/node-clingo/src/binding.cc
@@ -463,7 +463,7 @@ Napi::Value RemoveAllPrograms(const Napi::CallbackInfo& info)
 }
 
 /**
- * N-API function exposed to JavaScript as `getProgram`.
+ * N-API function exposed to JavaScript as `buildProgram`.
  * Assembles a complete logic program by combining the main program with stored base programs.
  * This function provides the same program assembly logic as `solve` but returns the complete
  * program text instead of executing it.
@@ -471,7 +471,7 @@ Napi::Value RemoveAllPrograms(const Napi::CallbackInfo& info)
  * @returns A Napi::String containing the complete assembled logic program.
  * @throws Napi::TypeError if arguments are invalid.
  */
-Napi::Value GetProgram(const Napi::CallbackInfo& info)
+Napi::Value BuildProgram(const Napi::CallbackInfo& info)
 {
     Napi::Env env = info.Env();
 
@@ -646,7 +646,7 @@ Napi::Object Init(Napi::Env env, Napi::Object exports)
 {
     exports.Set(Napi::String::New(env, "solve"), Napi::Function::New(env, Solve));
 
-    exports.Set(Napi::String::New(env, "getProgram"), Napi::Function::New(env, GetProgram));
+    exports.Set(Napi::String::New(env, "buildProgram"), Napi::Function::New(env, BuildProgram));
 
     exports.Set(Napi::String::New(env, "setProgram"), Napi::Function::New(env, SetProgram));
 

--- a/tools/node-clingo/src/binding.cc
+++ b/tools/node-clingo/src/binding.cc
@@ -186,11 +186,11 @@ namespace
             for (const auto& entry : g_programs)
             {
                 const std::string& key = entry.first;
-                const Program& prog = entry.second;
-                if (std::find(prog.categories.begin(), prog.categories.end(), ref) != prog.categories.end() &&
+                const Program& program = entry.second;
+                if (std::find(program.categories.begin(), program.categories.end(), ref) != program.categories.end() &&
                     addedPrograms.insert(key).second)
                 {
-                    handler(key, prog, ref);
+                    handler(key, program, ref);
                 }
             }
         }
@@ -366,8 +366,8 @@ Napi::Value SetProgram(const Napi::CallbackInfo& info)
     std::string content = info[1].As<Napi::String>().Utf8Value();
 
     // Create program entry
-    Program prog;
-    prog.content = content;
+    Program program;
+    program.content = content;
 
     // Add categories if provided
     if (info.Length() >= 3 && info[2].IsArray())
@@ -378,13 +378,13 @@ Napi::Value SetProgram(const Napi::CallbackInfo& info)
             Napi::Value val = categories[i];
             if (val.IsString())
             {
-                prog.categories.push_back(val.As<Napi::String>().Utf8Value());
+                program.categories.push_back(val.As<Napi::String>().Utf8Value());
             }
         }
     }
 
     // Store the program
-    g_programs[key] = std::move(prog);
+    g_programs[key] = std::move(program);
     return env.Undefined();
 }
 
@@ -433,8 +433,8 @@ Napi::Value RemoveProgramsByCategory(const Napi::CallbackInfo& info)
     auto it = g_programs.begin();
     while (it != g_programs.end())
     {
-        const auto& prog = it->second;
-        if (std::find(prog.categories.begin(), prog.categories.end(), category) != prog.categories.end())
+        const auto& program = it->second;
+        if (std::find(program.categories.begin(), program.categories.end(), category) != program.categories.end())
         {
             it = g_programs.erase(it);
             removedCount++;
@@ -492,7 +492,7 @@ Napi::Value GetProgram(const Napi::CallbackInfo& info)
     {
         std::set<std::string> refs = parse_refs_or_throw(info);
 
-        expand_refs_to_programs(refs, [&](const std::string& key, const Program& prog, std::string category) {
+        expand_refs_to_programs(refs, [&](const std::string& key, const Program& program, std::string category) {
             if (!category.empty())
             {
                 completeProgram << "% Program: " << key << " (category: " << category << ")\n";
@@ -501,7 +501,7 @@ Napi::Value GetProgram(const Napi::CallbackInfo& info)
             {
                 completeProgram << "% Program: " << key << "\n";
             }
-            completeProgram << prog.content << "\n\n";
+            completeProgram << program.content << "\n\n";
         });
     }
 
@@ -561,9 +561,9 @@ Napi::Value Solve(const Napi::CallbackInfo& info)
     {
         refs = parse_refs_or_throw(info);
 
-        expand_refs_to_programs(refs, [&](const std::string& key, const Program& prog, std::string category) {
+        expand_refs_to_programs(refs, [&](const std::string& key, const Program& program, std::string category) {
             (void)category; // unused
-            if (!clingo_control_add(ctl, key.c_str(), nullptr, 0, prog.content.c_str()))
+            if (!clingo_control_add(ctl, key.c_str(), nullptr, 0, program.content.c_str()))
             {
                 handle_clingo_error(env, key);
             }

--- a/tools/node-clingo/src/binding.cc
+++ b/tools/node-clingo/src/binding.cc
@@ -283,7 +283,7 @@ namespace
             return false;
         }
 
-        std::stringstream ss;
+        std::stringstream answerStream;
         bool success = true;
 
         // Convert each symbol to string
@@ -299,13 +299,13 @@ namespace
             }
 
             if (i > 0)
-                ss << std::endl;
-            ss << str;
+                answerStream << std::endl;
+            answerStream << str;
         }
 
         try
         {
-            answers->push_back(ss.str());
+            answers->push_back(answerStream.str());
         }
         catch (const std::bad_alloc&)
         {

--- a/tools/node-clingo/src/binding.cc
+++ b/tools/node-clingo/src/binding.cc
@@ -183,10 +183,10 @@ namespace
             }
 
             // If no direct match, check categories
-            for (const auto& kv : g_programs)
+            for (const auto& entry : g_programs)
             {
-                const std::string& key = kv.first;
-                const Program& prog = kv.second;
+                const std::string& key = entry.first;
+                const Program& prog = entry.second;
                 if (std::find(prog.categories.begin(), prog.categories.end(), ref) != prog.categories.end() &&
                     addedPrograms.insert(key).second)
                 {

--- a/tools/node-clingo/src/binding.cc
+++ b/tools/node-clingo/src/binding.cc
@@ -19,6 +19,7 @@
 #include <ctime>
 #include <iostream>
 #include <napi.h>
+#include <optional>
 #include <set>
 #include <sstream>
 #include <stdint.h>
@@ -26,111 +27,177 @@
 #include <unordered_map>
 #include <vector>
 
-struct ClingoLogMessage
+// unnamed namespace to avoid polluting the global namespace
+namespace
 {
-    clingo_warning_t code;
-    bool isError;
-    std::string message;
-};
-
-struct NodeClingoLogs
-{
-    Napi::Array errors;
-    Napi::Array warnings;
-
-    NodeClingoLogs(Napi::Env env)
+    struct ClingoLogMessage
     {
-        errors = Napi::Array::New(env);
-        warnings = Napi::Array::New(env);
-    }
-};
+        clingo_warning_t code;
+        bool isError;
+        std::string message;
+    };
 
-// Program with categories
-struct Program
-{
-    std::string content;
-    std::vector<std::string> categories;
-};
-
-// stores all programs
-std::unordered_map<std::string, Program> g_programs;
-
-// For now error messsages are stored in a global vector,
-// If async/threading is needed, we cannot use a single global variable
-std::vector<ClingoLogMessage> g_errorMessages;
-
-/**
- * A logger function for Clingo that captures messages.
- * Collects warnings and errors from Clingo for later processing.
- * @param code The warning code.
- * @param message The warning message.
- * @param data User data (unused).
- */
-void message_collector(clingo_warning_t code, char const* message, void* data)
-{
-    g_errorMessages.push_back({code, code == clingo_warning_runtime_error, message});
-}
-
-/**
- * Helper function to parse the error messages from Clingo
- * @param env The N-API environment.
- * @return NodeClingoLogs containing separated errors and warnings arrays.
- */
-NodeClingoLogs parse_clingo_logs(const Napi::Env& env)
-{
-    NodeClingoLogs logs(env);
-
-    size_t errorIndex = 0;
-    size_t warningIndex = 0;
-
-    for (const auto& msg : g_errorMessages)
+    struct NodeClingoLogs
     {
-        if (msg.isError)
+        Napi::Array errors;
+        Napi::Array warnings;
+
+        NodeClingoLogs(Napi::Env env)
         {
-            logs.errors.Set(errorIndex++, Napi::String::New(env, msg.message));
+            errors = Napi::Array::New(env);
+            warnings = Napi::Array::New(env);
         }
-        else
-        {
-            logs.warnings.Set(warningIndex++, Napi::String::New(env, msg.message));
-        }
+    };
+
+    // Program with categories
+    struct Program
+    {
+        std::string content;
+        std::vector<std::string> categories;
+    };
+
+    // stores all programs
+    std::unordered_map<std::string, Program> g_programs;
+
+    // For now error messsages are stored in a global vector,
+    // If async/threading is needed, we cannot use a single global variable
+    std::vector<ClingoLogMessage> g_errorMessages;
+
+    /**
+    * A logger function for Clingo that captures messages.
+    * Collects warnings and errors from Clingo for later processing.
+    * @param code The warning code.
+    * @param message The warning message.
+    * @param data User data (unused).
+    */
+    void message_collector(clingo_warning_t code, char const* message, void* data)
+    {
+        g_errorMessages.push_back({code, code == clingo_warning_runtime_error, message});
     }
 
-    return logs;
-}
-
-/**
- * Helper function to check for and handle Clingo errors.
- * If a Clingo error has occurred (clingo_error_code() != 0),
- * it throws a Napi::Error with the Clingo error message.
- * @param env The N-API environment.
- * @param programKey The string identifier of the program that caused the error
- */
-void handle_clingo_error(const Napi::Env& env, const std::string& programKey = "")
-{
-    // If clingo returns an error, we throw an error to the javascript side
-    if (clingo_error_code() != 0)
+    /**
+    * Helper function to parse the error messages from Clingo
+    * @param env The N-API environment.
+    * @return NodeClingoLogs containing separated errors and warnings arrays.
+    */
+    NodeClingoLogs parse_clingo_logs(const Napi::Env& env)
     {
-        Napi::Error error = Napi::Error::New(env, clingo_error_message());
+        NodeClingoLogs logs(env);
 
-        // Create an object to hold error details
-        Napi::Object errorObj = Napi::Object::New(env);
+        size_t errorIndex = 0;
+        size_t warningIndex = 0;
 
-        // Parse errors and warnings using the common routine
-        NodeClingoLogs logs = parse_clingo_logs(env);
-
-        errorObj.Set("errors", logs.errors);
-        errorObj.Set("warnings", logs.warnings);
-        if (!programKey.empty())
+        for (const auto& msg : g_errorMessages)
         {
-            errorObj.Set("program", Napi::String::New(env, programKey));
+            if (msg.isError)
+            {
+                logs.errors.Set(errorIndex++, Napi::String::New(env, msg.message));
+            }
+            else
+            {
+                logs.warnings.Set(warningIndex++, Napi::String::New(env, msg.message));
+            }
         }
 
-        error.Set("details", errorObj);
-        throw error;
+        return logs;
     }
-}
 
-/**
+    /**
+    * Helper function to check for and handle Clingo errors.
+    * If a Clingo error has occurred (clingo_error_code() != 0),
+    * it throws a Napi::Error with the Clingo error message.
+    * @param env The N-API environment.
+    * @param programKey The string identifier of the program that caused the error
+    */
+    void handle_clingo_error(const Napi::Env& env, const std::string& programKey = "")
+    {
+        // If clingo returns an error, we throw an error to the javascript side
+        if (clingo_error_code() != 0)
+        {
+            Napi::Error error = Napi::Error::New(env, clingo_error_message());
+
+            // Create an object to hold error details
+            Napi::Object errorObj = Napi::Object::New(env);
+
+            // Parse errors and warnings using the common routine
+            NodeClingoLogs logs = parse_clingo_logs(env);
+
+            errorObj.Set("errors", logs.errors);
+            errorObj.Set("warnings", logs.warnings);
+            if (!programKey.empty())
+            {
+                errorObj.Set("program", Napi::String::New(env, programKey));
+            }
+
+            error.Set("details", errorObj);
+            throw error;
+        }
+    }
+
+    /**
+    * Parse refs array argument from N-API info at given index.
+    * Throws TypeError if not an array of strings. Returns a set of refs.
+    */
+    std::set<std::string> parse_refs_or_throw(const Napi::CallbackInfo& info, size_t index = 1)
+    {
+        Napi::Env env = info.Env();
+        if (!info[index].IsArray())
+        {
+            throw Napi::TypeError::New(env, "Second argument must be an array of strings (refs)");
+        }
+
+        std::set<std::string> refs;
+        Napi::Array arr = info[index].As<Napi::Array>();
+        for (uint32_t i = 0; i < arr.Length(); ++i)
+        {
+            Napi::Value val = arr[i];
+            if (!val.IsString())
+            {
+                throw Napi::TypeError::New(env, "All refs must be strings");
+            }
+            std::string ref = val.As<Napi::String>().Utf8Value();
+            refs.insert(ref);
+        }
+        return refs;
+    }
+
+    /**
+    * Expand refs into concrete programs by exact key or matching category.
+    * Calls handler once per unique program. If the program came from a category
+    * match, category contains the category string; otherwise it is empty.
+    */
+    template <std::invocable<const std::string&, const Program&, std::optional<std::string>> Handler>
+    void expand_refs_to_programs(const std::set<std::string>& refs, Handler handler)
+    {
+        std::set<std::string> addedPrograms;
+
+        for (const auto& ref : refs)
+        {
+            auto it = g_programs.find(ref);
+            // insert.second is true if element was inserted
+            // thus, if it is false, the element was already in the set
+            if (it != g_programs.end() && addedPrograms.insert(ref).second)
+            {
+                handler(ref, it->second, std::optional<std::string>());
+                // no need to check other refs, as ref was a program, not a category
+                continue;
+            }
+
+            // If no direct match, check categories
+            for (const auto& kv : g_programs)
+            {
+                const std::string& key = kv.first;
+                const Program& prog = kv.second;
+                if (std::find(prog.categories.begin(), prog.categories.end(), ref) != prog.categories.end() &&
+                    addedPrograms.insert(key).second)
+                {
+                    handler(key, prog, std::optional<std::string>(ref));
+                }
+            }
+        }
+    }
+
+    /**
  * Callback function provided to clingo_control_ground.
  * This function is called by Clingo for each external function encountered during grounding.
  * It looks up the function name in the registered handlers and executes the corresponding handler.
@@ -143,30 +210,30 @@ void handle_clingo_error(const Napi::Env& env, const std::string& programKey = "
  * @param symbol_callback_data User data for the symbol_callback.
  * @returns True on success, false on error (propagated from the handler).
  */
-bool ground_callback(
-    clingo_location_t const* location,
-    char const* name,
-    clingo_symbol_t const* arguments,
-    size_t arguments_size,
-    void* data,
-    clingo_symbol_callback_t symbol_callback,
-    void* symbol_callback_data)
-{
-
-    // Find the handler for the function and call it
-    const auto& handlers = node_clingo::get_function_handlers();
-
-    auto it = handlers.find(name);
-    if (it != handlers.end())
+    bool ground_callback(
+        clingo_location_t const* location,
+        char const* name,
+        clingo_symbol_t const* arguments,
+        size_t arguments_size,
+        void* data,
+        clingo_symbol_callback_t symbol_callback,
+        void* symbol_callback_data)
     {
-        return it->second(arguments, arguments_size, symbol_callback, symbol_callback_data);
+
+        // Find the handler for the function and call it
+        const auto& handlers = node_clingo::get_function_handlers();
+
+        auto it = handlers.find(name);
+        if (it != handlers.end())
+        {
+            return it->second(arguments, arguments_size, symbol_callback, symbol_callback_data);
+        }
+
+        // If function name not matched, we simply do not handle it
+        return true;
     }
 
-    // If function name not matched, we simply do not handle it
-    return true;
-}
-
-/**
+    /**
  * Callback function provided to clingo_control_solve (via solve_event_callback).
  * This function is called by Clingo for each model (answer set) found.
  * It extracts the symbols from the model, converts them to strings, and stores them.
@@ -175,83 +242,83 @@ bool ground_callback(
  * @param go_on Output parameter; set to true to continue solving, false to stop.
  * @returns True on success, false on error (e.g., allocation failure).
  */
-bool on_model(clingo_model_t const* model, void* data, bool* go_on)
-{
-    if (!model || !data || !go_on)
+    bool on_model(clingo_model_t const* model, void* data, bool* go_on)
     {
-        return false;
-    }
-
-    std::vector<std::string>* answers = static_cast<std::vector<std::string>*>(data);
-
-    clingo_symbol_t* atoms = nullptr;
-    size_t atoms_size;
-
-    // Get the size of the model
-    if (!clingo_model_symbols_size(model, clingo_show_type_shown, &atoms_size))
-    {
-        return false;
-    }
-
-    if (atoms_size == 0)
-    {
-        answers->push_back("");
-        *go_on = true;
-        return true;
-    }
-
-    // Allocate space for the atoms
-    try
-    {
-        atoms = new clingo_symbol_t[atoms_size];
-    }
-    catch (const std::bad_alloc&)
-    {
-        return false;
-    }
-
-    // Get the model symbols
-    if (!clingo_model_symbols(model, clingo_show_type_shown, atoms, atoms_size))
-    {
-        delete[] atoms;
-        return false;
-    }
-
-    std::stringstream ss;
-    bool success = true;
-
-    // Convert each symbol to string
-    for (size_t i = 0; i < atoms_size && success; ++i)
-    {
-        // Get the string representation
-        std::string str = node_clingo::get_symbol_string(atoms[i]);
-
-        // If the string is empty, we skip it
-        if (str.empty())
+        if (!model || !data || !go_on)
         {
-            continue;
+            return false;
         }
 
-        if (i > 0)
-            ss << std::endl;
-        ss << str;
+        std::vector<std::string>* answers = static_cast<std::vector<std::string>*>(data);
+
+        clingo_symbol_t* atoms = nullptr;
+        size_t atoms_size;
+
+        // Get the size of the model
+        if (!clingo_model_symbols_size(model, clingo_show_type_shown, &atoms_size))
+        {
+            return false;
+        }
+
+        if (atoms_size == 0)
+        {
+            answers->push_back("");
+            *go_on = true;
+            return true;
+        }
+
+        // Allocate space for the atoms
+        try
+        {
+            atoms = new clingo_symbol_t[atoms_size];
+        }
+        catch (const std::bad_alloc&)
+        {
+            return false;
+        }
+
+        // Get the model symbols
+        if (!clingo_model_symbols(model, clingo_show_type_shown, atoms, atoms_size))
+        {
+            delete[] atoms;
+            return false;
+        }
+
+        std::stringstream ss;
+        bool success = true;
+
+        // Convert each symbol to string
+        for (size_t i = 0; i < atoms_size && success; ++i)
+        {
+            // Get the string representation
+            std::string str = node_clingo::get_symbol_string(atoms[i]);
+
+            // If the string is empty, we skip it
+            if (str.empty())
+            {
+                continue;
+            }
+
+            if (i > 0)
+                ss << std::endl;
+            ss << str;
+        }
+
+        try
+        {
+            answers->push_back(ss.str());
+        }
+        catch (const std::bad_alloc&)
+        {
+            success = false;
+        }
+
+        delete[] atoms;
+        *go_on = success;
+        return success;
     }
 
-    try
-    {
-        answers->push_back(ss.str());
-    }
-    catch (const std::bad_alloc&)
-    {
-        success = false;
-    }
-
-    delete[] atoms;
-    *go_on = success;
-    return success;
-}
-
-/**
+    /**
  * Wrapper callback for clingo_control_solve.
  * This function receives different types of solve events from Clingo.
  * If the event type is a model (clingo_solve_event_type_model), it calls the on_model handler.
@@ -261,20 +328,21 @@ bool on_model(clingo_model_t const* model, void* data, bool* go_on)
  * @param go_on Output parameter (passed through to on_model).
  * @returns True on success or if the event is not a model, false on error from on_model.
  */
-bool solve_event_callback(uint32_t type, void* event, void* data, bool* go_on)
-{
-    if (!event || !data || !go_on)
+    bool solve_event_callback(uint32_t type, void* event, void* data, bool* go_on)
     {
-        return false;
+        if (!event || !data || !go_on)
+        {
+            return false;
+        }
+
+        if (type == clingo_solve_event_type_model)
+        {
+            return on_model(static_cast<const clingo_model_t*>(event), data, go_on);
+        }
+        return true;
     }
 
-    if (type == clingo_solve_event_type_model)
-    {
-        return on_model(static_cast<const clingo_model_t*>(event), data, go_on);
-    }
-    return true;
-}
-
+} // namespace
 /**
  * N-API function exposed to JavaScript as `setProgram`.
  * Stores or updates a program with optional categories.
@@ -423,52 +491,20 @@ Napi::Value GetProgram(const Napi::CallbackInfo& info)
     // Apply base programs if specified
     if (info.Length() >= 2)
     {
-        if (!info[1].IsArray())
-        {
-            throw Napi::TypeError::New(env, "Second argument must be an array of strings (refs)");
-        }
+        std::set<std::string> refs = parse_refs_or_throw(info);
 
-        // Track which programs have already been added to prevent duplicates
-        std::set<std::string> addedPrograms;
-        std::set<std::string> refs;
-
-        Napi::Array arr = info[1].As<Napi::Array>();
-
-        for (uint32_t i = 0; i < arr.Length(); ++i)
-        {
-            Napi::Value val = arr[i];
-            if (!val.IsString())
-            {
-                throw Napi::TypeError::New(env, "All refs must be strings");
-            }
-            std::string ref = val.As<Napi::String>().Utf8Value();
-            refs.insert(ref);
-        }
-
-        for (const auto& ref : refs)
-        {
-            auto it = g_programs.find(ref);
-            if (it != g_programs.end() && addedPrograms.find(ref) == addedPrograms.end())
-            {
-                completeProgram << "% Program: " << ref << "\n";
-                completeProgram << it->second.content << "\n\n";
-                addedPrograms.insert(ref);
-                // no need to check other refs, as ref was a program, not a category
-                continue;
-            }
-
-            // If no direct match, check categories
-            for (const auto& [key, prog] : g_programs)
-            {
-                if (std::find(prog.categories.begin(), prog.categories.end(), ref) != prog.categories.end() &&
-                    addedPrograms.find(key) == addedPrograms.end())
+        expand_refs_to_programs(
+            refs, [&](const std::string& key, const Program& prog, std::optional<std::string> category) {
+                if (category.has_value())
                 {
-                    completeProgram << "% Program: " << key << " (category: " << ref << ")\n";
-                    completeProgram << prog.content << "\n\n";
-                    addedPrograms.insert(key);
+                    completeProgram << "% Program: " << key << " (category: " << category.value() << ")\n";
                 }
-            }
-        }
+                else
+                {
+                    completeProgram << "% Program: " << key << "\n";
+                }
+                completeProgram << prog.content << "\n\n";
+            });
     }
 
     // Add the main program last
@@ -525,62 +561,20 @@ Napi::Value Solve(const Napi::CallbackInfo& info)
     // Apply base programs if specified
     if (info.Length() >= 2)
     {
-        if (!info[1].IsArray())
-        {
-            throw Napi::TypeError::New(env, "Second argument must be an array of strings (refs)");
-        }
-        // Track which programs have already been added to prevent duplicates
-        std::set<std::string> addedPrograms;
+        refs = parse_refs_or_throw(info);
 
-        Napi::Array arr = info[1].As<Napi::Array>();
-
-        for (uint32_t i = 0; i < arr.Length(); ++i)
-        {
-            Napi::Value val = arr[i];
-            if (!val.IsString())
-            {
-                throw Napi::TypeError::New(env, "All refs must be strings");
-            }
-            std::string ref = val.As<Napi::String>().Utf8Value();
-            refs.insert(ref);
-        }
-
-        for (const auto& ref : refs)
-        {
-            auto it = g_programs.find(ref);
-            if (it != g_programs.end() && addedPrograms.find(ref) == addedPrograms.end())
-            {
-                if (!clingo_control_add(ctl, ref.c_str(), nullptr, 0, it->second.content.c_str()))
+        expand_refs_to_programs(
+            refs, [&](const std::string& key, const Program& prog, std::optional<std::string> category) {
+                (void)category; // unused
+                if (!clingo_control_add(ctl, key.c_str(), nullptr, 0, prog.content.c_str()))
                 {
-                    handle_clingo_error(env, ref);
+                    handle_clingo_error(env, key);
                 }
                 else
                 {
-                    parts.push_back({ref.c_str(), nullptr, 0});
-                    addedPrograms.insert(ref);
+                    parts.push_back({key.c_str(), nullptr, 0});
                 }
-                // no need to check other refs, as ref was a program, not a category
-                continue;
-            }
-
-            // If no direct match, check categories
-            for (const auto& [key, prog] : g_programs)
-            {
-                if (std::find(prog.categories.begin(), prog.categories.end(), ref) != prog.categories.end() &&
-                    addedPrograms.find(key) == addedPrograms.end())
-                {
-                    if (!clingo_control_add(ctl, key.c_str(), nullptr, 0, prog.content.c_str()))
-                    {
-                        handle_clingo_error(env, key);
-                    }
-                    else
-                    {
-                        parts.push_back({key.c_str(), nullptr, 0});
-                        addedPrograms.insert(key);
-                    }
-                }
-            }
-        }
+            });
     }
 
     // Add the main program last and its part

--- a/tools/node-clingo/src/binding.cc
+++ b/tools/node-clingo/src/binding.cc
@@ -290,17 +290,17 @@ namespace
         for (size_t i = 0; i < atoms_size && success; ++i)
         {
             // Get the string representation
-            std::string str = node_clingo::get_symbol_string(atoms[i]);
+            std::string symbolString = node_clingo::get_symbol_string(atoms[i]);
 
             // If the string is empty, we skip it
-            if (str.empty())
+            if (symbolString.empty())
             {
                 continue;
             }
 
             if (i > 0)
                 answerStream << std::endl;
-            answerStream << str;
+            answerStream << symbolString;
         }
 
         try

--- a/tools/node-clingo/src/function_handlers.cc
+++ b/tools/node-clingo/src/function_handlers.cc
@@ -17,7 +17,7 @@
 #include <cstring>
 #include <sstream>
 
-#if defined(__clang__) || __GNUC__ < 13
+#if __GNUC__ < 13
 #define USE_FORMAT_FALLBACK 1
 #else
 #define USE_FORMAT_FALLBACK 0

--- a/tools/node-clingo/test/solve.test.ts
+++ b/tools/node-clingo/test/solve.test.ts
@@ -5,6 +5,7 @@ import {
   removeAllPrograms,
   removeProgramsByCategory,
   removeProgram,
+  getProgram,
 } from '../lib/index.js';
 
 describe('Clingo solver', () => {
@@ -578,6 +579,141 @@ describe('Clingo solver', () => {
       removeAllPrograms();
       removeAllPrograms();
       removeAllPrograms();
+    });
+  });
+
+  describe('getProgram function', () => {
+    it('should return just the main program when no base programs are specified', () => {
+      const mainProgram = 'a. b. c(1).';
+      const result = getProgram(mainProgram);
+
+      expect(result).toContain('% Main program');
+      expect(result).toContain(mainProgram);
+      expect(result).not.toContain('% Program:');
+    });
+
+    it('should combine main program with a single base program', () => {
+      setProgram('base', 'base_fact(value).');
+
+      const mainProgram = 'main_fact.';
+      const result = getProgram(mainProgram, ['base']);
+
+      expect(result).toContain('% Program: base');
+      expect(result).toContain('base_fact(value).');
+      expect(result).toContain('% Main program');
+      expect(result).toContain('main_fact.');
+
+      // Base program should come before main program
+      const baseIndex = result.indexOf('base_fact(value)');
+      const mainIndex = result.indexOf('main_fact.');
+      expect(baseIndex).toBeLessThan(mainIndex);
+    });
+
+    it('should combine main program with multiple base programs', () => {
+      setProgram('colors', 'color(red). color(blue).');
+      setProgram('shapes', 'shape(circle). shape(square).');
+      setProgram('sizes', 'size(small). size(large).');
+
+      const mainProgram = 'valid :- color(X), shape(Y), size(Z).';
+      const result = getProgram(mainProgram, ['colors', 'shapes', 'sizes']);
+
+      expect(result).toContain('% Program: colors');
+      expect(result).toContain('color(red). color(blue).');
+      expect(result).toContain('% Program: shapes');
+      expect(result).toContain('shape(circle). shape(square).');
+      expect(result).toContain('% Program: sizes');
+      expect(result).toContain('size(small). size(large).');
+      expect(result).toContain('% Main program');
+      expect(result).toContain(mainProgram);
+    });
+
+    it('should work with category-based program inclusion', () => {
+      setProgram('query_rules', 'type(query).', ['query']);
+      setProgram('graph_rules', 'type(graph).', ['query']);
+      setProgram('base_rules', 'base(fact).', ['base']);
+
+      const mainProgram = 'valid :- type(X), base(Y).';
+      const result = getProgram(mainProgram, ['query']);
+
+      expect(result).toContain('% Program: query_rules (category: query)');
+      expect(result).toContain('type(query).');
+      expect(result).toContain('% Program: graph_rules (category: query)');
+      expect(result).toContain('type(graph).');
+      expect(result).toContain('% Main program');
+      expect(result).toContain(mainProgram);
+      expect(result).not.toContain('base(fact).');
+    });
+
+    it('should prevent duplicate programs when using mixed refs and categories', () => {
+      setProgram('common', 'common(value).', ['shared']);
+      setProgram('specific', 'specific(value).', ['shared']);
+
+      const mainProgram = 'test.';
+      const result = getProgram(mainProgram, ['common', 'shared']);
+
+      // 'common' should appear only once, even though it matches both direct ref and category
+      const commonMatches = (result.match(/common\(value\)/g) || []).length;
+      expect(commonMatches).toBe(1);
+
+      // 'specific' should appear once from category match
+      expect(result).toContain('specific(value)');
+    });
+
+    it('should handle non-existent program references gracefully', () => {
+      setProgram('exists', 'exists(fact).');
+
+      const mainProgram = 'main.';
+      const result = getProgram(mainProgram, [
+        'exists',
+        'non_existent',
+        'also_missing',
+      ]);
+
+      expect(result).toContain('% Program: exists');
+      expect(result).toContain('exists(fact).');
+      expect(result).toContain('% Main program');
+      expect(result).toContain('main.');
+      // Non-existent programs should not appear in output
+      expect(result).not.toContain('non_existent');
+      expect(result).not.toContain('also_missing');
+    });
+
+    it('should handle empty categories array', () => {
+      setProgram('unused', 'unused(fact).');
+
+      const mainProgram = 'only_main.';
+      const result = getProgram(mainProgram, []);
+
+      expect(result).toContain('% Main program');
+      expect(result).toContain('only_main.');
+      expect(result).not.toContain('unused(fact)');
+    });
+
+    it('should handle programs with categories that have multiple programs', () => {
+      setProgram('rule1', 'type(a).', ['group']);
+      setProgram('rule2', 'type(b).', ['group']);
+      setProgram('rule3', 'type(c).', ['group']);
+      setProgram('other', 'other(fact).', ['different']);
+
+      const mainProgram = 'collect :- type(X).';
+      const result = getProgram(mainProgram, ['group']);
+
+      expect(result).toContain('% Program: rule1 (category: group)');
+      expect(result).toContain('type(a).');
+      expect(result).toContain('% Program: rule2 (category: group)');
+      expect(result).toContain('type(b).');
+      expect(result).toContain('% Program: rule3 (category: group)');
+      expect(result).toContain('type(c).');
+      expect(result).not.toContain('other(fact)');
+    });
+
+    it('should throw TypeError for invalid arguments', () => {
+      expect(() => getProgram('test', 'not_an_array' as any)).toThrow(
+        'Second argument must be an array of strings (refs)',
+      );
+      expect(() =>
+        getProgram('test', ['valid', 123, 'also_valid'] as any),
+      ).toThrow('All refs must be strings');
     });
   });
 });

--- a/tools/node-clingo/test/solve.test.ts
+++ b/tools/node-clingo/test/solve.test.ts
@@ -5,7 +5,7 @@ import {
   removeAllPrograms,
   removeProgramsByCategory,
   removeProgram,
-  getProgram,
+  buildProgram,
 } from '../lib/index.js';
 
 describe('Clingo solver', () => {
@@ -582,10 +582,10 @@ describe('Clingo solver', () => {
     });
   });
 
-  describe('getProgram function', () => {
+  describe('buildProgram function', () => {
     it('should return just the main program when no base programs are specified', () => {
       const mainProgram = 'a. b. c(1).';
-      const result = getProgram(mainProgram);
+      const result = buildProgram(mainProgram);
 
       expect(result).toContain('% Main program');
       expect(result).toContain(mainProgram);
@@ -596,7 +596,7 @@ describe('Clingo solver', () => {
       setProgram('base', 'base_fact(value).');
 
       const mainProgram = 'main_fact.';
-      const result = getProgram(mainProgram, ['base']);
+      const result = buildProgram(mainProgram, ['base']);
 
       expect(result).toContain('% Program: base');
       expect(result).toContain('base_fact(value).');
@@ -615,7 +615,7 @@ describe('Clingo solver', () => {
       setProgram('sizes', 'size(small). size(large).');
 
       const mainProgram = 'valid :- color(X), shape(Y), size(Z).';
-      const result = getProgram(mainProgram, ['colors', 'shapes', 'sizes']);
+      const result = buildProgram(mainProgram, ['colors', 'shapes', 'sizes']);
 
       expect(result).toContain('% Program: colors');
       expect(result).toContain('color(red). color(blue).');
@@ -633,7 +633,7 @@ describe('Clingo solver', () => {
       setProgram('base_rules', 'base(fact).', ['base']);
 
       const mainProgram = 'valid :- type(X), base(Y).';
-      const result = getProgram(mainProgram, ['query']);
+      const result = buildProgram(mainProgram, ['query']);
 
       expect(result).toContain('% Program: query_rules (category: query)');
       expect(result).toContain('type(query).');
@@ -649,7 +649,7 @@ describe('Clingo solver', () => {
       setProgram('specific', 'specific(value).', ['shared']);
 
       const mainProgram = 'test.';
-      const result = getProgram(mainProgram, ['common', 'shared']);
+      const result = buildProgram(mainProgram, ['common', 'shared']);
 
       // 'common' should appear only once, even though it matches both direct ref and category
       const commonMatches = (result.match(/common\(value\)/g) || []).length;
@@ -663,7 +663,7 @@ describe('Clingo solver', () => {
       setProgram('exists', 'exists(fact).');
 
       const mainProgram = 'main.';
-      const result = getProgram(mainProgram, [
+      const result = buildProgram(mainProgram, [
         'exists',
         'non_existent',
         'also_missing',
@@ -682,7 +682,7 @@ describe('Clingo solver', () => {
       setProgram('unused', 'unused(fact).');
 
       const mainProgram = 'only_main.';
-      const result = getProgram(mainProgram, []);
+      const result = buildProgram(mainProgram, []);
 
       expect(result).toContain('% Main program');
       expect(result).toContain('only_main.');
@@ -696,7 +696,7 @@ describe('Clingo solver', () => {
       setProgram('other', 'other(fact).', ['different']);
 
       const mainProgram = 'collect :- type(X).';
-      const result = getProgram(mainProgram, ['group']);
+      const result = buildProgram(mainProgram, ['group']);
 
       expect(result).toContain('% Program: rule1 (category: group)');
       expect(result).toContain('type(a).');
@@ -708,11 +708,11 @@ describe('Clingo solver', () => {
     });
 
     it('should throw TypeError for invalid arguments', () => {
-      expect(() => getProgram('test', 'not_an_array' as any)).toThrow(
+      expect(() => buildProgram('test', 'not_an_array' as any)).toThrow(
         'Second argument must be an array of strings (refs)',
       );
       expect(() =>
-        getProgram('test', ['valid', 123, 'also_valid'] as any),
+        buildProgram('test', ['valid', 123, 'also_valid'] as any),
       ).toThrow('All refs must be strings');
     });
   });


### PR DESCRIPTION
Adds possibility of generating a logic program to a file through CLI. It is mostly useful to us as it is easier to inspect clingo programs by executing them manually.

Syntax:
`cyberismo calc generate <file name> [query]`
where query is a pre-existing query such as `tree` or `card`. This is useful for inspecting perf of said queries. If no query is specified, it will append the whole global program to the file without any queries.