### PR TITLE
Fix error messages & Remove link modification from static site

### DIFF
--- a/tools/app/src/components/ContentArea.tsx
+++ b/tools/app/src/components/ContentArea.tsx
@@ -1072,48 +1072,53 @@ export const ContentArea: React.FC<ContentAreaProps> = ({
                             )}
                           </Box>
                         </Stack>
-                        {link.linkSource === 'user' && !preview && (
-                          <Box
-                            gap={1}
-                            fontSize={24}
-                            alignItems="center"
-                            marginRight={2}
-                          >
-                            <IconButton
-                              className="actionButton"
-                              onClick={() => {
-                                const linkType = linkTypes.find(
-                                  (t) =>
-                                    t.name === link.linkType &&
-                                    t.direction === link.direction,
-                                );
-                                setEditLinkData({
-                                  linkType: linkType?.id ?? NO_LINK_TYPE,
-                                  connector: link.connector ?? 'card',
-                                  cardKey: link.connector ? '' : link.key,
-                                  externalItemKey: link.connector
-                                    ? link.key
-                                    : '',
-                                  linkDescription: link.linkDescription || '',
-                                  linkTypeName: link.linkType,
-                                  direction: link.direction,
-                                });
-                                openModal('editLink')();
-                              }}
+                        {link.linkSource === 'user' &&
+                          !preview &&
+                          !getConfig().staticMode && (
+                            <Box
+                              gap={1}
+                              fontSize={24}
+                              alignItems="center"
+                              marginRight={2}
                             >
-                              <Edit fontSize="inherit" />
-                            </IconButton>
-                            <IconButton
-                              className="actionButton"
-                              onClick={() => {
-                                setDeleteLinkData(link);
-                                openModal('deleteLink')();
-                              }}
-                            >
-                              <Delete fontSize="inherit" data-cy="DeleteIcon" />
-                            </IconButton>
-                          </Box>
-                        )}
+                              <IconButton
+                                className="actionButton"
+                                onClick={() => {
+                                  const linkType = linkTypes.find(
+                                    (t) =>
+                                      t.name === link.linkType &&
+                                      t.direction === link.direction,
+                                  );
+                                  setEditLinkData({
+                                    linkType: linkType?.id ?? NO_LINK_TYPE,
+                                    connector: link.connector ?? 'card',
+                                    cardKey: link.connector ? '' : link.key,
+                                    externalItemKey: link.connector
+                                      ? link.key
+                                      : '',
+                                    linkDescription: link.linkDescription || '',
+                                    linkTypeName: link.linkType,
+                                    direction: link.direction,
+                                  });
+                                  openModal('editLink')();
+                                }}
+                              >
+                                <Edit fontSize="inherit" />
+                              </IconButton>
+                              <IconButton
+                                className="actionButton"
+                                onClick={() => {
+                                  setDeleteLinkData(link);
+                                  openModal('deleteLink')();
+                                }}
+                              >
+                                <Delete
+                                  fontSize="inherit"
+                                  data-cy="DeleteIcon"
+                                />
+                              </IconButton>
+                            </Box>
+                          )}
                         {link.linkSource === 'calculated' && (
                           <IconButton color="primary">
                             <Tooltip title={t('linkForm.calculatedLink')}>

--- a/tools/backend/src/app.ts
+++ b/tools/backend/src/app.ts
@@ -98,7 +98,7 @@ export function createApp(
   // serve index.html for all other routes
   app.notFound(async (c) => {
     if (c.req.path.startsWith('/api')) {
-      return c.text('Not Found', 400);
+      return c.text('Not Found', 404);
     }
     const file = await readFile(
       path.join(import.meta.dirname, 'public', 'index.html'),

--- a/tools/backend/src/index.ts
+++ b/tools/backend/src/index.ts
@@ -36,11 +36,14 @@ const DEFAULT_MAX_PORT = DEFAULT_PORT + 100;
 export async function previewSite(dir: string, findPort: boolean = true) {
   const app = new Hono();
   app.use(serveStatic({ root: dir }));
-  app.get('*', (c) =>
-    c.html(
+  app.get('*', (c) => {
+    if (c.req.path.startsWith('/api/')) {
+      return c.json({ error: 'Resource not found' }, 404);
+    }
+    return c.html(
       readFile(path.join(dir, 'index.html')).then((file) => file.toString()),
-    ),
-  );
+    );
+  });
 
   let port = parseInt(process.env.PORT || DEFAULT_PORT.toString(), 10);
 

--- a/tools/backend/test/api.test.ts
+++ b/tools/backend/test/api.test.ts
@@ -101,7 +101,7 @@ test('invalid card key returns error', async () => {
 test('test invalid api path returns not found', async () => {
   const response = await app.request('/api/bogus');
   expect(response).not.toBe(null);
-  expect(response.status).toBe(400);
+  expect(response.status).toBe(404);
 });
 
 test('non-existing attachment file returns an error', async () => {


### PR DESCRIPTION
- Fix /api prefix matching to only match /api and /api/..., not unrelated paths like /apidocs or /apikey
- Return 404 instead of 400 for non-existent API routes
- Return 404 status for SPA fallback pages instead of 200 to prevent search engine indexing of non-existent pages
- Static site preview: return proper JSON 404 for missing API/JSON resources instead of serving
- Static site preview: return 404 status for unknown routes
- Hide link edit/delete buttons in exported static site