### PR TITLE
INTDEV-942 Include the project prefix in the URL

### DIFF
--- a/tools/app/cypress/e2e/app.cy.ts
+++ b/tools/app/cypress/e2e/app.cy.ts
@@ -11,6 +11,7 @@ describe('Navigation', () => {
 
   beforeEach(() => {
     cy.visit('');
+    cy.url().should('include', '/projects/');
   });
 
   it('delete page and verify empty project', () => {

--- a/tools/app/src/App.tsx
+++ b/tools/app/src/App.tsx
@@ -10,8 +10,8 @@
   details. You should have received a copy of the GNU Affero General Public
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
+import { useMemo } from 'react';
 import { RouterProvider } from 'react-router';
-import { router } from './routes';
 import { CssBaseline } from '@mui/joy';
 import { SWRConfig } from 'swr';
 import { getSwrConfig } from './lib/swr';
@@ -25,10 +25,12 @@ import { CssVarsProvider as JoyCssVarsProvider } from '@mui/joy/styles';
 import StoreProvider from './providers/StoreProvider';
 import SessionExpiredBanner from './components/SessionExpiredBanner';
 import './lib/i18n';
+import { createAppRouter } from './routes';
 
 const materialTheme = createTheme();
 
 function App() {
+  const router = useMemo(() => createAppRouter(), []);
   return (
     <ThemeProvider theme={{ [MATERIAL_THEME_ID]: materialTheme }}>
       <JoyCssVarsProvider

--- a/tools/app/src/components/ProjectBreadcrumbs.tsx
+++ b/tools/app/src/components/ProjectBreadcrumbs.tsx
@@ -12,6 +12,7 @@
 
 import React from 'react';
 import { Breadcrumbs, Link, styled } from '@mui/joy';
+import { Link as RouterLink } from 'react-router';
 import HomeIcon from '@mui/icons-material/Home';
 import { findPathTo } from '../lib/utils';
 import type { QueryResult } from '@cyberismo/data-handler/types/queries';
@@ -41,7 +42,8 @@ export const ProjectBreadcrumbs: React.FC<ProjectBreadcrumbsProps> = ({
       {pathComponents.map((node, index) => (
         <Link
           key={node.key}
-          href={`/cards/${node.key}`}
+          component={RouterLink}
+          to={`/cards/${node.key}`}
           style={{
             textDecorationColor: 'grey',
             color: 'grey',

--- a/tools/app/src/lib/hooks/utils.ts
+++ b/tools/app/src/lib/hooks/utils.ts
@@ -332,7 +332,7 @@ export function useDocumentTitle(title: string) {
  */
 export function useIsInCards() {
   const location = useLocation();
-  return location.pathname.startsWith('/cards');
+  return location.pathname.includes('/cards');
 }
 
 /**

--- a/tools/app/src/lib/projectUtils.ts
+++ b/tools/app/src/lib/projectUtils.ts
@@ -1,0 +1,27 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { getSwrConfig, apiPaths } from './swr.js';
+
+/**
+ * Fetch the list of available project prefixes.
+ * Currently uses GET /api/project (single project) and returns a one-element array.
+ * TODO: Replace with GET /api/projects when multi-project backend is available.
+ */
+export async function fetchAvailableProjects(): Promise<string[]> {
+  const { fetcher } = getSwrConfig();
+  const { cardKeyPrefix: prefix } = (await fetcher!(apiPaths.project())) as {
+    cardKeyPrefix?: string;
+  };
+  return prefix ? [prefix] : [];
+}

--- a/tools/app/src/lib/slices/index.ts
+++ b/tools/app/src/lib/slices/index.ts
@@ -17,6 +17,7 @@ import swr from './swr';
 import page from './pageState';
 import card from './card';
 import session from './session';
+import project from './project';
 
 const rootReducer = combineReducers({
   recentlyViewed,
@@ -25,6 +26,7 @@ const rootReducer = combineReducers({
   page,
   card,
   session,
+  project,
 });
 
 export default rootReducer;

--- a/tools/app/src/lib/slices/project.ts
+++ b/tools/app/src/lib/slices/project.ts
@@ -1,0 +1,38 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import type { RootState } from '../store';
+
+export interface ProjectState {
+  projectPrefix: string | undefined;
+}
+
+export const initialState: ProjectState = {
+  projectPrefix: undefined,
+};
+
+export const projectSlice = createSlice({
+  name: 'project',
+  initialState,
+  reducers: {
+    setProjectPrefix(state, action: PayloadAction<string>) {
+      state.projectPrefix = action.payload;
+    },
+  },
+});
+
+export const { setProjectPrefix } = projectSlice.actions;
+export const selectProjectPrefix = (state: RootState) =>
+  state.project.projectPrefix;
+export default projectSlice.reducer;

--- a/tools/app/src/routes.ts
+++ b/tools/app/src/routes.ts
@@ -22,7 +22,9 @@ import ResourceOverviewPage from './pages/configuration/resource-overview';
 import Layout from './pages/layout';
 import ConfigLayout from './pages/configuration/layout';
 import NotFoundPage from './pages/not-found';
-import { isSafeRedirectPath } from './lib/utils.js';
+import { store } from './lib/store.js';
+import { selectProjectPrefix, setProjectPrefix } from './lib/slices/project.js';
+import { fetchAvailableProjects } from './lib/projectUtils.js';
 
 // Export mode guard - unfortunately need to refetch config.json to check export mode since hooks
 function createEditLoader(cardKey: string) {
@@ -50,86 +52,130 @@ function createEditLoader(cardKey: string) {
   };
 }
 
+// Resolve which project to use: try the given prefix first, then persisted, then first available
+async function resolveProject(urlPrefix?: string) {
+  const projects = await fetchAvailableProjects().catch(() => [] as string[]);
+  const lastActive = selectProjectPrefix(store.getState());
+
+  // TODO: Remove single-project fallback when multi-project UI (project selection view) is implemented
+  const fallbackPrefix = projects[0];
+
+  const prefix =
+    (urlPrefix && projects.includes(urlPrefix) ? urlPrefix : null) ??
+    (lastActive && projects.includes(lastActive) ? lastActive : null) ??
+    fallbackPrefix;
+
+  if (prefix) {
+    store.dispatch(setProjectPrefix(prefix));
+  }
+
+  return { prefix, fromUrl: prefix === urlPrefix };
+}
+
 // wrap all the routes in a cards layout
-export const router = createBrowserRouter([
-  {
-    path: '/',
-    loader: () => {
-      if (window.location.search) {
-        const newPath = window.location.search.slice(2).split('&')[0];
-        if (newPath && isSafeRedirectPath(newPath)) {
-          return redirect(newPath);
-        }
-      }
-      return redirect('/cards');
+export function createAppRouter() {
+  return createBrowserRouter([
+    {
+      path: '/',
+      loader: async () => {
+        const { prefix } = await resolveProject();
+        return prefix ? redirect(`/projects/${prefix}/cards`) : null;
+      },
     },
-  },
-  {
-    Component: Layout,
-    children: [
-      {
-        Component: CardsLayout,
-        children: [
-          {
-            path: '/cards.html',
-            loader: () => redirect('/cards'),
-          },
-          {
-            path: '/cards',
-            Component: CardsPage,
-          },
-          {
-            path: '/cards/:key.html',
-            loader: ({ params }) => {
-              return redirect(`/cards/${params.key}`);
+    {
+      path: '/projects/:projectPrefix',
+      Component: Layout,
+      loader: async ({ params }) => {
+        const { prefix, fromUrl } = await resolveProject(params.projectPrefix);
+        if (fromUrl) return null;
+        if (prefix) return redirect(`/projects/${prefix}/cards`);
+        return redirect('/');
+      },
+      children: [
+        {
+          index: true,
+          loader: () => redirect('cards'),
+        },
+        {
+          Component: CardsLayout,
+          children: [
+            {
+              path: 'cards.html',
+              loader: () => redirect('cards'),
             },
-          },
-          {
-            path: '/cards/:key',
-            Component: CardPage,
-          },
-          {
-            path: '/cards/:key/edit.html',
-            loader: ({ params }) => {
-              return redirect(`/cards/${params.key}/edit`);
+            {
+              path: 'cards',
+              Component: CardsPage,
             },
-          },
-          {
-            path: '/cards/:key/edit',
-            loader: ({ params }) => createEditLoader(params.key!)(),
-            Component: CardEditPage,
-          },
-        ],
+            {
+              path: 'cards/:key.html',
+              loader: ({ params }) => {
+                return redirect(
+                  `/projects/${params.projectPrefix}/cards/${params.key}`,
+                );
+              },
+            },
+            {
+              path: 'cards/:key',
+              Component: CardPage,
+            },
+            {
+              path: 'cards/:key/edit.html',
+              loader: ({ params }) => {
+                return redirect(
+                  `/projects/${params.projectPrefix}/cards/${params.key}/edit`,
+                );
+              },
+            },
+            {
+              path: 'cards/:key/edit',
+              loader: ({ params }) => createEditLoader(params.key!)(),
+              Component: CardEditPage,
+            },
+          ],
+        },
+        {
+          Component: ConfigLayout,
+          children: [
+            {
+              path: 'configuration/',
+              Component: Configuration,
+            },
+            {
+              path: 'configuration/general',
+              Component: General,
+            },
+            {
+              path: 'configuration/:resourceType',
+              Component: ResourceOverviewPage,
+            },
+            {
+              path: 'configuration/:module/:type/:resource',
+              Component: Resource,
+            },
+            {
+              path: 'configuration/:module/:type/:resource/:file',
+              Component: Resource,
+            },
+          ],
+        },
+        {
+          path: '*',
+          Component: NotFoundPage,
+        },
+      ],
+    },
+    {
+      // Catch legacy URLs without /projects/ prefix (e.g. /cards/KEY, /configuration/...)
+      path: '*',
+      loader: async ({ request }) => {
+        const { prefix } = await resolveProject();
+        const url = new URL(request.url);
+        if (prefix) {
+          return redirect(`/projects/${prefix}${url.pathname}`);
+        }
+        return redirect('/');
       },
-      {
-        Component: ConfigLayout,
-        children: [
-          {
-            path: '/configuration/',
-            Component: Configuration,
-          },
-          {
-            path: '/configuration/general',
-            Component: General,
-          },
-          {
-            path: '/configuration/:resourceType',
-            Component: ResourceOverviewPage,
-          },
-          {
-            path: '/configuration/:module/:type/:resource',
-            Component: Resource,
-          },
-          {
-            path: '/configuration/:module/:type/:resource/:file',
-            Component: Resource,
-          },
-        ],
-      },
-      {
-        path: '*',
-        Component: NotFoundPage,
-      },
-    ],
-  },
-]);
+    },
+  ]);
+}


### PR DESCRIPTION
Mostly placeholders waiting for the backend implementation, currently this is basically a gimmick that shows the correct project in the url, while allowing all the URLs to work properly. Validations and selections are automated to project given by /api/project, but those should be easy to modify to fit the backend in the future. 

URL will be: http://localhost:3000/projects/<prefix>/cards/<cardKey>

Current idea how this could work:
1. User sees a separate? view where they can select the project from a list (no previous projects selected and no last project information)
2. Selection of project/project got from the navigation URL is set as a currentProject for the gui (validations against url project)
3. React Router will use this project name as a basename (/projects/prefix), also API calls should have this project information with API calls
4. Switching project will change the currentProject value (probably requires the full page navigation to new project url to create new router?)
5. ???
6. Profit  