### PR TITLE
INTDEV-984 Clarify modules 'properties' descriptions

### DIFF
--- a/tools/assets/src/schema/cardsConfigSchema.json
+++ b/tools/assets/src/schema/cardsConfigSchema.json
@@ -29,15 +29,15 @@
             "type": "string"
           },
           "location": {
-            "description": "Git remote URL, or relative file reference",
+            "description": "Git remote URL, or relative file reference.",
             "type": "string"
           },
           "branch": {
-            "description": "If using git remote URL in 'location' defines git branch. If empty, uses repository default branch'. ",
+            "description": "If using git remote URL in 'location' defines git branch. If empty, uses repository default branch'.",
             "type": "string"
           },
           "private": {
-            "description": "If true, the module is private and requires credentials (CYBERISMO_GIT_USER / CYBERISMO_GIT_TOKEN) or SSH. Does not apply for local file modules",
+            "description": "If true, the module is private and requires credentials (CYBERISMO_GIT_USER / CYBERISMO_GIT_TOKEN) or SSH. Does not apply for local file modules.",
             "type": "boolean"
           }
         },

--- a/tools/assets/src/schema/cardsConfigSchema.json
+++ b/tools/assets/src/schema/cardsConfigSchema.json
@@ -29,15 +29,15 @@
             "type": "string"
           },
           "location": {
-            "description": "URI that is either a git URL with HTTPS, or relative file reference",
+            "description": "Git remote URL, or relative file reference",
             "type": "string"
           },
           "branch": {
-            "description": "If using git URL in 'location' defines git branch. If empty, assumed to be 'main'. ",
+            "description": "If using git remote URL in 'location' defines git branch. If empty, uses repository default branch'. ",
             "type": "string"
           },
           "private": {
-            "description": "If true, the module is private and requires credentials (CYBERISMO_GIT_USER / CYBERISMO_GIT_TOKEN)",
+            "description": "If true, the module is private and requires credentials (CYBERISMO_GIT_USER / CYBERISMO_GIT_TOKEN) or SSH. Does not apply for local file modules",
             "type": "boolean"
           }
         },


### PR DESCRIPTION
The `descriptions` of multiple properties of `modules` are outdated since SSH support was added.
Clarify with better descriptions.


On a hindsight the whole object should have been defined as: 
```
"modules": {
      "description": "List of modules that have been included in the project",
      "type": "array",
      "items": {
        "type": "object",
        "properties": {
          "name": {
            "description": "Module name (project prefix). Must be unique.",
            "type": "string"
          },
          "gitLocation": {
            "description": "Git remote URL",
            "type": "string"
          },
          "fileLocation": {
            "description": "Relative file reference",
            "type": "string"
          },
          "branch": {
            "description": "Defines git branch. If empty, uses repository default branch'. ",
            "type": "string"
          },
          "private": {
            "description": "If true, the module is private and requires credentials (CYBERISMO_GIT_USER / CYBERISMO_GIT_TOKEN) or SSH.",
            "type": "boolean"
          }
        },
        "oneOf": [
          {
            "required": ["name", "gitLocation"]
          },
          {
            "required": ["name", "fileLocation"]
          }
        ],
        "dependantRequired": {
          "gitLocation": [ "branch", "private"]
        }
      }
    }
  }
  ```
  
  That way there would not have been a need to state "if empty", or "if using git".  But maybe in some other PR.
