### PR TITLE
Publish fix

### DIFF
--- a/.github/workflows/build-cyberismo-app-image.yml
+++ b/.github/workflows/build-cyberismo-app-image.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           ref: ${{ inputs.tag || '' }}
           fetch-depth: 1
+          submodules: recursive
 
       - name: Extract version from tag
         id: parse

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,8 +28,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
-        with:
-          version: 9
 
       - name: Setup node.js
         uses: actions/setup-node@v4
@@ -112,8 +110,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
-        with:
-          version: 9
 
       - name: Setup node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
We now define pnpm version in the source, but publish still had pnpm version number in the action, so it failed.