### PR TITLE
INTDEV-1089 Version support patch 1

### DIFF
--- a/tools/backend/src/domain/project/service.ts
+++ b/tools/backend/src/domain/project/service.ts
@@ -57,7 +57,7 @@ export async function getProject(
     const project = await commands.showCmd.showProject();
     const modules = await commands.showCmd.showModules();
     const moduleDetails = await Promise.all(
-      modules.map((mod) => toModuleInfo(commands, mod)),
+      modules.map((mod) => toModuleInfo(commands, mod.name)),
     );
 
     return {

--- a/tools/backend/src/domain/resources/service.ts
+++ b/tools/backend/src/domain/resources/service.ts
@@ -42,14 +42,14 @@ const resourceTypes: ResourceFolderType[] = [
 
 async function getModules(commands: CommandManager) {
   try {
-    const moduleNames = await commands.showCmd.showModules();
+    const modules = await commands.showCmd.showModules();
     return Promise.all(
-      moduleNames.map(async (moduleName) => {
+      modules.map(async (mod) => {
         try {
-          const module = await commands.showCmd.showModule(moduleName);
+          const module = await commands.showCmd.showModule(mod.name);
           return { name: module.name, cardKeyPrefix: module.cardKeyPrefix };
         } catch {
-          return { name: moduleName, cardKeyPrefix: moduleName };
+          return { name: mod.name, cardKeyPrefix: mod.name };
         }
       }),
     );

--- a/tools/backend/test/resources.service.test.ts
+++ b/tools/backend/test/resources.service.test.ts
@@ -30,7 +30,7 @@ const createMockCommandManager = (overrides: any = {}) => {
     consistent: vi.fn().mockImplementation((fn: () => unknown) => fn()),
     showCmd: {
       showProject: vi.fn().mockResolvedValue({ prefix: 'test' }),
-      showModules: vi.fn().mockResolvedValue([]),
+      showModules: vi.fn().mockResolvedValue([] as { name: string }[]),
       showModule: vi.fn(),
       showResources: vi.fn(),
       showResource: vi.fn(),
@@ -151,7 +151,7 @@ describe('Resources Service', () => {
       const mockCommands = createMockCommandManager({
         showCmd: {
           showProject: vi.fn().mockResolvedValue({ prefix: 'test' }),
-          showModules: vi.fn().mockResolvedValue(['module1']),
+          showModules: vi.fn().mockResolvedValue([{ name: 'module1' }]),
           showModule: vi.fn().mockResolvedValue({
             name: 'Module One',
             cardKeyPrefix: 'module1',
@@ -216,7 +216,7 @@ describe('Resources Service', () => {
       const mockCommands = createMockCommandManager({
         showCmd: {
           showProject: vi.fn().mockResolvedValue({ prefix: 'test' }),
-          showModules: vi.fn().mockResolvedValue(['module1']),
+          showModules: vi.fn().mockResolvedValue([{ name: 'module1' }]),
           showModule: vi.fn().mockResolvedValue({
             name: 'Module One',
             cardKeyPrefix: 'module1',

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -1419,13 +1419,17 @@ const updateModulesCmd = new CommandWithPath('update-modules')
   .description(
     'Updates to latest versions either all modules or a specific module',
   )
-  .argument('[moduleName]', 'Module name');
+  .argument('[moduleName]', 'Module name')
+  .argument(
+    '[version]',
+    'Target version to update to (only with a specific module)',
+  );
 program.addCommand(updateModulesCmd);
 updateModulesCmd.action(
-  async (moduleName, options: CommandOptions<'updateModules'>) => {
+  async (moduleName, version, options: CommandOptions<'updateModules'>) => {
     const result = await commandHandler.command(
       Cmd.updateModules,
-      [moduleName],
+      [moduleName, version],
       Object.assign({}, options, program.opts()),
       credentials(),
     );

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -23,6 +23,7 @@ import type {
   Credentials,
   HubSetting,
   ModuleContent,
+  ModuleInfo,
   ModuleSettingFromHub,
   ProjectMetadata,
   RemovableResourceTypes,
@@ -451,10 +452,19 @@ export class Commands {
           mappingTable,
         );
       } else if (command === Cmd.updateModules) {
-        const [module] = args;
+        const [module, targetVersion] = args;
         if (module) {
-          await this.commands?.importCmd.updateModule(module, credentials);
+          await this.commands?.importCmd.updateModule(
+            module,
+            credentials,
+            targetVersion,
+          );
         } else {
+          if (targetVersion) {
+            throw new Error(
+              'A target version can only be specified together with a module name',
+            );
+          }
           await this.commands?.importCmd.updateAllModules(credentials);
         }
       } else if (command === Cmd.validate) {
@@ -800,6 +810,7 @@ export class Commands {
       | CardListContainer[]
       | HubSetting[]
       | ModuleContent
+      | ModuleInfo[]
       | ModuleSettingFromHub[]
       | ProjectMetadata
       | AnyResourceContent

--- a/tools/data-handler/src/commands/import.ts
+++ b/tools/data-handler/src/commands/import.ts
@@ -13,6 +13,7 @@
 
 import { ModuleManager } from '../module-manager.js';
 import { readCsvFile } from '../utils/csv.js';
+import { versionToTag } from '../utils/git-manager.js';
 import { Validate } from './validate.js';
 import { write } from '../utils/rw-lock.js';
 
@@ -162,11 +163,15 @@ export class Import {
       );
     }
 
+    const moduleVersion =
+      await this.moduleManager.readModuleVersion(modulePrefix);
+
     const moduleSettings = {
       name: modulePrefix,
       branch: options ? options.branch : undefined,
       private: options ? options.private : undefined,
       location: gitModule ? source : `file:${source}`,
+      version: moduleVersion,
     };
 
     // Fetch module dependencies.
@@ -194,10 +199,15 @@ export class Import {
    * Updates a specific imported module.
    * @param moduleName Name (prefix) of module to update.
    * @param credentials Optional credentials for a private module.
+   * @param version Optional target version to update to.
    * @throws if module is not part of the project
    */
   @write((moduleName) => `Update module ${moduleName}`)
-  public async updateModule(moduleName: string, credentials?: Credentials) {
+  public async updateModule(
+    moduleName: string,
+    credentials?: Credentials,
+    version?: string,
+  ) {
     // Ensure module list is up to date before updating
     await this.fetchCmd.ensureModuleListUpToDate();
 
@@ -207,6 +217,23 @@ export class Import {
     if (!module) {
       throw new Error(`Module '${moduleName}' is not part of the project`);
     }
+
+    if (version) {
+      // Validate the requested version exists
+      const availableVersions = await this.moduleManager.listAvailableVersions(
+        module,
+        credentials,
+      );
+      if (!availableVersions.includes(version)) {
+        throw new Error(
+          `Version '${version}' is not available for module '${moduleName}'. Available versions: ${availableVersions.join(', ') || 'none'}`,
+        );
+      }
+      // Clone the version tag without mutating the stored config
+      const moduleForClone = { ...module, branch: versionToTag(version) };
+      return this.moduleManager.updateModule(moduleForClone, credentials);
+    }
+
     return this.moduleManager.updateModule(module, credentials);
   }
 

--- a/tools/data-handler/src/commands/show.ts
+++ b/tools/data-handler/src/commands/show.ts
@@ -32,6 +32,7 @@ import type {
   FileContentType,
   HubSetting,
   ModuleContent,
+  ModuleInfo,
   ModuleSettingFromHub,
   ProjectMetadata,
   ResourceType,
@@ -442,11 +443,11 @@ export class Show {
 
   /**
    * Shows all modules (if any) in a project.
-   * @returns all modules in a project.
+   * @returns all modules in a project with their installed versions.
    */
   @read
-  public async showModules(): Promise<string[]> {
-    return this.project.resources.moduleNames().sort();
+  public async showModules(): Promise<ModuleInfo[]> {
+    return this.project.moduleInfos();
   }
 
   /**

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -36,6 +36,7 @@ import {
   type FetchCardDetails,
   type MetadataContent,
   type ModuleContent,
+  type ModuleInfo,
   type ModuleSetting,
   type ProjectFetchCardDetails,
   type ProjectMetadata,
@@ -776,6 +777,7 @@ export class Project extends CardContainer {
       return {
         name: moduleConfig.name,
         description: moduleConfig.description || '',
+        version: moduleConfig.version,
         modules: moduleConfig.modules,
         hubs: moduleConfig.hubs,
         path: modulePath,
@@ -1053,6 +1055,19 @@ export class Project extends CardContainer {
   }
 
   /**
+   * Returns installed modules with their versions.
+   */
+  public moduleInfos(): ModuleInfo[] {
+    return this.resources
+      .moduleNames()
+      .sort()
+      .map((name) => {
+        const setting = this.configuration.modules.find((m) => m.name === name);
+        return { name, version: setting?.version };
+      });
+  }
+
+  /**
    * Shows details of a project.
    * @returns details of a project.
    */
@@ -1065,7 +1080,7 @@ export class Project extends CardContainer {
       description: this.configuration.description,
       version: this.configuration.version,
       hubs: this.configuration.hubs,
-      modules: this.resources.moduleNames(),
+      modules: this.moduleInfos(),
       numberOfCards: (await this.listCards(CardLocation.projectOnly))[0].cards
         .length,
     };

--- a/tools/data-handler/src/containers/project/project-paths.ts
+++ b/tools/data-handler/src/containers/project/project-paths.ts
@@ -100,6 +100,10 @@ export class ProjectPaths {
     return join(this.internalRootFolder, 'modules');
   }
 
+  public moduleConfigurationFile(modulePrefix: string): string {
+    return join(this.modulesFolder, modulePrefix, 'cardsConfig.json');
+  }
+
   public moduleResourcePath(
     modulePrefix: string,
     resourceType: ResourceFolderType,

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -173,6 +173,12 @@ export interface ProjectFile {
   name: string;
 }
 
+// Summary of an installed module.
+export interface ModuleInfo {
+  name: string;
+  version?: string;
+}
+
 // Project metadata details. @todo - this overlaps the above; check & merge
 export interface ProjectMetadata {
   name: string;
@@ -181,7 +187,7 @@ export interface ProjectMetadata {
   category?: string;
   description?: string;
   version?: string;
-  modules: string[];
+  modules: ModuleInfo[];
   hubs: HubSetting[];
   numberOfCards: number;
 }
@@ -222,6 +228,7 @@ export interface ModuleSettingOptions {
   branch?: string;
   private?: boolean;
   credentials?: Credentials;
+  version?: string;
 }
 
 // Resources that are possible to remove.

--- a/tools/data-handler/src/module-manager.ts
+++ b/tools/data-handler/src/module-manager.ts
@@ -17,6 +17,7 @@ import { mkdir, readdir, rm } from 'node:fs/promises';
 import { simpleGit, type SimpleGit } from 'simple-git';
 
 import { copyDir, deleteDir, pathExists } from './utils/file-utils.js';
+import { GitManager } from './utils/git-manager.js';
 import type {
   Credentials,
   ModuleSetting,
@@ -86,6 +87,31 @@ export class ModuleManager {
     return unused;
   }
 
+  // Builds the remote URL for a module, applying credentials if needed.
+  private buildRemoteUrl(
+    module: ModuleSetting,
+    credentials?: Credentials,
+  ): string {
+    if (
+      module.private &&
+      credentials?.username &&
+      credentials?.token &&
+      module.location.startsWith(HTTPS_PROTOCOL)
+    ) {
+      try {
+        const repoUrl = new URL(module.location);
+        const user = credentials.username;
+        const pass = credentials.token;
+        const host = repoUrl.host;
+        const path = repoUrl.pathname;
+        return `https://${user}:${pass}@${host}${path}`;
+      } catch {
+        throw new Error(`Invalid repository URL: ${module.location}`);
+      }
+    }
+    return module.location;
+  }
+
   // Handles cloning of a repository.
   private async clone(
     module: ModuleSetting,
@@ -98,40 +124,15 @@ export class ModuleManager {
 
     const destinationPath = join(this.tempModulesDir, module.name);
 
-    let remote = module.location;
-    if (module.private) {
-      if (
-        credentials &&
-        credentials?.username &&
-        credentials?.token &&
-        module.location.startsWith(HTTPS_PROTOCOL)
-      ) {
-        if (verbose) {
-          console.log(
-            `... Using HTTPS with credentials '${credentials?.username}' for cloning '${module.name}'`,
-          );
-        }
-        try {
-          const repoUrl = new URL(module.location);
-          const user = credentials?.username;
-          const pass = credentials?.token;
-          const host = repoUrl.host;
-          const path = repoUrl.pathname;
-          remote = `https://${user}:${pass}@${host}${path}`;
-        } catch {
-          throw new Error(`Invalid repository URL: ${module.location}`);
-        }
-      } else if (module.location.startsWith('git@')) {
-        if (verbose) {
-          console.log(`... Using SSH for cloning '${module.name}'`);
-        }
-      }
-    } else {
-      if (verbose) {
-        console.log(
-          `... Using HTTPS without credentials for cloning '${module.name}'`,
-        );
-      }
+    const remote = this.buildRemoteUrl(module, credentials);
+    if (verbose) {
+      const protocol =
+        module.private && remote !== module.location
+          ? 'HTTPS with credentials'
+          : module.private && module.location.startsWith('git@')
+            ? 'SSH'
+            : 'HTTPS without credentials';
+      console.log(`... Using ${protocol} for cloning '${module.name}'`);
     }
 
     try {
@@ -218,9 +219,8 @@ export class ModuleManager {
     if (!module) {
       throw new Error(`Module '${moduleName}' not found`);
     }
-    const modulePath = join(module.path, 'cardsConfig.json');
     const moduleConfiguration = (await readJsonFile(
-      modulePath,
+      this.project.paths.moduleConfigurationFile(moduleName),
     )) as ProjectConfiguration;
     return moduleConfiguration.modules
       ? new Set(moduleConfiguration.modules.map((m) => m.name))
@@ -267,6 +267,7 @@ export class ModuleManager {
     this.stripProtocolFromLocation(module);
     await this.remove(module);
     await this.importFromFolder(module.location, module.name);
+    await this.persistModuleVersion(module);
   }
 
   // Updates one module that is received from Git.
@@ -275,6 +276,7 @@ export class ModuleManager {
     const tempLocation = join(this.tempModulesDir, module.name);
     await this.remove(module);
     await this.importFromFolder(tempLocation, module.name);
+    await this.persistModuleVersion(module);
   }
 
   // Updates one module.
@@ -282,6 +284,31 @@ export class ModuleManager {
     return this.isGitModule(module)
       ? this.handleGitModule(module)
       : this.handleFileModule(module);
+  }
+
+  // Reads the version from a module's cardsConfig.json.
+  public async readModuleVersion(
+    moduleName: string,
+  ): Promise<string | undefined> {
+    const configPath = this.project.paths.moduleConfigurationFile(moduleName);
+    try {
+      const config = await readJsonFile(configPath);
+      return config?.version;
+    } catch {
+      return undefined;
+    }
+  }
+
+  // Reads and persists the installed module version from the module's config.
+  private async persistModuleVersion(module: ModuleSetting) {
+    const version = await this.readModuleVersion(module.name);
+    if (version) {
+      module.version = version;
+      await this.project.configuration.updateModuleVersion(
+        module.name,
+        version,
+      );
+    }
   }
 
   // Imports from a given folder. Is used both for .temp/<module name> and file locations.
@@ -566,6 +593,23 @@ export class ModuleManager {
         `Imported project has a prefix '${modulePrefix}' that is already used in the project. Cannot import from module.`,
       );
     }
+  }
+
+  /**
+   * Lists available version tags for a module from its remote repository.
+   * @param module Module to query versions for.
+   * @param credentials Optional credentials for private repositories.
+   * @returns Semver version strings sorted descending (e.g. ["2.1.0", "1.0.0"])
+   */
+  public async listAvailableVersions(
+    module: ModuleSetting,
+    credentials?: Credentials,
+  ): Promise<string[]> {
+    if (!this.isGitModule(module)) {
+      return [];
+    }
+    const remoteUrl = this.buildRemoteUrl(module, credentials);
+    return GitManager.listRemoteVersionTags(remoteUrl);
   }
 
   /**

--- a/tools/data-handler/src/project-settings.ts
+++ b/tools/data-handler/src/project-settings.ts
@@ -287,6 +287,20 @@ export class ProjectConfiguration implements ProjectSettings {
   }
 
   /**
+   * Updates the installed version of a module.
+   * @param moduleName Name of the module to update
+   * @param version Version string to set (or undefined to clear)
+   */
+  public async updateModuleVersion(moduleName: string, version?: string) {
+    const module = this.modules.find((item) => item.name === moduleName);
+    if (!module) {
+      throw new Error(`Module '${moduleName}' is not imported`);
+    }
+    module.version = version;
+    return this.save();
+  }
+
+  /**
    * Changes project name.
    * @param newName New project name
    */

--- a/tools/data-handler/src/utils/git-manager.ts
+++ b/tools/data-handler/src/utils/git-manager.ts
@@ -11,10 +11,21 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
+import semver from 'semver';
 import { simpleGit, type SimpleGit } from 'simple-git';
 import { getChildLogger } from './log-utils.js';
 
 const TAG_PREFIX = 'v';
+
+/** Convert a semver string to a git tag name (e.g. "1.2.3" → "v1.2.3"). */
+export function versionToTag(version: string): string {
+  return `${TAG_PREFIX}${version}`;
+}
+
+/** Strip the tag prefix and return the version, or return as-is if no prefix. */
+export function tagToVersion(tag: string): string {
+  return tag.startsWith(TAG_PREFIX) ? tag.substring(TAG_PREFIX.length) : tag;
+}
 
 export class GitManager {
   private git: SimpleGit;
@@ -99,14 +110,14 @@ export class GitManager {
    * @param message Optional tag message (defaults to the tag name)
    */
   async tagVersion(version: string, message?: string): Promise<void> {
-    const tag = `${TAG_PREFIX}${version}`;
+    const tag = versionToTag(version);
     this.logger.info({ tag }, 'Creating tag');
     await this.git.tag(['-a', tag, '-m', message ?? tag]);
   }
 
   /** Delete a local version tag. */
   async deleteTag(version: string): Promise<void> {
-    const tag = `${TAG_PREFIX}${version}`;
+    const tag = versionToTag(version);
     this.logger.info({ tag }, 'Deleting tag');
     await this.git.tag(['-d', tag]);
   }
@@ -129,5 +140,29 @@ export class GitManager {
       args.push('--follow-tags');
     }
     await this.git.push(args);
+  }
+
+  /**
+   * List available version tags from a remote repository.
+   * Does not require a local repo — queries the remote directly.
+   * @param remoteUrl Git remote URL to query
+   * @returns Semver version strings sorted descending (e.g. ["2.1.0", "1.0.0"])
+   */
+  static async listRemoteVersionTags(remoteUrl: string): Promise<string[]> {
+    const git = simpleGit();
+    const output = await git.listRemote(['--tags', '--refs', remoteUrl]);
+    if (!output.trim()) {
+      return [];
+    }
+    const versions: string[] = [];
+    for (const line of output.trim().split('\n')) {
+      const match = line.match(/refs\/tags\/(.+)$/);
+      if (!match) continue;
+      const version = tagToVersion(match[1]);
+      if (semver.valid(version)) {
+        versions.push(version);
+      }
+    }
+    return versions.sort(semver.rcompare);
   }
 }

--- a/tools/data-handler/test/command-import.test.ts
+++ b/tools/data-handler/test/command-import.test.ts
@@ -15,7 +15,11 @@ import { join } from 'node:path';
 import { copyDir } from '../src/utils/file-utils.js';
 import { Cmd, Commands } from '../src/command-handler.js';
 import { Fetch, Show } from '../src/commands/index.js';
-import { getTestProject } from './helpers/test-utils.js';
+import { ModuleManager } from '../src/module-manager.js';
+import {
+  getTestProject,
+  mockEnsureModuleListUpToDate,
+} from './helpers/test-utils.js';
 
 // Create test artifacts in a temp folder.
 const baseDir = import.meta.dirname;
@@ -183,10 +187,10 @@ describe('import module', () => {
       result = await commandHandler.command(Cmd.show, ['modules'], testOptions);
       expect(result.statusCode).toBe(200);
       if (result.payload) {
-        const modules = Object.values(result.payload);
+        const modules = result.payload as Array<{ name: string }>;
         expect(modules.length).toBe(2);
-        expect(modules).toContain('mini');
-        expect(modules).toContain('decision');
+        expect(modules.map((m) => m.name)).toContain('mini');
+        expect(modules.map((m) => m.name)).toContain('decision');
       }
     }, 10000);
     it('try to import module - no source', async () => {
@@ -363,5 +367,67 @@ describe('import module', () => {
       );
       expect(result.statusCode).toBe(400);
     });
+  });
+});
+
+describe('update-modules version arg', () => {
+  beforeEach(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir('test/test-data', testDir);
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('version without module name returns error', async () => {
+    const result = await commandHandler.command(
+      Cmd.updateModules,
+      ['', '1.0.0'],
+      optionsMini,
+    );
+    expect(result.statusCode).toBe(400);
+    expect(result.message).toContain(
+      'A target version can only be specified together with a module name',
+    );
+  });
+
+  it('version with unknown module name returns error', async () => {
+    mockEnsureModuleListUpToDate();
+    const result = await commandHandler.command(
+      Cmd.updateModules,
+      ['nonexistent-module', '1.0.0'],
+      optionsMini,
+    );
+    expect(result.statusCode).toBe(400);
+    expect(result.message).toContain(
+      "Module 'nonexistent-module' is not part of the project",
+    );
+  });
+
+  it('version not in available list returns error', async () => {
+    // Import a local module so it appears in project.configuration.modules
+    await commandHandler.command(
+      Cmd.import,
+      ['module', decisionRecordsPath],
+      optionsMini,
+    );
+
+    mockEnsureModuleListUpToDate();
+    vi.spyOn(
+      ModuleManager.prototype,
+      'listAvailableVersions',
+    ).mockResolvedValue(['2.0.0', '3.0.0']);
+
+    const result = await commandHandler.command(
+      Cmd.updateModules,
+      ['decision', '1.0.0'],
+      optionsMini,
+    );
+    expect(result.statusCode).toBe(400);
+    expect(result.message).toContain("Version '1.0.0' is not available");
+    expect(result.message).toContain('2.0.0');
+    expect(result.message).toContain('3.0.0');
   });
 });

--- a/tools/data-handler/test/command-show.test.ts
+++ b/tools/data-handler/test/command-show.test.ts
@@ -203,7 +203,7 @@ describe('shows command', () => {
       expect(result.statusCode).toBe(200);
       if (result.payload) {
         expect(result.payload).not.toBeUndefined();
-        const modules = Object.values(result.payload);
+        const modules = result.payload as Array<{ name: string }>;
         expect(modules.length).toBe(0);
       }
     });
@@ -336,12 +336,12 @@ describe('shows command', () => {
       );
       expect(result.statusCode).toBe(200);
       expect(result.payload!).not.toBeUndefined();
-      let modules = Object.values(result.payload!);
-      expect(modules.at(0)).toBe('mini');
+      let modules = result.payload as Array<{ name: string }>;
+      expect(modules.at(0)?.name).toBe('mini');
       result = await commandHandler.command(Cmd.show, ['modules'], optionsMini);
       expect(result.payload).not.toBeUndefined();
-      modules = Object.values(result.payload!);
-      expect(modules.at(0)).toBe('decision');
+      modules = result.payload as Array<{ name: string }>;
+      expect(modules.at(0)?.name).toBe('decision');
     });
     it('show particular module - success()', async () => {
       const result = await commandHandler.command(

--- a/tools/data-handler/test/module-manager.test.ts
+++ b/tools/data-handler/test/module-manager.test.ts
@@ -1,13 +1,24 @@
 // testing
-import { expect, describe, it, beforeEach, afterEach } from 'vitest';
+import { expect, describe, it, beforeEach, afterEach, vi } from 'vitest';
 
 // node
-import { mkdirSync, rmSync } from 'node:fs';
+import {
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import * as os from 'node:os';
 
+import { simpleGit } from 'simple-git';
+
 import { copyDir } from '../src/utils/file-utils.js';
 import { CommandManager } from '../src/command-manager.js';
+import { ModuleManager } from '../src/module-manager.js';
+import { GitManager } from '../src/utils/git-manager.js';
+import type { ModuleSetting } from '../src/interfaces/project-interfaces.js';
 
 describe('module-manager', () => {
   const skipTest = process.env.CI && os.platform() === 'win32';
@@ -149,4 +160,206 @@ describe('module-manager', () => {
     modules = await commands.showCmd.showModules();
     expect(modules.length).equals(2);
   }, 60000);
+});
+
+describe('ModuleManager.listAvailableVersions', () => {
+  const baseDir = import.meta.dirname;
+  const testDir = join(baseDir, 'tmp-module-manager-versions-tests');
+  const decisionRecordsPath = join(testDir, 'valid/decision-records');
+  let commands: CommandManager;
+
+  beforeEach(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir('test/test-data/', testDir);
+    commands = new CommandManager(decisionRecordsPath, {
+      autoSaveConfiguration: false,
+    });
+    await commands.initialize();
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('returns empty array for a local (non-git) module', async () => {
+    const manager = new ModuleManager(commands.project);
+    const localModule: ModuleSetting = {
+      name: 'local-mod',
+      location: '/some/local/path',
+    };
+    const versions = await manager.listAvailableVersions(localModule);
+    expect(versions).toEqual([]);
+  });
+
+  it('embeds credentials in the remote URL for a private git module', async () => {
+    const manager = new ModuleManager(commands.project);
+    const privateModule: ModuleSetting = {
+      name: 'private-mod',
+      location: 'https://github.com/example/module.git',
+      private: true,
+    };
+    const credentials = { username: 'alice', token: 'secret-token' };
+    let capturedUrl = '';
+    vi.spyOn(GitManager, 'listRemoteVersionTags').mockImplementation(
+      async (url) => {
+        capturedUrl = url;
+        return [];
+      },
+    );
+    await manager.listAvailableVersions(privateModule, credentials);
+    expect(capturedUrl).toContain('alice:secret-token@github.com');
+  });
+
+  it('does not embed credentials for a public git module', async () => {
+    const manager = new ModuleManager(commands.project);
+    const publicModule: ModuleSetting = {
+      name: 'public-mod',
+      location: 'https://github.com/example/module.git',
+    };
+    const credentials = { username: 'alice', token: 'secret-token' };
+    let capturedUrl = '';
+    vi.spyOn(GitManager, 'listRemoteVersionTags').mockImplementation(
+      async (url) => {
+        capturedUrl = url;
+        return [];
+      },
+    );
+    await manager.listAvailableVersions(publicModule, credentials);
+    expect(capturedUrl).toBe('https://github.com/example/module.git');
+    expect(capturedUrl).not.toContain('alice');
+  });
+});
+
+describe('ModuleManager git-based updates', () => {
+  const baseDir = import.meta.dirname;
+  const testDir = join(baseDir, 'tmp-module-manager-git-update-tests');
+  const decisionRecordsPath = join(testDir, 'valid/decision-records');
+  const fakeRemotePath = join(testDir, 'fake-remote');
+  let commands: CommandManager;
+
+  async function setupFakeRemote() {
+    mkdirSync(fakeRemotePath, { recursive: true });
+    await copyDir('test/test-data/valid/minimal', fakeRemotePath);
+
+    const git = simpleGit(fakeRemotePath, {
+      config: ['user.name=Test', 'user.email=test@test.com'],
+    });
+    await git.init();
+
+    // v1.0.0: just the base minimal structure with a version field
+    const configPath = join(
+      fakeRemotePath,
+      '.cards',
+      'local',
+      'cardsConfig.json',
+    );
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    config.version = '1.0.0';
+    writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+    await git.add('.');
+    await git.commit('Initial commit');
+    await git.addAnnotatedTag('v1.0.0', 'Version 1.0.0');
+
+    // v2.0.0: bump version and add a new card type
+    config.version = '2.0.0';
+    writeFileSync(configPath, JSON.stringify(config, null, 2));
+    writeFileSync(
+      join(fakeRemotePath, '.cards', 'local', 'cardTypes', 'newCardtype.json'),
+      JSON.stringify(
+        {
+          name: 'mini/cardTypes/newCardtype',
+          displayName: 'New Card Type',
+          workflow: 'mini/workflows/minimal',
+        },
+        null,
+        2,
+      ),
+    );
+
+    await git.add('.');
+    await git.commit('Bump to v2.0.0');
+    await git.addAnnotatedTag('v2.0.0', 'Version 2.0.0');
+  }
+
+  beforeEach(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir('test/test-data/', testDir);
+    await setupFakeRemote();
+    commands = new CommandManager(decisionRecordsPath, {
+      autoSaveConfiguration: false,
+    });
+    await commands.initialize();
+    // Import the minimal module so the project has an initial 'mini' state to update from
+    await commands.importCmd.importModule(
+      join(testDir, 'valid/minimal'),
+      commands.project.basePath,
+    );
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('updates module files to HEAD', async () => {
+    const manager = new ModuleManager(commands.project);
+    vi.spyOn(
+      manager as unknown as { isGitModule: (m: ModuleSetting) => boolean },
+      'isGitModule',
+    ).mockReturnValue(true);
+
+    await manager.updateModule({ name: 'mini', location: fakeRemotePath });
+
+    const installedConfig = JSON.parse(
+      readFileSync(
+        join(commands.project.paths.modulesFolder, 'mini', 'cardsConfig.json'),
+        'utf-8',
+      ),
+    );
+    expect(installedConfig.version).toBe('2.0.0');
+    expect(
+      existsSync(
+        join(
+          commands.project.paths.modulesFolder,
+          'mini',
+          'cardTypes',
+          'newCardtype.json',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('updates module files to a specific tagged version', async () => {
+    const manager = new ModuleManager(commands.project);
+    vi.spyOn(
+      manager as unknown as { isGitModule: (m: ModuleSetting) => boolean },
+      'isGitModule',
+    ).mockReturnValue(true);
+
+    await manager.updateModule({
+      name: 'mini',
+      location: fakeRemotePath,
+      branch: 'v1.0.0',
+    });
+
+    const installedConfig = JSON.parse(
+      readFileSync(
+        join(commands.project.paths.modulesFolder, 'mini', 'cardsConfig.json'),
+        'utf-8',
+      ),
+    );
+    expect(installedConfig.version).toBe('1.0.0');
+    expect(
+      existsSync(
+        join(
+          commands.project.paths.modulesFolder,
+          'mini',
+          'cardTypes',
+          'newCardtype.json',
+        ),
+      ),
+    ).toBe(false);
+  });
 });

--- a/tools/data-handler/test/utils/configuration-logger.test.ts
+++ b/tools/data-handler/test/utils/configuration-logger.test.ts
@@ -10,8 +10,6 @@ import {
 } from '../../src/utils/configuration-logger.js';
 import { deleteDir, pathExists } from '../../src/utils/file-utils.js';
 
-/* eslint-disable @typescript-eslint/no-unused-expressions */
-
 // Create test artifacts in a temp folder.
 const baseDir = import.meta.dirname;
 const testDir = join(baseDir, 'tmp-configuration-logger-tests');


### PR DESCRIPTION
First of a set of PRs realted to versioning. The following features are implemented here:

**cyberismo show modules:** shows all module names and installed version

**cyberismo show module <prefix>:** shows module details including installed version

**cyberismo show project:** shows both the project current version and all installed modules versions

**cyberismo update-modules [name] [version]**: Updates all modules or a specific one. If updating specific one, you may specify a version. 

Note that if you update a module, its dependencies are also updated. Because we don't have version ranges yet or anything, the transitive deps are updated to the latest version. A bit confusing behavior, but we need to enable version ranges before we could make this properly, but  I wanted to split PRs so that they're a bit more manageable to review instead of creating largest PR we've ever seen.