### PR TITLE
INTDEV-1021 Calc engine improvements

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,9 +322,6 @@ importers:
       '@viz-js/viz':
         specifier: ^3.24.0
         version: 3.24.0
-      async-mutex:
-        specifier: ^0.5.0
-        version: 0.5.0
       csv-parse:
         specifier: ^6.1.0
         version: 6.1.0
@@ -2467,9 +2464,6 @@ packages:
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
-
-  async-mutex@0.5.0:
-    resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -7592,10 +7586,6 @@ snapshots:
   assertion-error@2.0.1: {}
 
   astral-regex@2.0.0: {}
-
-  async-mutex@0.5.0:
-    dependencies:
-      tslib: 2.8.1
 
   asynckit@0.4.0: {}
 

--- a/tools/backend/src/domain/cards/lib.ts
+++ b/tools/backend/src/domain/cards/lib.ts
@@ -42,11 +42,6 @@ export async function getCardDetails(
       return { status: 400, message: `Card ${key} not found from project` };
     }
 
-    // always parse for now if not in export mode
-    if (!staticMode && !raw) {
-      await commands.calculateCmd.generate();
-    }
-
     let asciidocContent = '';
     try {
       asciidocContent = await evaluateMacros(
@@ -138,6 +133,7 @@ export async function getCardDetails(
       : await commands.calculateCmd.runQuery('card', 'localApp', {
           cardKey: key,
         });
+
     if (card.length !== 1) {
       throw new Error('Query failed. Check card-query syntax');
     }

--- a/tools/backend/src/domain/connectors/service.ts
+++ b/tools/backend/src/domain/connectors/service.ts
@@ -27,7 +27,6 @@ export interface Connector {
 export async function getConnectors(
   commands: CommandManager,
 ): Promise<Connector[]> {
-  await commands.calculateCmd.generate();
   const results = await commands.calculateCmd.runQuery(
     'connectors',
     'localApp',

--- a/tools/backend/src/domain/tree/service.ts
+++ b/tools/backend/src/domain/tree/service.ts
@@ -27,7 +27,6 @@ export async function getCardTree(
   cardKey?: string,
   recursive?: boolean,
 ): ReturnType<typeof commands.calculateCmd.runQuery> {
-  await commands.calculateCmd.generate();
   return commands.calculateCmd.runQuery(
     'tree',
     isSsg ? 'exportedSite' : 'localApp',

--- a/tools/backend/src/export.ts
+++ b/tools/backend/src/export.ts
@@ -52,7 +52,7 @@ export async function getCardQueryResult(
 ): Promise<QueryResult<'card'>[]> {
   if (!_cardQueryPromise) {
     // fetch all cards
-    _cardQueryPromise = commands.project.calculationEngine.runQuery(
+    _cardQueryPromise = commands.calculateCmd.runQuery(
       'card',
       'exportedSite',
       {},

--- a/tools/backend/src/export.ts
+++ b/tools/backend/src/export.ts
@@ -109,7 +109,6 @@ export async function exportSite(
   );
 
   reset();
-  await commands.project.calculationEngine.generate();
 
   // estimate total based on the number of cards to export
   const cards = await findAllCards(commands, opts);

--- a/tools/backend/test/export.test.ts
+++ b/tools/backend/test/export.test.ts
@@ -16,7 +16,7 @@ describe('export module', () => {
     function createMockCommands(mockCards: { key: string; title: string }[]) {
       const runQuery = vi.fn().mockResolvedValue(mockCards);
       const commands = {
-        calculatateCmd: { runQuery },
+        calculateCmd: { runQuery },
       } as unknown as CommandManager;
       return { commands, runQuery };
     }

--- a/tools/backend/test/export.test.ts
+++ b/tools/backend/test/export.test.ts
@@ -16,9 +16,7 @@ describe('export module', () => {
     function createMockCommands(mockCards: { key: string; title: string }[]) {
       const runQuery = vi.fn().mockResolvedValue(mockCards);
       const commands = {
-        project: {
-          calculationEngine: { runQuery },
-        },
+        calculatateCmd: { runQuery },
       } as unknown as CommandManager;
       return { commands, runQuery };
     }

--- a/tools/data-handler/package.json
+++ b/tools/data-handler/package.json
@@ -43,7 +43,6 @@
     "@cyberismo/node-clingo": "workspace:*",
     "@types/mime-types": "^3.0.1",
     "@viz-js/viz": "^3.24.0",
-    "async-mutex": "^0.5.0",
     "csv-parse": "^6.1.0",
     "directory-schema-validator": "^1.0.17",
     "dompurify": "^3.3.3",

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -221,7 +221,6 @@ export class Commands {
           if (!cardKey) {
             return { statusCode: 400, message: 'File path is missing' };
           }
-          await this.generateLogicProgram();
           return this.runLogicProgram(
             cardKey,
             (options as CalcCommandOptions).context || 'localApp',
@@ -229,7 +228,6 @@ export class Commands {
         }
         if (command === 'generate') {
           const [destination, query] = rest;
-          await this.generateLogicProgram();
           return this.exportLogicProgram(destination, query);
         }
       } else if (command === Cmd.create) {
@@ -664,16 +662,6 @@ export class Commands {
     }
     process.env.EXPORT_FORMAT = '';
     return { statusCode: 200, message: message };
-  }
-
-  // Generates logic program for a card.
-  private async generateLogicProgram(): Promise<requestStatus> {
-    try {
-      await this.commands?.calculateCmd.generate();
-      return { statusCode: 200 };
-    } catch (e) {
-      return { statusCode: 500, message: errorFunction(e) };
-    }
   }
 
   private async exportLogicProgram(

--- a/tools/data-handler/src/command-manager.ts
+++ b/tools/data-handler/src/command-manager.ts
@@ -134,6 +134,7 @@ export class CommandManager {
     this.project.resources.changedModules();
     await this.project.populateCaches();
     await this.project.initializeGit();
+    await this.project.calculationEngine.generate();
   }
 
   /**

--- a/tools/data-handler/src/commands/calculate.ts
+++ b/tools/data-handler/src/commands/calculate.ts
@@ -40,14 +40,6 @@ export class Calculate {
   }
 
   /**
-   * Generates a logic program.
-   */
-  @read
-  public async generate() {
-    return this.project.calculationEngine.generate();
-  }
-
-  /**
    * Runs given logic program and creates a graph using clingraph
    * @param data Provide a query or/and a file which can be given to clingraph
    * @param timeout Maximum amount of milliseconds clingraph is allowed to run

--- a/tools/data-handler/src/commands/export.ts
+++ b/tools/data-handler/src/commands/export.ts
@@ -298,8 +298,6 @@ export class Export {
       recursive: options.recursive ?? false,
     };
 
-    await this.project.calculationEngine.generate();
-
     const result = await generateReportContent({
       calculate: this.project.calculationEngine,
       contentTemplate: pdfReport.content,
@@ -343,7 +341,6 @@ export class Export {
       });
     }
 
-    await this.project.calculationEngine.generate();
     const tree = await this.project.calculationEngine.runQuery(
       'tree',
       'exportedDocument',

--- a/tools/data-handler/src/commands/rename.ts
+++ b/tools/data-handler/src/commands/rename.ts
@@ -291,7 +291,5 @@ export class Rename {
       operation: ConfigurationOperation.PROJECT_RENAME,
       target: this.to,
     });
-
-    return this.project.calculationEngine.generate();
   }
 }

--- a/tools/data-handler/src/commands/show.ts
+++ b/tools/data-handler/src/commands/show.ts
@@ -484,7 +484,6 @@ export class Show {
       throw new Error(`Report '${reportName}' does not exist`);
     }
 
-    await this.project.calculationEngine.generate();
     const reportMacro = new ReportMacro(new TaskQueue());
     let result = await reportMacro.handleStatic(
       {

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -145,6 +145,12 @@ export class Project extends CardContainer {
 
     this.gitManager = new GitManager(path);
 
+    // Regenerate Clingo facts after every write transaction so that
+    // metadata-only edits (e.g. title changes) are immediately visible.
+    this.lock.onAfterWrite(async () => {
+      await this.calculationEngine.generate();
+    });
+
     if (this.options.autocommit) {
       // Commit after successful writes
       this.lock.onAfterWrite(async () => {

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -168,6 +168,7 @@ export class Project extends CardContainer {
         this.cardCache.clear();
         await this.populateCardsCache();
         this.resources.changed();
+        await this.calculationEngine.generate();
       });
     }
   }

--- a/tools/data-handler/src/containers/project/calculation-engine.ts
+++ b/tools/data-handler/src/containers/project/calculation-engine.ts
@@ -72,22 +72,6 @@ export class CalculationEngine {
     });
   }
 
-  // Storage for in-memory program content
-  private modules: string = '';
-
-  private modulesInitialized = false;
-
-  // Initialize modules during construction
-  private async initializeModules() {
-    try {
-      // Collect all available calculations at initialization time
-      this.modules = await this.generateModules();
-      this.modulesInitialized = true;
-    } catch (error) {
-      this.logger.error(error, 'Failed to initialize modules');
-    }
-  }
-
   /**
    * Gets the logic program content for a specific card
    * @param cardKey The key of the card
@@ -311,17 +295,15 @@ export class CalculationEngine {
     );
     this.clingo.removeAllPrograms();
 
-    if (!this.modulesInitialized) {
-      await this.initializeModules();
-    }
-
     // Set base common programs with main category
     this.clingo.setProgram('base', lpFiles.common.base, [ALL_CATEGORY]);
     this.clingo.setProgram('queryLanguage', lpFiles.common.queryLanguage, [
       ALL_CATEGORY,
     ]);
     this.clingo.setProgram('utils', lpFiles.common.utils, [ALL_CATEGORY]);
-    this.clingo.setProgram('modules', this.modules, [ALL_CATEGORY]);
+    this.clingo.setProgram('modules', await this.generateModules(), [
+      ALL_CATEGORY,
+    ]);
 
     // Set individual resource type programs
     await this.setCardTreeContent();

--- a/tools/data-handler/src/containers/project/calculation-engine.ts
+++ b/tools/data-handler/src/containers/project/calculation-engine.ts
@@ -25,7 +25,7 @@ import type {
 } from '../../types/queries.js';
 import type { Card, Context } from '../../interfaces/project-interfaces.js';
 import ClingoParser from '../../utils/clingo-parser.js';
-import { Mutex } from 'async-mutex';
+
 import Handlebars from 'handlebars';
 import type { Project } from '../../containers/project.js';
 import { getChildLogger } from '../../utils/log-utils.js';
@@ -64,7 +64,6 @@ const ALL_CATEGORY = 'all';
 export class CalculationEngine {
   constructor(private project: Project) {}
 
-  private static mutex = new Mutex();
   private clingo = new ClingoContext();
 
   private get logger() {
@@ -262,25 +261,30 @@ export class CalculationEngine {
   //
   private async run(query: string, context: Context): Promise<string[]> {
     try {
-      const res = await CalculationEngine.mutex.runExclusive(async () => {
-        // Use the main category to include all programs
-        const basePrograms = [ALL_CATEGORY];
+      // Use the main category to include all programs
+      const basePrograms = [ALL_CATEGORY];
 
-        this.logger.trace(
-          {
-            clingo: true,
-          },
-          'Solving',
-        );
+      this.logger.trace(
+        {
+          clingo: true,
+        },
+        'Solving',
+      );
 
-        const contextFacts = createContextFacts(context);
-        this.clingo.setProgram('context', contextFacts, [ALL_CATEGORY]);
-        // Then solve with the program - need to pass the program as parameter
-        return this.clingo.solve(query, basePrograms);
-      });
+      // Inline context facts into the query string to avoid race conditions
+      // (concurrent reads could overwrite each other's 'context' program key)
+      const contextFacts = createContextFacts(context);
+      const result = await this.clingo.solve(
+        contextFacts + '\n' + query,
+        basePrograms,
+      );
+      this.logger.trace(
+        { stats: result.stats, clingo: true },
+        'Solve completed',
+      );
 
-      if (res && res.answers && res.answers.length > 0) {
-        return res.answers;
+      if (result && result.answers && result.answers.length > 0) {
+        return result.answers;
       }
       throw new Error('Failed to run Clingo solve. No answers returned.');
     } catch (error) {
@@ -299,44 +303,42 @@ export class CalculationEngine {
    * Generates a logic program.
    */
   public async generate() {
-    await CalculationEngine.mutex.runExclusive(async () => {
-      this.logger.trace(
-        {
-          clingo: true,
-        },
-        'Generating logic program',
-      );
-      this.clingo.removeAllPrograms();
+    this.logger.trace(
+      {
+        clingo: true,
+      },
+      'Generating logic program',
+    );
+    this.clingo.removeAllPrograms();
 
-      if (!this.modulesInitialized) {
-        await this.initializeModules();
-      }
+    if (!this.modulesInitialized) {
+      await this.initializeModules();
+    }
 
-      // Set base common programs with main category
-      this.clingo.setProgram('base', lpFiles.common.base, [ALL_CATEGORY]);
-      this.clingo.setProgram('queryLanguage', lpFiles.common.queryLanguage, [
-        ALL_CATEGORY,
-      ]);
-      this.clingo.setProgram('utils', lpFiles.common.utils, [ALL_CATEGORY]);
-      this.clingo.setProgram('modules', this.modules, [ALL_CATEGORY]);
+    // Set base common programs with main category
+    this.clingo.setProgram('base', lpFiles.common.base, [ALL_CATEGORY]);
+    this.clingo.setProgram('queryLanguage', lpFiles.common.queryLanguage, [
+      ALL_CATEGORY,
+    ]);
+    this.clingo.setProgram('utils', lpFiles.common.utils, [ALL_CATEGORY]);
+    this.clingo.setProgram('modules', this.modules, [ALL_CATEGORY]);
 
-      // Set individual resource type programs
-      await this.setCardTreeContent();
-      await this.setCardTypesPrograms();
-      await this.setFieldTypesPrograms();
-      await this.setLinkTypesPrograms();
-      await this.setWorkflowsPrograms();
-      await this.setReportsPrograms();
-      await this.setTemplatesPrograms();
-      await this.setCalculationsPrograms();
+    // Set individual resource type programs
+    await this.setCardTreeContent();
+    await this.setCardTypesPrograms();
+    await this.setFieldTypesPrograms();
+    await this.setLinkTypesPrograms();
+    await this.setWorkflowsPrograms();
+    await this.setReportsPrograms();
+    await this.setTemplatesPrograms();
+    await this.setCalculationsPrograms();
 
-      this.logger.trace(
-        {
-          clingo: true,
-        },
-        'Logic program set',
-      );
-    });
+    this.logger.trace(
+      {
+        clingo: true,
+      },
+      'Logic program set',
+    );
   }
 
   /**
@@ -344,9 +346,7 @@ export class CalculationEngine {
    * @param changedCard Card that was changed.
    */
   public async handleCardChanged(changedCard: Card) {
-    await CalculationEngine.mutex.runExclusive(async () => {
-      await this.setCardContent(changedCard);
-    });
+    await this.setCardContent(changedCard);
   }
 
   /**
@@ -355,10 +355,8 @@ export class CalculationEngine {
    * the complete card tree facts to ensure consistency.
    */
   public async handleCardMoved() {
-    await CalculationEngine.mutex.runExclusive(async () => {
-      // Rebuild entire tree structure from scratch to ensure all relationships are correct
-      await this.setCardTreeContent();
-    });
+    // Rebuild entire tree structure from scratch to ensure all relationships are correct
+    await this.setCardTreeContent();
   }
 
   /**
@@ -370,16 +368,14 @@ export class CalculationEngine {
       return;
     }
     try {
-      await CalculationEngine.mutex.runExclusive(async () => {
-        if (!this.clingo.removeProgram(deletedCard.key)) {
-          this.logger.warn(
-            {
-              cardKey: deletedCard.key,
-            },
-            'Tried to remove card program that does not exist',
-          );
-        }
-      });
+      if (!this.clingo.removeProgram(deletedCard.key)) {
+        this.logger.warn(
+          {
+            cardKey: deletedCard.key,
+          },
+          'Tried to remove card program that does not exist',
+        );
+      }
     } catch {
       this.logger.warn('Removing program failed');
     }
@@ -393,11 +389,9 @@ export class CalculationEngine {
     if (!cards) {
       return;
     }
-    await CalculationEngine.mutex.runExclusive(async () => {
-      for (const card of cards) {
-        await this.setCardContent(card);
-      }
-    });
+    for (const card of cards) {
+      await this.setCardContent(card);
+    }
     const cardKeys = cards.map((item) => item.key);
     const queryResult = await this.creationQuery(cardKeys, 'localApp');
     if (

--- a/tools/data-handler/src/permissions/action-guard.ts
+++ b/tools/data-handler/src/permissions/action-guard.ts
@@ -38,7 +38,6 @@ export class ActionGuard {
     cardKey: string,
     param?: string,
   ) {
-    await this.calculate.generate();
     const cards = await this.calculate.runQuery('card', 'localApp', {
       cardKey,
     });

--- a/tools/data-handler/test/command-rank.test.ts
+++ b/tools/data-handler/test/command-rank.test.ts
@@ -40,7 +40,7 @@ describe('rank command', () => {
       options,
     );
 
-    // To avoid logged errors from clingo queries during tests, generate calculations.
+    // Populate caches and generate calculations for test queries.
     const project = getTestProject(decisionRecordsPath);
     await project.populateCaches();
     await project.calculationEngine.generate();

--- a/tools/data-handler/test/command-remove.test.ts
+++ b/tools/data-handler/test/command-remove.test.ts
@@ -533,7 +533,6 @@ describe('remove card', () => {
       autoSaveConfiguration: false,
     });
     await commands.initialize();
-    await commands.project.calculationEngine.generate();
   });
 
   afterEach(() => {

--- a/tools/mcp/src/lib/render.ts
+++ b/tools/mcp/src/lib/render.ts
@@ -153,7 +153,6 @@ export async function renderCard(
     const rawContent = card.content || '';
     let parsedContent = rawContent;
 
-    // Generate calculations and run card query
     let cardQueryResult: QueryResult<'card'> | null = null;
 
     if (!options.raw) {

--- a/tools/mcp/src/lib/render.ts
+++ b/tools/mcp/src/lib/render.ts
@@ -157,9 +157,6 @@ export async function renderCard(
     let cardQueryResult: QueryResult<'card'> | null = null;
 
     if (!options.raw) {
-      // Generate logic program for calculations
-      await commands.calculateCmd.generate();
-
       // Evaluate macros (Clingo, graphs, reports)
       try {
         const asciidocContent = await evaluateMacros(rawContent, {
@@ -405,7 +402,6 @@ function transformNotifications(
  */
 export async function getCardTree(commands: CommandManager): Promise<unknown> {
   return commands.consistent(async () => {
-    await commands.calculateCmd.generate();
     const result = await commands.calculateCmd.runQuery('tree', 'localApp', {});
     return result;
   });


### PR DESCRIPTION
This PR removes unnecessary generate calls. Instead, generate is currently called at init and for every single write operation. This is a simple solution and could be optimized further if needed. However, writes are pretty rare, recalculating all calculations after a write is not that expensive, at least compared to what clingo does. Remember that resources live in memory.

Also removes the unnecessary global mutex. This enables actually running requests concurrently. This now means that the role of @write and @read locks are even more important, because using calc engines generate and runProgram at the same is safe from a technical perspective(program won't crash), but leads to stale outputs as runProgram may be called half way. Technically, we could use the RW lock also in calculate, but since have application level guarantees for read/write operations, I didn't think it was needed, but should be kept in mind.