### PR TITLE
Enable ESLint promise checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,7 @@ updates:
         patterns:
           - "eslint"
           - "eslint-config-prettier"
+          - "eslint-plugin-promise"
           - "typescript-eslint"
           - "@eslint/js"
           - "@typescript-eslint/parser"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "cross-env": "^7.0.3",
     "eslint": "^9.32.0",
     "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-promise": "^7.2.1",
     "mocha": "^11.7.1",
     "mocha-suppress-logs": "^0.6.0",
     "prettier": "^3.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@9.32.0)
+      eslint-plugin-promise:
+        specifier: ^7.2.1
+        version: 7.2.1(eslint@9.32.0)
       mocha:
         specifier: ^11.7.1
         version: 11.7.1
@@ -2457,6 +2460,12 @@ packages:
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
+
+  eslint-plugin-promise@7.2.1:
+    resolution: {integrity: sha512-SWKjd+EuvWkYaS+uN2csvj0KoP43YTu7+phKQ5v+xw6+A0gutVX2yqCeCkC3uLCJFiPfR2dD8Es5L7yUsmvEaA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
 
   eslint-plugin-react-hooks@5.2.0:
     resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
@@ -5400,7 +5409,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -6737,6 +6746,10 @@ snapshots:
     optionalDependencies:
       supports-color: 8.1.1
 
+  debug@4.4.1:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.1(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -6936,6 +6949,11 @@ snapshots:
 
   eslint-config-prettier@10.1.8(eslint@9.32.0):
     dependencies:
+      eslint: 9.32.0
+
+  eslint-plugin-promise@7.2.1(eslint@9.32.0):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.32.0)
       eslint: 9.32.0
 
   eslint-plugin-react-hooks@5.2.0(eslint@9.32.0):
@@ -7384,7 +7402,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -7397,7 +7415,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -8456,7 +8474,7 @@ snapshots:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 

--- a/tools/backend/eslint.config.js
+++ b/tools/backend/eslint.config.js
@@ -3,17 +3,32 @@
 import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import eslintConfigPrettier from 'eslint-config-prettier';
+import promisePlugin from 'eslint-plugin-promise';
 
 export default [
   {
-    ignores: ['**/dist/*', '**/init.js'],
+    ignores: ['**/dist/*', '**/init.js', 'eslint.config.js', 'vitest.config.ts'],
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
+  promisePlugin.configs['flat/recommended'],
   eslintConfigPrettier,
   {
+    files: ['**/*.ts', '**/*.tsx'],
+    languageOptions: {
+      parserOptions: {
+        project: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
     rules: {
       '@typescript-eslint/consistent-type-imports': 'error',
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+      'promise/catch-or-return': 'error',
+      'promise/always-return': 'error',
+      'promise/no-promise-in-callback': 'error',
+      'promise/prefer-await-to-then': 'warn',
     },
   },
 ];

--- a/tools/backend/eslint.config.js
+++ b/tools/backend/eslint.config.js
@@ -7,7 +7,12 @@ import promisePlugin from 'eslint-plugin-promise';
 
 export default [
   {
-    ignores: ['**/dist/*', '**/init.js', 'eslint.config.js', 'vitest.config.ts'],
+    ignores: [
+      '**/dist/*',
+      '**/init.js',
+      'eslint.config.js',
+      'vitest.config.ts',
+    ],
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
@@ -26,9 +31,7 @@ export default [
       '@typescript-eslint/no-floating-promises': 'error',
       '@typescript-eslint/no-misused-promises': 'error',
       'promise/catch-or-return': 'error',
-      'promise/always-return': 'error',
       'promise/no-promise-in-callback': 'error',
-      'promise/prefer-await-to-then': 'warn',
     },
   },
 ];

--- a/tools/backend/src/main.ts
+++ b/tools/backend/src/main.ts
@@ -18,7 +18,7 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 if (process.argv.includes('--export')) {
-  exportSite(process.env.npm_config_project_path || '');
+  await exportSite(process.env.npm_config_project_path || '');
 } else {
-  startServer(process.env.npm_config_project_path || '');
+  await startServer(process.env.npm_config_project_path || '');
 }

--- a/tools/cli/eslint.config.js
+++ b/tools/cli/eslint.config.js
@@ -26,9 +26,7 @@ export default [
       '@typescript-eslint/no-floating-promises': 'error',
       '@typescript-eslint/no-misused-promises': 'error',
       'promise/catch-or-return': 'error',
-      'promise/always-return': 'error',
       'promise/no-promise-in-callback': 'error',
-      'promise/prefer-await-to-then': 'warn',
     },
   },
 ];

--- a/tools/cli/eslint.config.js
+++ b/tools/cli/eslint.config.js
@@ -3,17 +3,32 @@
 import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import eslintConfigPrettier from 'eslint-config-prettier';
+import promisePlugin from 'eslint-plugin-promise';
 
 export default [
   {
-    ignores: ['**/dist/*', '**/init.js'],
+    ignores: ['**/dist/*', '**/init.js', 'eslint.config.js'],
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
+  promisePlugin.configs['flat/recommended'],
   eslintConfigPrettier,
   {
+    files: ['**/*.ts', '**/*.tsx'],
+    languageOptions: {
+      parserOptions: {
+        project: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
     rules: {
       '@typescript-eslint/consistent-type-imports': 'error',
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+      'promise/catch-or-return': 'error',
+      'promise/always-return': 'error',
+      'promise/no-promise-in-callback': 'error',
+      'promise/prefer-await-to-then': 'warn',
     },
   },
 ];

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -889,7 +889,7 @@ program
         return;
       }
     }
-    startServer(await commandHandler.getProjectPath(options.projectPath));
+    await startServer(await commandHandler.getProjectPath(options.projectPath));
   });
 
 export default program;

--- a/tools/data-handler/eslint.config.js
+++ b/tools/data-handler/eslint.config.js
@@ -26,8 +26,8 @@ export default [
       '@typescript-eslint/no-floating-promises': 'error',
       '@typescript-eslint/no-misused-promises': 'error',
       'promise/catch-or-return': 'error',
-      'promise/always-return': 'error',
       'promise/no-promise-in-callback': 'error',
+      'promise/always-return': 'off',
     },
   },
 ];

--- a/tools/data-handler/eslint.config.js
+++ b/tools/data-handler/eslint.config.js
@@ -3,17 +3,31 @@
 import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import eslintConfigPrettier from 'eslint-config-prettier';
+import promisePlugin from 'eslint-plugin-promise';
 
 export default [
   {
-    ignores: ['**/dist/*', '**/init.js'],
+    ignores: ['**/dist/*', '**/init.js', 'eslint.config.js'],
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
+  promisePlugin.configs['flat/recommended'],
   eslintConfigPrettier,
   {
+    files: ['**/*.ts', '**/*.tsx'],
+    languageOptions: {
+      parserOptions: {
+        project: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
     rules: {
       '@typescript-eslint/consistent-type-imports': 'error',
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+      'promise/catch-or-return': 'error',
+      'promise/always-return': 'error',
+      'promise/no-promise-in-callback': 'error',
     },
   },
 ];

--- a/tools/data-handler/src/card-metadata-updater.ts
+++ b/tools/data-handler/src/card-metadata-updater.ts
@@ -180,7 +180,7 @@ export class CardMetadataUpdater {
     }
 
     if (result.success) {
-      project.updateCardMetadata(card, card.metadata);
+      await project.updateCardMetadata(card, card.metadata);
     }
     return result;
   }

--- a/tools/data-handler/src/commands/create.ts
+++ b/tools/data-handler/src/commands/create.ts
@@ -122,13 +122,13 @@ export class Create {
       ? await templateObject.findSpecificCard(card)
       : undefined;
     if (card && !specificCard) {
-      throw Error(
+      throw new Error(
         `Card '${card}' was not found from template '${origTemplateName}'`,
       );
     }
 
     if (templateObject.templateFolder().includes(`${sep}modules${sep}`)) {
-      throw Error(`Cannot add cards to imported module templates`);
+      throw new Error(`Cannot add cards to imported module templates`);
     }
 
     // Collect all add-card promises and settle them in parallel.

--- a/tools/data-handler/src/macros/index.ts
+++ b/tools/data-handler/src/macros/index.ts
@@ -240,7 +240,7 @@ export async function evaluateMacros(
   registerMacros(handlebars, context, tasks);
   let result = content;
   while ((context.maxTries ?? 10) > 0) {
-    tasks.reset();
+    void tasks.reset();
     try {
       const compiled = handlebars.compile(preprocessRawBlocks(result), {
         strict: true,

--- a/tools/data-handler/src/resources/field-type-resource.ts
+++ b/tools/data-handler/src/resources/field-type-resource.ts
@@ -305,6 +305,7 @@ export class FieldTypeResource extends FileResource {
   /**
    * Creates a new field type object. Base class writes the object to disk automatically.
    * @param dataType Type for the new field type.
+   * @throws if called with unknown data type
    */
   public async createFieldType(dataType: DataType) {
     if (!FieldTypeResource.fieldDataTypes().includes(dataType)) {
@@ -418,6 +419,10 @@ export class FieldTypeResource extends FileResource {
    * Updates field type resource.
    * @param key Key to modify
    * @param op Operation to perform on 'key'
+   * @throws
+   *  - when called with unknown data type
+   *  - when called with data type conversion that cannot be done
+   *  - when called with unknown property to update
    */
   public async update<Type>(key: string, op: Operation<Type>) {
     const nameChange = key === 'name';

--- a/tools/data-handler/src/resources/field-type-resource.ts
+++ b/tools/data-handler/src/resources/field-type-resource.ts
@@ -150,13 +150,13 @@ export class FieldTypeResource extends FileResource {
     const allCards = [...projectCards, ...templateCards];
 
     // Finally, convert values and update the cards.
-    allCards.forEach(async (card) => {
+    for (const card of allCards) {
       const metadata = card.metadata!;
       const fieldName = resourceNameToString(this.resourceName);
       try {
         metadata[fieldName] = this.convertValue(metadata[fieldName]);
         // Either value was already null, or couldn't convert.
-        if (metadata[fieldName] === null) return;
+        if (metadata[fieldName] === null) continue;
 
         await this.project.updateCardMetadata(card, metadata);
       } catch (error) {
@@ -164,7 +164,7 @@ export class FieldTypeResource extends FileResource {
           `In card '${card.key}': ${error instanceof Error ? error.message : String(error)}`,
         );
       }
-    });
+    }
   }
 
   // Checks that enum with 'enumValue' exists.

--- a/tools/data-handler/test/macros/index.test.ts
+++ b/tools/data-handler/test/macros/index.test.ts
@@ -42,7 +42,7 @@ class TestMacro extends BaseMacro {
     );
   }
 
-  handleValidate = async (data: { content: string }) => {
+  handleValidate = (data: { content: string }) => {
     return 'test-static: ' + data.content;
   };
 

--- a/tools/data-handler/test/resources.test.ts
+++ b/tools/data-handler/test/resources.test.ts
@@ -48,7 +48,7 @@ import type {
 } from '../src/resources/resource-object.js';
 
 describe('resources', function () {
-  const baseDir = dirname(fileURLToPath(import.meta.url));
+  const baseDir = import.meta.dirname;
   const testDir = join(baseDir, 'tmp-resource-tests');
   const decisionRecordsPath = join(testDir, 'valid/decision-records');
   const minimalPath = join(testDir, 'valid/minimal');
@@ -346,14 +346,15 @@ describe('resources', function () {
           removeType as RemovableResourceTypes,
           nameForResource,
         );
+        collector.collectLocalResources();
         exists = await collector.resourceExists(resourceType, nameForResource);
         expect(exists).to.equal(false);
       }
 
-      checkResource('graphModels');
-      checkResource('graphViews');
-      checkResource('reports');
-      checkResource('templates');
+      await checkResource('graphModels');
+      await checkResource('graphViews');
+      await checkResource('reports');
+      await checkResource('templates');
     });
   });
 


### PR DESCRIPTION
Add more rules and warnings related to promises.

Code that caused promise-plugin to nag is fixed in a separate commit. 

I set the `'promise/always-return'` to `off` since it was nagging from all `Promises` without `returns`; even `Promise<void>` ones. Thus, whole lot of new lines with `return;` would have been needed. If reviewers disagree, let's discuss. 