### PR TITLE
INTDEV-1034 Make video blocks full width

### DIFF
--- a/tools/app/src/globals.css
+++ b/tools/app/src/globals.css
@@ -1113,7 +1113,6 @@
   min-width: 160px;
 }
 
-
 /* ------------------------------------------------------------
    Responsive video embeds for AsciiDoc-generated videoblock
    (.doc .videoblock). This wraps the existing iframe in an

--- a/tools/app/src/globals.css
+++ b/tools/app/src/globals.css
@@ -1112,3 +1112,32 @@
 .contentSidebar {
   min-width: 160px;
 }
+
+
+/* ------------------------------------------------------------
+   Responsive video embeds for AsciiDoc-generated videoblock
+   (.doc .videoblock). This wraps the existing iframe in an
+   intrinsic ratio box using the .content div.
+   ------------------------------------------------------------ */
+.doc .videoblock .content {
+  position: relative;
+  width: 100%;
+  max-width: 100%;
+}
+
+.doc .videoblock .content::before {
+  content: '';
+  display: block;
+  padding-top: 56.25%; /* 16:9 */
+}
+
+.doc .videoblock .content > iframe,
+.doc .videoblock .content > video {
+  position: absolute;
+  inset: 0;
+  width: 100% !important;
+  height: 100% !important;
+  border: 0;
+  background: #000;
+  display: block;
+}


### PR DESCRIPTION
Tested at least with 16:9 aspect ratio Vimeo embed.

Unfortunately, the CSS is dependent on a fixed aspect ratio. But this is better than nothing, I suppose.

<img width="1080" height="609" alt="image" src="https://github.com/user-attachments/assets/b4df30f1-7d6b-455d-8adf-d22b47e4879c" />
