### PR TITLE
INTDEV-1035 Fix default JSON file

### DIFF
--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -679,7 +679,7 @@ importCmd
             options.projectPath,
           );
           const moduleListPath = resolve(projectPath, '.temp/moduleList.json');
-          let moduleListContent = '{ modules: [] }';
+          let moduleListContent = '{ "modules": [] }';
           try {
             moduleListContent = await readFile(moduleListPath, 'utf-8');
           } catch {


### PR DESCRIPTION
The default JSON for `modules` needs to have quotes to avoid spewing out error when JSON is written.