### PR TITLE
INTDEV-987 Fix xref in export site

### DIFF
--- a/tools/backend/src/domain/cards/lib.ts
+++ b/tools/backend/src/domain/cards/lib.ts
@@ -64,7 +64,7 @@ export async function getCardDetails(
   try {
     asciidocContent = await evaluateMacros(cardDetailsResponse.content || '', {
       context: staticMode ? 'exportedSite' : 'localApp',
-      mode: staticMode ? 'static' : 'inject',
+      mode: staticMode ? 'staticSite' : 'inject',
       project: commands.project,
       cardKey: key,
     });

--- a/tools/data-handler/src/commands/show.ts
+++ b/tools/data-handler/src/commands/show.ts
@@ -457,7 +457,7 @@ export class Show {
 
     await this.project.calculationEngine.generate();
     const reportMacro = new ReportMacro(new TaskQueue());
-    let result = await reportMacro.handleInject(
+    let result = await reportMacro.handleStatic(
       {
         project: this.project,
         cardKey: cardKey,

--- a/tools/data-handler/src/interfaces/macros.ts
+++ b/tools/data-handler/src/interfaces/macros.ts
@@ -15,7 +15,7 @@ import type { Project } from '../containers/project.js';
 import type { MacroError } from '../exceptions/index.js';
 import type { Context } from './project-interfaces.js';
 
-export type Mode = 'validate' | 'static' | 'inject';
+export type Mode = 'validate' | 'static' | 'inject' | 'staticSite';
 
 export interface MacroGenerationContext {
   context: Context;

--- a/tools/data-handler/src/macros/createCards/index.ts
+++ b/tools/data-handler/src/macros/createCards/index.ts
@@ -48,6 +48,11 @@ class CreateCardsMacro extends BaseMacro {
     return createHtmlPlaceholder(this.metadata, options);
   };
 
+  handleStaticSite = async () => {
+    // export site does not support createCards
+    return '';
+  };
+
   private validate(input: unknown): CreateCardsOptions {
     return validateMacroContent<CreateCardsOptions>(this.metadata, input);
   }

--- a/tools/data-handler/src/macros/graph/index.ts
+++ b/tools/data-handler/src/macros/graph/index.ts
@@ -40,10 +40,6 @@ class ReportMacro extends BaseMacro {
   };
 
   handleStatic = async (context: MacroGenerationContext, input: unknown) => {
-    return this.handleInject(context, input);
-  };
-
-  handleInject = async (context: MacroGenerationContext, input: unknown) => {
     const resourceNameToPath = (name: string, fileName: string) => {
       const { identifier, prefix, type } = resourceName(name);
       if (prefix === context.project.projectPrefix) {

--- a/tools/data-handler/src/macros/include/index.ts
+++ b/tools/data-handler/src/macros/include/index.ts
@@ -87,10 +87,6 @@ export default class IncludeMacro extends BaseMacro {
     return adjustedContent;
   };
 
-  handleInject = async (context: MacroGenerationContext, input: unknown) => {
-    return this.handleStatic(context, input);
-  };
-
   private validate(input: unknown): IncludeMacroOptions {
     return validateMacroContent<IncludeMacroOptions>(this.metadata, input);
   }

--- a/tools/data-handler/src/macros/percentage/index.ts
+++ b/tools/data-handler/src/macros/percentage/index.ts
@@ -42,10 +42,6 @@ class PercentageMacro extends BaseMacro {
     );
   };
 
-  handleInject = async (context: MacroGenerationContext, input: unknown) => {
-    return this.handleStatic(context, input);
-  };
-
   private validate(input: unknown): PercentageOptions {
     return validateMacroContent<PercentageOptions>(this.metadata, input);
   }

--- a/tools/data-handler/src/macros/report/index.ts
+++ b/tools/data-handler/src/macros/report/index.ts
@@ -36,10 +36,6 @@ class ReportMacro extends BaseMacro {
   };
 
   handleStatic = async (context: MacroGenerationContext, data: unknown) => {
-    return this.handleInject(context, data);
-  };
-
-  handleInject = async (context: MacroGenerationContext, data: unknown) => {
     const options = this.validate(data);
     const resource = new ReportResource(
       context.project,

--- a/tools/data-handler/src/macros/scoreCard/index.ts
+++ b/tools/data-handler/src/macros/scoreCard/index.ts
@@ -43,10 +43,6 @@ class ScoreCardMacro extends BaseMacro {
     );
   };
 
-  handleInject = async (context: MacroGenerationContext, input: unknown) => {
-    return this.handleStatic(context, input);
-  };
-
   private validate(input: unknown): ScoreCardOptions {
     return validateMacroContent<ScoreCardOptions>(this.metadata, input);
   }

--- a/tools/data-handler/src/macros/vegalite/index.ts
+++ b/tools/data-handler/src/macros/vegalite/index.ts
@@ -38,10 +38,6 @@ class VegaLiteMacro extends BaseMacro {
     });
   };
 
-  handleInject = async (context: MacroGenerationContext, input: unknown) => {
-    return this.handleStatic(context, input);
-  };
-
   private validate(input: unknown): VegaLiteMacroInput {
     return validateMacroContent<VegaLiteMacroInput>(this.metadata, input);
   }

--- a/tools/data-handler/test/macros/index.test.ts
+++ b/tools/data-handler/test/macros/index.test.ts
@@ -151,6 +151,15 @@ describe('macros', () => {
         });
         expect(result).to.not.contain('<create-cards>');
       });
+      it('createCards exportSite (success)', async () => {
+        const result = await evaluateMacros(validAdoc, {
+          mode: 'staticSite',
+          project: project,
+          cardKey: '',
+          context: 'localApp',
+        });
+        expect(result).to.not.contain('<create-cards');
+      });
     });
     describe('raw', () => {
       it('raw macro (success)', async () => {
@@ -268,6 +277,16 @@ Some content here`;
         });
         expect(result).to.contain('<svg');
       });
+      it('scoreCard exportSite (success)', async () => {
+        const macro = `{{#scoreCard}}"title": "Scorecard", "value": 99, "unit": "%", "legend": "complete"{{/scoreCard}}`;
+        const result = await evaluateMacros(macro, {
+          mode: 'staticSite',
+          project: project,
+          cardKey: '',
+          context: 'localApp',
+        });
+        expect(result).to.contain('<svg');
+      });
     });
     describe('percentage', () => {
       it('percentage inject (success)', async () => {
@@ -293,6 +312,18 @@ Some content here`;
         expect(result).to.contain('<svg');
         expect(result).to.contain('Static Percentage');
         expect(result).to.contain('42%');
+      });
+      it('percentage exportSite (success)', async () => {
+        const macro = `{{#percentage}}"title": "Test Percentage", "value": 85, "legend": "of Assets", "colour": "red"{{/percentage}}`;
+        const result = await evaluateMacros(macro, {
+          mode: 'staticSite',
+          project: project,
+          cardKey: '',
+          context: 'localApp',
+        });
+        expect(result).to.contain('<svg');
+        expect(result).to.contain('Test Percentage');
+        expect(result).to.contain('85%');
       });
       it('percentage missing title (failure)', async () => {
         const macro = `{{#percentage}}"value": 50, "legend": "missing title"{{/percentage}}`;
@@ -397,7 +428,7 @@ Some content here`;
       afterEach(() => {
         cardDetailsByIdStub.restore();
       });
-      ['static', 'inject'].forEach((mode) => {
+      ['static', 'inject', 'staticSite'].forEach((mode) => {
         it(`includeMacro ${mode} (success)`, async () => {
           try {
             const macro = `{{#include}}"cardKey": "test-card"{{/include}}`;
@@ -636,7 +667,7 @@ Some content here`;
         cardDetailsByIdStub.restore();
       });
 
-      ['static', 'inject'].forEach((mode) => {
+      ['static', 'inject', 'staticSite'].forEach((mode) => {
         it(`xrefMacro ${mode} (success)`, async () => {
           const macro = `{{#xref}}"cardKey": "xref-test-card"{{/xref}}`;
           const result = await evaluateMacros(macro, {
@@ -716,6 +747,20 @@ Some content here`;
         const macro = `{{#image}}"fileName": "the-needle.heic"{{/image}}`;
         const result = await evaluateMacros(macro, {
           mode: 'inject',
+          project: project,
+          cardKey: 'decision_1',
+          context: 'localApp',
+        });
+
+        expect(result).to.equal(
+          'image::/api/cards/decision_1/a/the-needle.heic[]',
+        );
+      });
+
+      it('imageMacro exportSite mode (success)', async () => {
+        const macro = `{{#image}}"fileName": "the-needle.heic"{{/image}}`;
+        const result = await evaluateMacros(macro, {
+          mode: 'staticSite',
           project: project,
           cardKey: 'decision_1',
           context: 'localApp',


### PR DESCRIPTION
We have a problem: For now, we've only had 2 modes(excluding `validate`), which are `static` and `inject`. Static was meant to be used when only adoc is usable while inject was meant to be used for app, which supports html. However, the new static site falls between these: It could render content just like app can, but it's content is static so we do not want to render the `createCards` button.

So I added I third mode: `exportSite`. I feel like the naming is a bit confusing and it would probably be a better idea to simply move on to using `context` also in macros. Now we have both the mode and context, which also partially overlap. 