### PR TITLE
INTDEV-1004 - Fix fluctuating unit test

### DIFF
--- a/tools/data-handler/src/commands/create.ts
+++ b/tools/data-handler/src/commands/create.ts
@@ -528,20 +528,23 @@ export class Create {
         ),
       );
     });
-    Create.JSONFileContent.forEach(async (entry) => {
-      if ('cardKeyPrefix' in entry.content) {
-        if (entry.content.cardKeyPrefix.includes('$PROJECT-PREFIX')) {
-          entry.content.cardKeyPrefix = projectPrefix.toLowerCase();
+
+    await Promise.all(
+      Create.JSONFileContent.map(async (entry) => {
+        if ('cardKeyPrefix' in entry.content) {
+          if (entry.content.cardKeyPrefix.includes('$PROJECT-PREFIX')) {
+            entry.content.cardKeyPrefix = projectPrefix.toLowerCase();
+          }
+          if (entry.content.name.includes('$PROJECT-NAME')) {
+            entry.content.name = projectName;
+          }
         }
-        if (entry.content.name.includes('$PROJECT-NAME')) {
-          entry.content.name = projectName;
-        }
-      }
-      await writeJsonFile(
-        join(projectPath, entry.path, entry.name),
-        entry.content,
-      );
-    });
+        await writeJsonFile(
+          join(projectPath, entry.path, entry.name),
+          entry.content,
+        );
+      }),
+    );
 
     try {
       await writeFile(

--- a/tools/data-handler/src/commands/remove.ts
+++ b/tools/data-handler/src/commands/remove.ts
@@ -95,13 +95,16 @@ export class Remove {
       },
     );
     const promiseContainer: Promise<void>[] = [];
-    allCards.filter((item) => {
-      item.metadata?.links.forEach(async (link) => {
+
+    for (const item of allCards) {
+      const links = item.metadata?.links ?? [];
+      for (const link of links) {
         if (link.cardKey === cardKey) {
           promiseContainer.push(this.removeLink(item.key, link.cardKey));
         }
-      });
-    });
+      }
+    }
+
     await Promise.all(promiseContainer);
 
     // Calculations need to be updated before card is removed.

--- a/tools/data-handler/src/commands/rename.ts
+++ b/tools/data-handler/src/commands/rename.ts
@@ -160,17 +160,17 @@ export class Rename {
     );
 
     // Then replace all values that match in the conversion map.
-    files.forEach(async (item) => {
-      const target = join(item.parentPath, item.name);
-      let fileContent = await readFile(target, {
-        encoding: 'utf-8',
-      });
-      for (const [key, value] of conversionMap) {
-        const re = new RegExp(key, 'g');
-        fileContent = fileContent.replaceAll(re, value);
-      }
-      await writeFile(target, fileContent);
-    });
+    await Promise.all(
+      files.map(async (item) => {
+        const target = join(item.parentPath, item.name);
+        let fileContent = await readFile(target, { encoding: 'utf-8' });
+        for (const [key, value] of conversionMap) {
+          const re = new RegExp(key, 'g');
+          fileContent = fileContent.replace(re, value);
+        }
+        await writeFile(target, fileContent);
+      }),
+    );
   }
 
   // Changes the name of a resource to match the new prefix.

--- a/tools/data-handler/src/resources/workflow-resource.ts
+++ b/tools/data-handler/src/resources/workflow-resource.ts
@@ -190,12 +190,13 @@ export class WorkflowResource extends FileResource {
   // Update card states when state is changed
   private async updateCardStates(oldState: string, newState: string) {
     const cards = await this.collectCardsUsingWorkflow();
-    cards.forEach(async (card) => {
-      if (card.metadata?.workflowState === oldState) {
-        card.metadata.workflowState = newState;
-        await this.project.updateCardMetadata(card, card.metadata);
-      }
-    });
+    const promises = cards
+      .filter((card) => card.metadata?.workflowState === oldState)
+      .map(async (card) => {
+        card.metadata!.workflowState = newState;
+        await this.project.updateCardMetadata(card, card.metadata!);
+      });
+    await Promise.all(promises);
   }
 
   // Update dependant card types.

--- a/tools/data-handler/test/command-handler-import.test.ts
+++ b/tools/data-handler/test/command-handler-import.test.ts
@@ -157,41 +157,34 @@ describe('import module', () => {
       const name = 'test-project';
       const projectDir = join(testDir, name);
       const testOptions: CardsOptions = { projectPath: projectDir };
-      await commandHandler
-        .command(Cmd.create, ['project', name, prefix], testOptions)
-        .then(async (data) => {
-          expect(data.statusCode).to.equal(200);
-          let result = await commandHandler.command(
-            Cmd.import,
-            ['module', decisionRecordsPath],
-            testOptions,
-          );
-          expect(result.statusCode).to.equal(200);
-          result = await commandHandler.command(
-            Cmd.import,
-            ['module', minimalPath],
-            testOptions,
-          );
-          expect(result.statusCode).to.equal(200);
-          result = await commandHandler.command(
-            Cmd.updateModules,
-            [],
-            testOptions,
-          );
-          expect(result.statusCode).to.equal(200);
-          result = await commandHandler.command(
-            Cmd.show,
-            ['modules'],
-            testOptions,
-          );
-          expect(result.statusCode).to.equal(200);
-          if (result.payload) {
-            const modules = Object.values(result.payload);
-            expect(modules.length).to.equal(2);
-            expect(modules).to.contain('mini');
-            expect(modules).to.contain('decision');
-          }
-        });
+      const data = await commandHandler.command(
+        Cmd.create,
+        ['project', name, prefix],
+        testOptions,
+      );
+      expect(data.statusCode).to.equal(200);
+      let result = await commandHandler.command(
+        Cmd.import,
+        ['module', decisionRecordsPath],
+        testOptions,
+      );
+      expect(result.statusCode).to.equal(200);
+      result = await commandHandler.command(
+        Cmd.import,
+        ['module', minimalPath],
+        testOptions,
+      );
+      expect(result.statusCode).to.equal(200);
+      result = await commandHandler.command(Cmd.updateModules, [], testOptions);
+      expect(result.statusCode).to.equal(200);
+      result = await commandHandler.command(Cmd.show, ['modules'], testOptions);
+      expect(result.statusCode).to.equal(200);
+      if (result.payload) {
+        const modules = Object.values(result.payload);
+        expect(modules.length).to.equal(2);
+        expect(modules).to.contain('mini');
+        expect(modules).to.contain('decision');
+      }
     }).timeout(10000);
     it('try to import module - no source', async () => {
       const stubProjectPath = sinon


### PR DESCRIPTION
Fixed one unit test that periodically failed on local system (MacOS). The test was fixed by removing the `.then()`  part and instead just `await` the result of the first call before subsequent calls. 

But this test actually revealed a potential error in project creation when it writes JSON files. Used `forEach` with `async` callback to write JSON config files, causing the function to return before all files were written. Fixed by changing to `Promise.all` with `map`. 

Similar fixes were applied to three other places:

1) In card removal, there was a bit dubious `filter` (the return value was ignored)  and `async` callback, whereas in reality each filtered value was just put into a `Promise` container. 
2) In replace operation, `forEach` was potentially returning before all file operations were finished. Fixed by changing to `Promise.all` with `map`. 
3) Workflow state update was similarly using `forEach` with `async` file operations. Fixed similarly as earlier.