### PR TITLE
Remove stderr about invalid JSON

### DIFF
--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -663,7 +663,7 @@ importCmd
             options.projectPath,
           );
           const moduleListPath = resolve(projectPath, '.temp/moduleList.json');
-          let moduleListContent = '';
+          let moduleListContent = '{ modules: [] }';
           try {
             moduleListContent = await readFile(moduleListPath, 'utf-8');
           } catch {


### PR DESCRIPTION
Running "app" tests prints out `<<<CYPRESS.STDERR.START>>>Unexpected end of JSON input...` in both locally and in CI. 

This is caused by CLI actually when it tries to read module list and fails. 