### PR TITLE
INTDEV-837 Interactive module installation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,6 +268,9 @@ importers:
       '@inquirer/confirm':
         specifier: ^5.1.16
         version: 5.1.16(@types/node@22.18.1)
+      '@inquirer/prompts':
+        specifier: ^7.8.4
+        version: 7.8.4(@types/node@22.15.29)
       cli-progress:
         specifier: ^3.12.0
         version: 3.12.0
@@ -1959,6 +1962,9 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  chardet@2.1.0:
+    resolution: {integrity: sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==}
 
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
@@ -5340,6 +5346,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.18.1
 
+  '@inquirer/type@3.0.8(@types/node@22.15.29)':
+    optionalDependencies:
+      '@types/node': 22.15.29
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -6383,6 +6393,8 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  chardet@2.1.0: {}
 
   check-error@2.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,7 +270,7 @@ importers:
         version: 5.1.16(@types/node@22.18.1)
       '@inquirer/prompts':
         specifier: ^7.8.4
-        version: 7.8.4(@types/node@22.15.29)
+        version: 7.8.4(@types/node@22.18.1)
       cli-progress:
         specifier: ^3.12.0
         version: 3.12.0
@@ -876,6 +876,15 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@inquirer/checkbox@4.2.2':
+    resolution: {integrity: sha512-E+KExNurKcUJJdxmjglTl141EwxWyAHplvsYJQgSwXf8qiNWkTxTuCCqmhFEmbIXd4zLaGMfQFJ6WrZ7fSeV3g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.18.1
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/confirm@5.1.16':
     resolution: {integrity: sha512-j1a5VstaK5KQy8Mu8cHmuQvN1Zc62TbLhjJxwHvKPPKEoowSF6h/0UdOpA9DNdWZ+9Inq73+puRq1df6OJ8Sag==}
     engines: {node: '>=18'}
@@ -894,9 +903,99 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/editor@4.2.18':
+    resolution: {integrity: sha512-yeQN3AXjCm7+Hmq5L6Dm2wEDeBRdAZuyZ4I7tWSSanbxDzqM0KqzoDbKM7p4ebllAYdoQuPJS6N71/3L281i6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.18.1
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@4.0.18':
+    resolution: {integrity: sha512-xUjteYtavH7HwDMzq4Cn2X4Qsh5NozoDHCJTdoXg9HfZ4w3R6mxV1B9tL7DGJX2eq/zqtsFjhm0/RJIMGlh3ag==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.18.1
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@1.0.1':
+    resolution: {integrity: sha512-Oau4yL24d2B5IL4ma4UpbQigkVhzPDXLoqy1ggK4gnHg/stmkffJE4oOXHXF3uz0UEpywG68KcyXsyYpA1Re/Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.18.1
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/figures@1.0.13':
     resolution: {integrity: sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==}
     engines: {node: '>=18'}
+
+  '@inquirer/input@4.2.2':
+    resolution: {integrity: sha512-hqOvBZj/MhQCpHUuD3MVq18SSoDNHy7wEnQ8mtvs71K8OPZVXJinOzcvQna33dNYLYE4LkA9BlhAhK6MJcsVbw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.18.1
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@3.0.18':
+    resolution: {integrity: sha512-7exgBm52WXZRczsydCVftozFTrrwbG5ySE0GqUd2zLNSBXyIucs2Wnm7ZKLe/aUu6NUg9dg7Q80QIHCdZJiY4A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.18.1
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@4.0.18':
+    resolution: {integrity: sha512-zXvzAGxPQTNk/SbT3carAD4Iqi6A2JS2qtcqQjsL22uvD+JfQzUrDEtPjLL7PLn8zlSNyPdY02IiQjzoL9TStA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.18.1
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@7.8.4':
+    resolution: {integrity: sha512-MuxVZ1en1g5oGamXV3DWP89GEkdD54alcfhHd7InUW5BifAdKQEK9SLFa/5hlWbvuhMPlobF0WAx7Okq988Jxg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.18.1
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@4.1.6':
+    resolution: {integrity: sha512-KOZqa3QNr3f0pMnufzL7K+nweFFCCBs6LCXZzXDrVGTyssjLeudn5ySktZYv1XiSqobyHRYYK0c6QsOxJEhXKA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.18.1
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@3.1.1':
+    resolution: {integrity: sha512-TkMUY+A2p2EYVY3GCTItYGvqT6LiLzHBnqsU1rJbrpXUijFfM6zvUx0R4civofVwFCmJZcKqOVwwWAjplKkhxA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.18.1
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@4.3.2':
+    resolution: {integrity: sha512-nwous24r31M+WyDEHV+qckXkepvihxhnyIaod2MG7eCE6G0Zm/HUF6jgN8GXgf4U7AU6SLseKdanY195cwvU6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': ^22.18.1
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@inquirer/type@3.0.8':
     resolution: {integrity: sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==}
@@ -5320,6 +5419,16 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@inquirer/checkbox@4.2.2(@types/node@22.18.1)':
+    dependencies:
+      '@inquirer/core': 10.2.0(@types/node@22.18.1)
+      '@inquirer/figures': 1.0.13
+      '@inquirer/type': 3.0.8(@types/node@22.18.1)
+      ansi-escapes: 4.3.2
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.18.1
+
   '@inquirer/confirm@5.1.16(@types/node@22.18.1)':
     dependencies:
       '@inquirer/core': 10.2.0(@types/node@22.18.1)
@@ -5340,15 +5449,98 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.18.1
 
+  '@inquirer/editor@4.2.18(@types/node@22.18.1)':
+    dependencies:
+      '@inquirer/core': 10.2.0(@types/node@22.18.1)
+      '@inquirer/external-editor': 1.0.1(@types/node@22.18.1)
+      '@inquirer/type': 3.0.8(@types/node@22.18.1)
+    optionalDependencies:
+      '@types/node': 22.18.1
+
+  '@inquirer/expand@4.0.18(@types/node@22.18.1)':
+    dependencies:
+      '@inquirer/core': 10.2.0(@types/node@22.18.1)
+      '@inquirer/type': 3.0.8(@types/node@22.18.1)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.18.1
+
+  '@inquirer/external-editor@1.0.1(@types/node@22.18.1)':
+    dependencies:
+      chardet: 2.1.0
+      iconv-lite: 0.6.3
+    optionalDependencies:
+      '@types/node': 22.18.1
+
   '@inquirer/figures@1.0.13': {}
+
+  '@inquirer/input@4.2.2(@types/node@22.18.1)':
+    dependencies:
+      '@inquirer/core': 10.2.0(@types/node@22.18.1)
+      '@inquirer/type': 3.0.8(@types/node@22.18.1)
+    optionalDependencies:
+      '@types/node': 22.18.1
+
+  '@inquirer/number@3.0.18(@types/node@22.18.1)':
+    dependencies:
+      '@inquirer/core': 10.2.0(@types/node@22.18.1)
+      '@inquirer/type': 3.0.8(@types/node@22.18.1)
+    optionalDependencies:
+      '@types/node': 22.18.1
+
+  '@inquirer/password@4.0.18(@types/node@22.18.1)':
+    dependencies:
+      '@inquirer/core': 10.2.0(@types/node@22.18.1)
+      '@inquirer/type': 3.0.8(@types/node@22.18.1)
+      ansi-escapes: 4.3.2
+    optionalDependencies:
+      '@types/node': 22.18.1
+
+  '@inquirer/prompts@7.8.4(@types/node@22.18.1)':
+    dependencies:
+      '@inquirer/checkbox': 4.2.2(@types/node@22.18.1)
+      '@inquirer/confirm': 5.1.16(@types/node@22.18.1)
+      '@inquirer/editor': 4.2.18(@types/node@22.18.1)
+      '@inquirer/expand': 4.0.18(@types/node@22.18.1)
+      '@inquirer/input': 4.2.2(@types/node@22.18.1)
+      '@inquirer/number': 3.0.18(@types/node@22.18.1)
+      '@inquirer/password': 4.0.18(@types/node@22.18.1)
+      '@inquirer/rawlist': 4.1.6(@types/node@22.18.1)
+      '@inquirer/search': 3.1.1(@types/node@22.18.1)
+      '@inquirer/select': 4.3.2(@types/node@22.18.1)
+    optionalDependencies:
+      '@types/node': 22.18.1
+
+  '@inquirer/rawlist@4.1.6(@types/node@22.18.1)':
+    dependencies:
+      '@inquirer/core': 10.2.0(@types/node@22.18.1)
+      '@inquirer/type': 3.0.8(@types/node@22.18.1)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.18.1
+
+  '@inquirer/search@3.1.1(@types/node@22.18.1)':
+    dependencies:
+      '@inquirer/core': 10.2.0(@types/node@22.18.1)
+      '@inquirer/figures': 1.0.13
+      '@inquirer/type': 3.0.8(@types/node@22.18.1)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.18.1
+
+  '@inquirer/select@4.3.2(@types/node@22.18.1)':
+    dependencies:
+      '@inquirer/core': 10.2.0(@types/node@22.18.1)
+      '@inquirer/figures': 1.0.13
+      '@inquirer/type': 3.0.8(@types/node@22.18.1)
+      ansi-escapes: 4.3.2
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.18.1
 
   '@inquirer/type@3.0.8(@types/node@22.18.1)':
     optionalDependencies:
       '@types/node': 22.18.1
-
-  '@inquirer/type@3.0.8(@types/node@22.15.29)':
-    optionalDependencies:
-      '@types/node': 22.15.29
 
   '@isaacs/cliui@8.0.2':
     dependencies:

--- a/tools/app/cypress.config.ts
+++ b/tools/app/cypress.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
           }
           // Create test project from test-module
           execSync(
-            'cd ../../.tmp&&cyberismo create project "Basic Acceptance Test" bat cyberismo-bat&&cd cyberismo-bat&&cyberismo import module ../../module-test&&cyberismo create card test/templates/pageContent',
+            'cd ../../.tmp&&cyberismo create project "Basic Acceptance Test" bat cyberismo-bat --skipModuleImport&&cd cyberismo-bat&&cyberismo import module ../../module-test&&cyberismo create card test/templates/pageContent',
           );
           return true;
         },

--- a/tools/assets/src/hub/moduleList.json
+++ b/tools/assets/src/hub/moduleList.json
@@ -1,0 +1,34 @@
+{
+  "description": "Cyberismo default hub",
+  "displayName": "Cyberismo default hub",
+  "modules": [
+    {
+      "name": "base",
+      "displayName": "Base module",
+      "category": "essentials",
+      "location": "git@github.com:CyberismoCom/module-base.git",
+      "documentationLocation": "https://github.com/CyberismoCom/module-base/blob/main/README.adoc"
+    },
+    {
+      "name": "eucra",
+      "displayName": "Cyberismo EU Cyber Resilience Act",
+      "category": "essentials",
+      "location": "git@github.com:CyberismoCom/module-eu-cra.git",
+      "documentationLocation": "https://github.com/CyberismoCom/module-eu-cra/blob/main/README.adoc"
+    },
+    {
+      "name": "ismsa",
+      "displayName": "ISMS Essentials",
+      "category": "essentials",
+      "location": "git@github.com:CyberismoCom/module-isms-essentials.git",
+      "documentationLocation": "https://github.com/CyberismoCom/module-isms-essentials/blob/main/README.adoc"
+    },
+    {
+      "name": "secdeva",
+      "displayName": "Secure development essentials",
+      "category": "essentials",
+      "location": "git@github.com:CyberismoCom/module-secure-development-essentials.git",
+      "documentationLocation": "https://github.com/CyberismoCom/module-secure-development-essentials/blob/main/README.adoc"
+    }
+  ]
+}

--- a/tools/assets/src/schema/hubSchema.json
+++ b/tools/assets/src/schema/hubSchema.json
@@ -14,7 +14,7 @@
       "minLength": 1
     },
     "modules": {
-      "description": "List of modules that are available in the module hub",
+      "description": "List of modules that are available in the hub",
       "type": "array",
       "items": {
         "type": "object",

--- a/tools/assets/src/schema/hubSchema.json
+++ b/tools/assets/src/schema/hubSchema.json
@@ -1,40 +1,44 @@
 {
-  "$id": "cardsConfigSchema",
+  "title": "Hub",
+  "$id": "hubSchema",
+  "description": "The contents of a Cyberismo hub.",
+  "type": "object",
   "additionalProperties": false,
-  "description": "General configuration settings for the card tree.",
   "properties": {
-    "cardKeyPrefix": {
+    "displayName": {
+      "description": "Display name of the hub",
       "type": "string",
-      "description": "The prefix or the fist component of the card key. For example, ABC",
-      "pattern": "^[a-z]+$",
-      "minLength": 3,
-      "maxLength": 10
+      "minLength": 1
     },
-    "name": {
-      "description": "Name of the project",
+    "description": {
+      "description": "Description of the hub",
       "type": "string",
-      "minLength": 1,
-      "pattern": "^[A-Za-z ._-]+$"
-    },
-    "hubs": {
-      "description": "List of hubs from where to fetch module information",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
+      "minLength": 1
     },
     "modules": {
-      "description": "List of modules that have been included in the project",
+      "description": "List of modules that are available in the module hub",
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
           "name": {
-            "description": "Module name (project prefix). Must be unique.",
+            "description": "Module name (project prefix). Must be unique globally.",
+            "type": "string"
+          },
+          "displayName": {
+            "description": "Display name of the module",
+            "type": "string"
+          },
+          "category": {
+            "description": "Category of the module",
             "type": "string"
           },
           "location": {
             "description": "Git remote URL, or relative file reference.",
+            "type": "string"
+          },
+          "documentationLocation": {
+            "description": "URI to the documentation of the module",
             "type": "string"
           },
           "branch": {
@@ -50,7 +54,5 @@
       }
     }
   },
-  "required": ["cardKeyPrefix"],
-  "title": "CardsConfig",
-  "type": "object"
+  "required": ["displayName", "description"]
 }

--- a/tools/assets/src/schema/hubSchema.json
+++ b/tools/assets/src/schema/hubSchema.json
@@ -1,9 +1,7 @@
 {
-  "title": "Hub",
   "$id": "hubSchema",
-  "description": "The contents of a Cyberismo hub.",
-  "type": "object",
   "additionalProperties": false,
+  "description": "The contents of a Cyberismo hub.",
   "properties": {
     "displayName": {
       "description": "Display name of the hub",
@@ -54,5 +52,7 @@
       }
     }
   },
-  "required": ["displayName", "description"]
+  "required": ["displayName", "description"],
+  "title": "Hub",
+  "type": "object"
 }

--- a/tools/assets/src/schemas.ts
+++ b/tools/assets/src/schemas.ts
@@ -22,6 +22,7 @@ import fieldTypeSchema from './schema/resources/fieldTypeSchema.json' with { typ
 import graphMacroBaseSchema from './schema/macros/graphMacroBaseSchema.json' with { type: 'json' };
 import graphModelSchema from './schema/resources/graphModelSchema.json' with { type: 'json' };
 import graphViewSchema from './schema/resources/graphViewSchema.json' with { type: 'json' };
+import hubSchema from './schema/hubSchema.json' with { type: 'json' };
 import imageMacroSchema from './schema/macros/imageMacroSchema.json' with { type: 'json' };
 import includeMacroSchema from './schema/macros/includeMacroSchema.json' with { type: 'json' };
 import linkTypeSchema from './schema/resources/linkTypeSchema.json' with { type: 'json' };
@@ -48,6 +49,7 @@ export const schemas = [
   graphMacroBaseSchema,
   graphModelSchema,
   graphViewSchema,
+  hubSchema,
   imageMacroSchema,
   includeMacroSchema,
   linkTypeSchema,

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -24,6 +24,7 @@
     "@cyberismo/backend": "workspace:*",
     "@cyberismo/data-handler": "workspace:*",
     "@inquirer/confirm": "^5.1.16",
+    "@inquirer/prompts": "^7.8.4",
     "cli-progress": "^3.12.0",
     "commander": "^14.0.0",
     "dotenv": "^17.2.2"

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -465,6 +465,7 @@ program
           const choices = await importableModules(commandOptions);
           const selectedModules = await checkbox({
             message: 'Select modules to import',
+            theme: { helpMode: 'always' },
             choices,
           });
 

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -212,7 +212,7 @@ const additionalHelpForRemove = `Sub-command help:
       <name> Name of the module to remove
 
   remove hub <location>, where
-      <location> URL of module hub to remove
+      <location> URL of hub to remove
 
   remove <resourceName>, where
     <resourceName> is <project prefix>/<type>/<identifier>, where
@@ -299,8 +299,8 @@ addCmd
 
 addCmd
   .command('hub')
-  .description('Add module hub to the project')
-  .argument('<location>', 'Module hub URL')
+  .description('Add a hub to the project')
+  .argument('<location>', 'Hub URL')
   .option('-p, --project-path [path]', `${pathGuideline}`)
   .action(async (location: string, options: CardsOptions) => {
     const result = await commandHandler.command(

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -37,7 +37,7 @@ import cliProgress from 'cli-progress';
 // How many validation errors are shown when staring app, if any.
 const VALIDATION_ERROR_ROW_LIMIT = 10;
 const DEFAULT_HUB =
-  'https://raw.githubusercontent.com/Fuzzbender/testModuleHub/main/';
+  'https://raw.githubusercontent.com/CyberismoCom/cyberismo/feature/samimerila/modules-list/tools/assets/src/hub/';
 
 // To avoid duplication, fetch description and version from package.json file.
 // Importing dynamically allows filtering of warnings in cli/bin/run.

--- a/tools/cli/src/resource-type-parser.ts
+++ b/tools/cli/src/resource-type-parser.ts
@@ -84,6 +84,8 @@ abstract class ShowTypes {
     'attachments',
     'card',
     'cards',
+    'hubs',
+    'importableModules',
     'labels',
     'module',
     'project',
@@ -117,6 +119,7 @@ abstract class RemoveTypes {
   private static ResourceLikeTypes = [
     'attachment',
     'card',
+    'hub',
     'label',
     'link',
     'module',

--- a/tools/cli/test/cli.test.ts
+++ b/tools/cli/test/cli.test.ts
@@ -38,7 +38,7 @@ describe('Cli BAT test', function () {
   });
   it('Create and validate new project', function (done) {
     exec(
-      'cd ../../.tmp&&cyberismo create project "CLI Basic Acceptance Test" bat cyberismo-cli&&cd cyberismo-cli&&cyberismo validate',
+      'cd ../../.tmp&&cyberismo create project "CLI Basic Acceptance Test" bat cyberismo-cli --skipModuleImport &&cd cyberismo-cli&&cyberismo validate',
       (error, stdout, _stderr) => {
         if (error != null) {
           console.log(error);
@@ -178,7 +178,7 @@ describe('Cli BAT test', function () {
   });
   it('Add a card of the new cardtype to the newly created template', function (done) {
     exec(
-      `cd ../../.tmp/cyberismo-cli&&cyberismo add bat/templates/templateTest bat/cardTypes/cardTypeTest&&cyberismo validate`,
+      `cd ../../.tmp/cyberismo-cli&&cyberismo add card bat/templates/templateTest bat/cardTypes/cardTypeTest&&cyberismo validate`,
       (error, stdout, _stderr) => {
         if (error != null) {
           console.log(error);

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -82,7 +82,6 @@ export enum Cmd {
   move = 'move',
   rank = 'rank',
   remove = 'remove',
-  removeHub = 'removeHub',
   rename = 'rename',
   report = 'report',
   show = 'show',
@@ -505,7 +504,7 @@ export class Commands {
     };
   }
 
-  // Adds module hub to the project.
+  // Adds a hub to the project.
   private async addHub(name: string) {
     await this.commands?.createCmd.addHubLocation(name);
     return {

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -23,6 +23,7 @@ import type {
   Credentials,
   FileContentType,
   ModuleContent,
+  ModuleSettingFromHub,
   ProjectMetadata,
   RemovableResourceTypes,
   ResourceTypes,
@@ -49,21 +50,23 @@ import { type Context } from './interfaces/project-interfaces.js';
 
 // Generic options interface
 export interface CardsOptions {
+  context?: Context;
+  date?: string;
   details?: boolean;
   forceStart?: boolean;
-  watchResourceChanges?: boolean;
-  projectPath?: string;
-  repeat?: number;
-  showUse?: boolean;
   logLevel?: Level;
-  context?: Context;
-  recursive?: boolean;
-  title?: string;
-  name?: string;
-  date?: string;
-  version?: string;
-  revremark?: string;
   mappingFile?: string;
+  name?: string;
+  projectPath?: string;
+  recursive?: boolean;
+  repeat?: number;
+  revremark?: string;
+  showAll?: boolean;
+  showUse?: boolean;
+  skipModuleImport?: boolean;
+  title?: string;
+  version?: string;
+  watchResourceChanges?: boolean;
 }
 
 // Commands that this class supports.
@@ -74,10 +77,12 @@ export enum Cmd {
   create = 'create',
   edit = 'edit',
   export = 'export',
+  fetch = 'fetch',
   import = 'import',
   move = 'move',
   rank = 'rank',
   remove = 'remove',
+  removeHub = 'removeHub',
   rename = 'rename',
   report = 'report',
   show = 'show',
@@ -195,8 +200,13 @@ export class Commands {
   ) {
     try {
       if (command === Cmd.add) {
-        const [template, cardType, cardKey] = args;
-        return await this.addCard(template, cardType, cardKey, options.repeat);
+        const [type, target, cardType, cardKey] = args;
+        if (type === 'card') {
+          return await this.addCard(target, cardType, cardKey, options.repeat);
+        }
+        if (type === 'hub') {
+          return await this.addHub(target);
+        }
       } else if (command === Cmd.calc) {
         const [command, cardKey] = args;
         if (command === 'run') {
@@ -281,6 +291,12 @@ export class Commands {
           cardKey,
           options,
         );
+      } else if (command === Cmd.fetch) {
+        const [target] = args;
+        if (target !== 'hubs') {
+          throw new Error(`Unknown type to fetch: '${target}'`);
+        }
+        await this.commands?.fetchCmd.fetchHubs();
       } else if (command === Cmd.import) {
         const target = args.splice(0, 1)[0];
         if (target === 'module') {
@@ -489,6 +505,15 @@ export class Commands {
     };
   }
 
+  // Adds module hub to the project.
+  private async addHub(name: string) {
+    await this.commands?.createCmd.addHubLocation(name);
+    return {
+      statusCode: 200,
+      message: `Hub '${name}' was added to the project`,
+    };
+  }
+
   // Creates a new card to a project, or to a template.
   private async createCard(
     templateName: string,
@@ -666,6 +691,7 @@ export class Commands {
       | CardAttachment[]
       | CardListContainer[]
       | ModuleContent
+      | ModuleSettingFromHub[]
       | ProjectMetadata
       | ResourceContent
       | string[]
@@ -712,12 +738,23 @@ export class Commands {
       case 'workflows':
         promise = this.commands!.showCmd.showResources(type);
         break;
+      case 'importableModules':
+        promise = this.commands!.showCmd.showImportableModules(
+          options?.showAll,
+          options?.details,
+        );
+        break;
       case 'labels':
         promise = this.commands!.showCmd.showLabels();
         break;
       case 'module':
         promise = this.commands!.showCmd.showModule(detail);
         break;
+      case 'hubs':
+        return {
+          statusCode: 200,
+          payload: this.commands!.showCmd.showHubs(),
+        };
       case 'modules':
         promise = this.commands!.showCmd.showModules();
         break;

--- a/tools/data-handler/src/command-manager.ts
+++ b/tools/data-handler/src/command-manager.ts
@@ -15,6 +15,7 @@ import {
   Create,
   Edit,
   Export,
+  Fetch,
   Import,
   Move,
   Remove,
@@ -43,6 +44,7 @@ export class CommandManager {
   public createCmd: Create;
   public editCmd: Edit;
   public exportCmd: Export;
+  public fetchCmd: Fetch;
   public importCmd: Import;
   public moveCmd: Move;
   public removeCmd: Remove;
@@ -63,6 +65,7 @@ export class CommandManager {
     this.createCmd = new Create(this.project);
     this.editCmd = new Edit(this.project);
     this.exportCmd = new Export(this.project, this.showCmd);
+    this.fetchCmd = new Fetch(this.project);
     this.importCmd = new Import(this.project, this.createCmd);
     this.moveCmd = new Move(this.project);
     this.removeCmd = new Remove(this.project);

--- a/tools/data-handler/src/commands/create.ts
+++ b/tools/data-handler/src/commands/create.ts
@@ -65,6 +65,7 @@ export class Create {
         cardKeyPrefix: '$PROJECT-PREFIX',
         name: '$PROJECT-NAME',
         modules: [],
+        hubs: [],
       },
       name: Project.projectConfigFileName,
     },
@@ -157,6 +158,14 @@ export class Create {
     } else {
       throw new Error('Unknown error');
     }
+  }
+
+  /**
+   * Adds a new hub location.
+   * @param hubUrl URL of the hub
+   */
+  public async addHubLocation(hubUrl: string) {
+    return this.project.configuration.addHub(hubUrl);
   }
 
   /**

--- a/tools/data-handler/src/commands/fetch.ts
+++ b/tools/data-handler/src/commands/fetch.ts
@@ -20,7 +20,7 @@ import { validateJson } from '../utils/validate.js';
 import { type ModuleSetting } from '../interfaces/project-interfaces.js';
 import { errorFunction, getChildLogger } from '../utils/log-utils.js';
 
-const FETCH_TIMEOUT = 30000; // 30s timeout for fetching a module hub file.
+const FETCH_TIMEOUT = 30000; // 30s timeout for fetching a hub file.
 const MAX_RESPONSE_SIZE = 1024 * 1024; // 1MB limit for safety
 const HUB_SCHEMA = 'hubSchema';
 const MODULE_LIST_FILE = 'moduleList.json';
@@ -91,9 +91,11 @@ export class Fetch {
 
       return json;
     } catch (error) {
-      const errorMessage = `Failed to fetch module list from ${location}: ${errorFunction(error)}`;
-      this.logger.error(errorMessage);
-      throw new Error(errorMessage);
+      this.logger.error(
+        error,
+        `Failed to fetch module list from ${location}: ${errorFunction(error)}`,
+      );
+      throw error;
     }
   }
 
@@ -140,9 +142,11 @@ export class Fetch {
       });
       this.logger.info(`Module list written to: ${fullPath}`);
     } catch (error) {
-      const errorMessage = `Failed to write module list to local file: ${errorFunction(error)}`;
-      this.logger.error(errorMessage);
-      throw new Error(errorMessage);
+      this.logger.error(
+        error,
+        `Failed to write module list to local file: ${errorFunction(error)}`,
+      );
+      throw error;
     }
   }
 }

--- a/tools/data-handler/src/commands/fetch.ts
+++ b/tools/data-handler/src/commands/fetch.ts
@@ -1,0 +1,114 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2025
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { mkdir } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import type { Project } from '../containers/project.js';
+
+import { writeJsonFile } from '../utils/json.js';
+import { validateJson } from '../utils/validate.js';
+import { type ModuleSetting } from '../interfaces/project-interfaces.js';
+import { errorFunction, getChildLogger } from '../utils/log-utils.js';
+
+const FETCH_TIMEOUT = 30000; // 30s timeout for fetching a module hub file.
+const HUB_SCHEMA = 'hubSchema';
+const MODULE_LIST_FILE = 'moduleList.json';
+const TEMP_FOLDER = `.temp`;
+
+export const MODULE_LIST_FULL_PATH = `${TEMP_FOLDER}/${MODULE_LIST_FILE}`;
+
+export class Fetch {
+  constructor(private project: Project) {}
+
+  private get logger() {
+    return getChildLogger({
+      module: 'fetch',
+    });
+  }
+
+  private async fetchJSONFile(location: string) {
+    try {
+      const url = new URL(`${location}/${MODULE_LIST_FILE}`);
+      if (!['http:', 'https:'].includes(url.protocol)) {
+        throw new Error(
+          `Invalid protocol: ${url.protocol}. Only HTTP and HTTPS are supported.`,
+        );
+      }
+
+      this.logger.info(`Fetching module list from: ${url.toString()}`);
+      const response = await fetch(url.toString(), {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+          'User-Agent': 'Cyberismo/1.0',
+        },
+        signal: AbortSignal.timeout(FETCH_TIMEOUT),
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `HTTP ${response.status}: ${response.statusText} when fetching from ${url.toString()}`,
+        );
+      }
+
+      const contentType = response.headers.get('content-type');
+      if (!contentType?.includes('application/json')) {
+        this.logger.warn(`Expected JSON response, got: ${contentType}`);
+      }
+
+      return await response.json();
+    } catch (error) {
+      const errorMessage = `Failed to fetch module list from ${location}: ${errorFunction(error)}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+  }
+
+  /**
+   * Fetches modules from modules hub(s) and writes them to a file.
+   */
+  public async fetchHubs() {
+    const hubs = this.project.configuration.hubs;
+
+    const moduleMap: Map<string, ModuleSetting> = new Map([]);
+
+    for (const hub of hubs) {
+      const json = await this.fetchJSONFile(hub.location);
+      await validateJson(json, { schemaId: HUB_SCHEMA });
+      json.modules.forEach((module: ModuleSetting) => {
+        if (!moduleMap.has(module.name)) {
+          moduleMap.set(module.name, module);
+        } else {
+          this.logger.info(
+            `Skipping module '${module.name}' since it was already listed.`,
+          );
+        }
+      });
+    }
+
+    try {
+      const fullPath = resolve(this.project.basePath, MODULE_LIST_FULL_PATH);
+      await mkdir(resolve(this.project.basePath, TEMP_FOLDER), {
+        recursive: true,
+      });
+      await writeJsonFile(fullPath, {
+        modules: Array.from(moduleMap.values()),
+      });
+      this.logger.info(`Module list written to: ${fullPath}`);
+    } catch (error) {
+      const errorMessage = `Failed to write module list to local file: ${errorFunction(error)}`;
+      this.logger.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+  }
+}

--- a/tools/data-handler/src/commands/index.ts
+++ b/tools/data-handler/src/commands/index.ts
@@ -15,6 +15,7 @@ import { Calculate } from './calculate.js';
 import { Create } from './create.js';
 import { Edit } from './edit.js';
 import { Export } from './export.js';
+import { Fetch } from './fetch.js';
 import { Import } from './import.js';
 import { Move } from './move.js';
 import { Remove } from './remove.js';
@@ -29,6 +30,7 @@ export {
   Create,
   Edit,
   Export,
+  Fetch,
   Import,
   Move,
   Remove,

--- a/tools/data-handler/src/commands/remove.ts
+++ b/tools/data-handler/src/commands/remove.ts
@@ -185,6 +185,11 @@ export class Remove {
     await this.project.updateCardMetadataKey(sourceCardKey, 'links', newLinks);
   }
 
+  // Remove module hub from project.
+  private async removeHubLocation(name: string) {
+    await this.project.configuration.removeHub(name);
+  }
+
   /**
    * Removes either attachment, card, imported module, link or resource from project.
    * @param type Type of resource
@@ -224,14 +229,15 @@ export class Remove {
       return resource?.delete();
     } else {
       // Something else than resources...
-      if (type == 'attachment')
+      if (type === 'attachment')
         return this.removeAttachment(targetName, rest[0]);
-      else if (type == 'card') return this.removeCard(targetName);
-      else if (type == 'link')
+      else if (type === 'card') return this.removeCard(targetName);
+      else if (type === 'link')
         return this.removeLink(targetName, rest[0], rest[1], rest.at(2));
-      else if (type == 'module')
+      else if (type === 'module')
         return this.moduleManager.removeModule(targetName);
-      else if (type == 'label') return this.removeLabel(targetName, rest[0]);
+      else if (type === 'label') return this.removeLabel(targetName, rest[0]);
+      else if (type === 'hub') return this.removeHubLocation(targetName);
     }
     throw new Error(`Unknown resource type '${type}'`);
   }

--- a/tools/data-handler/src/commands/remove.ts
+++ b/tools/data-handler/src/commands/remove.ts
@@ -185,7 +185,7 @@ export class Remove {
     await this.project.updateCardMetadataKey(sourceCardKey, 'links', newLinks);
   }
 
-  // Remove module hub from project.
+  // Remove a hub from project.
   private async removeHubLocation(name: string) {
     await this.project.configuration.removeHub(name);
   }

--- a/tools/data-handler/src/commands/show.ts
+++ b/tools/data-handler/src/commands/show.ts
@@ -58,6 +58,7 @@ import TaskQueue from '../macros/task-queue.js';
 import { evaluateMacros } from '../macros/index.js';
 import { FolderResource } from '../resources/folder-resource.js';
 import { readJsonFile } from '../utils/json.js';
+import { getChildLogger } from '../utils/log-utils.js';
 
 /**
  * Show command.
@@ -79,6 +80,12 @@ export class Show {
       ['templates', this.project.templates.bind(this.project)],
       ['workflows', this.project.workflows.bind(this.project)],
     ]);
+  }
+
+  private get logger() {
+    return getChildLogger({
+      module: 'show',
+    });
   }
 
   // Collect all labels from cards.
@@ -413,7 +420,10 @@ export class Show {
       }
       // By default return the non-imported modules
       return nonImportedModules.map((item: ModuleSettingFromHub) => item?.name);
-    } catch {
+    } catch (error) {
+      if (error instanceof Error) {
+        this.logger.error(error.message);
+      }
       // Module list doesn't exist, return empty list
       return [];
     }

--- a/tools/data-handler/src/commands/validate.ts
+++ b/tools/data-handler/src/commands/validate.ts
@@ -606,16 +606,16 @@ export class Validate {
             });
           }
         }
+        // Validate that there are no duplicate card keys
+        for (const [key, count] of cardIds) {
+          if (count > 1) {
+            errorMsg.push(`Duplicate card key '${key}' found ${count} times`);
+          }
+        }
         if (errorMsg.length) {
           validationErrors += errorMsg
             .filter(this.removeDuplicateEntries)
             .join('\n');
-        }
-        // Validate that there are no duplicate card keys
-        for (const [key, count] of cardIds) {
-          if (count > 1) {
-            validationErrors += `Duplicate card key '${key}' found ${count} times\n`;
-          }
         }
       }
     } catch (error) {

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -681,6 +681,7 @@ export class Project extends CardContainer {
       return {
         name: moduleConfig.name,
         modules: moduleConfig.modules,
+        hubs: moduleConfig.hubs,
         path: modulePath,
         cardKeyPrefix: moduleConfig.cardKeyPrefix,
         calculations: [
@@ -1005,6 +1006,7 @@ export class Project extends CardContainer {
       name: this.containerName,
       path: this.basePath,
       prefix: this.projectPrefix,
+      hubs: this.configuration.hubs,
       modules: (await this.modules()).map((item) => item.name),
       numberOfCards: (await this.listCards(CardLocation.projectOnly))[0].cards
         .length,

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -164,6 +164,7 @@ export interface ProjectMetadata {
   path: string;
   prefix: string;
   modules: string[];
+  hubs: HubSetting[];
   numberOfCards: number;
 }
 
@@ -172,6 +173,20 @@ export interface ProjectSettings {
   cardKeyPrefix: string;
   name: string;
   modules: ModuleSetting[];
+  hubs: HubSetting[];
+}
+
+// Hub configuration
+export interface HubSetting {
+  location: string;
+  description?: string;
+  displayName?: string;
+}
+
+// Module configuration for a hub.
+export interface ModuleSettingFromHub extends ModuleSetting {
+  documentationLocation: string;
+  displayName: string;
 }
 
 // Module configuration.
@@ -195,6 +210,7 @@ export type RemovableResourceTypes =
   | 'fieldType'
   | 'graphModel'
   | 'graphView'
+  | 'hub'
   | 'link'
   | 'linkType'
   | 'module'
@@ -229,6 +245,8 @@ export type ResourceTypes =
   | 'attachments'
   | 'calculation'
   | 'cards'
+  | 'hubs'
+  | 'importableModules'
   | 'label'
   | 'labels'
   | 'links'

--- a/tools/data-handler/test/command-handler-add.test.ts
+++ b/tools/data-handler/test/command-handler-add.test.ts
@@ -3,15 +3,14 @@ import { expect } from 'chai';
 
 // node
 import { mkdirSync, rmSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 
 // cyberismo
 import { type CardsOptions, Cmd, Commands } from '../src/command-handler.js';
 import { copyDir } from '../src/utils/file-utils.js';
 
 // Create test artifacts in a temp folder.
-const baseDir = dirname(fileURLToPath(import.meta.url));
+const baseDir = import.meta.dirname;
 const testDir = join(baseDir, 'tmp-command-handler-add-tests');
 
 const decisionRecordsPath = join(testDir, 'valid/decision-records');
@@ -119,7 +118,6 @@ describe('add command', () => {
       ['hub', 'https://example.com/'],
       options,
     );
-    console.log(result);
     expect(result.statusCode).to.equal(200);
   });
   it('try to add invalid hub URL to the project', async () => {

--- a/tools/data-handler/test/command-handler-add.test.ts
+++ b/tools/data-handler/test/command-handler-add.test.ts
@@ -32,7 +32,7 @@ describe('add command', () => {
   it('add template card (success)', async () => {
     const result = await commandHandler.command(
       Cmd.add,
-      ['decision/templates/decision', 'decision/cardTypes/decision'],
+      ['card', 'decision/templates/decision', 'decision/cardTypes/decision'],
       options,
     );
     expect(result.statusCode).to.equal(200);
@@ -56,6 +56,7 @@ describe('add command', () => {
     const result = await commandHandler.command(
       Cmd.add,
       [
+        'card',
         'decision/templates/decision',
         'decision/cardTypes/decision',
         'decision_1',
@@ -64,10 +65,19 @@ describe('add command', () => {
     );
     expect(result.statusCode).to.equal(200);
   });
+  it('add template cards with repeat (success)', async () => {
+    const result = await commandHandler.command(
+      Cmd.add,
+      ['card', 'decision/templates/decision', 'decision/cardTypes/decision'],
+      { projectPath: options.projectPath, repeat: 10 },
+    );
+    expect(result.statusCode).to.equal(200);
+    expect(result.affectsCards?.length).to.equal(10);
+  });
   it('try to add template card to non-existent template', async () => {
     const result = await commandHandler.command(
       Cmd.add,
-      ['decision/templates/idontexists', 'decision/cardTypes/decision'],
+      ['card', 'decision/templates/idontexists', 'decision/cardTypes/decision'],
       options,
     );
     expect(result.statusCode).to.equal(400);
@@ -76,6 +86,7 @@ describe('add command', () => {
     const result = await commandHandler.command(
       Cmd.add,
       [
+        'card',
         'decision/templates/decision',
         'decision/cardTypes/decision',
         'decision_999',
@@ -87,7 +98,7 @@ describe('add command', () => {
   it('try to add template card with invalid path', async () => {
     const result = await commandHandler.command(
       Cmd.add,
-      ['decision/templates/decision', 'decision/cardTypes/decision'],
+      ['card', 'decision/templates/decision', 'decision/cardTypes/decision'],
       { projectPath: 'random-path' },
     );
     expect(result.statusCode).to.equal(400);
@@ -96,10 +107,44 @@ describe('add command', () => {
     options.repeat = -1;
     const result = await commandHandler.command(
       Cmd.add,
-      ['decision/templates/decision', 'decision/cardTypes/decision'],
+      ['card', 'decision/templates/decision', 'decision/cardTypes/decision'],
       options,
     );
     expect(result.statusCode).to.equal(400);
   });
+
+  it('add hub to the project (success)', async () => {
+    const result = await commandHandler.command(
+      Cmd.add,
+      ['hub', 'https://example.com/'],
+      options,
+    );
+    console.log(result);
+    expect(result.statusCode).to.equal(200);
+  });
+  it('try to add invalid hub URL to the project', async () => {
+    const result = await commandHandler.command(
+      Cmd.add,
+      ['hub', 'invalid'],
+      options,
+    );
+    expect(result.statusCode).to.equal(400);
+  });
+  it('try to add duplicate hub to the project', async () => {
+    await commandHandler.command(
+      Cmd.add,
+      ['hub', 'https://example.com/'],
+      options,
+    );
+    const result = await commandHandler.command(
+      Cmd.add,
+      ['hub', 'https://example.com/'],
+      options,
+    );
+    expect(result.statusCode).to.equal(400);
+  });
+  it('try to add hub without URL to the project', async () => {
+    const result = await commandHandler.command(Cmd.add, ['hub'], options);
+    expect(result.statusCode).to.equal(400);
+  });
 });
-// todo: no test case with valid repeat number

--- a/tools/data-handler/test/command-handler-fetch.test.ts
+++ b/tools/data-handler/test/command-handler-fetch.test.ts
@@ -1,0 +1,44 @@
+// testing
+import { expect } from 'chai';
+
+// node
+import { mkdirSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// cyberismo
+import { type CardsOptions, Cmd, Commands } from '../src/command-handler.js';
+import { copyDir } from '../src/utils/file-utils.js';
+
+// Create test artifacts in a temp folder.
+const baseDir = dirname(fileURLToPath(import.meta.url));
+const testDir = join(baseDir, 'tmp-command-handler-fetch-tests');
+
+const decisionRecordsPath = join(testDir, 'valid/decision-records');
+
+const commandHandler: Commands = new Commands();
+const options: CardsOptions = { projectPath: decisionRecordsPath };
+
+describe('fetch command', () => {
+  before(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir('test/test-data', testDir);
+  });
+
+  after(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('fetch hubs (success)', async () => {
+    const result = await commandHandler.command(Cmd.fetch, ['hubs'], options);
+    expect(result.statusCode).to.equal(200);
+  });
+  it('try to fetch incorrect type', async () => {
+    const result = await commandHandler.command(
+      Cmd.fetch,
+      ['unknown'],
+      options,
+    );
+    expect(result.statusCode).to.equal(400);
+  });
+});

--- a/tools/data-handler/test/command-handler-fetch.test.ts
+++ b/tools/data-handler/test/command-handler-fetch.test.ts
@@ -3,15 +3,14 @@ import { expect } from 'chai';
 
 // node
 import { mkdirSync, rmSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 
 // cyberismo
 import { type CardsOptions, Cmd, Commands } from '../src/command-handler.js';
 import { copyDir } from '../src/utils/file-utils.js';
 
 // Create test artifacts in a temp folder.
-const baseDir = dirname(fileURLToPath(import.meta.url));
+const baseDir = import.meta.dirname;
 const testDir = join(baseDir, 'tmp-command-handler-fetch-tests');
 
 const decisionRecordsPath = join(testDir, 'valid/decision-records');

--- a/tools/data-handler/test/command-handler-import.test.ts
+++ b/tools/data-handler/test/command-handler-import.test.ts
@@ -261,7 +261,7 @@ describe('import module', () => {
       const cardKey = '';
       const result = await commandHandler.command(
         Cmd.add,
-        [templateName, cardType, cardKey],
+        ['card', templateName, cardType, cardKey],
         options,
       );
       expect(result.statusCode).to.equal(400);
@@ -273,7 +273,7 @@ describe('import module', () => {
       // try to add new card to decision_2 when 'decision-records' has been imported to 'minimal'
       const result = await commandHandler.command(
         Cmd.add,
-        [templateName, cardType, cardKey],
+        ['card', templateName, cardType, cardKey],
         optionsMini,
       );
       expect(result.statusCode).to.equal(400);

--- a/tools/data-handler/test/command-handler-import.test.ts
+++ b/tools/data-handler/test/command-handler-import.test.ts
@@ -4,8 +4,7 @@ import * as sinon from 'sinon';
 
 // node
 import { mkdirSync, rmSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 
 // cyberismo
 import { copyDir } from '../src/utils/file-utils.js';
@@ -14,7 +13,7 @@ import { Project } from '../src/containers/project.js';
 import { Show } from '../src/commands/index.js';
 
 // Create test artifacts in a temp folder.
-const baseDir = dirname(fileURLToPath(import.meta.url));
+const baseDir = import.meta.dirname;
 const testDir = join(baseDir, 'tmp-command-handler-import-tests');
 
 const decisionRecordsPath = join(testDir, 'valid/decision-records');

--- a/tools/data-handler/test/command-handler-remove.test.ts
+++ b/tools/data-handler/test/command-handler-remove.test.ts
@@ -278,7 +278,7 @@ describe('remove command', () => {
     it('remove hub', async () => {
       // todo: Change to correct one, once CyberismoCom has one.
       const hub =
-        'https://raw.githubusercontent.com/Fuzzbender/testModuleHub/main/';
+        'https://raw.githubusercontent.com/CyberismoCom/cyberismo/feature/samimerila/modules-list/tools/assets/src/hub/';
 
       // add hub first, since test data does not have module hubs
       await commandHandler.command(Cmd.add, ['hub', hub], options);

--- a/tools/data-handler/test/command-handler-remove.test.ts
+++ b/tools/data-handler/test/command-handler-remove.test.ts
@@ -84,24 +84,6 @@ describe('remove command', () => {
       );
       expect(result2.statusCode).to.equal(200);
     });
-
-    it('try remove label - does not exist', async () => {
-      const result2 = await commandHandler.command(
-        Cmd.remove,
-        ['label', 'decision_6'],
-        options,
-      );
-      expect(result2.statusCode).to.equal(400);
-    });
-
-    it('try remove label - card does not exist', async () => {
-      const result2 = await commandHandler.command(
-        Cmd.remove,
-        ['label', 'decision_8', 'test'],
-        options,
-      );
-      expect(result2.statusCode).to.equal(400);
-    });
     /*
     it('remove link (success)', async () => {
       const linkName = 'testLinkName';
@@ -294,14 +276,20 @@ describe('remove command', () => {
       );
       expect(result.statusCode).to.equal(200);
     });
-    it('try to remove workflow that this is still used', async () => {
-      const workflowName = `decision/workflows/decision`;
+    it('remove hub', async () => {
+      // todo: Change to correct one, once CyberismoCom has one.
+      const hub =
+        'https://raw.githubusercontent.com/Fuzzbender/testModuleHub/main/';
+
+      // add hub first, since test data does not have module hubs
+      await commandHandler.command(Cmd.add, ['hub', hub], options);
+      // then remove it
       const result = await commandHandler.command(
         Cmd.remove,
-        ['workflow', workflowName],
+        ['hub', hub],
         options,
       );
-      expect(result.statusCode).to.equal(400);
+      expect(result.statusCode).to.equal(200);
     });
   });
 
@@ -314,7 +302,7 @@ describe('remove command', () => {
     afterEach(() => {
       rmSync(testDir, { recursive: true, force: true });
     });
-    it('remove card - project missing', async () => {
+    it('try to remove card - project missing', async () => {
       const cardId = 'decision_5';
       const invalidProject = { projectPath: 'idontexist' };
       const result = await commandHandler.command(
@@ -324,8 +312,7 @@ describe('remove command', () => {
       );
       expect(result.statusCode).to.equal(400);
     });
-
-    it('remove card - card not found', async () => {
+    it('try to remove card - card not found', async () => {
       const cardId = 'decision_999';
       const result = await commandHandler.command(
         Cmd.remove,
@@ -334,7 +321,23 @@ describe('remove command', () => {
       );
       expect(result.statusCode).to.equal(400);
     });
-    it('remove linkType - linkType missing', async () => {
+    it('try to remove label - does not exist', async () => {
+      const result2 = await commandHandler.command(
+        Cmd.remove,
+        ['label', 'decision_6'],
+        options,
+      );
+      expect(result2.statusCode).to.equal(400);
+    });
+    it('try to remove label - card does not exist', async () => {
+      const result2 = await commandHandler.command(
+        Cmd.remove,
+        ['label', 'decision_8', 'test'],
+        options,
+      );
+      expect(result2.statusCode).to.equal(400);
+    });
+    it('try to remove linkType - linkType missing', async () => {
       const linkType = 'mini/linkTypes/lt_name';
       const result = await commandHandler.command(
         Cmd.remove,
@@ -343,7 +346,7 @@ describe('remove command', () => {
       );
       expect(result.statusCode).to.equal(400);
     });
-    it('try remove link - link not found', async () => {
+    it('try to remove link - link not found', async () => {
       const result = await commandHandler.command(
         Cmd.remove,
         ['link', 'decision_5', 'decision_6', 'does-not-exist'],
@@ -351,7 +354,7 @@ describe('remove command', () => {
       );
       expect(result.statusCode).to.equal(400);
     });
-    it('remove attachment - project missing', async () => {
+    it('try to remove attachment - project missing', async () => {
       const cardId = 'decision_5';
       const attachment = 'the-needle.heic';
       const invalidProject = { projectPath: 'idontexist' };
@@ -362,7 +365,7 @@ describe('remove command', () => {
       );
       expect(result.statusCode).to.equal(400);
     });
-    it('remove attachment - attachment not found', async () => {
+    it('try to remove attachment - attachment not found', async () => {
       const cardId = 'decision_5';
       const attachment = 'i-dont-exist.jpg';
       const result = await commandHandler.command(
@@ -372,7 +375,7 @@ describe('remove command', () => {
       );
       expect(result.statusCode).to.equal(400);
     });
-    it('remove cardType - card type missing', async () => {
+    it('try to remove cardType - card type missing', async () => {
       const cardTypeName = 'decision/cardTypes/i-do-not-exist';
       const result = await commandHandler.command(
         Cmd.remove,
@@ -381,7 +384,7 @@ describe('remove command', () => {
       );
       expect(result.statusCode).to.equal(400);
     });
-    it('remove fieldType - field type missing', async () => {
+    it('try to remove fieldType - field type missing', async () => {
       const fieldTypeName = 'decision/fieldTypes/i-do-not-exist';
       const result = await commandHandler.command(
         Cmd.remove,
@@ -390,7 +393,7 @@ describe('remove command', () => {
       );
       expect(result.statusCode).to.equal(400);
     });
-    it('remove report - report missing', async () => {
+    it('try to remove report - report missing', async () => {
       const reportName = 'decision/reports/i-do-not-exist';
       const result = await commandHandler.command(
         Cmd.remove,
@@ -399,7 +402,7 @@ describe('remove command', () => {
       );
       expect(result.statusCode).to.equal(400);
     });
-    it('remove template - template missing', async () => {
+    it('try to remove template - template missing', async () => {
       const templateName = 'decision/templates/i-do-not-exist';
       const result = await commandHandler.command(
         Cmd.remove,
@@ -408,7 +411,7 @@ describe('remove command', () => {
       );
       expect(result.statusCode).to.equal(400);
     });
-    it('remove template - project missing', async () => {
+    it('try to remove template - project missing', async () => {
       const templateName = 'decision/templates/simplepage';
       const invalidProject = { projectPath: 'i-do-not-exist' };
       const result = await commandHandler.command(
@@ -418,7 +421,7 @@ describe('remove command', () => {
       );
       expect(result.statusCode).to.equal(400);
     });
-    it('remove workflow - workflow missing', async () => {
+    it('try to remove workflow - workflow missing', async () => {
       const workflowName = 'decision/workflows/i-do-not-exist';
       const result = await commandHandler.command(
         Cmd.remove,
@@ -436,7 +439,7 @@ describe('remove command', () => {
       );
       expect(result.statusCode).to.equal(400);
     });
-    it('remove() - try to remove non-existing attachment', async () => {
+    it('try to remove non-existing attachment', async () => {
       const cardId = 'decision_5';
       const project = new Project(decisionRecordsPath);
       const removeCmd = new Remove(project);
@@ -449,7 +452,7 @@ describe('remove command', () => {
           expect(true);
         });
     });
-    it('remove() - try to remove attachment from non-existing card', async () => {
+    it('try to remove attachment from non-existing card', async () => {
       const cardId = 'decision_999';
       const project = new Project(decisionRecordsPath);
       const removeCmd = new Remove(project);
@@ -462,7 +465,7 @@ describe('remove command', () => {
           expect(true);
         });
     });
-    it('remove() - try to remove non-existing module', async () => {
+    it('try to remove non-existing module', async () => {
       const project = new Project(decisionRecordsPath);
       const removeCmd = new Remove(project);
       await removeCmd
@@ -473,6 +476,24 @@ describe('remove command', () => {
         .catch(() => {
           expect(true);
         });
+    });
+    it('try to remove workflow that this is still used', async () => {
+      const workflowName = `decision/workflows/decision`;
+      const result = await commandHandler.command(
+        Cmd.remove,
+        ['workflow', workflowName],
+        options,
+      );
+      expect(result.statusCode).to.equal(400);
+    });
+    it('try to remove hub - not existing in the project', async () => {
+      const hub = `https://example.com/nonExisting`;
+      const result = await commandHandler.command(
+        Cmd.remove,
+        ['hub', hub],
+        options,
+      );
+      expect(result.statusCode).to.equal(400);
     });
   });
 });

--- a/tools/data-handler/test/command-handler-remove.test.ts
+++ b/tools/data-handler/test/command-handler-remove.test.ts
@@ -3,8 +3,7 @@ import { expect } from 'chai';
 
 // node
 import { mkdirSync, rmSync } from 'node:fs';
-import { dirname, join, sep } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join, sep } from 'node:path';
 
 // cyberismo
 import { type CardsOptions, Cmd, Commands } from '../src/command-handler.js';
@@ -16,7 +15,7 @@ import type { Card } from '../src/interfaces/project-interfaces.js';
 import type { requestStatus } from '../src/interfaces/request-status-interfaces.js';
 
 // Create test artifacts in a temp folder.
-const baseDir = dirname(fileURLToPath(import.meta.url));
+const baseDir = import.meta.dirname;
 const testDir = join(baseDir, 'tmp-command-handler-remove-tests');
 
 const decisionRecordsPath = join(testDir, 'valid/decision-records');

--- a/tools/data-handler/test/command-handler-remove.test.ts
+++ b/tools/data-handler/test/command-handler-remove.test.ts
@@ -280,7 +280,7 @@ describe('remove command', () => {
       const hub =
         'https://raw.githubusercontent.com/CyberismoCom/cyberismo/feature/samimerila/modules-list/tools/assets/src/hub/';
 
-      // add hub first, since test data does not have module hubs
+      // add hub first, since test data does not have hubs
       await commandHandler.command(Cmd.add, ['hub', hub], options);
       // then remove it
       const result = await commandHandler.command(
@@ -321,20 +321,20 @@ describe('remove command', () => {
       expect(result.statusCode).to.equal(400);
     });
     it('try to remove label - does not exist', async () => {
-      const result2 = await commandHandler.command(
+      const result = await commandHandler.command(
         Cmd.remove,
         ['label', 'decision_6'],
         options,
       );
-      expect(result2.statusCode).to.equal(400);
+      expect(result.statusCode).to.equal(400);
     });
     it('try to remove label - card does not exist', async () => {
-      const result2 = await commandHandler.command(
+      const result = await commandHandler.command(
         Cmd.remove,
         ['label', 'decision_8', 'test'],
         options,
       );
-      expect(result2.statusCode).to.equal(400);
+      expect(result.statusCode).to.equal(400);
     });
     it('try to remove linkType - linkType missing', async () => {
       const linkType = 'mini/linkTypes/lt_name';

--- a/tools/data-handler/test/command-handler-show.test.ts
+++ b/tools/data-handler/test/command-handler-show.test.ts
@@ -505,7 +505,7 @@ describe('shows command', () => {
         Cmd.add,
         [
           'hub',
-          'https://raw.githubusercontent.com/Fuzzbender/testModuleHub/main/',
+          'https://raw.githubusercontent.com/CyberismoCom/cyberismo/feature/samimerila/modules-list/tools/assets/src/hub/',
         ],
         optionsDecision,
       );
@@ -518,7 +518,7 @@ describe('shows command', () => {
         Cmd.remove,
         [
           'hub',
-          'https://raw.githubusercontent.com/Fuzzbender/testModuleHub/main/',
+          'https://raw.githubusercontent.com/CyberismoCom/cyberismo/feature/samimerila/modules-list/tools/assets/src/hub/',
         ],
         optionsDecision,
       );
@@ -533,9 +533,11 @@ describe('shows command', () => {
       );
       expect(result.statusCode).to.equal(200);
       const payloadAsArray = Object.values(result.payload!);
-      expect(payloadAsArray.length === 2);
+      expect(payloadAsArray.length === 4);
       expect(payloadAsArray.at(0)).to.equal('base');
-      expect(payloadAsArray.at(1)).to.equal('ismsa');
+      expect(payloadAsArray.at(1)).to.equal('eucra');
+      expect(payloadAsArray.at(2)).to.equal('ismsa');
+      expect(payloadAsArray.at(3)).to.equal('secdeva');
     });
 
     it('show importable modules details - success()', async () => {
@@ -547,11 +549,15 @@ describe('shows command', () => {
       );
       expect(result.statusCode).to.equal(200);
       const payloadAsArray = Object.values(result.payload!);
-      expect(payloadAsArray.length === 2);
+      expect(payloadAsArray.length === 4);
       expect(payloadAsArray.at(0).name).to.equal('base');
-      expect(payloadAsArray.at(1).name).to.equal('ismsa');
+      expect(payloadAsArray.at(1).name).to.equal('eucra');
+      expect(payloadAsArray.at(2).name).to.equal('ismsa');
+      expect(payloadAsArray.at(3).name).to.equal('secdeva');
       expect(payloadAsArray.at(0).category).to.equal('essentials');
       expect(payloadAsArray.at(1).category).to.equal('essentials');
+      expect(payloadAsArray.at(2).category).to.equal('essentials');
+      expect(payloadAsArray.at(3).category).to.equal('essentials');
     });
 
     it('show importableModule all - success()', async () => {

--- a/tools/data-handler/test/command-handler-show.test.ts
+++ b/tools/data-handler/test/command-handler-show.test.ts
@@ -3,8 +3,7 @@ import { expect } from 'chai';
 
 // node
 import { mkdirSync, rmSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 
 // cyberismo
 import { type CardsOptions, Cmd, Commands } from '../src/command-handler.js';
@@ -15,7 +14,7 @@ import { Project } from '../src/containers/project.js';
 import { Show } from '../src/commands/index.js';
 
 // validation tests do not modify the content - so they can use the original files
-const baseDir = dirname(fileURLToPath(import.meta.url));
+const baseDir = import.meta.dirname;
 const testDir = join(baseDir, 'tmp-command-handler-show-tests');
 
 const decisionRecordsPath = join(testDir, 'valid/decision-records');


### PR DESCRIPTION
**New commands**

`cyberismo show module hub` - lists hubs in the project. Existing projects will not have any until a hub has been added.
`cyberismo add hub <location>` - adds a new URL location as a hub 
`cyberismo remove hub <location>` removes a hub from the project
`cyberismo fetch hubs` - fetches module information from already added hubs to local filesystem (to a temporary file `.temp/moduleList.json`). 
`cyberismo show importableModules` - shows module names that have not yet been imported to the project.

Hubs should have a means to retrieve JSON file (`moduleList`) from an URL. The file should implement the JSON schema `hubSchema`. 

**Changed commands**

`cyberismo show project` - will show hub details also
`cyberismo import` - if given without a parameter will automatically prompt for known, but not yet imported modules. And it is possible to give module-name as a parameter instead of a path to local file reference, or URL. In that case, the name must match to a module name in already fetched hub data.
`cyberismo create project` - will automatically add default hub for all new projects. Note that we do not have default module hub as of yet. One is needed to be implemented before merging this (or just after). There is test default hub here: https://raw.githubusercontent.com/Fuzzbender/testModuleHub/main/moduleList.json 

**Breaking change** 
This change "breaks" CLI command `add` compatibility. Earlier no type was needed for the command. Now it requires that either `card` or `hub` is given as first parameter.

Additionally, there was one validation error that was shown a bit differently from others. I fixed that in this PR so that it is shown on its own line as other validation errors. 
