### PR TITLE
INTDEV-1007 Use resource content through existing resource APIs

### DIFF
--- a/tools/app/src/components/modals/NewCardModal.tsx
+++ b/tools/app/src/components/modals/NewCardModal.tsx
@@ -136,15 +136,13 @@ export function NewCardModal({ open, onClose, cardKey }: NewCardModalProps) {
   const categories = (templates || []).reduce<
     Record<string, TemplateConfiguration[]>
   >((acc, template) => {
-    const category = template.metadata.category || 'Uncategorized';
+    const category = template.category || 'Uncategorized';
     if (!acc[category]) {
       acc[category] = [];
     }
     if (
       !filter ||
-      template.metadata.displayName
-        ?.toLowerCase()
-        .includes(filter.toLowerCase()) ||
+      template.displayName?.toLowerCase().includes(filter.toLowerCase()) ||
       category.toLowerCase().includes(filter.toLowerCase())
     ) {
       acc[category].push(template);
@@ -238,10 +236,8 @@ export function NewCardModal({ open, onClose, cardKey }: NewCardModalProps) {
                             key={template.name}
                             isChosen={chosenTemplate === template.name}
                             onClick={() => setChosenTemplate(template.name)}
-                            name={
-                              template.metadata.displayName ?? template.name
-                            }
-                            description={template.metadata.description ?? ''}
+                            name={template.displayName ?? template.name}
+                            description={template.description ?? ''}
                           />
                         ))}
                       </Grid>

--- a/tools/backend/src/domain/resources/service.ts
+++ b/tools/backend/src/domain/resources/service.ts
@@ -384,6 +384,7 @@ export async function getFileContent(
   resource: string,
   fileName: string,
 ) {
+  // TODO: Use resource APIs to fetch resource content; showFile will be removed
   return commands.showCmd.showFile(
     resourceName(`${module}/${type}/${resource}`),
     fileName,

--- a/tools/backend/test/api.test.ts
+++ b/tools/backend/test/api.test.ts
@@ -110,9 +110,9 @@ test('templates endpoint returns proper data', async () => {
   expect(response.status).toBe(200);
   expect(result.length).toBe(3);
   expect(result[0].name).toBe('decision/templates/decision');
-  expect(result[0].metadata.description).toBe('description');
-  expect(result[0].metadata.displayName).toBe('Decision');
-  expect(result[0].metadata.category).toBe('category');
+  expect(result[0].description).toBe('description');
+  expect(result[0].displayName).toBe('Decision');
+  expect(result[0].category).toBe('category');
 });
 
 test('tree endpoint returns proper data', async () => {

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -989,6 +989,16 @@ program
         [type, typeDetail],
         Object.assign({}, options, program.opts()),
       );
+      // By default, do not show resources' content files
+      if (!options.details) {
+        if (
+          typeof result.payload === 'object' &&
+          result.payload !== null &&
+          'content' in result.payload
+        ) {
+          delete (result.payload as { content?: unknown }).content;
+        }
+      }
       handleResponse(result);
     }
   });

--- a/tools/data-handler/src/commands/show.ts
+++ b/tools/data-handler/src/commands/show.ts
@@ -332,6 +332,8 @@ export class Show {
 
   /**
    * Shows the content of a file in a resource.
+   * TODO: To be removed
+   * @deprecated
    * @param resourceName Name of the resource.
    * @param fileName Name of the file to show.
    * @returns the content of the file.
@@ -360,6 +362,8 @@ export class Show {
 
   /**
    * Shows all file names in a folder resource.
+   * TODO: To be removed
+   * @deprecated
    * @param resourceName Name of the resource.
    * @returns all file names in the resource.
    */

--- a/tools/data-handler/src/containers/card-container.ts
+++ b/tools/data-handler/src/containers/card-container.ts
@@ -18,9 +18,9 @@ import type { Dirent } from 'node:fs';
 import { readdir, readFile, writeFile } from 'node:fs/promises';
 
 import { findParentPath } from '../utils/card-utils.js';
+import { getFilesSync } from '../utils/file-utils.js';
 import { readJsonFile } from '../utils/json.js';
 import { writeJsonFile } from '../utils/json.js';
-import { getFilesSync } from '../utils/file-utils.js';
 
 // interfaces
 import {

--- a/tools/data-handler/src/interfaces/folder-content-interfaces.ts
+++ b/tools/data-handler/src/interfaces/folder-content-interfaces.ts
@@ -31,13 +31,6 @@ export const REVERSE_FILE_MAPPINGS = {
   viewTemplate: 'view.lp.hbs',
 } as const;
 
-// Content interface for Report resources
-export interface ReportContent {
-  contentTemplate: string;
-  queryTemplate: string;
-  schema?: Schema;
-}
-
 // Content interface for Graph Model resources
 export interface GraphModelContent {
   model?: string;
@@ -48,14 +41,29 @@ export interface GraphViewContent {
   viewTemplate?: string;
 }
 
-// Get property name for a filename
-export function propertyName(filename: string): string | undefined {
-  return ALL_FILE_MAPPINGS[filename as keyof typeof ALL_FILE_MAPPINGS];
+// Content interface for Report resources
+export interface ReportContent {
+  contentTemplate: string;
+  queryTemplate: string;
+  schema?: Schema;
 }
 
-// Get filename with property name
+/**
+ * Get filename with property name
+ * @param propertyName Property name.
+ * @returns filename that matches property name
+ */
 export function filename(propertyName: string): string | undefined {
   return REVERSE_FILE_MAPPINGS[
     propertyName as keyof typeof REVERSE_FILE_MAPPINGS
   ];
+}
+
+/**
+ * Get property name for a filename
+ * @param filename Filename.
+ * @returns property name that matches filename
+ */
+export function propertyName(filename: string): string | undefined {
+  return ALL_FILE_MAPPINGS[filename as keyof typeof ALL_FILE_MAPPINGS];
 }

--- a/tools/data-handler/src/interfaces/folder-content-interfaces.ts
+++ b/tools/data-handler/src/interfaces/folder-content-interfaces.ts
@@ -1,0 +1,97 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2025
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { Schema } from 'jsonschema';
+
+// File mappings for Report resources
+export const REPORT_FILE_MAPPINGS = {
+  'index.adoc.hbs': 'contentTemplate',
+  'query.lp.hbs': 'queryTemplate',
+  'parameterSchema.json': 'schema',
+};
+
+// File mappings for Graph Model resources
+export const GRAPH_MODEL_FILE_MAPPINGS = {
+  'model.lp': 'model',
+};
+
+// File mappings for Graph View resources
+export const GRAPH_VIEW_FILE_MAPPINGS = {
+  'view.lp.hbs': 'viewTemplate',
+};
+
+// All file mappings combined for lookup
+export const ALL_FILE_MAPPINGS = {
+  ...REPORT_FILE_MAPPINGS,
+  ...GRAPH_MODEL_FILE_MAPPINGS,
+  ...GRAPH_VIEW_FILE_MAPPINGS,
+};
+
+// Reverse mappings from property names to filenames
+export const REVERSE_FILE_MAPPINGS = {
+  contentTemplate: 'index.adoc.hbs',
+  queryTemplate: 'query.lp.hbs',
+  schema: 'parameterSchema.json',
+  model: 'model.lp',
+  viewTemplate: 'view.lp.hbs',
+};
+
+// Content interface for Report resources
+export interface ReportContent {
+  contentTemplate: string;
+  queryTemplate: string;
+  schema?: Schema;
+}
+
+// Content interface for Graph Model resources
+export interface GraphModelContent {
+  model?: string;
+}
+
+// Content interface for Graph View resources
+export interface GraphViewContent {
+  viewTemplate?: string;
+}
+
+// Check if a filename is a report file
+export function isReportFile(
+  filename: string,
+): filename is keyof typeof REPORT_FILE_MAPPINGS {
+  return filename in REPORT_FILE_MAPPINGS;
+}
+
+// Check if a filename is a graph model file
+export function isGraphModelFile(
+  filename: string,
+): filename is keyof typeof GRAPH_MODEL_FILE_MAPPINGS {
+  return filename in GRAPH_MODEL_FILE_MAPPINGS;
+}
+
+// Check if a filename is a graph view file
+export function isGraphViewFile(
+  filename: string,
+): filename is keyof typeof GRAPH_VIEW_FILE_MAPPINGS {
+  return filename in GRAPH_VIEW_FILE_MAPPINGS;
+}
+
+// Get property name for a filename
+export function propertyName(filename: string): string | undefined {
+  return ALL_FILE_MAPPINGS[filename as keyof typeof ALL_FILE_MAPPINGS];
+}
+
+// Get filename with property name
+export function filename(propertyName: string): string | undefined {
+  return REVERSE_FILE_MAPPINGS[
+    propertyName as keyof typeof REVERSE_FILE_MAPPINGS
+  ];
+}

--- a/tools/data-handler/src/interfaces/folder-content-interfaces.ts
+++ b/tools/data-handler/src/interfaces/folder-content-interfaces.ts
@@ -13,29 +13,14 @@
 
 import type { Schema } from 'jsonschema';
 
-// File mappings for Report resources
-export const REPORT_FILE_MAPPINGS = {
+// All file mappings for lookup (filename -> property name)
+export const ALL_FILE_MAPPINGS = {
   'index.adoc.hbs': 'contentTemplate',
   'query.lp.hbs': 'queryTemplate',
   'parameterSchema.json': 'schema',
-};
-
-// File mappings for Graph Model resources
-export const GRAPH_MODEL_FILE_MAPPINGS = {
   'model.lp': 'model',
-};
-
-// File mappings for Graph View resources
-export const GRAPH_VIEW_FILE_MAPPINGS = {
   'view.lp.hbs': 'viewTemplate',
-};
-
-// All file mappings combined for lookup
-export const ALL_FILE_MAPPINGS = {
-  ...REPORT_FILE_MAPPINGS,
-  ...GRAPH_MODEL_FILE_MAPPINGS,
-  ...GRAPH_VIEW_FILE_MAPPINGS,
-};
+} as const;
 
 // Reverse mappings from property names to filenames
 export const REVERSE_FILE_MAPPINGS = {
@@ -44,7 +29,7 @@ export const REVERSE_FILE_MAPPINGS = {
   schema: 'parameterSchema.json',
   model: 'model.lp',
   viewTemplate: 'view.lp.hbs',
-};
+} as const;
 
 // Content interface for Report resources
 export interface ReportContent {
@@ -61,27 +46,6 @@ export interface GraphModelContent {
 // Content interface for Graph View resources
 export interface GraphViewContent {
   viewTemplate?: string;
-}
-
-// Check if a filename is a report file
-export function isReportFile(
-  filename: string,
-): filename is keyof typeof REPORT_FILE_MAPPINGS {
-  return filename in REPORT_FILE_MAPPINGS;
-}
-
-// Check if a filename is a graph model file
-export function isGraphModelFile(
-  filename: string,
-): filename is keyof typeof GRAPH_MODEL_FILE_MAPPINGS {
-  return filename in GRAPH_MODEL_FILE_MAPPINGS;
-}
-
-// Check if a filename is a graph view file
-export function isGraphViewFile(
-  filename: string,
-): filename is keyof typeof GRAPH_VIEW_FILE_MAPPINGS {
-  return filename in GRAPH_VIEW_FILE_MAPPINGS;
 }
 
 // Get property name for a filename

--- a/tools/data-handler/src/interfaces/resource-interfaces.ts
+++ b/tools/data-handler/src/interfaces/resource-interfaces.ts
@@ -11,7 +11,11 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import type { Schema } from 'jsonschema';
+import type {
+  ReportContent,
+  GraphModelContent,
+  GraphViewContent,
+} from './folder-content-interfaces.js';
 
 /**
  * Each resource represents a file (or a folder in some cases) with metadata stored
@@ -73,18 +77,16 @@ export interface GraphModelMetadata extends ResourceBaseMetadata {
 }
 
 export interface GraphModel extends GraphModelMetadata {
-  calculationFile: string;
+  content: GraphModelContent;
 }
-
 // Graph view content.
 export interface GraphViewMetadata extends ResourceBaseMetadata {
   category?: string;
 }
 
 export interface GraphView extends GraphViewMetadata {
-  handleBarFile: string;
+  content: GraphViewContent;
 }
-
 // Link content.
 export interface Link {
   linkType: string;
@@ -103,11 +105,7 @@ export interface LinkType extends ResourceBaseMetadata {
 
 // Report resource.
 export interface Report extends ResourceBaseMetadata {
-  name: string;
-  metadata: ReportMetadata;
-  contentTemplate: string;
-  queryTemplate: string;
-  schema?: Schema;
+  content: ReportContent;
 }
 
 // Metadata for report

--- a/tools/data-handler/src/interfaces/resource-interfaces.ts
+++ b/tools/data-handler/src/interfaces/resource-interfaces.ts
@@ -12,9 +12,9 @@
 */
 
 import type {
-  ReportContent,
   GraphModelContent,
   GraphViewContent,
+  ReportContent,
 } from './folder-content-interfaces.js';
 
 /**
@@ -34,6 +34,12 @@ export interface CardType extends ResourceBaseMetadata {
   customFields: CustomField[];
   alwaysVisibleFields: string[];
   optionallyVisibleFields: string[];
+}
+
+// Base content update key interface
+export interface ContentUpdateKey {
+  key: 'content';
+  subKey: string; // Resource-specific types should narrow this
 }
 
 // Custom field
@@ -75,18 +81,30 @@ export interface FieldType extends ResourceBaseMetadata {
 export interface GraphModelMetadata extends ResourceBaseMetadata {
   category?: string;
 }
-
 export interface GraphModel extends GraphModelMetadata {
   content: GraphModelContent;
 }
+export type GraphModelContentPropertyName = 'model';
+export interface GraphModelContentUpdateKey {
+  key: 'content';
+  subKey: GraphModelContentPropertyName;
+}
+export type GraphModelUpdateKey = string | GraphModelContentUpdateKey;
+
 // Graph view content.
 export interface GraphViewMetadata extends ResourceBaseMetadata {
   category?: string;
 }
-
+export type GraphViewContentPropertyName = 'viewTemplate';
 export interface GraphView extends GraphViewMetadata {
   content: GraphViewContent;
 }
+export interface GraphViewContentUpdateKey {
+  key: 'content';
+  subKey: GraphViewContentPropertyName;
+}
+export type GraphViewUpdateKey = string | GraphViewContentUpdateKey;
+
 // Link content.
 export interface Link {
   linkType: string;
@@ -107,6 +125,18 @@ export interface LinkType extends ResourceBaseMetadata {
 export interface Report extends ResourceBaseMetadata {
   content: ReportContent;
 }
+
+// Resource-specific content names
+export type ReportContentPropertyName =
+  | 'contentTemplate'
+  | 'queryTemplate'
+  | 'schema';
+// Resource-specific content update keys
+export interface ReportContentUpdateKey {
+  key: 'content';
+  subKey: ReportContentPropertyName;
+}
+export type ReportUpdateKey = string | ReportContentUpdateKey;
 
 // Metadata for report
 export interface ReportMetadata extends ResourceBaseMetadata {
@@ -144,6 +174,9 @@ export interface TemplateConfiguration extends ResourceBaseMetadata {
 export interface TemplateMetadata extends ResourceBaseMetadata {
   category?: string;
 }
+
+// Generic update key (content updates only use typed keys)
+export type UpdateKey = string | ContentUpdateKey;
 
 // Workflow's json file content.
 export interface Workflow extends ResourceBaseMetadata {

--- a/tools/data-handler/src/interfaces/resource-interfaces.ts
+++ b/tools/data-handler/src/interfaces/resource-interfaces.ts
@@ -131,7 +131,6 @@ export type ReportContentPropertyName =
   | 'contentTemplate'
   | 'queryTemplate'
   | 'schema';
-// Resource-specific content update keys
 export interface ReportContentUpdateKey {
   key: 'content';
   subKey: ReportContentPropertyName;
@@ -164,10 +163,9 @@ export type ResourceContent =
   | Workflow;
 
 // Template configuration details.
-export interface TemplateConfiguration extends ResourceBaseMetadata {
+export interface TemplateConfiguration extends TemplateMetadata {
   path: string;
   numberOfCards: number;
-  metadata: TemplateMetadata;
 }
 
 // Template configuration content details.
@@ -175,7 +173,7 @@ export interface TemplateMetadata extends ResourceBaseMetadata {
   category?: string;
 }
 
-// Generic update key (content updates only use typed keys)
+// Generic update key
 export type UpdateKey = string | ContentUpdateKey;
 
 // Workflow's json file content.

--- a/tools/data-handler/src/macros/report/index.ts
+++ b/tools/data-handler/src/macros/report/index.ts
@@ -45,16 +45,16 @@ class ReportMacro extends BaseMacro {
 
     if (!report) throw new Error(`Report ${options.name} does not exist`);
 
-    if (report.schema) {
+    if (report.content.schema) {
       validateJson(options, {
-        schema: report.schema,
+        schema: report.content.schema,
       });
     }
     try {
       return await generateReportContent({
         calculate: context.project.calculationEngine,
-        contentTemplate: report.contentTemplate,
-        queryTemplate: report.queryTemplate,
+        contentTemplate: report.content.contentTemplate,
+        queryTemplate: report.content.queryTemplate,
         options: {
           cardKey: context.cardKey,
           ...options,

--- a/tools/data-handler/src/resources/graph-model-resource.ts
+++ b/tools/data-handler/src/resources/graph-model-resource.ts
@@ -30,6 +30,7 @@ import {
 import type {
   GraphModel,
   GraphModelMetadata,
+  GraphModelUpdateKey,
 } from '../interfaces/resource-interfaces.js';
 import type { GraphModelContent } from '../interfaces/folder-content-interfaces.js';
 import { writeFileSafe } from '../utils/file-utils.js';
@@ -47,8 +48,11 @@ export class GraphModelResource extends FolderResource {
     this.initialize();
   }
 
-  // When resource name changes.
-  private async handleNameChange(existingName: string) {
+  /**
+   * Handle name changes for graph models
+   * @param existingName The previous name before the change
+   */
+  protected async onNameChange(existingName: string): Promise<void> {
     await Promise.all([
       super.updateHandleBars(existingName, this.content.name, [
         await this.calculationFile(),
@@ -123,7 +127,7 @@ export class GraphModelResource extends FolderResource {
   public async rename(newName: ResourceName) {
     const existingName = this.content.name;
     await super.rename(newName);
-    return this.handleNameChange(existingName);
+    return this.onNameChange(existingName);
   }
 
   /**
@@ -142,39 +146,17 @@ export class GraphModelResource extends FolderResource {
    * Updates graph model resource.
    * @param key Key to modify
    * @param op Operation to perform on 'key'
-   * @throws if key is unknown.
    */
-  public async update<Type>(key: string, op: Operation<Type>) {
-    const nameChange = key === 'name';
-    const existingName = this.content.name;
-    if (key === 'content' || super.isContentFilePath(key)) {
-      return key === 'content'
-        ? await super.handleContentUpdate(op)
-        : await super.handleContentFileUpdate(key, op);
+  public async update<Type>(key: GraphModelUpdateKey, op: Operation<Type>) {
+    if (key === 'category') {
+      const content = structuredClone(this.content) as GraphModelMetadata;
+      content.category = super.handleScalar(op) as string;
+
+      await super.postUpdate(content, key, op);
+      return;
     }
 
     await super.update(key, op);
-
-    const content = structuredClone(this.content) as GraphModel;
-
-    if (key === 'name') {
-      content.name = super.handleScalar(op) as string;
-    } else if (key === 'displayName') {
-      content.displayName = super.handleScalar(op) as string;
-    } else if (key === 'description') {
-      content.description = super.handleScalar(op) as string;
-    } else if (key === 'category') {
-      content.category = super.handleScalar(op) as string;
-    } else {
-      throw new Error(`Unknown property '${key}' for GraphModel`);
-    }
-
-    await super.postUpdate(content, key, op);
-
-    // Renaming this graph model causes that references to its name must be updated.
-    if (nameChange) {
-      await this.handleNameChange(existingName);
-    }
   }
 
   /**

--- a/tools/data-handler/src/resources/report-resource.ts
+++ b/tools/data-handler/src/resources/report-resource.ts
@@ -17,17 +17,21 @@ import { readFileSync } from 'node:fs';
 import { extname, join } from 'node:path';
 
 import { copyDir } from '../utils/file-utils.js';
-import type {
-  Card,
-  Operation,
-  Project,
-  ResourceName,
-} from './folder-resource.js';
 import {
   DefaultContent,
   FolderResource,
   resourceNameToString,
   sortCards,
+} from './folder-resource.js';
+import { getStaticDirectoryPath } from '@cyberismo/assets';
+import { filename } from '../interfaces/folder-content-interfaces.js';
+import { Validate } from '../commands/validate.js';
+
+import type {
+  Card,
+  Operation,
+  Project,
+  ResourceName,
 } from './folder-resource.js';
 import type {
   Report,
@@ -36,8 +40,6 @@ import type {
 } from '../interfaces/resource-interfaces.js';
 import type { ReportContent } from '../interfaces/folder-content-interfaces.js';
 import type { Schema } from 'jsonschema';
-import { getStaticDirectoryPath } from '@cyberismo/assets';
-import { Validate } from '../commands/validate.js';
 
 const REPORT_SCHEMA_FILE = 'parameterSchema.json';
 const PARAMETER_SCHEMA_ID = 'jsonSchema';
@@ -180,7 +182,7 @@ export class ReportResource extends FolderResource {
       key.subKey === 'schema'
     ) {
       const fileContent = JSON.stringify(super.handleScalar(op), null, 2);
-      await this.updateFile('parameterSchema.json', fileContent);
+      await this.updateFile(filename(key.subKey)!, fileContent);
       return;
     }
 

--- a/tools/data-handler/src/resources/template-resource.ts
+++ b/tools/data-handler/src/resources/template-resource.ts
@@ -119,8 +119,8 @@ export class TemplateResource extends FolderResource {
     const container = this.templateObject();
 
     return {
-      metadata: templateMetadata,
       name: resourceNameToString(this.resourceName),
+      category: templateMetadata.category,
       displayName: templateMetadata.displayName,
       description: templateMetadata.description,
       path: this.fileName,

--- a/tools/data-handler/src/resources/template-resource.ts
+++ b/tools/data-handler/src/resources/template-resource.ts
@@ -57,13 +57,15 @@ export class TemplateResource extends FolderResource {
     });
   }
 
-  // When resource name changes.
-  private async handleNameChange(existingName: string) {
+  /**
+   * Handle name changes for templates
+   * @param existingName The previous name before the change
+   */
+  protected async onNameChange(existingName: string): Promise<void> {
     await Promise.all([
       super.updateHandleBars(existingName, this.content.name),
       super.updateCalculations(existingName, this.content.name),
     ]);
-    // Finally, write updated content.
     await this.write();
   }
 
@@ -105,7 +107,7 @@ export class TemplateResource extends FolderResource {
   public async rename(newName: ResourceName) {
     const existingName = this.content.name;
     await super.rename(newName);
-    return this.handleNameChange(existingName);
+    return this.onNameChange(existingName);
   }
 
   /**
@@ -144,7 +146,10 @@ export class TemplateResource extends FolderResource {
     const nameChange = key === 'name';
     const existingName = this.content.name;
 
-    await super.update(key, op);
+    // Only call super.update for keys that base class supports
+    if (key === 'name' || key === 'displayName' || key === 'description') {
+      await super.update(key, op);
+    }
 
     const content = structuredClone(this.content) as TemplateMetadata;
 
@@ -164,7 +169,7 @@ export class TemplateResource extends FolderResource {
 
     // Renaming this template causes that references to its name must be updated.
     if (nameChange) {
-      await this.handleNameChange(existingName);
+      await this.onNameChange(existingName);
     }
   }
 

--- a/tools/data-handler/test/command-edit.test.ts
+++ b/tools/data-handler/test/command-edit.test.ts
@@ -7,6 +7,7 @@ import { copyDir } from '../src/utils/file-utils.js';
 import { CommandManager } from '../src/command-manager.js';
 import { type Edit } from '../src/commands/index.js';
 import type { ResourceName } from '../src/resources/file-resource.js';
+import { GraphViewResource } from '../src/resources/graph-view-resource.js';
 
 describe('edit card', () => {
   const baseDir = import.meta.dirname;
@@ -214,13 +215,11 @@ describe('edit card', () => {
       identifier: 'test',
     };
     await editCmd.editResourceContent(resourceName, 'view.lp.hbs', 'whoopie');
-    const content = await commands.showCmd.showFile(
-      resourceName,
-      'view.lp.hbs',
-    );
-    expect(content).to.equal('whoopie');
+    const res = new GraphViewResource(commands.project, resourceName);
+    const data = await res.show();
+    expect(data.content.viewTemplate).to.equal('whoopie');
   });
-  it('try to edit folder resource content - file is not whitelisted', async () => {
+  it('try to edit folder resource content - file is not allowed', async () => {
     const resourceName = {
       prefix: 'decision',
       type: 'graphViews',
@@ -228,7 +227,7 @@ describe('edit card', () => {
     };
     await expect(
       editCmd.editResourceContent(resourceName, 'random.file', 'whoopie'),
-    ).to.be.rejectedWith("File 'random.file' is not whitelisted");
+    ).to.be.rejectedWith("File 'random.file' is not allowed");
   });
   describe('edit calculation', () => {
     before(async () => {

--- a/tools/data-handler/test/command-show.test.ts
+++ b/tools/data-handler/test/command-show.test.ts
@@ -11,6 +11,7 @@ import { copyDir, writeFileSafe } from '../src/utils/file-utils.js';
 import { errorFunction } from '../src/utils/log-utils.js';
 import { Project } from '../src/containers/project.js';
 import { resourceName } from '../src/resources/file-resource.js';
+import { ReportResource } from '../src/resources/report-resource.js';
 import { Show } from '../src/commands/index.js';
 import { writeJsonFile } from '../src/utils/json.js';
 import type {
@@ -1019,18 +1020,20 @@ describe('show', () => {
   });
 
   it('showFile (success)', async () => {
+    // TODO: Test to be renamed and moved to resource tests once showFile has been removed
     const resourceNameStr = 'decision/reports/anotherReport';
-    const fileName = 'index.adoc.hbs';
-    const result = await showCmd.showFile(
+    const res = new ReportResource(
+      commands.project,
       resourceName(resourceNameStr),
-      fileName,
     );
+    const result = (await res.show()).content.contentTemplate;
     expect(result).to.not.equal(undefined);
     expect(result).to.be.a('string');
     expect(result.length).to.be.greaterThan(0);
   });
 
   it('showFile - resource does not exist', async () => {
+    // TODO: Test to be removed once showFile has been removed
     const resourceNameStr = 'decision/reports/nonExistentReport';
     const fileName = 'index.adoc.hbs';
     await showCmd
@@ -1043,6 +1046,7 @@ describe('show', () => {
   });
 
   it('showFile - resource is not a folder resource', async () => {
+    // TODO: Test to be removed once showFile has been removed
     const resourceNameStr = 'decision/cardTypes/decision';
     const fileName = 'some-file.txt';
     await showCmd
@@ -1055,6 +1059,7 @@ describe('show', () => {
   });
 
   it('showFile - file does not exist in resource', async () => {
+    // TODO: Test to be removed once showFile has been removed
     const resourceNameStr = 'decision/reports/anotherReport';
     const fileName = 'nonExistentFile.txt';
     await showCmd

--- a/tools/data-handler/test/resources.test.ts
+++ b/tools/data-handler/test/resources.test.ts
@@ -1949,26 +1949,19 @@ describe('resources', function () {
         project,
         resourceName('decision/reports/newREP'),
       );
-      await res.update('content/contentTemplate', {
-        name: 'change',
-        target: '',
-        to: 'Updated template',
-      });
-      const data = await res.show();
-      expect(data.content.contentTemplate).to.include('Updated');
-    });
-    it('try to update report content that is not valid', async () => {
-      const res = new ReportResource(
-        project,
-        resourceName('decision/reports/newREP'),
-      );
-      await expect(
-        res.update('content/nonExists', {
+      await res.update(
+        {
+          key: 'content',
+          subKey: 'contentTemplate',
+        },
+        {
           name: 'change',
           target: '',
-          to: 'Updated description',
-        }),
-      ).to.be.rejectedWith("File 'nonExists' is not allowed");
+          to: 'Updated template',
+        },
+      );
+      const data = await res.show();
+      expect(data.content.contentTemplate).to.include('Updated');
     });
     it('update template scalar values', async () => {
       const res = new TemplateResource(

--- a/tools/data-handler/test/resources.test.ts
+++ b/tools/data-handler/test/resources.test.ts
@@ -1089,10 +1089,7 @@ describe('resources', function () {
       const { path, ...others } = data;
       expect(others).to.deep.equal({
         description: undefined,
-        metadata: {
-          name: 'decision/templates/newTEMP',
-          displayName: '',
-        },
+        category: undefined,
         name: 'decision/templates/newTEMP',
         displayName: '',
         numberOfCards: 0,

--- a/tools/data-handler/test/template.test.ts
+++ b/tools/data-handler/test/template.test.ts
@@ -390,12 +390,15 @@ describe('template', () => {
     );
 
     const templateDetails = await template.show();
+
+    console.error(templateDetails);
+
     expect(templateDetails.name).to.equal('decision/templates/decision');
     expect(templateDetails.path).includes('.cards');
     expect(templateDetails.path).includes('decision');
-    expect(templateDetails.metadata.description).to.equal('description');
-    expect(templateDetails.metadata.category).to.equal('category');
-    expect(templateDetails.metadata.displayName).to.equal('Decision');
+    expect(templateDetails.description).to.equal('description');
+    expect(templateDetails.category).to.equal('category');
+    expect(templateDetails.displayName).to.equal('Decision');
   });
   it('list template cards', async () => {
     const decisionRecordsPath = join(testDir, 'valid/decision-records');


### PR DESCRIPTION
Add new property `content` for folder based resources (except `template` which has cards, and have its own APIs for handling them). 

Content for each folder resource can be seen through using `show()` and changed through `update()`. 
Accessing certain known content type uses well-known names (e.g. `schema`, `templateContent`). 

Interfaces for the folder resources have been modified. Report has been standardised not to have double `displayName` and `description` properties visible when using `show()`.  There are APIs in place (for internal use) that map well known names to actual filenames and vice versa. 

For example, to update the Graph Model calculations (in file 'model.lp'), one would call:
```
const res = new GraphModelResource(
    project,
    resourceName('decision/graphModels/newGraphModel'),
);
...
await res.update(
    {
        key: 'content',
        subKey: 'model', // note that this is now strongly typed; so calling with 'whatever' will cause compilation error
    },
    {
        name: 'change',
        target: '',
        to: '<new content>',
    },
);
```
<del>
 It is also possible to update ALL of the content (files) by using just `content` and then providing an object where each property match to well known property.
</del>

Folder resources have internal cache for files. Thus, the files are not read from disk again unless resource is being changed.

By default, CLI will show "basic" data of the resources. If using `--details` it will show `content` object as well.


**Once this has been merged:** 
- remove `Show::showFile()` method, should use resource specific `show()`
- remove `Show::showFileNames()` method, should use resource specific `show()`
- remove `Edit::editCalculation()` method, should calculation resource `update()`
- remove `Create::createCalculation()` method, should use normal create resource methods
- change `Edit:resourceContent()` to use `update()` with `content/<type>`
- for removed method callers, change to use various resource methods.


