### PR TITLE
Fix errors in schemas

### DIFF
--- a/tools/assets/src/schema/macros/includeMacroSchema.json
+++ b/tools/assets/src/schema/macros/includeMacroSchema.json
@@ -11,12 +11,12 @@
       "description": "Optional offset to adjust the heading levels of the included content. Should be a number as string (e.g., '+1', '+2' or '-1')."
     },
     "title": {
-      "type": "enum",
+      "type": "string",
       "description": "Whether to include the title of the card in the included content. If 'only' is selected, the title will be the only content included.",
       "enum": ["include", "exclude", "only"]
     },
     "pageTitles": {
-      "type": "enum",
+      "type": "string",
       "description": "If discrete, page titles will be included as discrete headings(read asciidoctor docs for more info). If normal, page titles will be included as normal headings.",
       "enum": ["normal", "discrete"]
     }

--- a/tools/assets/src/schema/resources/graphModelSchema.json
+++ b/tools/assets/src/schema/resources/graphModelSchema.json
@@ -22,7 +22,7 @@
       "type": "string"
     }
   },
-  "required": ["displayName", "name", "displayName"],
+  "required": ["displayName", "name"],
   "title": "GraphModel",
   "type": "object"
 }

--- a/tools/assets/src/schema/resources/graphViewSchema.json
+++ b/tools/assets/src/schema/resources/graphViewSchema.json
@@ -22,7 +22,7 @@
       "type": "string"
     }
   },
-  "required": ["displayName", "name", "displayName"],
+  "required": ["displayName", "name"],
   "title": "GraphView",
   "type": "object"
 }


### PR DESCRIPTION
There are two minor errors in the current schemas: 
- for graphs, it refers to `displayName` being twice in `required` fields
- for macros, it uses `"type": "enum"` which is invalid JSON schema type. Replace it with `"string"`