### PR TITLE
Make react dependency group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,14 +15,9 @@ updates:
       react-dependencies: # Update all React dependencies in one PR
         patterns:
           - "react"
-          - "react-arborist"
           - "react-dom"
-          - "react-hook-form"
-          - "react-redux"
-          - "react-router"
           - "@types/react"
           - "@types/react-dom"
-          - "@uiw/react-codemirror"
       chai-dependencies: # Update all Chai dependencies in one PR
         patterns:
           - "@types/chai"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,17 @@ updates:
     rebase-strategy: "auto"
     open-pull-requests-limit: 20 # Increase from default of 5 to 20 (maximum allowed)
     groups:
+      react-dependencies: # Update all React dependencies in one PR
+        patterns:
+          - "react"
+          - "react-arborist"
+          - "react-dom"
+          - "react-hook-form"
+          - "react-redux"
+          - "react-router"
+          - "@types/react"
+          - "@types/react-dom"
+          - "@uiw/react-codemirror"
       chai-dependencies: # Update all Chai dependencies in one PR
         patterns:
           - "@types/chai"


### PR DESCRIPTION
Since some of the react dependencies are connected to each other (cannot update one unless the other is updated as well), move at least some of the React related dependencies to be updated with one PR. This will also lower the amount of PRs that the Dependabot creates.