### PR TITLE
Make docker container version listen on all interfaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ ENV SHELL=/bin/bash
 ENV PATH=/usr/local/share/pnpm:$PATH
 ENV PNPM_HOME=/usr/local/share/pnpm
 
+# bind the backend to all interfaces so published ports are reachable
+ENV HOST=0.0.0.0
+
 WORKDIR /app
 
 # make sure logs directory exists and is writable


### PR DESCRIPTION
Running cyberismo via docker won't work, if it only listens on localhost. After tightening CLI to listen on localhost by default, dockerfile was not updated.