### PR TITLE
Feature/joonalepola/intdev 1100

### DIFF
--- a/tools/app/__tests__/utils.test.ts
+++ b/tools/app/__tests__/utils.test.ts
@@ -25,6 +25,7 @@ import {
   canCreateLinkToCard,
   parseNestedDataAttributes,
   parseDataAttributes,
+  getInitials,
 } from '@/lib/utils';
 
 test('flattenTree works with test data', async () => {
@@ -792,5 +793,35 @@ describe('isSafeRedirectPath', () => {
     'cards/../../etc/passwd',
   ])('blocks %s', (path) => {
     expect(isSafeRedirectPath(path)).toBe(false);
+  });
+});
+
+describe('getInitials', () => {
+  test('returns initials from two-part name', () => {
+    expect(getInitials('John Doe')).toBe('JD');
+  });
+
+  test('returns single initial from single name', () => {
+    expect(getInitials('Alice')).toBe('A');
+  });
+
+  test('takes only first two initials from multi-part name', () => {
+    expect(getInitials('Jean-Luc Picard III')).toBe('JP');
+  });
+
+  test('handles multiple spaces between parts', () => {
+    expect(getInitials('Bob    Smith')).toBe('BS');
+  });
+
+  test('returns uppercase initials from lowercase name', () => {
+    expect(getInitials('jane doe')).toBe('JD');
+  });
+
+  test('returns empty string for empty input', () => {
+    expect(getInitials('')).toBe('');
+  });
+
+  test('handles whitespace-only input', () => {
+    expect(getInitials('   ')).toBe('');
   });
 });

--- a/tools/app/src/components/PresenceIndicator.tsx
+++ b/tools/app/src/components/PresenceIndicator.tsx
@@ -1,0 +1,99 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Chip, Stack, Tooltip, Typography } from '@mui/joy';
+import EditIcon from '@mui/icons-material/Edit';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import { useTranslation } from 'react-i18next';
+import type { PresenceEntry } from '@/lib/api/presence';
+import { getInitials } from '@/lib/utils';
+
+const MAX_VISIBLE = 2;
+
+const groups = [
+  {
+    mode: 'editing',
+    color: 'warning',
+    icon: <EditIcon sx={{ fontSize: 14 }} />,
+  },
+  {
+    mode: 'viewing',
+    color: 'neutral',
+    icon: <VisibilityIcon sx={{ fontSize: 14 }} />,
+  },
+] as const;
+
+interface PresenceIndicatorProps {
+  presence: PresenceEntry[];
+  currentUserId?: string;
+}
+
+export default function PresenceIndicator({
+  presence,
+  currentUserId,
+}: PresenceIndicatorProps) {
+  const { t } = useTranslation();
+
+  const others = currentUserId
+    ? presence.filter((e) => e.userId !== currentUserId)
+    : presence;
+
+  if (others.length === 0) return null;
+
+  return (
+    <Stack direction="row" gap={1} alignItems="center" sx={{ mx: 1 }}>
+      {groups.map(({ mode, color, icon }) => {
+        const users = others.filter((e) => e.mode === mode);
+        if (users.length === 0) return null;
+        const visible = users.slice(0, MAX_VISIBLE);
+        const hiddenCount = users.length - MAX_VISIBLE;
+        const tooltip = t(`presence.${mode}`, {
+          names: users.map((e) => e.userName).join(', '),
+        });
+
+        return (
+          <Tooltip
+            key={mode}
+            title={tooltip}
+            placement="bottom"
+            sx={{ whiteSpace: 'pre-line' }}
+          >
+            <Chip size="sm" variant="soft" color={color} endDecorator={icon}>
+              <Stack direction="row" gap={0.5}>
+                {visible.map((user) => (
+                  <Typography
+                    key={user.userId}
+                    level="body-xs"
+                    component="span"
+                    sx={{ fontWeight: 600 }}
+                  >
+                    {getInitials(user.userName)}
+                  </Typography>
+                ))}
+                {hiddenCount > 0 && (
+                  <Typography
+                    level="body-xs"
+                    component="span"
+                    sx={{ fontWeight: 600 }}
+                  >
+                    +{hiddenCount}
+                  </Typography>
+                )}
+              </Stack>
+            </Chip>
+          </Tooltip>
+        );
+      })}
+    </Stack>
+  );
+}

--- a/tools/app/src/components/UserMenu.tsx
+++ b/tools/app/src/components/UserMenu.tsx
@@ -23,18 +23,8 @@ import {
 } from '@mui/joy';
 import LogoutOutlined from '@mui/icons-material/LogoutOutlined';
 import { useUser } from '@/lib/api';
-import { getConfig } from '@/lib/utils';
+import { getConfig, getInitials } from '@/lib/utils';
 import { useTranslation } from 'react-i18next';
-
-function getInitials(name: string): string {
-  return name
-    .split(/\s+/)
-    .map((part) => part[0])
-    .filter(Boolean)
-    .slice(0, 2)
-    .join('')
-    .toUpperCase();
-}
 
 export default function UserMenu() {
   const { user } = useUser();

--- a/tools/app/src/components/toolbar/CardToolbar.tsx
+++ b/tools/app/src/components/toolbar/CardToolbar.tsx
@@ -22,12 +22,19 @@ import StatusSelector from '../StateSelector';
 import { findWorkflowForCardType } from '../../lib/utils';
 import { useAppRouter, useAppSelector } from '../../lib/hooks';
 import { useTranslation } from 'react-i18next';
-import { useCard, useProject, useTree } from '../../lib/api';
+import {
+  useCard,
+  usePresence,
+  useProject,
+  useTree,
+  useUser,
+} from '../../lib/api';
 import { useAppDispatch } from '../../lib/hooks';
 import { addNotification } from '../../lib/slices/notifications';
 import { getConfig } from '@/lib/utils';
 import BaseToolbar from './BaseToolbar';
 import { CardContextMenu } from '@/components/context-menus';
+import PresenceIndicator from '@/components/PresenceIndicator';
 
 interface CardToolbarProps {
   cardKey: string;
@@ -55,6 +62,9 @@ export function CardToolbar({
   const { tree } = useTree();
   const isEdited = useAppSelector((state) => state.page.isEdited);
   const { card, updateWorkFlowState, isUpdating } = useCard(cardKey);
+  const { user } = useUser();
+  const presenceMode = mode === CardMode.EDIT ? 'editing' : 'viewing';
+  const presence = usePresence(cardKey, presenceMode);
 
   const dispatch = useAppDispatch();
 
@@ -166,7 +176,12 @@ export function CardToolbar({
     <BaseToolbar
       breadcrumbs={breadcrumbs}
       contextMenu={
-        !getConfig().staticMode && <CardContextMenu cardKey={cardKey} />
+        !getConfig().staticMode && (
+          <>
+            <PresenceIndicator presence={presence} currentUserId={user?.id} />
+            <CardContextMenu cardKey={cardKey} />
+          </>
+        )
       }
       actions={actions}
     />

--- a/tools/app/src/lib/api/index.ts
+++ b/tools/app/src/lib/api/index.ts
@@ -30,4 +30,5 @@ export * from './report';
 export * from './workflow';
 export * from './labels';
 export * from './user';
+export * from './presence';
 export type { CardUpdate };

--- a/tools/app/src/lib/api/presence.ts
+++ b/tools/app/src/lib/api/presence.ts
@@ -1,0 +1,75 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { useEffect, useState } from 'react';
+import { getConfig } from '@/lib/utils';
+import { apiPaths } from '@/lib/swr.js';
+import { z } from 'zod';
+
+const presenceEntrySchema = z.object({
+  userId: z.string(),
+  userName: z.string(),
+  mode: z.enum(['viewing', 'editing']),
+});
+
+const presenceEventSchema = z.object({
+  editors: z.array(presenceEntrySchema),
+});
+
+export type PresenceEntry = z.infer<typeof presenceEntrySchema>;
+
+/**
+ * Hook that connects to the card presence SSE endpoint.
+ * Returns a list of users currently viewing or editing the card.
+ *
+ * @param cardKey - The card to track presence for
+ * @param mode - Whether the current user is 'viewing' or 'editing'
+ */
+export function usePresence(
+  cardKey: string | null,
+  mode: 'viewing' | 'editing' = 'viewing',
+): PresenceEntry[] {
+  const [editors, setEditors] = useState<PresenceEntry[]>([]);
+
+  useEffect(() => {
+    if (!cardKey || getConfig().staticMode) {
+      return;
+    }
+
+    const url = apiPaths.presence(cardKey, mode);
+    const eventSource = new EventSource(url);
+
+    eventSource.addEventListener('presence', (event) => {
+      try {
+        const data = presenceEventSchema.parse(JSON.parse(event.data));
+        setEditors(data.editors);
+      } catch (e) {
+        console.warn('Malformed presence event', e);
+      }
+    });
+
+    eventSource.addEventListener('error', () => {
+      // EventSource will auto-reconnect; clear state on error
+      setEditors([]);
+    });
+
+    return () => {
+      eventSource.close();
+      setEditors([]);
+    };
+  }, [cardKey, mode]);
+
+  if (!cardKey || getConfig().staticMode) return [];
+
+  return editors;
+}

--- a/tools/app/src/lib/swr.ts
+++ b/tools/app/src/lib/swr.ts
@@ -139,4 +139,6 @@ export const apiPaths = {
   projectModuleDelete: (module: string) =>
     `/api/project/modules/${encodeURIComponent(module)}`,
   projectModulesImportable: () => '/api/project/modules/importable',
+  presence: (cardKey: string, mode: string) =>
+    `/api/cards/${encodeURIComponent(cardKey)}/presence?mode=${mode}`,
 };

--- a/tools/app/src/lib/utils.ts
+++ b/tools/app/src/lib/utils.ts
@@ -629,3 +629,13 @@ export async function withUpdating<T>(
     setIsUpdating(false);
   }
 }
+
+export function getInitials(name: string): string {
+  return name
+    .split(/\s+/)
+    .map((part) => part[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join('')
+    .toUpperCase();
+}

--- a/tools/app/src/locales/en/translation.json
+++ b/tools/app/src/locales/en/translation.json
@@ -358,6 +358,10 @@
   },
   "policyCheckFail": "FAIL",
   "policyCheckPass": "PASS",
+  "presence": {
+    "editing": "Editing: {{names}}",
+    "viewing": "Viewing: {{names}}"
+  },
   "preview": "Preview",
   "project": "Project",
   "recents": "Recents",

--- a/tools/backend/src/domain/cards/index.ts
+++ b/tools/backend/src/domain/cards/index.ts
@@ -13,11 +13,13 @@
 
 import { type Context, Hono } from 'hono';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
+import { streamSSE } from 'hono/streaming';
 import { getCardDetails } from './lib.js';
 import * as cardService from './service.js';
 import { isSSGContext, ssgParams } from 'hono/ssg';
 import type { AppContext } from '../../types.js';
 import { UserRole } from '../../types.js';
+import { presenceStore } from './presence.js';
 import { requireRole } from '../../middleware/auth.js';
 
 const router = new Hono();
@@ -672,5 +674,55 @@ router.get(
     }
   },
 );
+/**
+ * @swagger
+ * /api/cards/{key}/presence:
+ *   get:
+ *     summary: SSE stream of users currently viewing or editing this card
+ *     parameters:
+ *       - name: key
+ *         in: path
+ *         required: true
+ *         description: Card key (string)
+ *       - name: mode
+ *         in: query
+ *         required: false
+ *         schema:
+ *           type: string
+ *           enum: [viewing, editing]
+ *         description: Whether the user is viewing or editing (default: viewing)
+ *     responses:
+ *       200:
+ *         description: SSE stream with presence events
+ */
+router.get('/:key/presence', requireRole(UserRole.Reader), (c) => {
+  const key = c.req.param('key');
+  const mode = c.req.query('mode') === 'editing' ? 'editing' : 'viewing';
+  const user = c.get('user');
 
+  if (!key) {
+    return c.text('No card key', 400);
+  }
+
+  return streamSSE(c, async (stream) => {
+    const connId = presenceStore.add(
+      key,
+      user,
+      mode,
+      (data) => void stream.writeSSE(data),
+    );
+
+    let aborted = false;
+    stream.onAbort(() => {
+      aborted = true;
+      presenceStore.remove(key, connId);
+    });
+
+    // Keep connection alive with periodic heartbeat
+    while (!aborted) {
+      await stream.write(': hb\n\n');
+      await stream.sleep(30000);
+    }
+  });
+});
 export default router;

--- a/tools/backend/src/domain/cards/presence.ts
+++ b/tools/backend/src/domain/cards/presence.ts
@@ -1,0 +1,124 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { UserInfo } from '../../types.js';
+import type { SSEMessage } from 'hono/streaming';
+
+export interface PresenceEntry {
+  userId: string;
+  userName: string;
+  mode: 'viewing' | 'editing';
+}
+
+interface Connection {
+  user: UserInfo;
+  mode: 'viewing' | 'editing';
+  send: (message: SSEMessage) => void;
+}
+
+/**
+ * In-memory presence tracker for card editing/viewing.
+ * Tracks which users are currently looking at or editing each card,
+ * and notifies all connected clients via SSE when presence changes.
+ */
+class PresenceStore {
+  // cardKey -> connectionId -> Connection
+  private connections = new Map<string, Map<string, Connection>>();
+  private nextId = 0;
+
+  /**
+   * Add a user connection for a card. Returns a connection ID for later removal.
+   */
+  add(
+    cardKey: string,
+    user: UserInfo,
+    mode: 'viewing' | 'editing',
+    send: (message: SSEMessage) => void,
+  ): string {
+    const connId = String(this.nextId++);
+
+    if (!this.connections.has(cardKey)) {
+      this.connections.set(cardKey, new Map());
+    }
+
+    this.connections.get(cardKey)!.set(connId, { user, mode, send });
+    this.broadcast(cardKey);
+
+    return connId;
+  }
+
+  /**
+   * Remove a connection and broadcast updated presence.
+   */
+  remove(cardKey: string, connId: string): void {
+    const cardConns = this.connections.get(cardKey);
+    if (!cardConns) return;
+
+    cardConns.delete(connId);
+
+    if (cardConns.size === 0) {
+      this.connections.delete(cardKey);
+    } else {
+      this.broadcast(cardKey);
+    }
+  }
+
+  /**
+   * Get current presence list for a card.
+   */
+  getPresence(cardKey: string): PresenceEntry[] {
+    const cardConns = this.connections.get(cardKey);
+    if (!cardConns) return [];
+
+    // Deduplicate by userId — if a user has multiple connections,
+    // prefer the 'editing' mode
+    const byUser = new Map<string, PresenceEntry>();
+    for (const conn of cardConns.values()) {
+      const existing = byUser.get(conn.user.id);
+      if (!existing || conn.mode === 'editing') {
+        byUser.set(conn.user.id, {
+          userId: conn.user.id,
+          userName: conn.user.name,
+          mode: conn.mode,
+        });
+      }
+    }
+
+    return Array.from(byUser.values());
+  }
+
+  /**
+   * Broadcast current presence to all connected clients for a card.
+   */
+  private broadcast(cardKey: string): void {
+    const cardConns = this.connections.get(cardKey);
+    if (!cardConns) return;
+
+    const presence = this.getPresence(cardKey);
+    const data = JSON.stringify({ editors: presence });
+    const message: SSEMessage = { event: 'presence', data };
+
+    for (const conn of cardConns.values()) {
+      conn.send(message);
+    }
+  }
+
+  /**
+   * Remove all connections. Intended for test cleanup.
+   */
+  removeAll(): void {
+    this.connections.clear();
+  }
+}
+
+export const presenceStore = new PresenceStore();

--- a/tools/backend/test/presence.test.ts
+++ b/tools/backend/test/presence.test.ts
@@ -1,0 +1,235 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
+import { CommandManager } from '@cyberismo/data-handler';
+import { createApp } from '../src/app.js';
+import { MockAuthProvider } from '../src/auth/mock.js';
+import { presenceStore } from '../src/domain/cards/presence.js';
+import { UserRole } from '../src/types.js';
+import type { SSEMessage } from 'hono/streaming';
+import { createTempTestData, cleanupTempTestData } from './test-utils.js';
+
+let app: ReturnType<typeof createApp>;
+let tempTestDataPath: string;
+
+beforeAll(async () => {
+  process.argv = [];
+  tempTestDataPath = await createTempTestData('decision-records');
+  const commands = await CommandManager.getInstance(tempTestDataPath);
+  app = createApp(new MockAuthProvider(), commands);
+});
+
+afterAll(async () => {
+  await cleanupTempTestData(tempTestDataPath);
+});
+
+/**
+ * Parse SSE text into individual events.
+ * Each event is separated by double newline, fields by single newline.
+ */
+function parseSSEEvents(
+  text: string,
+): Array<{ event?: string; data?: string }> {
+  return text
+    .split('\n\n')
+    .filter((block) => block.trim())
+    .map((block) => {
+      const result: { event?: string; data?: string } = {};
+      for (const line of block.split('\n')) {
+        if (line.startsWith('event: ')) result.event = line.slice(7);
+        else if (line.startsWith('data: ')) result.data = line.slice(6);
+        else if (line.startsWith('data:')) result.data = line.slice(5);
+      }
+      return result;
+    });
+}
+
+describe('GET /api/cards/:key/presence', () => {
+  test('returns 200 with text/event-stream content type', async () => {
+    const response = await app.request(
+      '/api/cards/decision_5/presence?mode=viewing',
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/event-stream');
+  });
+
+  test('emits an initial presence event with the connected user', async () => {
+    const response = await app.request(
+      '/api/cards/decision_5/presence?mode=editing',
+    );
+    expect(response.status).toBe(200);
+
+    // Read enough of the stream to get the initial presence event
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+    let text = '';
+
+    // Read chunks until we have a complete presence event
+    for (let i = 0; i < 10; i++) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      text += decoder.decode(value, { stream: true });
+      if (text.includes('data:') && text.includes('\n\n')) break;
+    }
+    void reader.cancel();
+
+    const events = parseSSEEvents(text);
+    const presenceEvent = events.find((e) => e.event === 'presence');
+    expect(presenceEvent).toBeDefined();
+
+    const data = JSON.parse(presenceEvent!.data!) as {
+      editors: Array<{ userId: string; userName: string; mode: string }>;
+    };
+    expect(data.editors).toBeInstanceOf(Array);
+    expect(data.editors.length).toBeGreaterThan(0);
+
+    const mockUser = data.editors.find((e) => e.userId === 'mock-user');
+    expect(mockUser).toBeDefined();
+    expect(mockUser!.userName).toBe('Local Admin');
+    expect(mockUser!.mode).toBe('editing');
+  });
+
+  test('defaults mode to viewing when not specified', async () => {
+    const response = await app.request('/api/cards/decision_5/presence');
+    expect(response.status).toBe(200);
+
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+    let text = '';
+
+    for (let i = 0; i < 10; i++) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      text += decoder.decode(value, { stream: true });
+      if (text.includes('data:') && text.includes('\n\n')) break;
+    }
+    void reader.cancel();
+
+    const events = parseSSEEvents(text);
+    const presenceEvent = events.find((e) => e.event === 'presence');
+    expect(presenceEvent).toBeDefined();
+
+    const data = JSON.parse(presenceEvent!.data!) as {
+      editors: Array<{ userId: string; mode: string }>;
+    };
+    const mockUser = data.editors.find((e) => e.userId === 'mock-user');
+    expect(mockUser).toBeDefined();
+    expect(mockUser!.mode).toBe('viewing');
+  });
+});
+
+describe('PresenceStore unit tests', () => {
+  afterEach(() => {
+    presenceStore.removeAll();
+  });
+
+  test('add registers a connection and broadcasts', () => {
+    const messages: SSEMessage[] = [];
+    const connId = presenceStore.add(
+      'test-card-1',
+      {
+        id: 'user-1',
+        name: 'Alice',
+        email: 'a@test.com',
+        role: UserRole.Reader,
+      },
+      'viewing',
+      (data) => messages.push(data),
+    );
+
+    expect(connId).toBeDefined();
+    // Should have received a broadcast with the initial presence
+    expect(messages.length).toBe(1);
+    expect(messages[0].data as string).toContain('"userId":"user-1"');
+    expect(messages[0].data as string).toContain('"mode":"viewing"');
+  });
+
+  test('remove cleans up connection and broadcasts to remaining', () => {
+    const messages1: SSEMessage[] = [];
+    const messages2: SSEMessage[] = [];
+
+    const conn1 = presenceStore.add(
+      'test-card-2',
+      {
+        id: 'user-1',
+        name: 'Alice',
+        email: 'a@test.com',
+        role: UserRole.Reader,
+      },
+      'viewing',
+      (data) => messages1.push(data),
+    );
+    presenceStore.add(
+      'test-card-2',
+      { id: 'user-2', name: 'Bob', email: 'b@test.com', role: UserRole.Reader },
+      'editing',
+      (data) => messages2.push(data),
+    );
+
+    // Both should have received broadcasts
+    expect(messages1.length).toBeGreaterThan(0);
+    expect(messages2.length).toBeGreaterThan(0);
+
+    // Clear messages to track removal broadcast
+    messages1.length = 0;
+    messages2.length = 0;
+
+    // Remove user-1
+    presenceStore.remove('test-card-2', conn1);
+
+    // user-2 should get an updated broadcast without user-1
+    expect(messages2.length).toBe(1);
+    const data = JSON.parse(messages2[0].data as string) as {
+      editors: Array<{ userId: string }>;
+    };
+    expect(data.editors.length).toBe(1);
+    expect(data.editors[0].userId).toBe('user-2');
+  });
+
+  test('getPresence deduplicates by user and prefers editing', () => {
+    const noop = () => {};
+
+    presenceStore.add(
+      'test-card-3',
+      {
+        id: 'user-1',
+        name: 'Alice',
+        email: 'a@test.com',
+        role: UserRole.Reader,
+      },
+      'viewing',
+      noop,
+    );
+    presenceStore.add(
+      'test-card-3',
+      {
+        id: 'user-1',
+        name: 'Alice',
+        email: 'a@test.com',
+        role: UserRole.Reader,
+      },
+      'editing',
+      noop,
+    );
+
+    const presence = presenceStore.getPresence('test-card-3');
+    expect(presence.length).toBe(1);
+    expect(presence[0].userId).toBe('user-1');
+    expect(presence[0].mode).toBe('editing');
+  });
+
+  test('remove last connection deletes the card entry', () => {
+    const conn = presenceStore.add(
+      'test-card-5',
+      {
+        id: 'user-1',
+        name: 'Alice',
+        email: 'a@test.com',
+        role: UserRole.Reader,
+      },
+      'viewing',
+      () => {},
+    );
+
+    presenceStore.remove('test-card-5', conn);
+    expect(presenceStore.getPresence('test-card-5')).toEqual([]);
+  });
+});


### PR DESCRIPTION
"Simple" solution to bring users valuable information of other users currently working with the same card that they are working. This will add a simple indicator whether somebody else is viewing/editing the current document, like this:

<img width="493" height="246" alt="image" src="https://github.com/user-attachments/assets/b2eaa10b-7f77-4eab-9f04-8453e5e0b136" />

<img width="352" height="287" alt="image" src="https://github.com/user-attachments/assets/8630cba9-a059-4c48-80cf-3bf6d1ebd057" />

The viewers and editors are combined separately and by hovering over then, we can see the list of users.

This uses Hono's Server Sent Events: Open up a connection to the server, create event to the frontend, server sends new information when needed, GUI gets updated

