### PR TITLE
INTDEV-1006 Make 'cardAttachmentFolder' throw when path is incorrect

### DIFF
--- a/tools/data-handler/src/commands/create.ts
+++ b/tools/data-handler/src/commands/create.ts
@@ -44,6 +44,8 @@ import { ReportResource } from '../resources/report-resource.js';
 import { TemplateResource } from '../resources/template-resource.js';
 import { WorkflowResource } from '../resources/workflow-resource.js';
 
+const MODULES_PATH = `${sep}modules${sep}`;
+
 // todo: Is there a easy to way to make JSON schema into a TypeScript interface/type?
 //       Check this out: https://www.npmjs.com/package/json-schema-to-ts
 
@@ -185,12 +187,10 @@ export class Create {
       );
     }
     const attachmentFolder = await this.project.cardAttachmentFolder(cardKey);
-    if (!attachmentFolder) {
-      throw new Error(`Attachment folder for '${cardKey}' not found`);
-    }
 
     // Imported templates cannot be modified.
-    if (attachmentFolder.includes(`${sep}modules${sep}`)) {
+    // @todo: make MODULES_PATH project level constant
+    if (attachmentFolder.includes(MODULES_PATH)) {
       throw new Error(`Cannot modify imported module`);
     }
 

--- a/tools/data-handler/src/commands/remove.ts
+++ b/tools/data-handler/src/commands/remove.ts
@@ -53,9 +53,6 @@ export class Remove {
     }
 
     const attachmentFolder = await this.project.cardAttachmentFolder(cardKey);
-    if (!attachmentFolder) {
-      throw new Error(`Card '${cardKey}' not found`);
-    }
 
     // Imported templates cannot be modified.
     if (attachmentFolder.includes(MODULES_PATH)) {

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -196,6 +196,7 @@ export class Project extends CardContainer {
    * Returns path to card's attachment folder.
    * @param cardKey card key
    * @returns path to card's attachment folder.
+   * @throws if card path cannot be found
    */
   public async cardAttachmentFolder(cardKey: string): Promise<string> {
     // Check if it is a template card.
@@ -205,9 +206,10 @@ export class Project extends CardContainer {
     }
 
     const pathToProjectCard = this.pathToCard(cardKey);
-    return pathToProjectCard
-      ? join(this.paths.cardRootFolder, pathToProjectCard, 'a')
-      : '';
+    if (!pathToProjectCard) {
+      throw new Error(`Card '${cardKey}' not found`);
+    }
+    return join(this.paths.cardRootFolder, pathToProjectCard, 'a');
   }
 
   /**

--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -439,7 +439,7 @@ export class Template extends CardContainer {
   public async cardAttachmentFolder(cardKey: string): Promise<string> {
     const pathToCard = await this.cardFolder(cardKey);
     if (!pathToCard) {
-      return '';
+      throw new Error(`Template card '${cardKey}' not found`);
     }
     return join(pathToCard, 'a');
   }

--- a/tools/data-handler/src/macros/image/index.ts
+++ b/tools/data-handler/src/macros/image/index.ts
@@ -58,9 +58,6 @@ export default class ImageMacro extends BaseMacro {
     // Get the attachment folder path
     const attachmentFolder =
       await context.project.cardAttachmentFolder(cardKey);
-    if (!attachmentFolder) {
-      throw new Error(`Card '${cardKey}' not found`);
-    }
 
     // Read the file and convert to base64
     const attachmentPath = join(attachmentFolder, options.fileName);
@@ -90,9 +87,6 @@ export default class ImageMacro extends BaseMacro {
     // Verify that the card and attachment folder exist
     const attachmentFolder =
       await context.project.cardAttachmentFolder(cardKey);
-    if (!attachmentFolder) {
-      throw new Error(`Card '${cardKey}' not found`);
-    }
 
     const attachmentPath = join(attachmentFolder, options.fileName);
     if (!existsSync(attachmentPath)) {

--- a/tools/data-handler/test/template.test.ts
+++ b/tools/data-handler/test/template.test.ts
@@ -327,13 +327,13 @@ describe('template', () => {
     // Project can fetch the template's attachment's folder.
     const attachmentFolder1 = await project.cardAttachmentFolder('decision_1');
     const attachmentFolder2 = await template.cardAttachmentFolder('decision_1');
-    const nonExistingAttachmentFolder =
-      await template.cardAttachmentFolder('decision_999');
     expect(attachmentFolder1).to.include('decision_1');
     expect(attachmentFolder1).to.include(sep + 'a');
     expect(attachmentFolder1).to.equal(attachmentFolder2);
 
-    expect(nonExistingAttachmentFolder).to.equal('');
+    await expect(
+      template.cardAttachmentFolder('decision_999'),
+    ).to.be.rejectedWith(`Template card 'decision_999' not found`);
 
     const templateAttachments = await template.attachments();
     expect(templateAttachments.length).to.equal(1);


### PR DESCRIPTION
Code is simplified, if `cardAttachmentFolder` throws instead of if callers of that function throw when path is incorrect.