### PR TITLE
INTDEV-947 use show more directly

### DIFF
--- a/tools/assets/src/calculations/common/queryLanguage.lp
+++ b/tools/assets/src/calculations/common/queryLanguage.lp
@@ -60,7 +60,23 @@ showField(Key, Field) :-
 % showField is also defined if showAll is defined so there is only a single show predicate for each result
 showField(Key, Field) :- showAll(Key), field(Key, Field, _).
 
-% Fields
+% Allow specifying up to 3 fields at the same time for showField, similar to field
+% For specifying 2 fields
+resultField(Key, Field, Value, DataType) :-
+    resultFields(Key, Field, Value, DataType, _, _, _).
+
+resultField(Key, Field, Value, DataType) :-
+    resultFields(Key, _, _, _, Field, Value, DataType).
+
+% For specifying 3 fields
+resultField(Key, Field, Value, DataType) :-
+    resultFields(Key, Field, Value, DataType, _, _, _, _, _, _).
+
+resultField(Key, Field, Value, DataType) :-
+    resultFields(Key, _, _, _, Field, Value, DataType, _, _, _).
+    
+resultField(Key, Field, Value, DataType) :-
+    resultFields(Key, _, _, _, _, _, _, Field, Value, DataType).
 %
 % field(key, field, value, data type):
 % "field" of result/child result "key" has value "value",
@@ -79,6 +95,11 @@ showField(Key, Field) :- showAll(Key), field(Key, Field, _).
     DataType != "list",
     showField(Key, Field).
 
+#show field(Key, Field, Value, DataType) :
+    DataType != "enum",
+    DataType != "list",
+    resultField(Key, Field, Value, DataType).
+
 #show field(Key, Field, Value, "shortText") :
     field(Key, Field, Value),
     not dataType(Key, Field, _),
@@ -86,45 +107,83 @@ showField(Key, Field) :- showAll(Key), field(Key, Field, _).
 
 % list
 childResult(Key, (Key, Field, Value), Field) :-
+    DataType = "list",
+    resultField(Key, Field, Value, DataType).
+
+resultField((Key, Field, Value), "value", Value, "shortText") :-
+    childResult(Key, (Key, Field, Value), Field),
+    resultField(Key, Field, Value, _).
+
+resultField((Key, Field, Value), "index", Index, "integer") :-
+    childResult(Key, (Key, Field, Value), Field),
+    resultField(Key, Field, Value, _),
+    field((Field, Value), "index", Index).
+
+resultField((Key, Field, Value), "displayName", EnumDisplayValue, "shortText") :-
+    childResult(Key, (Key, Field, Value), Field),
+    resultField(Key, Field, Value, _),
+    field((Field, Value), "enumDisplayValue", EnumDisplayValue).
+
+childResult(Key, (Key, Field, Value), Field) :-
     field(Key, Field, Value),
     dataType(Key, Field, "list"),
     showField(Key, Field).
 
-field((Key, Field, Value), "value", Value, "shortText") :-
+resultField((Key, Field, Value), "value", Value, "shortText") :-
     childResult(Key, (Key, Field, Value), Field),
     field(Key, Field, Value),
     dataType(Key, Field, "list").
 
-field((Key, Field, Value), "index", Index, "integer") :-
+resultField((Key, Field, Value), "index", Index, "integer") :-
     childResult(Key, (Key, Field, Value), Field),
     field(Key, Field, Value),
     dataType(Key, Field, "list"),
     field((Field, Value), "index", Index).
 
-field((Key, Field, Value), "displayName", EnumDisplayValue, "shortText") :-
+resultField((Key, Field, Value), "displayName", EnumDisplayValue, "shortText") :-
     childResult(Key, (Key, Field, Value), Field),
     field(Key, Field, Value),
     dataType(Key, Field, "list"),
     field((Field, Value), "enumDisplayValue", EnumDisplayValue).
 
 % enum
+
+
+childObject(Key, (Key, Field), Field) :-
+    DataType = "enum",
+    resultField(Key, Field, _, DataType).
+
+resultField((Key, Field), "value", Value, "shortText") :-
+    childObject(Key, (Key, Field), Field),
+    resultField(Key, Field, Value, _).
+
+resultField((Key, Field), "index", Index, "integer") :-
+    childObject(Key, (Key, Field), Field),
+    resultField(Key, Field, _, _),
+    field((Field, Value), "index", Index).
+
+resultField((Key, Field), "displayValue", EnumDisplayValue, "shortText") :-
+    childObject(Key, (Key, Field), Field),
+    field((Field, Value), "enumDisplayValue", EnumDisplayValue).
+
+
 childObject(Key, (Key, Field), Field) :-
     field(Key, Field, _),
     dataType(Key, Field, "enum"),
     showField(Key, Field).
 
-field((Key, Field), "value", Value, "shortText") :-
+resultField((Key, Field), "value", Value, "shortText") :-
     childObject(Key, (Key, Field), Field),
     field(Key, Field, Value),
     dataType(Key, Field, "enum").
 
-field((Key, Field), "index", Index, "integer") :-
+resultField((Key, Field), "index", Index, "integer") :-
     childObject(Key, (Key, Field), Field),
     field(Key, Field, Value),
     dataType(Key, Field, "enum"),
     field((Field, Value), "index", Index).
 
-field((Key, Field), "displayValue", EnumDisplayValue, "shortText") :-
+resultField((Key, Field), "displayValue", EnumDisplayValue, "shortText") :-
     childObject(Key, (Key, Field), Field),
     field(Key, Field, Value),
     dataType(Key, Field, "enum"),
@@ -148,10 +207,6 @@ field(Key, Field, Value) :-
 
 % allow using field directly
 % fields are always shown
-% TODO: instead of creating datatype and showField facts, we should simply show the field directly with #show
-showField(Key, Field) :- field(Key, Field, _, _).
-field(Key, Field, Value) :- field(Key, Field, Value, _).
-dataType(Key, Field, DataType) :- field(Key, Field, _, DataType).
 
 
 % childResultCollection(ParentKey, Collection): Defines a childResult. Allows guaranteeing an empty list, if no elements are present

--- a/tools/assets/src/calculations/common/utils.lp
+++ b/tools/assets/src/calculations/common/utils.lp
@@ -1,12 +1,6 @@
 % Utils extends the cyberismo query language
 
 % policy checks
-selectCollectionField("successes", "title").
-selectCollectionField("successes", "category").
-selectCollectionField("failures", "title").
-selectCollectionField("failures", "category").
-selectCollectionField("failures", "errorMessage").
-selectCollectionField("failures", "fieldName").
 
 childObject(Card, (Card, "policyChecks"), "policyChecks") :-
     showField(Card, "policyChecks").
@@ -22,7 +16,7 @@ childResult((Card, "policyChecks"), (Card, Category, Title), "successes") :-
     childObject(Card, (Card, "policyChecks"), "policyChecks"),
     policyCheckSuccess(Card, Category, Title).
 
-fields((Card, Category, Title), "category", Category, "title", Title) :-
+resultFields((Card, Category, Title), "category", Category, "shortText", "title", Title, "shortText") :-
     childObject(Card, (Card, "policyChecks"), "policyChecks"),
     policyCheckSuccess(Card, Category, Title).
 
@@ -37,11 +31,11 @@ childResult((Card, "policyChecks"), (Card, Category, Title, ErrorMessage, Field)
     childObject(Card, (Card, "policyChecks"), "policyChecks"),
     policyCheckFailure(Card, Category, Title, ErrorMessage, Field).
 
-fields((Card, Category, Title, ErrorMessage, Field), "category", Category, "title", Title, "errorMessage", ErrorMessage) :-
+resultFields((Card, Category, Title, ErrorMessage, Field), "category", Category, "shortText", "title", Title, "shortText", "errorMessage", ErrorMessage, "shortText") :-
     childObject(Card, (Card, "policyChecks"), "policyChecks"),
     policyCheckFailure(Card, Category, Title, ErrorMessage, Field).
 
-field((Card, Category, Title, ErrorMessage, Field), "fieldName", Field) :-
+resultField((Card, Category, Title, ErrorMessage, Field), "fieldName", Field, "shortText") :-
     childObject(Card, (Card, "policyChecks"), "policyChecks"),
     Field != "",
     policyCheckFailure(Card, Category, Title, ErrorMessage, Field).
@@ -49,14 +43,6 @@ field((Card, Category, Title, ErrorMessage, Field), "fieldName", Field) :-
 
 
 % links
-selectCollectionField("links", "displayName").
-selectCollectionField("links", "linkDescription").
-selectCollectionField("links", "direction").
-selectCollectionField("links", "linkType").
-selectCollectionField("links", "displayName").
-selectCollectionField("links", "linkSource").
-selectCollectionField("links", "title").
-selectCollectionField("links", "key").
 
 childResultCollection(Card, "links") :-
     showField(Card, "links").
@@ -78,66 +64,62 @@ childResult(Card, (Source, Card, LinkType, LinkDescription, "inbound"), "links")
     showField(Card, "links").
 
 % links: displayName
-field((Source, Destination, LinkType, LinkDescription, Direction), "displayName", DisplayName, "shortText") :-
+resultField((Source, Destination, LinkType, LinkDescription, Direction), "displayName", DisplayName, "shortText") :-
     childResult(_, (Source, Destination, LinkType, LinkDescription, Direction), "links"),
     Direction = "outbound",
     field(LinkType, "outboundDisplayName", DisplayName).
 
-field((Source, Destination, LinkType, LinkDescription, Direction), "displayName", DisplayName, "shortText") :-
+resultField((Source, Destination, LinkType, LinkDescription, Direction), "displayName", DisplayName, "shortText") :-
     childResult(_, (Source, Destination, LinkType, LinkDescription, Direction), "links"),
     Direction = "inbound",
     field(LinkType, "inboundDisplayName", DisplayName).
 
 % links: link description
-field((Source, Destination, LinkType, LinkDescription, Direction), "linkDescription", LinkDescription, "shortText") :-
+resultField((Source, Destination, LinkType, LinkDescription, Direction), "linkDescription", LinkDescription, "shortText") :-
     LinkDescription != "",
     childResult(_, (Source, Destination, LinkType, LinkDescription, Direction), "links").
 
 % links: direction and link type
-fields((Source, Destination, LinkType, LinkDescription, Direction), "direction", Direction, "linkType", LinkType) :-
+resultFields((Source, Destination, LinkType, LinkDescription, Direction), "direction", Direction, "shortText", "linkType", LinkType, "shortText") :-
     childResult(_, (Source, Destination, LinkType, LinkDescription, Direction), "links").
 
 % links: link source
 
-field((Source, Destination, LinkType, LinkDescription, Direction), "linkSource", "user", "shortText") :-
+resultField((Source, Destination, LinkType, LinkDescription, Direction), "linkSource", "user", "shortText") :-
     childResult(_, (Source, Destination, LinkType, LinkDescription, Direction), "links"),
     userLink(Source, Destination, LinkType).
 
-field((Source, Destination, LinkType, LinkDescription, Direction), "linkSource", "user", "shortText") :-
+resultField((Source, Destination, LinkType, LinkDescription, Direction), "linkSource", "user", "shortText") :-
     childResult(_, (Source, Destination, LinkType, LinkDescription, Direction), "links"),
     userLink(Source, Destination, LinkType, LinkDescription).
 
-field((Source, Destination, LinkType, LinkDescription, Direction), "linkSource", "calculated", "shortText") :-
+resultField((Source, Destination, LinkType, LinkDescription, Direction), "linkSource", "calculated", "shortText") :-
     childResult(_, (Source, Destination, LinkType, LinkDescription, Direction), "links"),
     calculatedLink(Source, Destination, LinkType).
 
-field((Source, Destination, LinkType, LinkDescription, Direction), "linkSource", "calculated", "shortText") :-
+resultField((Source, Destination, LinkType, LinkDescription, Direction), "linkSource", "calculated", "shortText") :-
     childResult(_, (Source, Destination, LinkType, LinkDescription, Direction), "links"),
     calculatedLink(Source, Destination, LinkType, LinkDescription).
 
 % links: title
-field((Card, Destination, LinkType, LinkDescription, Direction), "title", Title, "shortText") :-
+resultField((Card, Destination, LinkType, LinkDescription, Direction), "title", Title, "shortText") :-
     childResult(Card, (Card, Destination, LinkType, LinkDescription, Direction), "links"),
     field(Destination, "title", Title).
 
-field((Source, Card, LinkType, LinkDescription, Direction), "title", Title, "shortText") :-
+resultField((Source, Card, LinkType, LinkDescription, Direction), "title", Title, "shortText") :-
     childResult(Card, (Source, Card, LinkType, LinkDescription, Direction), "links"),
     field(Source, "title", Title).
 
 % links: key
-field((Card, Destination, LinkType, LinkDescription, Direction), "key", Destination, "shortText") :-
+resultField((Card, Destination, LinkType, LinkDescription, Direction), "key", Destination, "shortText") :-
     childResult(Card, (Card, Destination, LinkType, LinkDescription, Direction), "links").
 
-field((Source, Card, LinkType, LinkDescription, Direction), "key", Source, "shortText") :-
+resultField((Source, Card, LinkType, LinkDescription, Direction), "key", Source, "shortText") :-
     childResult(Card, (Source, Card, LinkType, LinkDescription, Direction), "links"),
     field(Source, "title", Title).
 
 
 % notifications
-select(2, "notifications", "title").
-select(2, "notifications", "category").
-select(2, "notifications", "message").
-
 childResultCollection(Card, "notifications") :-
     showField(Card, "notifications").
 
@@ -146,21 +128,14 @@ childResult(Card, (Card, Category, Title, Message), "notifications") :-
     showField(Card, "notifications"),
     notification(Card, Category, Title, Message).
 
-fields((Card, Category, Title, Message), "key", Card, "category", Category, "title", Title) :-
+resultFields((Card, Category, Title, Message), "key", Card, "shortText", "category", Category, "shortText", "title", Title, "shortText") :-
     childResult(Card, (Card, Category, Title, Message), "notifications").
 
-field((Card, Category, Title, Message), "message", Message) :-
+resultField((Card, Category, Title, Message), "message", Message, "shortText") :-
     childResult(Card, (Card, Category, Title, Message), "notifications").
 
 
 % denied operations
-selectCollectionField("transition", "transitionName").
-selectCollectionField("transition", "errorMessage").
-selectCollectionField("move", "errorMessage").
-selectCollectionField("delete", "errorMessage").
-selectCollectionField("editField", "fieldName").
-selectCollectionField("editField", "errorMessage").
-selectCollectionField("editContent", "errorMessage").
 
 childObject(Card, (Card, "deniedOperations"), "deniedOperations") :-
     showField(Card, "deniedOperations").
@@ -173,7 +148,7 @@ childResult((Card, "deniedOperations"), (Card, TransitionName, ErrorMessage), "t
     childObject(Card, (Card, "deniedOperations"), "deniedOperations"),
     transitionDenied(Card, TransitionName, ErrorMessage).
 
-fields((Card, TransitionName, ErrorMessage), "transitionName", TransitionName, "errorMessage", ErrorMessage) :-
+resultFields((Card, TransitionName, ErrorMessage), "transitionName", TransitionName, "shortText", "errorMessage", ErrorMessage, "shortText") :-
     childResult((Card, "deniedOperations"), (Card, TransitionName, ErrorMessage), "transition").
 
 % move denied operations
@@ -184,7 +159,7 @@ childResult((Card, "deniedOperations"), (Card, ErrorMessage), "move") :-
     childObject(Card, (Card, "deniedOperations"), "deniedOperations"),
     movingCardDenied(Card, ErrorMessage).
 
-field((Card, ErrorMessage), "errorMessage", ErrorMessage) :-
+resultField((Card, ErrorMessage), "errorMessage", ErrorMessage, "shortText") :-
     childResult((Card, "deniedOperations"), (Card, ErrorMessage), "move").
 
 % delete denied operations
@@ -195,7 +170,7 @@ childResult((Card, "deniedOperations"), (Card, ErrorMessage), "delete") :-
     childObject(Card, (Card, "deniedOperations"), "deniedOperations"),
     deletingCardDenied(Card, ErrorMessage).
 
-field((Card, ErrorMessage), "errorMessage", ErrorMessage) :-
+resultField((Card, ErrorMessage), "errorMessage", ErrorMessage, "shortText") :-
     childResult((Card, "deniedOperations"), (Card, ErrorMessage), "delete").
 
 % editField denied operations
@@ -206,7 +181,7 @@ childResult((Card, "deniedOperations"), (Card, FieldName, ErrorMessage), "editFi
     childObject(Card, (Card, "deniedOperations"), "deniedOperations"),
     editingFieldDenied(Card, FieldName, ErrorMessage).
 
-fields((Card, FieldName, ErrorMessage), "fieldName", FieldName, "errorMessage", ErrorMessage) :-
+resultFields((Card, FieldName, ErrorMessage), "fieldName", FieldName, "shortText", "errorMessage", ErrorMessage, "shortText") :-
     childResult((Card, "deniedOperations"), (Card, FieldName, ErrorMessage), "editField").
 
 % editContent denied operations
@@ -217,7 +192,7 @@ childResult((Card, "deniedOperations"), (Card, ErrorMessage), "editContent") :-
     childObject(Card, (Card, "deniedOperations"), "deniedOperations"),
     editingContentDenied(Card, ErrorMessage).
 
-field((Card, ErrorMessage), "errorMessage", ErrorMessage) :-
+resultField((Card, ErrorMessage), "errorMessage", ErrorMessage, "shortText") :-
     childResult((Card, "deniedOperations"), (Card, ErrorMessage), "editContent").
 
 
@@ -225,6 +200,6 @@ field((Card, ErrorMessage), "errorMessage", ErrorMessage) :-
 childResultCollection(Card, "labels") :-
     showField(Card, "labels").
 
-field(Card, "labels", Label, "stringList") :-
+resultField(Card, "labels", Label, "stringList") :-
     showField(Card, "labels"),
     label(Card, Label).

--- a/tools/assets/src/calculations/queries/card.lp
+++ b/tools/assets/src/calculations/queries/card.lp
@@ -22,39 +22,38 @@ displayName(Card, (Card, Field), DisplayName) :-
 % we include the card key in the key of the fields, because the same query is used
 % when generating static sites for all project cards at the same time
 
-field((Card, Field), "key", Field) :-
+resultField((Card, Field), "key", Field, "shortText") :-
     customField(CardType, Field),
     field(Card, "cardType", CardType),
     result(Card).
-
-field((Card, Field), "visibility", "always") :-
+resultField((Card, Field), "visibility", "always", "shortText") :-
     alwaysVisibleField(CardType, Field),
     field(Card, "cardType", CardType),
     result(Card).
 
-field((Card, Field), "visibility", "optional") :-
+resultField((Card, Field), "visibility", "optional", "shortText") :-
     optionallyVisibleField(CardType, Field),
     field(Card, "cardType", CardType),
     result(Card).
 
-field((Card, Field), "index", Index) :-
+resultField((Card, Field), "index", Index, "integer") :-
     alwaysVisibleField(CardType, Field),
     field((CardType, Field), "index", Index),
     field(Card, "cardType", CardType),
     result(Card).
 
-field((Card, Field), "index", Index) :-
+resultField((Card, Field), "index", Index, "integer") :-
     optionallyVisibleField(CardType, Field),
     field((CardType, Field), "index", Index),
     field(Card, "cardType", CardType),
     result(Card).
 
-field((Card, Field), "fieldDisplayName", DisplayName, "shortText") :-
+resultField((Card, Field), "fieldDisplayName", DisplayName, "shortText") :-
     childResult(Card, (Card, Field), "fields"),
     result(Card),
     displayName(Card, (Card, Field), DisplayName).
 
-field((Card, Field), "fieldDescription", Description, "shortText") :-
+resultField((Card, Field), "fieldDescription", Description, "shortText") :-
     childResult(Card, (Card, Field), "fields"),
     result(Card),
     field(Field, "description", Description).
@@ -63,64 +62,47 @@ dataType((Card, Field), "isCalculated", "boolean") :-
     childResult(Card, (Card, Field), "fields"),
     field((Card, Field), "isCalculated", _).
 
-field((Card, Field), "isCalculated", true) :-
+resultField((Card, Field), "isCalculated", true, "boolean") :-
     result(Card),
     field(Card, "cardType", CardType),
     calculatedField(CardType, Field).
 
-field((Card, Field), "isCalculated", false) :-
+field((Card, Field), "isCalculated", false, "boolean") :-
     childResult(Card, (Card, Field), "fields"),
     result(Card),
     field(Card, "cardType", CardType),
     not calculatedField(CardType, Field).
 
 % add dataType of field
-field((Card, Field), "dataType", DataType, "shortText") :-
+resultField((Card, Field), "dataType", DataType, "shortText") :-
     childResult(Card, (Card, Field), "fields"),
     result(Card),
     field(Field, "dataType", DataType).
 
 % add value
-dataType((Card, Field), "value", DataType) :-
+resultField((Card, Field), "value", Value, DataType) :-
     childResult(Card, (Card, Field), "fields"),
-    result(Card),
-    field(Card, Field, Value),
-    dataType(Card, Field, DataType).
-
-% add value
-field((Card, Field), "value", Value) :-
-    childResult(Card, (Card, Field), "fields"),
+    dataType(Card, Field, DataType),
     field(Card, Field, Value).
 
 % add cardTypeDisplayName
-field(Card, "cardTypeDisplayName", DisplayName, "shortText") :-
+resultField(Card, "cardTypeDisplayName", DisplayName, "shortText") :-
     result(Card),
     field(Card, "cardType", CardType),
     field(CardType, "displayName", DisplayName).
 
 % select only non-custom fields
-select(1, "cardType").
-select(1, "cardTypeDisplayName").
-select(1, "title").
-select(1, "key").
-select(1, "lastUpdated").
-select(1, "workflowState").
-select(1, "policyChecks").
-select(1, "links").
-select(1, "notifications").
-select(1, "deniedOperations").
-select(1, "labels").
-
-% Fields
-
-select(2, "fields", "key").
-select(2, "fields", "visibility").
-select(2, "fields", "index").
-select(2, "fields", "fieldDisplayName").
-select(2, "fields", "fieldDescription").
-select(2, "fields", "dataType").
-select(2, "fields", "isCalculated").
-select(2, "fields", "value").
+select(1, "results", "cardType").
+select(1, "results", "cardTypeDisplayName").
+select(1, "results", "title").
+select(1, "results", "key").
+select(1, "results", "lastUpdated").
+select(1, "results", "workflowState").
+select(1, "results", "policyChecks").
+select(1, "results", "links").
+select(1, "results", "notifications").
+select(1, "results", "deniedOperations").
+select(1, "results", "labels").
 
 childResultCollection(Card, "fields") :-
     result(Card).
@@ -136,10 +118,10 @@ childResult(Card, (Card, Field), "fields") :-
     result(Card).
 
 % for enum fields, add enum values as child results:
-select(3, "index").
-select(3, "enumDisplayValue").
-select(3, "enumDescription").
-select(3, "enumValue").
+select(3, "enumValues", "index").
+select(3, "enumValues", "enumDisplayValue").
+select(3, "enumValues", "enumDescription").
+select(3, "enumValues", "enumValue").
 
 childResult((Card, Field), (Field, EnumValue), "enumValues") :-
     enumValue(Field, EnumValue),


### PR DESCRIPTION
This also seems to fix INTDEV-956. After using normal fields for displaying more complex content like enums, notifications etc, clingo seemed to slow down significantly. I think one of the main issues is that we were using broad select facts, which caused unnecessary logic that had to be handled by clingo. Select does make sense for accessing properties that are part of the data, but having to use select for fields that only part of a specific query is unnecessarily complex. Thus, I added an extension to `showField`:
`showField(Key, Field, Value, DataType)` allows skipping select checks and results in a `#show field(Key, Field, Value, DataType)`. Similarly to `fields`, `showFields` allows specifying multiple fields directly. I recommend that `showField` should replace all cases, where a `field` must be created on the fly.

Note: This is a breaking change. A few months ago, `field(Key, Field, Value, DataType).` was added, but it has been now removed. That used to create a normal `field`, `dataType` and `showField` facts, so it did exactly what `showField` now does. I've thought this field fact has not been used yet by anyone else except me, but it would be probably good to check existing reports anyway.