### PR TITLE
Use simpler way to set base directory

### DIFF
--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -11,9 +11,8 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { dirname, join, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import { execFileSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
 import { readFileSync } from 'node:fs';
 
 import type {
@@ -773,7 +772,7 @@ export class Commands {
   // Starts the Cyberismo app by running npm start in the app project folder
   private async startApp(forceStart: boolean = false): Promise<requestStatus> {
     // __dirname when running cards ends with /tools/data-handler/dist - use that to navigate to app path
-    const baseDir = dirname(fileURLToPath(import.meta.url));
+    const baseDir = import.meta.dirname;
     const appPath = resolve(baseDir, '../../app');
 
     // since current working directory changes, we need to resolve the project path

--- a/tools/data-handler/src/commands/validate.ts
+++ b/tools/data-handler/src/commands/validate.ts
@@ -14,7 +14,6 @@
 // node
 import { type Dirent } from 'node:fs';
 import { basename, dirname, extname, join, parse, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { readdir } from 'node:fs/promises';
 
 // dependencies
@@ -52,7 +51,7 @@ const SHORT_TEXT_MAX_LENGTH = 80;
 
 import * as EmailValidator from 'email-validator';
 import { evaluateMacros } from '../macros/index.js';
-const baseDir = dirname(fileURLToPath(import.meta.url));
+const baseDir = import.meta.dirname;
 const subFoldersToValidate = ['.cards', 'cardRoot'];
 
 export interface LengthProvider {

--- a/tools/data-handler/test/0_validate.test.ts
+++ b/tools/data-handler/test/0_validate.test.ts
@@ -1,7 +1,6 @@
 // node
 import { readdir } from 'node:fs/promises';
-import { dirname, join, resolve, sep } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join, resolve, sep } from 'node:path';
 
 // testing
 import { expect } from 'chai';
@@ -16,7 +15,7 @@ import { resourceName } from '../src/utils/resource-utils.js';
 import type { ResourceTypes } from '../src/interfaces/project-interfaces.js';
 
 describe('validate cmd tests', () => {
-  const baseDir = dirname(fileURLToPath(import.meta.url));
+  const baseDir = import.meta.dirname;
   const testDir = join(baseDir, 'test-data');
   const validateCmd = Validate.getInstance();
 

--- a/tools/data-handler/test/calculate.test.ts
+++ b/tools/data-handler/test/calculate.test.ts
@@ -1,10 +1,9 @@
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import { mkdirSync, rmSync } from 'node:fs';
 import { copyDir } from '../src/utils/file-utils.js';
-import { fileURLToPath } from 'node:url';
 import { Project } from '../src/containers/project.js';
 import type { QueryResult } from '../src/types/queries.js';
 import { lpFiles } from '@cyberismo/assets';
@@ -29,7 +28,7 @@ const expectedTree: QueryResult<'tree'>[] = [
 ];
 
 describe('calculate', () => {
-  const baseDir = dirname(fileURLToPath(import.meta.url));
+  const baseDir = import.meta.dirname;
   const testDir = join(baseDir, 'tmp-calculate-tests');
   const decisionRecordsPath = join(testDir, 'valid/decision-records');
   let project: Project;

--- a/tools/data-handler/test/command-handler-create.test.ts
+++ b/tools/data-handler/test/command-handler-create.test.ts
@@ -4,8 +4,7 @@ import { expect } from 'chai';
 // node
 import { access } from 'node:fs/promises';
 import { constants as fsConstants, mkdirSync, rmSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 
 // cyberismo
 import { type CardsOptions, Cmd, Commands } from '../src/command-handler.js';
@@ -21,7 +20,7 @@ import { resourceName } from '../src/utils/resource-utils.js';
 import { TemplateResource } from '../src/resources/template-resource.js';
 
 // Create test artifacts in a temp folder.
-const baseDir = dirname(fileURLToPath(import.meta.url));
+const baseDir = import.meta.dirname;
 const testDir = join(baseDir, 'tmp-command-handler-create-tests');
 
 const decisionRecordsPath = join(testDir, 'valid/decision-records');

--- a/tools/data-handler/test/command-handler-move.test.ts
+++ b/tools/data-handler/test/command-handler-move.test.ts
@@ -3,8 +3,7 @@ import { expect } from 'chai';
 
 // node
 import { mkdirSync, rmSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 
 // cyberismo
 import { type CardsOptions, Cmd, Commands } from '../src/command-handler.js';
@@ -13,7 +12,7 @@ import { Project } from '../src/containers/project.js';
 import { Show } from '../src/commands/index.js';
 
 // Create test artifacts in a temp folder.
-const baseDir = dirname(fileURLToPath(import.meta.url));
+const baseDir = import.meta.dirname;
 const testDir = join(baseDir, 'tmp-command-handler-move-tests');
 
 const decisionRecordsPath = join(testDir, 'valid/decision-records');

--- a/tools/data-handler/test/command-handler-rank.test.ts
+++ b/tools/data-handler/test/command-handler-rank.test.ts
@@ -3,8 +3,7 @@ import { expect } from 'chai';
 
 // node
 import { mkdirSync, rmSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 
 // cyberismo
 import { copyDir } from '../src/utils/file-utils.js';
@@ -13,7 +12,7 @@ import { Project } from '../src/containers/project.js';
 import { Show } from '../src/commands/index.js';
 
 // Create test artifacts in a temp folder.
-const baseDir = dirname(fileURLToPath(import.meta.url));
+const baseDir = import.meta.dirname;
 const testDir = join(baseDir, 'tmp-command-handler-rank-tests');
 
 const decisionRecordsPath = join(testDir, 'valid/decision-records');

--- a/tools/data-handler/test/command-handler-rename.test.ts
+++ b/tools/data-handler/test/command-handler-rename.test.ts
@@ -3,8 +3,7 @@ import { expect } from 'chai';
 
 // node
 import { mkdirSync, rmSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 
 // cyberismo
 import { copyDir } from '../src/utils/file-utils.js';
@@ -12,7 +11,7 @@ import { type CardsOptions, Cmd, Commands } from '../src/command-handler.js';
 import { errorFunction } from '../src/utils/log-utils.js';
 
 // Create test artifacts in a temp folder.
-const baseDir = dirname(fileURLToPath(import.meta.url));
+const baseDir = import.meta.dirname;
 const testDir = join(baseDir, 'tmp-command-handler-rename-tests');
 
 const decisionRecordsPath = join(testDir, 'valid/decision-records');

--- a/tools/data-handler/test/command-handler-report.test.ts
+++ b/tools/data-handler/test/command-handler-report.test.ts
@@ -4,15 +4,14 @@ import { expect } from 'chai';
 // node
 import { mkdirSync, rmSync } from 'node:fs';
 import { readFile, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 
 // cyberismo
 import { type CardsOptions, Cmd, Commands } from '../src/command-handler.js';
 import { copyDir } from '../src/utils/file-utils.js';
 
 // validation tests do not modify the content - so they can use the original files
-const baseDir = dirname(fileURLToPath(import.meta.url));
+const baseDir = import.meta.dirname;
 const testDir = join(baseDir, 'tmp-command-handler-report-tests');
 
 const decisionRecordsPath = join(testDir, 'valid/decision-records');

--- a/tools/data-handler/test/command-handler-transition.test.ts
+++ b/tools/data-handler/test/command-handler-transition.test.ts
@@ -4,8 +4,7 @@ import * as sinon from 'sinon';
 
 // node
 import { mkdirSync, rmSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 
 // cyberismo
 import { copyDir } from '../src/utils/file-utils.js';
@@ -14,7 +13,7 @@ import { Project } from '../src/containers/project.js';
 import { Show } from '../src/commands/index.js';
 
 // Create test artifacts in a temp folder.
-const baseDir = dirname(fileURLToPath(import.meta.url));
+const baseDir = import.meta.dirname;
 const testDir = join(baseDir, 'tmp-command-handler-transition-tests');
 const decisionRecordsPath = join(testDir, 'valid/decision-records');
 

--- a/tools/data-handler/test/command-handler-update.test.ts
+++ b/tools/data-handler/test/command-handler-update.test.ts
@@ -2,8 +2,7 @@
 import { expect } from 'chai';
 
 // node
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import { mkdirSync, rmSync } from 'node:fs';
 
 import { type CardType } from '../src/interfaces/resource-interfaces.js';
@@ -12,7 +11,7 @@ import { Project } from '../src/containers/project.js';
 import { ResourceCollector } from '../src/containers/project/resource-collector.js';
 import { Show, Update } from '../src/commands/index.js';
 
-const baseDir = dirname(fileURLToPath(import.meta.url));
+const baseDir = import.meta.dirname;
 const testDir = join(baseDir, 'tmp-update-tests');
 const decisionRecordsPath = join(testDir, 'valid/decision-records');
 let project: Project;

--- a/tools/data-handler/test/edit.test.ts
+++ b/tools/data-handler/test/edit.test.ts
@@ -1,16 +1,15 @@
 import { expect } from 'chai';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import { mkdirSync, rmSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 
 import { copyDir } from '../src/utils/file-utils.js';
 import { CommandManager } from '../src/command-manager.js';
 import { type Edit } from '../src/commands/index.js';
-import { fileURLToPath } from 'node:url';
 import type { ResourceName } from '../src/resources/file-resource.js';
 
 describe('edit card', () => {
-  const baseDir = dirname(fileURLToPath(import.meta.url));
+  const baseDir = import.meta.dirname;
   const testDir = join(baseDir, 'tmp-edit-tests');
   const decisionRecordsPath = join(testDir, 'valid/decision-records');
   let commands: CommandManager;

--- a/tools/data-handler/test/export.test.ts
+++ b/tools/data-handler/test/export.test.ts
@@ -1,13 +1,12 @@
 import { expect } from 'chai';
 
 import { mkdirSync, rmSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 
 import { type CardsOptions, Cmd, Commands } from '../src/command-handler.js';
 import { copyDir } from '../src/utils/file-utils.js';
-import { fileURLToPath } from 'node:url';
 
-const baseDir = dirname(fileURLToPath(import.meta.url));
+const baseDir = import.meta.dirname;
 const testDir = join(baseDir, 'tmp-export-tests');
 const testDirForExport = join(baseDir, 'tmp-command-export-site-tests');
 

--- a/tools/data-handler/test/macros/index.test.ts
+++ b/tools/data-handler/test/macros/index.test.ts
@@ -3,6 +3,17 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { stub } from 'sinon';
 
+// node
+import { join } from 'node:path';
+import { mkdirSync, rmSync } from 'node:fs';
+
+// dependencies
+import { Validator } from 'jsonschema';
+import Handlebars from 'handlebars';
+
+// cyberismo
+import BaseMacro from '../../src/macros/base-macro.js';
+import { copyDir } from '../../src/utils/file-utils.js';
 import {
   createAdmonition,
   createHtmlPlaceholder,
@@ -11,21 +22,16 @@ import {
   registerMacros,
   validateMacroContent,
 } from '../../src/macros/index.js';
-import { copyDir } from '../../src/utils/file-utils.js';
-import { dirname, join } from 'node:path';
-import { mkdirSync, rmSync } from 'node:fs';
-import { Validator } from 'jsonschema';
-import Handlebars from 'handlebars';
-import BaseMacro from '../../src/macros/base-macro.js';
-import type { MacroGenerationContext } from '../../src/interfaces/macros.js';
-import TaskQueue from '../../src/macros/task-queue.js';
-import { fileURLToPath } from 'node:url';
 import { Project } from '../../src/containers/project.js';
-import type { Mode } from '../../src/interfaces/macros.js';
-import type { Card } from '../../src/interfaces/project-interfaces.js';
+import TaskQueue from '../../src/macros/task-queue.js';
+
 import { MAX_LEVEL_OFFSET } from '../../src/utils/constants.js';
 
-const baseDir = dirname(fileURLToPath(import.meta.url));
+import type { Card } from '../../src/interfaces/project-interfaces.js';
+import type { MacroGenerationContext } from '../../src/interfaces/macros.js';
+import type { Mode } from '../../src/interfaces/macros.js';
+
+const baseDir = import.meta.dirname;
 const testDir = join(baseDir, 'tmp-calculate-tests');
 const decisionRecordsPath = join(testDir, 'valid/decision-records');
 let project: Project;

--- a/tools/data-handler/test/module-manager.test.ts
+++ b/tools/data-handler/test/module-manager.test.ts
@@ -4,16 +4,15 @@ import { describe, it } from 'mocha';
 
 // node
 import { mkdirSync, rmSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import * as os from 'node:os';
 
 import { copyDir } from '../src/utils/file-utils.js';
-import { fileURLToPath } from 'node:url';
 import { CommandManager } from '../src/command-manager.js';
 
 describe('module-manager', () => {
   const skipTest = process.env.CI && os.platform() === 'win32';
-  const baseDir = dirname(fileURLToPath(import.meta.url));
+  const baseDir = import.meta.dirname;
   const testDir = join(baseDir, 'tmp-module-manager-tests');
   const decisionRecordsPath = join(testDir, 'valid/decision-records');
   let commands: CommandManager;

--- a/tools/data-handler/test/project.test.ts
+++ b/tools/data-handler/test/project.test.ts
@@ -4,8 +4,7 @@ import { after, before, describe, it } from 'mocha';
 
 // node
 import { mkdirSync, rmSync } from 'node:fs';
-import { basename, dirname, join, resolve, sep } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { basename, join, resolve, sep } from 'node:path';
 
 import { copyDir } from '../src/utils/file-utils.js';
 import {
@@ -31,7 +30,7 @@ import type { WorkflowResource } from '../src/resources/workflow-resource.js';
 
 describe('project', () => {
   // Create test artifacts in a temp folder.
-  const baseDir = dirname(fileURLToPath(import.meta.url));
+  const baseDir = import.meta.dirname;
   const testDir = join(baseDir, 'tmp-project-tests');
 
   before(async () => {

--- a/tools/data-handler/test/remove.test.ts
+++ b/tools/data-handler/test/remove.test.ts
@@ -1,15 +1,13 @@
 import { expect } from 'chai';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import { mkdirSync, rmSync } from 'node:fs';
 
 import { copyDir } from '../src/utils/file-utils.js';
 import { CommandManager } from '../src/command-manager.js';
 import { Remove } from '../src/commands/remove.js';
 
-import { fileURLToPath } from 'node:url';
-
 describe('remove card', () => {
-  const baseDir = dirname(fileURLToPath(import.meta.url));
+  const baseDir = import.meta.dirname;
   const testDir = join(baseDir, 'tmp-remove-tests');
   const decisionRecordsPath = join(testDir, 'valid/decision-records');
   let commands: CommandManager;

--- a/tools/data-handler/test/resources.test.ts
+++ b/tools/data-handler/test/resources.test.ts
@@ -2,8 +2,7 @@
 import { expect } from 'chai';
 
 // node
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import { mkdirSync, rmSync } from 'node:fs';
 
 import { copyDir } from '../src/utils/file-utils.js';
@@ -359,7 +358,7 @@ describe('resources', function () {
   });
 
   describe('resource basic operations', () => {
-    const baseDir = dirname(fileURLToPath(import.meta.url));
+    const baseDir = import.meta.dirname;
     const testDir = join(baseDir, 'tmp-resource-classes-tests');
     const decisionRecordsPath = join(testDir, 'valid/decision-records');
     let project: Project;

--- a/tools/data-handler/test/show.test.ts
+++ b/tools/data-handler/test/show.test.ts
@@ -1,19 +1,18 @@
 import { expect } from 'chai';
 import { mkdirSync, rmSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import { readFile } from 'node:fs/promises';
 
 import { CommandManager } from '../src/command-manager.js';
 import { copyDir, writeFileSafe } from '../src/utils/file-utils.js';
 import { errorFunction } from '../src/utils/log-utils.js';
 import type { FetchCardDetails } from '../src/interfaces/project-interfaces.js';
-import { fileURLToPath } from 'node:url';
 import type { Show } from '../src/commands/index.js';
 import { writeJsonFile } from '../src/utils/json.js';
 import { resourceName } from '../src/resources/file-resource.js';
 
 describe('show', () => {
-  const baseDir = dirname(fileURLToPath(import.meta.url));
+  const baseDir = import.meta.dirname;
   const testDir = join(baseDir, 'tmp-show-tests');
   mkdirSync(testDir, { recursive: true });
   const decisionRecordsPath = join(testDir, 'valid/decision-records');

--- a/tools/data-handler/test/template.test.ts
+++ b/tools/data-handler/test/template.test.ts
@@ -4,8 +4,7 @@ import { after, before, describe, it } from 'mocha';
 
 // node
 import { mkdirSync, rmSync } from 'node:fs';
-import { dirname, join, sep } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join, sep } from 'node:path';
 
 import type {
   Card,
@@ -18,7 +17,7 @@ import { Template } from '../src/containers/template.js';
 import { TemplateResource } from '../src/resources/template-resource.js';
 
 // Create test artifacts in a temp directory.
-const baseDir = dirname(fileURLToPath(import.meta.url));
+const baseDir = import.meta.dirname;
 const testDir = join(baseDir, 'tmp-template-tests');
 let project: Project;
 let decisionRecordsPath: string;

--- a/tools/data-handler/test/utils/file-utils.test.ts
+++ b/tools/data-handler/test/utils/file-utils.test.ts
@@ -5,8 +5,7 @@ import { after, describe, it } from 'mocha';
 // node
 import { rmSync } from 'node:fs';
 import { access, mkdir, writeFile } from 'node:fs/promises';
-import { dirname, join, sep } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join, sep } from 'node:path';
 
 import {
   copyDir,
@@ -18,7 +17,7 @@ import {
   stripExtension,
 } from '../../src/utils/file-utils.js';
 
-const baseDir = dirname(fileURLToPath(import.meta.url));
+const baseDir = import.meta.dirname;
 const testDir = join(baseDir, 'tmp-file-utils-tests');
 
 before(async () => {

--- a/tools/data-handler/test/utils/resource-utils.test.ts
+++ b/tools/data-handler/test/utils/resource-utils.test.ts
@@ -3,8 +3,7 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
 // node
-import { dirname, join, sep } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join, sep } from 'node:path';
 
 import {
   pathToResourceName,
@@ -14,7 +13,6 @@ import {
   resourceNameToString,
   resourceFilePath,
 } from '../../src/utils/resource-utils.js';
-
 import { Project } from '../../src/containers/project.js';
 
 describe('resource utils', () => {
@@ -93,7 +91,7 @@ describe('resource utils', () => {
 describe('resource utils with Project instance', () => {
   let project: Project;
   before(() => {
-    const baseDir = dirname(fileURLToPath(import.meta.url));
+    const baseDir = import.meta.dirname;
     const decisionRecordsPath = join(
       baseDir,
       '../test-data/valid/decision-records',


### PR DESCRIPTION
There was recently one PR comment that `baseDir` was defined in a too complex way. The offending line was fixed. 

`BaseDir` should be set similarly elsewhere as well. 
