### PR TITLE
INTDEV-960 Define nodeJS version in only one place

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [${{ vars.NODE_VERSION }}]
+        node-version: ["${{ vars.NODE_VERSION }}"]
 
     permissions:
       contents: read

--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [${{ vars.NODE_VERSION }}]
 
     permissions:
       contents: read

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [${{ vars.NODE_VERSION }}]
+        node-version: ["${{ vars.NODE_VERSION }}"]
 
     permissions:
       contents: read

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [${{ vars.NODE_VERSION }}]
 
     permissions:
       contents: read

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [${{ vars.NODE_VERSION }}]
+        node-version: ["${{ vars.NODE_VERSION }}"]
 
     permissions:
       contents: read

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [${{ vars.NODE_VERSION }}]
 
     permissions:
       contents: read

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ vars.NODE_VERSION }}
 
       - name: Setup Miniconda
         if: runner.os == 'Windows'
@@ -120,10 +120,10 @@ jobs:
         run: |
           brew install clingo --ignore-dependencies
 
-      - name: Use Node.js 22
+      - name: Use Node.js ${{ vars.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ vars.NODE_VERSION }}
           cache: 'pnpm'
           registry-url: 'https://npm.pkg.github.com'
           scope: '@cyberismo'
@@ -210,7 +210,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ vars.NODE_VERSION }}
 
       - name: Download all prebuilds
         uses: actions/download-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ vars.NODE_VERSION }}
           cache: 'pnpm'
 
       - name: Set publishing config

--- a/.github/workflows/test-pr-docker.yml
+++ b/.github/workflows/test-pr-docker.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
-        node-version: [22.x]
+        node-version: [${{ vars.NODE_VERSION }}]
     runs-on: ${{ matrix.os }}
 
     permissions:

--- a/.github/workflows/test-pr-docker.yml
+++ b/.github/workflows/test-pr-docker.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
-        node-version: [${{ vars.NODE_VERSION }}]
+        node-version: ["${{ vars.NODE_VERSION }}"]
     runs-on: ${{ matrix.os }}
 
     permissions:


### PR DESCRIPTION
Instead of defining nodeJS version each time it is required by GitHub workflows, define the variable once and re-use the variable from all other places. 

Variable has been defined to : Settings - Secrets and variables - Actions - Variables tab as `NODE_VERSION` and its value has been set to `22.x`. This works as long as we are using workflows from one repository only. Once we have multiple repositories, the value needs to be defined on organisational level.
<img width="575" height="156" alt="Screenshot 2025-09-03 at 15 49 08" src="https://github.com/user-attachments/assets/1843e75d-8ef4-47bf-9c8f-15022c63b2b0" />
