### PR TITLE
Fix Dependabot when it gives errors from public monorepo subprojects.…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,25 +6,11 @@
 version: 2
 updates:
   - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/tools/data-handler" # Location of package manifests
+    directory: "/" # Location of package manifests (root workspace manages all packages)
     schedule:
       interval: "monthly"
     rebase-strategy: "auto"
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/tools/cli" # Location of package manifests
-    schedule:
-      interval: "monthly"
-    rebase-strategy: "auto"
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/tools/app" # Location of package manifests
-    schedule:
-      interval: "monthly"
-    rebase-strategy: "auto"
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "monthly"
-    rebase-strategy: "auto"
+    open-pull-requests-limit: 20 # Increase from default of 5 to 20 (maximum allowed)
     groups:
       chai-dependencies: # Update all Chai dependencies in one PR
         patterns:


### PR DESCRIPTION
Also increase open PR count to maximum.

Public subprojects give this kind of error: 
<img width="952" height="280" alt="Screenshot 2025-09-05 at 11 40 10" src="https://github.com/user-attachments/assets/c3ebfa2b-ca71-40f1-939f-9fb7de1bd462" />

`app` does not since it is `private`.

The recommended way to fix this is to use only Dependabot on root level and it **should** automatically pick up the requirements.