### PR TITLE
INTDEV-1015 CLI: Show version command

### DIFF
--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -129,6 +129,16 @@ dotenv.config({ quiet: true });
 // Commander
 const program = new Command();
 
+// Version information
+program.command('--version', 'show binary version').action(async () => {
+  const pack = (
+    await import('../package.json', {
+      with: { type: 'json' },
+    })
+  ).default;
+  console.log(pack.version);
+});
+
 // CLI command handler
 const commandHandler = new Commands();
 

--- a/tools/cli/test/cli.test.ts
+++ b/tools/cli/test/cli.test.ts
@@ -25,7 +25,11 @@ describe('Cli BAT test', function () {
         console.log(error);
       }
       expect(error).to.be.null;
-      expect(stdout).to.include('0.0.12');
+      // Expect version information to be <int>.<int>.<int>,
+      // where each can be single or multiple digits (0-9)
+      const re = /^(\d+\.)?(\d+\.)?(\d+)$/gm;
+      const valid = re.test(stdout.trim());
+      expect(valid).to.equal(true);
       done();
     });
   });

--- a/tools/cli/test/cli.test.ts
+++ b/tools/cli/test/cli.test.ts
@@ -19,6 +19,16 @@ describe('Cli BAT test', function () {
     rmSync(cliPath, { recursive: true, force: true });
     return true;
   });
+  it('check version', function (done) {
+    exec('cyberismo --version', (error, stdout, _stderr) => {
+      if (error != null) {
+        console.log(error);
+      }
+      expect(error).to.be.null;
+      expect(stdout).to.include('0.0.12');
+      done();
+    });
+  });
   it('validate test-module', function (done) {
     exec(
       `cd ../../module-test&&cyberismo validate`,


### PR DESCRIPTION
Shows version information by using: `cyberismo show version`. 
For now, only singular version (data-handler's) is shown in the received object.

In the future, we can expand this with other sub-projects (though they should share same version name) and versions of the data (if we make data versional apart from binary version) and used modules.