### PR TITLE
INTDEV-943 Add multiproject functionality

### DIFF
--- a/tools/app/__tests__/components.test.tsx
+++ b/tools/app/__tests__/components.test.tsx
@@ -19,6 +19,7 @@ vi.mock('../src/lib/hooks', async () => {
     useAppRouter: vi.fn(() => ({
       push: vi.fn(),
     })),
+    useAppSelector: vi.fn(() => 'decision'),
     useResizeObserver: vi.fn(() => {
       if (callCount++ % 2 === 0) {
         return { width: 800, height: 2000, ref: vi.fn() }; // Main container height

--- a/tools/app/__tests__/swr.test.ts
+++ b/tools/app/__tests__/swr.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { globalApiPaths, projectApiPaths } from '@/lib/swr';
+
+describe('globalApiPaths', () => {
+  it('returns /api/projects for projects()', () => {
+    expect(globalApiPaths.projects()).toBe('/api/projects');
+  });
+
+  it('returns /api/auth/me for user()', () => {
+    expect(globalApiPaths.user()).toBe('/api/auth/me');
+  });
+});
+
+describe('projectApiPaths', () => {
+  describe('with explicit prefix', () => {
+    it('builds correct base path', () => {
+      const paths = projectApiPaths('TST');
+      expect(paths.cards()).toBe('/api/projects/TST/cards');
+    });
+
+    it('encodes special characters in prefix', () => {
+      const paths = projectApiPaths('my project');
+      expect(paths.cards()).toBe('/api/projects/my%20project/cards');
+    });
+
+    it('builds card path with key', () => {
+      const paths = projectApiPaths('TST');
+      expect(paths.card('TST_1')).toBe('/api/projects/TST/cards/TST_1');
+    });
+
+    it('builds raw card path', () => {
+      const paths = projectApiPaths('TST');
+      expect(paths.rawCard('TST_1')).toBe(
+        '/api/projects/TST/cards/TST_1?raw=true',
+      );
+    });
+
+    it('builds attachment path with encoding', () => {
+      const paths = projectApiPaths('TST');
+      expect(paths.attachment('TST_1', 'my file.png')).toBe(
+        '/api/projects/TST/cards/TST_1/a/my%20file.png',
+      );
+    });
+
+    it('builds cardTypeFieldVisibility path with encoding', () => {
+      const paths = projectApiPaths('TST');
+      expect(paths.cardTypeFieldVisibility('my/type')).toBe(
+        '/api/projects/TST/cardTypes/my%2Ftype/field-visibility',
+      );
+    });
+
+    it('builds presence path', () => {
+      const paths = projectApiPaths('TST');
+      expect(paths.presence('TST_1', 'editing')).toBe(
+        '/api/projects/TST/cards/TST_1/presence?mode=editing',
+      );
+    });
+
+    it('builds resource paths', () => {
+      const paths = projectApiPaths('TST');
+      expect(paths.resourceTree()).toBe('/api/projects/TST/resources/tree');
+      expect(paths.resource('fieldTypes/myField')).toBe(
+        '/api/projects/TST/resources/fieldTypes/myField',
+      );
+      expect(paths.resourceOperation('fieldTypes/myField')).toBe(
+        '/api/projects/TST/resources/fieldTypes/myField/operation',
+      );
+    });
+
+    it('builds project module paths', () => {
+      const paths = projectApiPaths('TST');
+      expect(paths.project()).toBe('/api/projects/TST/project');
+      expect(paths.projectModulesAdd()).toBe(
+        '/api/projects/TST/project/modules',
+      );
+      expect(paths.projectModulesUpdate()).toBe(
+        '/api/projects/TST/project/modules/update',
+      );
+      expect(paths.projectModuleUpdate('my-mod')).toBe(
+        '/api/projects/TST/project/modules/my-mod/update',
+      );
+      expect(paths.projectModuleDelete('my-mod')).toBe(
+        '/api/projects/TST/project/modules/my-mod',
+      );
+      expect(paths.projectModulesImportable()).toBe(
+        '/api/projects/TST/project/modules/importable',
+      );
+    });
+  });
+
+  describe('different prefixes produce different paths', () => {
+    it('uses the prefix in all paths', () => {
+      const pathsA = projectApiPaths('AAA');
+      const pathsB = projectApiPaths('BBB');
+      expect(pathsA.cards()).not.toBe(pathsB.cards());
+      expect(pathsA.tree()).toBe('/api/projects/AAA/tree');
+      expect(pathsB.tree()).toBe('/api/projects/BBB/tree');
+    });
+  });
+
+});

--- a/tools/app/cypress/e2e/xss.cy.ts
+++ b/tools/app/cypress/e2e/xss.cy.ts
@@ -14,8 +14,11 @@ const createPageCard = () => {
 const patchCardContent = (content: string) => {
   cy.url().then((url) => {
     const cardKey = url.split('/cards/')[1];
-    cy.request('PATCH', `/api/cards/${cardKey}`, { content });
-    cy.visit(`/cards/${cardKey}`);
+    const projectPrefix = url.split('/projects/')[1].split('/')[0];
+    cy.request('PATCH', `/api/projects/${projectPrefix}/cards/${cardKey}`, {
+      content,
+    });
+    cy.visit(`/projects/${projectPrefix}/cards/${cardKey}`);
   });
 };
 

--- a/tools/app/src/components/CardEditor.tsx
+++ b/tools/app/src/components/CardEditor.tsx
@@ -73,7 +73,7 @@ import {
   findCurrentTitleFromADoc,
   findSection,
 } from '@/lib/codemirror';
-import { apiPaths } from '@/lib/swr';
+import { projectApiPaths } from '@/lib/swr';
 import { useAttachments } from '@/lib/api/attachments';
 import { isEdited, viewChanged } from '@/lib/slices/pageState';
 import LoadingGate from '@/components/LoadingGate';
@@ -118,6 +118,8 @@ function AttachmentPreviewCard({
   const dispatch = useAppDispatch();
 
   const { t } = useTranslation();
+
+  const apiPaths = projectApiPaths();
 
   return (
     <Card
@@ -258,6 +260,8 @@ export default function CardEditor({
 
   const { card, error: errorCard, isLoading: isLoadingCard } = cardData;
   const { updateCard } = useCardMutations(cardKey);
+
+  const apiPaths = projectApiPaths();
 
   const {
     linkTypes,

--- a/tools/app/src/components/SearchableTreeMenu.tsx
+++ b/tools/app/src/components/SearchableTreeMenu.tsx
@@ -14,11 +14,16 @@
 import { useState, useMemo } from 'react';
 import type { NodeApi } from 'react-arborist';
 import type { QueryResult } from '@cyberismo/data-handler/types/queries';
-import { Input, Stack, IconButton } from '@mui/joy';
+import { Input, Stack, IconButton, Select, Option } from '@mui/joy';
 import SearchIcon from '@mui/icons-material/Search';
 import CloseIcon from '@mui/icons-material/Close';
+import FolderOpen from '@mui/icons-material/FolderOpen';
 import { TreeMenu } from './TreeMenu';
 import { useTranslation } from 'react-i18next';
+import useSWR from 'swr';
+import { globalApiPaths } from '../lib/swr';
+import { useNavigate, useParams } from 'react-router';
+import type { AvailableProject } from '../lib/projectUtils';
 
 type SearchableTreeMenuProps = {
   title?: string;
@@ -67,6 +72,13 @@ export const SearchableTreeMenu = ({
 }: SearchableTreeMenuProps) => {
   const { t } = useTranslation();
   const [searchQuery, setSearchQuery] = useState('');
+  const navigate = useNavigate();
+  const { projectPrefix: currentPrefix } = useParams();
+  // TODO: Replace with a dedicated project management view
+  const { data: projects } = useSWR<AvailableProject[]>(
+    globalApiPaths.projects(),
+  );
+  const showProjectSelector = projects && projects.length > 1;
 
   const handleClearSearch = () => {
     setSearchQuery('');
@@ -87,8 +99,31 @@ export const SearchableTreeMenu = ({
 
   return (
     <Stack height="100%" width="100%" bgcolor="background.surface">
+      {/* Project selector — placeholder until the next feature update with proper project manager/selector */}
+      {showProjectSelector && (
+        <Stack px={3} pt={3} pb={0}>
+          <Select
+            value={currentPrefix ?? ''}
+            onChange={(_e, value) => {
+              if (value && value !== currentPrefix) {
+                navigate(`/projects/${value}/cards`);
+              }
+            }}
+            size="sm"
+            startDecorator={<FolderOpen />}
+            sx={{ bgcolor: 'transparent' }}
+          >
+            {projects.map((p) => (
+              <Option key={p.prefix} value={p.prefix}>
+                {p.name}
+              </Option>
+            ))}
+          </Select>
+        </Stack>
+      )}
+
       {/* Search input */}
-      <Stack px={3} pt={3} pb={1}>
+      <Stack px={3} pt={showProjectSelector ? 1 : 3} pb={1}>
         <Input
           placeholder={t('searchCards')}
           value={searchQuery}

--- a/tools/app/src/components/modals/AddModuleModal.tsx
+++ b/tools/app/src/components/modals/AddModuleModal.tsx
@@ -29,7 +29,7 @@ import {
   Divider,
 } from '@mui/joy';
 import { useTranslation } from 'react-i18next';
-import { apiPaths } from '@/lib/swr';
+import { projectApiPaths } from '@/lib/swr';
 import type { ModuleSettingFromHub } from '@cyberismo/data-handler';
 import { CategoryOption } from './OptionCards';
 import { addNotification } from '@/lib/slices/notifications';
@@ -50,7 +50,7 @@ export function AddModuleModal({ open, onClose, onAdd }: AddModuleModalProps) {
   const [isImporting, setIsImporting] = useState(false);
 
   const { data: hubModules } = useSWR<ModuleSettingFromHub[]>(
-    apiPaths.projectModulesImportable(),
+    projectApiPaths().projectModulesImportable(),
   );
 
   const handleSelectModule = (moduleName: string) => {

--- a/tools/app/src/lib/api/actions/attachments.ts
+++ b/tools/app/src/lib/api/actions/attachments.ts
@@ -10,14 +10,29 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { callApi } from '../../swr';
+import { callApi, projectApiPaths } from '../../swr';
 
-export async function addAttachments(key: string, formData: FormData) {
-  return callApi(`/api/cards/${key}/attachments`, 'POST', formData);
+export async function addAttachments(
+  key: string,
+  formData: FormData,
+  projectPrefix?: string,
+) {
+  return callApi(
+    projectApiPaths(projectPrefix).cardAttachments(key),
+    'POST',
+    formData,
+  );
 }
 
-export async function removeAttachment(key: string, filename: string) {
-  return callApi(`/api/cards/${key}/attachments/${filename}`, 'DELETE');
+export async function removeAttachment(
+  key: string,
+  filename: string,
+  projectPrefix?: string,
+) {
+  return callApi(
+    projectApiPaths(projectPrefix).cardAttachment(key, filename),
+    'DELETE',
+  );
 }
 
 /**
@@ -26,6 +41,13 @@ export async function removeAttachment(key: string, filename: string) {
  * @param filename
  * @returns
  */
-export async function openAttachment(key: string, filename: string) {
-  return callApi(`/api/cards/${key}/attachments/${filename}/open`, 'POST');
+export async function openAttachment(
+  key: string,
+  filename: string,
+  projectPrefix?: string,
+) {
+  return callApi(
+    projectApiPaths(projectPrefix).cardAttachmentOpen(key, filename),
+    'POST',
+  );
 }

--- a/tools/app/src/lib/api/actions/card.ts
+++ b/tools/app/src/lib/api/actions/card.ts
@@ -10,11 +10,15 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { callApi } from '../../swr';
+import { callApi, projectApiPaths } from '../../swr';
 
-export async function parseContent(key: string, content: string) {
+export async function parseContent(
+  key: string,
+  content: string,
+  projectPrefix?: string,
+) {
   const result = await callApi<{ parsedContent: string }>(
-    `/api/cards/${key}/parse`,
+    projectApiPaths(projectPrefix).cardParse(key),
     'POST',
     { content },
   );

--- a/tools/app/src/lib/api/actions/link.ts
+++ b/tools/app/src/lib/api/actions/link.ts
@@ -10,7 +10,7 @@
     License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { callApi } from '../../swr';
+import { callApi, projectApiPaths } from '../../swr';
 
 export async function createLink(
   fromCard: string,
@@ -18,8 +18,10 @@ export async function createLink(
   linkType: string,
   linkDescription?: string,
   direction: 'outbound' | 'inbound' = 'outbound',
+  projectPrefix?: string,
 ) {
-  return callApi(`/api/cards/${fromCard}/links`, 'POST', {
+  const apiPaths = projectApiPaths(projectPrefix);
+  return callApi(apiPaths.cardLinks(fromCard), 'POST', {
     toCard,
     linkType,
     description: linkDescription,
@@ -33,8 +35,10 @@ export async function removeLink(
   linkType: string,
   linkDescription?: string,
   direction: 'outbound' | 'inbound' = 'outbound',
+  projectPrefix?: string,
 ) {
-  return callApi(`/api/cards/${fromCard}/links`, 'DELETE', {
+  const apiPaths = projectApiPaths(projectPrefix);
+  return callApi(apiPaths.cardLinks(fromCard), 'DELETE', {
     toCard,
     linkType,
     description: linkDescription,
@@ -52,8 +56,10 @@ export async function updateLink(
   previousDirection: 'outbound' | 'inbound' = 'outbound',
   linkDescription?: string,
   previousLinkDescription?: string,
+  projectPrefix?: string,
 ) {
-  return callApi(`/api/cards/${fromCard}/links`, 'PUT', {
+  const apiPaths = projectApiPaths(projectPrefix);
+  return callApi(apiPaths.cardLinks(fromCard), 'PUT', {
     toCard,
     linkType,
     description: linkDescription,

--- a/tools/app/src/lib/api/attachments.ts
+++ b/tools/app/src/lib/api/attachments.ts
@@ -15,14 +15,16 @@ import { useCard } from './card';
 import { useUpdating } from '../hooks';
 import { addAttachments, removeAttachment } from './actions';
 import { mutate } from 'swr';
-import { apiPaths } from '../swr';
+import { projectApiPaths } from '../swr';
 import type { AttachmentAction } from './action-types';
 
 export const useAttachments = (
   key: string | null,
   options?: SWRConfiguration,
+  projectPrefix?: string,
 ) => {
   const { card } = useCard(key, options);
+  const apiPaths = projectApiPaths(projectPrefix);
   // NOTE: not an swrkey, but this pretends to be one
   const swrKey = key != null && card ? `${key}/a` : null;
   const { isUpdating, call } = useUpdating(swrKey);
@@ -32,7 +34,7 @@ export const useAttachments = (
       call(() => {
         const formData = new FormData();
         files.forEach((file) => formData.append('files', file));
-        return addAttachments(key, formData).then(() => {
+        return addAttachments(key, formData, projectPrefix).then(() => {
           mutate(apiPaths.card(key));
           mutate(apiPaths.rawCard(key));
         });
@@ -41,7 +43,7 @@ export const useAttachments = (
       key &&
       call(
         () =>
-          removeAttachment(key, fileName).then(() => {
+          removeAttachment(key, fileName, projectPrefix).then(() => {
             mutate(apiPaths.card(key));
             mutate(apiPaths.rawCard(key));
           }),

--- a/tools/app/src/lib/api/calculation.ts
+++ b/tools/app/src/lib/api/calculation.ts
@@ -11,24 +11,28 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { callApi } from '../swr';
-import { apiPaths } from '../swr';
+import { callApi, projectApiPaths } from '../swr';
 import { mutate } from 'swr';
 import type { CreateCalculationData } from '@/lib/definitions';
 import { useUpdating } from '../hooks';
 
-export const createCalculation = async (data: CreateCalculationData) => {
+export const createCalculation = async (
+  data: CreateCalculationData,
+  projectPrefix?: string,
+) => {
+  const apiPaths = projectApiPaths(projectPrefix);
   await callApi(apiPaths.calculations(), 'POST', data);
   mutate(apiPaths.calculations());
   mutate(apiPaths.resourceTree());
 };
 
-export const useCalculations = () => {
+export const useCalculations = (projectPrefix?: string) => {
+  const apiPaths = projectApiPaths(projectPrefix);
   const { call, isUpdating } = useUpdating(apiPaths.calculations());
 
   return {
     isUpdating: (action?: string) => isUpdating(action),
     createCalculation: async (data: CreateCalculationData) =>
-      await call(() => createCalculation(data), 'create'),
+      await call(() => createCalculation(data, projectPrefix), 'create'),
   };
 };

--- a/tools/app/src/lib/api/card.ts
+++ b/tools/app/src/lib/api/card.ts
@@ -11,7 +11,7 @@
 */
 
 import { useSWRHook } from './common';
-import { callApi, apiPaths } from '../swr';
+import { callApi, projectApiPaths } from '../swr';
 
 import type { SWRConfiguration } from 'swr';
 import { mutate } from 'swr';
@@ -31,7 +31,9 @@ const useCardData = (
   key: string | null,
   raw: boolean = false,
   options?: SWRConfiguration,
+  projectPrefix?: string,
 ) => {
+  const apiPaths = projectApiPaths(projectPrefix);
   const {
     // TODO: get rid of these functions from useSWRHook
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -54,9 +56,13 @@ export type CardData = ReturnType<typeof useCardData>;
 export const useRawCard = (key: string | null, options?: SWRConfiguration) =>
   useCardData(key, true, options);
 
-export const useCardMutations = (key: string | null) => {
+export const useCardMutations = (
+  key: string | null,
+  projectPrefix?: string,
+) => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
+  const apiPaths = projectApiPaths(projectPrefix);
 
   // since writes and reads are separate, we can use apiPath.card here
   const swrKey = key ? apiPaths.card(key) : null;
@@ -189,7 +195,12 @@ export const useCard = (key: string | null, options?: SWRConfiguration) => {
 
   return { ...cardData, ...mutations };
 };
-export async function updateCard(key: string, cardUpdate: CardUpdate) {
+export async function updateCard(
+  key: string,
+  cardUpdate: CardUpdate,
+  projectPrefix?: string,
+) {
+  const apiPaths = projectApiPaths(projectPrefix);
   const swrKey = apiPaths.card(key);
   const result = await callApi<CardDetails>(swrKey, 'PATCH', cardUpdate);
 
@@ -201,7 +212,8 @@ export async function updateCard(key: string, cardUpdate: CardUpdate) {
   mutate(apiPaths.tree());
 }
 
-export async function deleteCard(key: string) {
+export async function deleteCard(key: string, projectPrefix?: string) {
+  const apiPaths = projectApiPaths(projectPrefix);
   const swrKey = apiPaths.card(key);
   await callApi(swrKey, 'DELETE');
 
@@ -214,7 +226,9 @@ export async function deleteCard(key: string) {
 export async function createCard(
   parentKey: string,
   template: string,
+  projectPrefix?: string,
 ): Promise<Card[]> {
+  const apiPaths = projectApiPaths(projectPrefix);
   const result = await callApi<Card[]>(apiPaths.card(parentKey), 'POST', {
     template,
   });

--- a/tools/app/src/lib/api/cardType.ts
+++ b/tools/app/src/lib/api/cardType.ts
@@ -11,7 +11,7 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 import { callApi } from '../swr';
-import { apiPaths } from '../swr';
+import { projectApiPaths } from '../swr';
 import { mutate } from 'swr';
 import type { CreateCardTypeData } from '@/lib/definitions';
 import { useUpdating } from '../hooks';
@@ -24,7 +24,11 @@ export type FieldVisibilityUpdate = {
   index?: number;
 };
 
-export const createCardType = async (data: CreateCardTypeData) => {
+export const createCardType = async (
+  data: CreateCardTypeData,
+  projectPrefix?: string,
+) => {
+  const apiPaths = projectApiPaths(projectPrefix);
   await callApi(apiPaths.cardTypes(), 'POST', data);
   mutate(apiPaths.cardTypes());
   mutate(apiPaths.resourceTree());
@@ -33,19 +37,24 @@ export const createCardType = async (data: CreateCardTypeData) => {
 export const updateFieldVisibility = async (
   cardTypeName: string,
   body: FieldVisibilityUpdate,
+  projectPrefix?: string,
 ) => {
+  const apiPaths = projectApiPaths(projectPrefix);
   await callApi(apiPaths.cardTypeFieldVisibility(cardTypeName), 'PATCH', body);
   mutate(apiPaths.resourceTree());
 };
 
-export const useCardTypeMutations = (cardTypeName: string) => {
+export const useCardTypeMutations = (
+  cardTypeName: string,
+  projectPrefix?: string,
+) => {
   const { isUpdating, call } = useUpdating(cardTypeName);
 
   return {
     isUpdating: (action?: string) => isUpdating(action),
     updateFieldVisibility: async (body: FieldVisibilityUpdate) => {
       await call(
-        () => updateFieldVisibility(cardTypeName, body),
+        () => updateFieldVisibility(cardTypeName, body, projectPrefix),
         'fieldVisibility',
       );
     },

--- a/tools/app/src/lib/api/connectors.ts
+++ b/tools/app/src/lib/api/connectors.ts
@@ -12,9 +12,17 @@
 */
 
 import { useSWRHook } from './common';
-import { apiPaths } from '../swr';
+import { projectApiPaths } from '../swr';
 
 import type { SWRConfiguration } from 'swr';
 
-export const useConnectors = (options?: SWRConfiguration) =>
-  useSWRHook<'connectors'>(apiPaths.connectors(), 'connectors', null, options);
+export const useConnectors = (
+  options?: SWRConfiguration,
+  projectPrefix?: string,
+) =>
+  useSWRHook<'connectors'>(
+    projectApiPaths(projectPrefix).connectors(),
+    'connectors',
+    null,
+    options,
+  );

--- a/tools/app/src/lib/api/fieldTypes.ts
+++ b/tools/app/src/lib/api/fieldTypes.ts
@@ -11,16 +11,28 @@
 */
 
 import { useSWRHook } from './common';
-import { apiPaths, callApi } from '../swr';
+import { projectApiPaths, callApi } from '../swr';
 
 import type { SWRConfiguration } from 'swr';
 import { mutate } from 'swr';
 import type { CreateFieldTypeData } from '@/lib/definitions';
 
-export const useFieldTypes = (options?: SWRConfiguration) =>
-  useSWRHook<'fieldTypes'>(apiPaths.fieldTypes(), 'fieldTypes', null, options);
+export const useFieldTypes = (
+  options?: SWRConfiguration,
+  projectPrefix?: string,
+) =>
+  useSWRHook<'fieldTypes'>(
+    projectApiPaths(projectPrefix).fieldTypes(),
+    'fieldTypes',
+    null,
+    options,
+  );
 
-export const createFieldType = async (data: CreateFieldTypeData) => {
+export const createFieldType = async (
+  data: CreateFieldTypeData,
+  projectPrefix?: string,
+) => {
+  const apiPaths = projectApiPaths(projectPrefix);
   await callApi(apiPaths.fieldTypes(), 'POST', data);
   mutate(apiPaths.fieldTypes());
   mutate(apiPaths.resourceTree());

--- a/tools/app/src/lib/api/graphModel.ts
+++ b/tools/app/src/lib/api/graphModel.ts
@@ -10,12 +10,15 @@
   details. You should have received a copy of the GNU Affero General Public
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
-import { callApi } from '../swr';
-import { apiPaths } from '../swr';
+import { callApi, projectApiPaths } from '../swr';
 import { mutate } from 'swr';
 import type { CreateGraphModelData } from '@/lib/definitions';
 
-export const createGraphModel = async (data: CreateGraphModelData) => {
+export const createGraphModel = async (
+  data: CreateGraphModelData,
+  projectPrefix?: string,
+) => {
+  const apiPaths = projectApiPaths(projectPrefix);
   await callApi(apiPaths.graphModels(), 'POST', data);
   mutate(apiPaths.graphModels());
   mutate(apiPaths.resourceTree());

--- a/tools/app/src/lib/api/graphView.ts
+++ b/tools/app/src/lib/api/graphView.ts
@@ -10,12 +10,15 @@
   details. You should have received a copy of the GNU Affero General Public
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
-import { callApi } from '../swr';
-import { apiPaths } from '../swr';
+import { callApi, projectApiPaths } from '../swr';
 import { mutate } from 'swr';
 import type { CreateGraphViewData } from '@/lib/definitions';
 
-export const createGraphView = async (data: CreateGraphViewData) => {
+export const createGraphView = async (
+  data: CreateGraphViewData,
+  projectPrefix?: string,
+) => {
+  const apiPaths = projectApiPaths(projectPrefix);
   await callApi(apiPaths.graphViews(), 'POST', data);
   mutate(apiPaths.graphViews());
   mutate(apiPaths.resourceTree());

--- a/tools/app/src/lib/api/labels.ts
+++ b/tools/app/src/lib/api/labels.ts
@@ -12,9 +12,14 @@
 */
 
 import { useSWRHook } from './common';
-import { apiPaths } from '../swr';
+import { projectApiPaths } from '../swr';
 
 import type { SWRConfiguration } from 'swr';
 
-export const useLabels = (options?: SWRConfiguration) =>
-  useSWRHook<'labels', string[]>(apiPaths.labels(), 'labels', [], options);
+export const useLabels = (options?: SWRConfiguration, projectPrefix?: string) =>
+  useSWRHook<'labels', string[]>(
+    projectApiPaths(projectPrefix).labels(),
+    'labels',
+    [],
+    options,
+  );

--- a/tools/app/src/lib/api/linkTypes.ts
+++ b/tools/app/src/lib/api/linkTypes.ts
@@ -11,16 +11,28 @@
 */
 
 import { useSWRHook } from './common';
-import { apiPaths, callApi } from '../swr';
+import { projectApiPaths, callApi } from '../swr';
 import { mutate } from 'swr';
 import type { CreateLinkTypeData } from '@/lib/definitions';
 
 import type { SWRConfiguration } from 'swr';
 
-export const useLinkTypes = (options?: SWRConfiguration) =>
-  useSWRHook<'linkTypes'>(apiPaths.linkTypes(), 'linkTypes', null, options);
+export const useLinkTypes = (
+  options?: SWRConfiguration,
+  projectPrefix?: string,
+) =>
+  useSWRHook<'linkTypes'>(
+    projectApiPaths(projectPrefix).linkTypes(),
+    'linkTypes',
+    null,
+    options,
+  );
 
-export const createLinkType = async (data: CreateLinkTypeData) => {
+export const createLinkType = async (
+  data: CreateLinkTypeData,
+  projectPrefix?: string,
+) => {
+  const apiPaths = projectApiPaths(projectPrefix);
   await callApi(apiPaths.linkTypes(), 'POST', data);
   mutate(apiPaths.linkTypes());
   mutate(apiPaths.resourceTree());

--- a/tools/app/src/lib/api/logicPrograms.ts
+++ b/tools/app/src/lib/api/logicPrograms.ts
@@ -12,16 +12,17 @@
 */
 
 import { useSWRHook } from './common';
-import { apiPaths } from '../swr';
+import { projectApiPaths } from '../swr';
 
 import type { SWRConfiguration } from 'swr';
 
 export const useLogicPrograms = (
   resourceName: string,
   options?: SWRConfiguration,
+  projectPrefix?: string,
 ) =>
   useSWRHook<'logicPrograms'>(
-    apiPaths.logicPrograms(resourceName),
+    projectApiPaths(projectPrefix).logicPrograms(resourceName),
     'logicPrograms',
     null,
     options,

--- a/tools/app/src/lib/api/presence.ts
+++ b/tools/app/src/lib/api/presence.ts
@@ -13,7 +13,7 @@
 
 import { useEffect, useState } from 'react';
 import { getConfig } from '@/lib/utils';
-import { apiPaths } from '@/lib/swr.js';
+import { projectApiPaths } from '@/lib/swr.js';
 import { z } from 'zod';
 
 const presenceEntrySchema = z.object({
@@ -38,15 +38,18 @@ export type PresenceEntry = z.infer<typeof presenceEntrySchema>;
 export function usePresence(
   cardKey: string | null,
   mode: 'viewing' | 'editing' = 'viewing',
+  projectPrefix?: string,
 ): PresenceEntry[] {
   const [editors, setEditors] = useState<PresenceEntry[]>([]);
+  const url = cardKey
+    ? projectApiPaths(projectPrefix).presence(cardKey, mode)
+    : null;
 
   useEffect(() => {
-    if (!cardKey || getConfig().staticMode) {
+    if (!url || getConfig().staticMode) {
       return;
     }
 
-    const url = apiPaths.presence(cardKey, mode);
     const eventSource = new EventSource(url);
 
     eventSource.addEventListener('presence', (event) => {
@@ -67,7 +70,7 @@ export function usePresence(
       eventSource.close();
       setEditors([]);
     };
-  }, [cardKey, mode]);
+  }, [url]);
 
   if (!cardKey || getConfig().staticMode) return [];
 

--- a/tools/app/src/lib/api/project.ts
+++ b/tools/app/src/lib/api/project.ts
@@ -11,7 +11,7 @@
 */
 
 import { useSWRHook } from './common';
-import { apiPaths } from '../swr';
+import { projectApiPaths } from '../swr';
 
 import type { SWRConfiguration } from 'swr';
 import type { CardUpdate } from './types';
@@ -20,7 +20,11 @@ import { updateCard } from './card';
 /**
  * @deprecated Use useProjectSettings for project configuration. Use resource hooks for resources
  */
-export const useProject = (options?: SWRConfiguration) => {
+export const useProject = (
+  options?: SWRConfiguration,
+  projectPrefix?: string,
+) => {
+  const apiPaths = projectApiPaths(projectPrefix);
   const { callUpdate, ...rest } = useSWRHook<'project'>(
     apiPaths.cards(),
     'project',

--- a/tools/app/src/lib/api/projectSettings.ts
+++ b/tools/app/src/lib/api/projectSettings.ts
@@ -13,64 +13,92 @@
 
 import type { SWRConfiguration } from 'swr';
 import { mutate } from 'swr';
-import { apiPaths, callApi } from '../swr';
+import { projectApiPaths, callApi } from '../swr';
 import { useSWRHook } from './common';
 import type { GeneralSettings } from './types';
 import { useUpdating } from '../hooks';
 
-export const useProjectSettings = (options?: SWRConfiguration) =>
-  useSWRHook<'general'>(apiPaths.project(), 'general', null, options);
+export const useProjectSettings = (
+  options?: SWRConfiguration,
+  projectPrefix?: string,
+) =>
+  useSWRHook<'general'>(
+    projectApiPaths(projectPrefix).project(),
+    'general',
+    null,
+    options,
+  );
 
 export const updateProjectSettings = async (
   body: Partial<Pick<GeneralSettings, 'cardKeyPrefix'>>,
+  projectPrefix?: string,
 ) => {
+  const apiPaths = projectApiPaths(projectPrefix);
   await callApi(apiPaths.project(), 'PATCH', body);
   mutate(apiPaths.project());
   mutate(apiPaths.resourceTree());
 };
 
-export const updateProjectModule = async (moduleName: string) => {
+export const updateProjectModule = async (
+  moduleName: string,
+  projectPrefix?: string,
+) => {
+  const apiPaths = projectApiPaths(projectPrefix);
   await callApi(apiPaths.projectModuleUpdate(moduleName), 'POST');
   mutate(apiPaths.project());
   mutate(apiPaths.resourceTree());
 };
 
-export const deleteProjectModule = async (moduleName: string) => {
+export const deleteProjectModule = async (
+  moduleName: string,
+  projectPrefix?: string,
+) => {
+  const apiPaths = projectApiPaths(projectPrefix);
   await callApi(apiPaths.projectModuleDelete(moduleName), 'DELETE');
   mutate(apiPaths.project());
   mutate(apiPaths.resourceTree());
   mutate(apiPaths.templates());
 };
 
-export const updateAllProjectModules = async () => {
+export const updateAllProjectModules = async (projectPrefix?: string) => {
+  const apiPaths = projectApiPaths(projectPrefix);
   await callApi(apiPaths.projectModulesUpdate(), 'POST');
   mutate(apiPaths.project());
   mutate(apiPaths.resourceTree());
 };
 
-export const addModule = async (source: string) => {
-  await callApi('/api/project/modules', 'POST', { source });
+export const addModule = async (source: string, projectPrefix?: string) => {
+  const apiPaths = projectApiPaths(projectPrefix);
+  await callApi(apiPaths.projectModulesAdd(), 'POST', { source });
   mutate(apiPaths.project());
   mutate(apiPaths.resourceTree());
   mutate(apiPaths.templates());
   mutate(apiPaths.projectModulesImportable());
 };
 
-export const useProjectSettingsMutations = () => {
+export const useProjectSettingsMutations = (projectPrefix?: string) => {
+  const apiPaths = projectApiPaths(projectPrefix);
   const { call, isUpdating } = useUpdating(apiPaths.project());
   const mutations = {
     isUpdating: (action?: string) => isUpdating(action),
     updateProject: (
       body: Partial<Pick<GeneralSettings, 'name' | 'cardKeyPrefix'>>,
       action: string = 'update',
-    ) => call(() => updateProjectSettings(body), action),
+    ) => call(() => updateProjectSettings(body, projectPrefix), action),
     updateModule: (moduleName: string) =>
-      call(() => updateProjectModule(moduleName), `update-${moduleName}`),
+      call(
+        () => updateProjectModule(moduleName, projectPrefix),
+        `update-${moduleName}`,
+      ),
     deleteModule: (moduleName: string) =>
-      call(() => deleteProjectModule(moduleName), `delete-${moduleName}`),
+      call(
+        () => deleteProjectModule(moduleName, projectPrefix),
+        `delete-${moduleName}`,
+      ),
     updateAllModules: () =>
-      call(() => updateAllProjectModules(), 'update-all-modules'),
-    addModule: (source: string) => call(() => addModule(source), 'add-module'),
+      call(() => updateAllProjectModules(projectPrefix), 'update-all-modules'),
+    addModule: (source: string) =>
+      call(() => addModule(source, projectPrefix), 'add-module'),
   };
   return mutations;
 };

--- a/tools/app/src/lib/api/report.ts
+++ b/tools/app/src/lib/api/report.ts
@@ -10,12 +10,15 @@
   details. You should have received a copy of the GNU Affero General Public
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
-
-import { callApi, apiPaths } from '../swr';
+import { callApi, projectApiPaths } from '../swr';
 import { mutate } from 'swr';
 import type { CreateReportData } from '@/lib/definitions';
 
-export const createReport = async (data: CreateReportData) => {
+export const createReport = async (
+  data: CreateReportData,
+  projectPrefix?: string,
+) => {
+  const apiPaths = projectApiPaths(projectPrefix);
   await callApi(apiPaths.reports(), 'POST', data);
   mutate(apiPaths.reports());
   mutate(apiPaths.resourceTree());

--- a/tools/app/src/lib/api/resources.ts
+++ b/tools/app/src/lib/api/resources.ts
@@ -13,7 +13,7 @@
 
 import type { SWRConfiguration } from 'swr';
 import { mutate } from 'swr';
-import { apiPaths, callApi } from '../swr';
+import { projectApiPaths, callApi } from '../swr';
 import type { ResourceBaseMetadata } from '@cyberismo/data-handler/interfaces/resource-interfaces';
 import { useSWRHook } from './common';
 import type { AnyNode } from './types';
@@ -27,28 +27,45 @@ export const hasResourceData = (
   return 'data' in node;
 };
 
-export const useResourceTree = (options?: SWRConfiguration) =>
-  useSWRHook(apiPaths.resourceTree(), 'resourceTree', [], options);
+export const useResourceTree = (
+  options?: SWRConfiguration,
+  projectPrefix?: string,
+) =>
+  useSWRHook(
+    projectApiPaths(projectPrefix).resourceTree(),
+    'resourceTree',
+    [],
+    options,
+  );
 
-export const useResource = (resourceName: string) => {
+export const useResource = (resourceName: string, projectPrefix?: string) => {
   const { isUpdating, call } = useUpdating(resourceName);
   return {
     isUpdating: (action?: string) => isUpdating(action),
     deleteResource: async () => {
-      await deleteResource(resourceName);
+      await deleteResource(resourceName, projectPrefix);
     },
     update: async <Type, T extends UpdateOperations>(
       body: UpdateOperationBody<Type, T>,
     ) => {
       await call(
-        () => updateResourceWithOperation<Type, T>(resourceName, body),
+        () =>
+          updateResourceWithOperation<Type, T>(
+            resourceName,
+            body,
+            projectPrefix,
+          ),
         'update',
       );
     },
   };
 };
 
-export const deleteResource = async (resourceName: string) => {
+export const deleteResource = async (
+  resourceName: string,
+  projectPrefix?: string,
+) => {
+  const apiPaths = projectApiPaths(projectPrefix);
   const swrKey = apiPaths.resource(resourceName);
   await callApi(swrKey, 'DELETE');
   mutate(swrKey);
@@ -70,7 +87,9 @@ export const updateResourceWithOperation = async <
 >(
   resourceName: string,
   body: UpdateOperationBody<Type, T>,
+  projectPrefix?: string,
 ) => {
+  const apiPaths = projectApiPaths(projectPrefix);
   const swrKey = apiPaths.resource(resourceName);
   await callApi(apiPaths.resourceOperation(resourceName), 'POST', body);
   mutate(swrKey);

--- a/tools/app/src/lib/api/templates.ts
+++ b/tools/app/src/lib/api/templates.ts
@@ -11,16 +11,28 @@
 */
 
 import { useSWRHook } from './common';
-import { apiPaths, callApi } from '../swr';
+import { projectApiPaths, callApi } from '../swr';
 import { mutate } from 'swr';
 import type { CreateTemplateData } from '@/lib/definitions';
 
 import type { SWRConfiguration } from 'swr';
 
-export const useTemplates = (options?: SWRConfiguration) =>
-  useSWRHook<'templates'>(apiPaths.templates(), 'templates', null, options);
+export const useTemplates = (
+  options?: SWRConfiguration,
+  projectPrefix?: string,
+) =>
+  useSWRHook<'templates'>(
+    projectApiPaths(projectPrefix).templates(),
+    'templates',
+    null,
+    options,
+  );
 
-export const createTemplate = async (data: CreateTemplateData) => {
+export const createTemplate = async (
+  data: CreateTemplateData,
+  projectPrefix?: string,
+) => {
+  const apiPaths = projectApiPaths(projectPrefix);
   await callApi(apiPaths.templates(), 'POST', data);
   mutate(apiPaths.templates());
   mutate(apiPaths.resourceTree());
@@ -31,7 +43,9 @@ export const createTemplateCard = async (
   cardType: string,
   parentKey?: string,
   count?: number,
+  projectPrefix?: string,
 ) => {
+  const apiPaths = projectApiPaths(projectPrefix);
   const result = await callApi<{ cards: string[] }>(
     apiPaths.templateCard(),
     'POST',

--- a/tools/app/src/lib/api/tree.ts
+++ b/tools/app/src/lib/api/tree.ts
@@ -11,9 +11,14 @@
 */
 
 import { useSWRHook } from './common';
-import { apiPaths } from '../swr';
+import { projectApiPaths } from '../swr';
 
 import type { SWRConfiguration } from 'swr';
 
-export const useTree = (options?: SWRConfiguration) =>
-  useSWRHook<'tree'>(apiPaths.tree(), 'tree', null, options);
+export const useTree = (options?: SWRConfiguration, projectPrefix?: string) =>
+  useSWRHook<'tree'>(
+    projectApiPaths(projectPrefix).tree(),
+    'tree',
+    null,
+    options,
+  );

--- a/tools/app/src/lib/api/user.ts
+++ b/tools/app/src/lib/api/user.ts
@@ -12,14 +12,14 @@
 */
 
 import { useSWRHook } from './common';
-import { apiPaths } from '../swr';
+import { globalApiPaths } from '../swr';
 import { getConfig } from '../utils';
 
 import type { SWRConfiguration } from 'swr';
 
 export const useUser = (options?: SWRConfiguration) =>
   useSWRHook<'user'>(
-    getConfig().staticMode ? null : apiPaths.user(),
+    getConfig().staticMode ? null : globalApiPaths.user(),
     'user',
     null,
     options,

--- a/tools/app/src/lib/api/validate.ts
+++ b/tools/app/src/lib/api/validate.ts
@@ -12,15 +12,16 @@
 */
 
 import type { SWRConfiguration } from 'swr';
-import { apiPaths } from '../swr';
+import { projectApiPaths } from '../swr';
 import { useSWRHook } from './common';
 
 export const useValidateResource = (
   resourceName: string,
   options?: SWRConfiguration,
+  projectPrefix?: string,
 ) =>
   useSWRHook<'validateResource'>(
-    apiPaths.validateResource(resourceName),
+    projectApiPaths(projectPrefix).validateResource(resourceName),
     'validateResource',
     null,
     options,

--- a/tools/app/src/lib/api/workflow.ts
+++ b/tools/app/src/lib/api/workflow.ts
@@ -11,12 +11,15 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { callApi } from '../swr';
-import { apiPaths } from '../swr';
+import { callApi, projectApiPaths } from '../swr';
 import { mutate } from 'swr';
 import type { CreateWorkflowData } from '@/lib/definitions';
 
-export const createWorkflow = async (data: CreateWorkflowData) => {
+export const createWorkflow = async (
+  data: CreateWorkflowData,
+  projectPrefix?: string,
+) => {
+  const apiPaths = projectApiPaths(projectPrefix);
   await callApi(apiPaths.workflows(), 'POST', data);
   mutate(apiPaths.workflows());
   mutate(apiPaths.resourceTree());

--- a/tools/app/src/lib/codemirror/index.ts
+++ b/tools/app/src/lib/codemirror/index.ts
@@ -11,7 +11,7 @@
 */
 
 import type { EditorView } from '@uiw/react-codemirror';
-import { apiPaths } from '../swr';
+import { projectApiPaths } from '../swr';
 import type { CardAttachment } from '@cyberismo/data-handler/interfaces/project-interfaces';
 import type { Document, Section } from '@asciidoctor/core';
 
@@ -124,7 +124,9 @@ export function addAttachment(
   editor: EditorView,
   { fileName, mimeType }: CardAttachment,
   cardKey: string,
+  projectPrefix?: string,
 ) {
+  const apiPaths = projectApiPaths(projectPrefix);
   const target = editor.state.selection.main.to;
 
   if (mimeType?.startsWith('image')) {

--- a/tools/app/src/lib/projectUtils.ts
+++ b/tools/app/src/lib/projectUtils.ts
@@ -11,17 +11,18 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { getSwrConfig, apiPaths } from './swr.js';
+import { getSwrConfig, globalApiPaths } from './swr.js';
+
+// Mirrors ProjectListItem from @cyberismo/backend (project-registry.ts)
+export type AvailableProject = { prefix: string; name: string };
 
 /**
- * Fetch the list of available project prefixes.
- * Currently uses GET /api/project (single project) and returns a one-element array.
- * TODO: Replace with GET /api/projects when multi-project backend is available.
+ * Fetch the list of available projects from the backend.
  */
-export async function fetchAvailableProjects(): Promise<string[]> {
+export async function fetchAvailableProjects(): Promise<AvailableProject[]> {
   const { fetcher } = getSwrConfig();
-  const { cardKeyPrefix: prefix } = (await fetcher!(apiPaths.project())) as {
-    cardKeyPrefix?: string;
-  };
-  return prefix ? [prefix] : [];
+  const projects = (await fetcher!(
+    globalApiPaths.projects(),
+  )) as AvailableProject[];
+  return projects ?? [];
 }

--- a/tools/app/src/lib/swr.ts
+++ b/tools/app/src/lib/swr.ts
@@ -15,6 +15,82 @@ import { getConfig } from './utils';
 import { store } from './store';
 import { setSessionExpired } from './slices/session';
 
+/**
+ * Resolves the project prefix from the URL if not explicitly provided.
+ */
+function resolveProjectPrefix(projectPrefix?: string): string {
+  if (projectPrefix) return projectPrefix;
+  const match = window.location.pathname.match(/\/projects\/([^/]+)/);
+  if (!match) throw new Error('No project prefix found in URL');
+  return decodeURIComponent(match[1]);
+}
+
+/** Global API paths that are not project-scoped. */
+export const globalApiPaths = {
+  projects: () => '/api/projects',
+  user: () => '/api/auth/me',
+};
+
+/**
+ * Returns project-scoped API paths for the given project.
+ * If `projectPrefix` is omitted, it is resolved from `window.location.pathname`.
+ */
+export function projectApiPaths(projectPrefix?: string) {
+  const base = `/api/projects/${encodeURIComponent(resolveProjectPrefix(projectPrefix))}`;
+  return {
+    cards: () => `${base}/cards`,
+    card: (key: string) => `${base}/cards/${key}`,
+    rawCard: (key: string) => `${base}/cards/${key}?raw=true`,
+    calculations: () => `${base}/calculations`,
+    calculation: (name: string) => `${base}/calculations/${name}`,
+    cardTypes: () => `${base}/cardTypes`,
+    cardTypeFieldVisibility: (cardTypeName: string) =>
+      `${base}/cardTypes/${encodeURIComponent(cardTypeName)}/field-visibility`,
+    connectors: () => `${base}/connectors`,
+    fieldTypes: () => `${base}/fieldTypes`,
+    graphModels: () => `${base}/graphModels`,
+    graphViews: () => `${base}/graphViews`,
+    logicPrograms: (resourceName: string) =>
+      `${base}/logicPrograms/${resourceName}`,
+    cardType: (cardType: string) => `${base}/cardTypes?name=${cardType}`,
+    templates: () => `${base}/templates`,
+    templateCard: () => `${base}/templates/card`,
+    templateTree: () => `${base}/templates/tree`,
+    attachment: (cardKey: string, attachment: string) =>
+      `${base}/cards/${cardKey}/a/${encodeURIComponent(attachment)}`,
+    cardAttachments: (cardKey: string) =>
+      `${base}/cards/${cardKey}/attachments`,
+    cardAttachment: (cardKey: string, filename: string) =>
+      `${base}/cards/${cardKey}/attachments/${encodeURIComponent(filename)}`,
+    cardAttachmentOpen: (cardKey: string, filename: string) =>
+      `${base}/cards/${cardKey}/attachments/${encodeURIComponent(filename)}/open`,
+    cardLinks: (cardKey: string) => `${base}/cards/${cardKey}/links`,
+    cardParse: (cardKey: string) => `${base}/cards/${cardKey}/parse`,
+    linkTypes: () => `${base}/linkTypes`,
+    reports: () => `${base}/reports`,
+    workflows: () => `${base}/workflows`,
+    resources: (type: string) => `${base}/resources/${type}`,
+    resourceTree: () => `${base}/resources/tree`,
+    resource: (resourceName: string) => `${base}/resources/${resourceName}`,
+    resourceOperation: (resourceName: string) =>
+      `${base}/resources/${resourceName}/operation`,
+    tree: () => `${base}/tree`,
+    labels: () => `${base}/labels`,
+    validateResource: (resourceName: string) =>
+      `${base}/resources/${resourceName}/validate`,
+    project: () => `${base}/project`,
+    projectModulesUpdate: () => `${base}/project/modules/update`,
+    projectModuleUpdate: (module: string) =>
+      `${base}/project/modules/${encodeURIComponent(module)}/update`,
+    projectModuleDelete: (module: string) =>
+      `${base}/project/modules/${encodeURIComponent(module)}`,
+    projectModulesAdd: () => `${base}/project/modules`,
+    projectModulesImportable: () => `${base}/project/modules/importable`,
+    presence: (cardKey: string, mode: string) =>
+      `${base}/cards/${encodeURIComponent(cardKey)}/presence?mode=${mode}`,
+  };
+}
+
 export class ApiCallError extends Error {
   public reason: string;
   constructor(
@@ -106,47 +182,3 @@ export function getSwrConfig(): SWRConfiguration {
       : fetcher,
   };
 }
-
-export const apiPaths = {
-  cards: () => '/api/cards',
-  card: (key: string) => `/api/cards/${key}`,
-  rawCard: (key: string) => `/api/cards/${key}?raw=true`,
-  calculations: () => '/api/calculations',
-  calculation: (name: string) => `/api/calculations/${name}`,
-  cardTypes: () => '/api/cardTypes',
-  cardTypeFieldVisibility: (cardTypeName: string) =>
-    `/api/cardTypes/${encodeURIComponent(cardTypeName)}/field-visibility`,
-  connectors: () => '/api/connectors',
-  fieldTypes: () => '/api/fieldTypes',
-  graphModels: () => '/api/graphModels',
-  graphViews: () => '/api/graphViews',
-  logicPrograms: (resourceName: string) => `/api/logicPrograms/${resourceName}`,
-  cardType: (cardType: string) => `/api/cardTypes?name=${cardType}`,
-  templates: () => '/api/templates',
-  templateCard: () => '/api/templates/card',
-  templateTree: () => '/api/templates/tree',
-  attachment: (cardKey: string, attachment: string) =>
-    `/api/cards/${cardKey}/a/${attachment}`,
-  linkTypes: () => '/api/linkTypes',
-  reports: () => '/api/reports',
-  workflows: () => '/api/workflows',
-  resources: (type: string) => `/api/resources/${type}`,
-  resourceTree: () => '/api/resources/tree',
-  resource: (resourceName: string) => `/api/resources/${resourceName}`,
-  resourceOperation: (resourceName: string) =>
-    `/api/resources/${resourceName}/operation`,
-  tree: () => '/api/tree',
-  labels: () => '/api/labels',
-  validateResource: (resourceName: string) =>
-    `/api/resources/${resourceName}/validate`,
-  project: () => '/api/project',
-  user: () => '/api/auth/me',
-  projectModulesUpdate: () => '/api/project/modules/update',
-  projectModuleUpdate: (module: string) =>
-    `/api/project/modules/${encodeURIComponent(module)}/update`,
-  projectModuleDelete: (module: string) =>
-    `/api/project/modules/${encodeURIComponent(module)}`,
-  projectModulesImportable: () => '/api/project/modules/importable',
-  presence: (cardKey: string, mode: string) =>
-    `/api/cards/${encodeURIComponent(cardKey)}/presence?mode=${mode}`,
-};

--- a/tools/app/src/routes.ts
+++ b/tools/app/src/routes.ts
@@ -25,6 +25,7 @@ import NotFoundPage from './pages/not-found';
 import { store } from './lib/store.js';
 import { selectProjectPrefix, setProjectPrefix } from './lib/slices/project.js';
 import { fetchAvailableProjects } from './lib/projectUtils.js';
+import type { AvailableProject } from './lib/projectUtils.js';
 
 // Export mode guard - unfortunately need to refetch config.json to check export mode since hooks
 function createEditLoader(cardKey: string) {
@@ -54,15 +55,18 @@ function createEditLoader(cardKey: string) {
 
 // Resolve which project to use: try the given prefix first, then persisted, then first available
 async function resolveProject(urlPrefix?: string) {
-  const projects = await fetchAvailableProjects().catch(() => [] as string[]);
+  const projects = await fetchAvailableProjects().catch(
+    () => [] as AvailableProject[],
+  );
+  const prefixes = projects.map((p) => p.prefix);
   const lastActive = selectProjectPrefix(store.getState());
 
   // TODO: Remove single-project fallback when multi-project UI (project selection view) is implemented
-  const fallbackPrefix = projects[0];
+  const fallbackPrefix = prefixes[0];
 
   const prefix =
-    (urlPrefix && projects.includes(urlPrefix) ? urlPrefix : null) ??
-    (lastActive && projects.includes(lastActive) ? lastActive : null) ??
+    (urlPrefix && prefixes.includes(urlPrefix) ? urlPrefix : null) ??
+    (lastActive && prefixes.includes(lastActive) ? lastActive : null) ??
     fallbackPrefix;
 
   if (prefix) {

--- a/tools/backend/src/app.ts
+++ b/tools/backend/src/app.ts
@@ -13,7 +13,10 @@
 import { Hono } from 'hono';
 import { staticFrontendDirRelative } from './utils.js';
 import { serveStatic } from '@hono/node-server/serve-static';
-import { attachCommandManager } from './middleware/commandManager.js';
+import {
+  attachCommandManager,
+  attachProjectRegistry,
+} from './middleware/commandManager.js';
 import calculationsRouter from './domain/calculations/index.js';
 import cardsRouter from './domain/cards/index.js';
 import cardTypesRouter from './domain/cardTypes/index.js';
@@ -32,7 +35,6 @@ import path from 'node:path';
 import resourcesRouter from './domain/resources/index.js';
 import logicProgramsRouter from './domain/logicPrograms/index.js';
 import { isSSGContext } from 'hono/ssg';
-import type { CommandManager } from '@cyberismo/data-handler';
 import type { AppVars, TreeOptions } from './types.js';
 import treeMiddleware from './middleware/tree.js';
 import projectRouter from './domain/project/index.js';
@@ -40,15 +42,17 @@ import mcpRouter from './domain/mcp/index.js';
 import { createAuthRouter } from './domain/auth/index.js';
 import { createAuthMiddleware } from './middleware/auth.js';
 import type { AuthProvider } from './auth/types.js';
+import type { ProjectRegistry } from './project-registry.js';
+import { createProjectsRouter } from './domain/projects/index.js';
 
 /**
  * Create the Hono app for the backend
  * @param authProvider - Authentication provider
- * @param commands - CommandManager instance for the project
+ * @param registry - ProjectRegistry holding all project CommandManagers
  */
 export function createApp(
   authProvider: AuthProvider,
-  commands: CommandManager,
+  registry: ProjectRegistry,
   opts?: TreeOptions,
 ) {
   const app = new Hono<{ Variables: AppVars }>();
@@ -59,33 +63,46 @@ export function createApp(
   app.use('/mcp', createAuthMiddleware(authProvider));
   app.use('/mcp/*', createAuthMiddleware(authProvider));
 
-  // Attach CommandManager to API and MCP routes
-  const commandManagerMiddleware = attachCommandManager(commands);
-  app.use('/api/*', commandManagerMiddleware);
-  app.use('/mcp', commandManagerMiddleware);
-  app.use('/mcp/*', commandManagerMiddleware);
-  // Wire up routes
+  // Global routes (no project-specific CommandManager needed)
   app.route('/api/auth', createAuthRouter());
+  app.route('/api/projects', createProjectsRouter(registry));
 
-  // Mount routers
-  app.route('/api/calculations', calculationsRouter);
-  app.route('/api/cards', cardsRouter);
-  app.route('/api/cardTypes', cardTypesRouter);
-  app.route('/api/connectors', connectorsRouter);
-  app.route('/api/fieldTypes', fieldTypesRouter);
-  app.route('/api/graphModels', graphModelsRouter);
-  app.route('/api/graphViews', graphViewsRouter);
-  app.route('/api/linkTypes', linkTypesRouter);
-  app.route('/api/reports', reportsRouter);
-  app.route('/api/templates', templatesRouter);
-  app.route('/api/tree', treeRouter);
-  app.route('/api/workflows', workflowsRouter);
-  app.route('/api/resources', resourcesRouter);
-  app.route('/api/logicPrograms', logicProgramsRouter);
-  app.route('/api/labels', labelsRouter);
-  app.route('/api/project', projectRouter);
+  // Project-scoped routes under /api/projects/:prefix/
+  const projectScoped = new Hono<{ Variables: AppVars }>();
+  projectScoped.use('*', attachProjectRegistry(registry, !!opts));
+  projectScoped.route('/calculations', calculationsRouter);
+  projectScoped.route('/cards', cardsRouter);
+  projectScoped.route('/cardTypes', cardTypesRouter);
+  projectScoped.route('/connectors', connectorsRouter);
+  projectScoped.route('/fieldTypes', fieldTypesRouter);
+  projectScoped.route('/graphModels', graphModelsRouter);
+  projectScoped.route('/graphViews', graphViewsRouter);
+  projectScoped.route('/linkTypes', linkTypesRouter);
+  projectScoped.route('/reports', reportsRouter);
+  projectScoped.route('/templates', templatesRouter);
+  projectScoped.route('/tree', treeRouter);
+  projectScoped.route('/workflows', workflowsRouter);
+  projectScoped.route('/resources', resourcesRouter);
+  projectScoped.route('/logicPrograms', logicProgramsRouter);
+  projectScoped.route('/labels', labelsRouter);
+  projectScoped.route('/project', projectRouter);
+
+  // In export mode (opts set), mount at the concrete prefix so SSG sees
+  // static routes instead of dynamic :prefix patterns it would skip.
+  const exportPrefix = opts ? registry.list()[0]?.prefix : undefined;
+  app.route(
+    exportPrefix ? `/api/projects/${exportPrefix}` : '/api/projects/:prefix',
+    projectScoped,
+  );
 
   // MCP endpoint for AI assistant integration
+  // TODO: Make MCP project-scoped when multi-project MCP is implemented
+  const mcpCommands = registry.first();
+  if (mcpCommands) {
+    const mcpMiddleware = attachCommandManager(mcpCommands);
+    app.use('/mcp', mcpMiddleware);
+    app.use('/mcp/*', mcpMiddleware);
+  }
   app.route('/mcp', mcpRouter);
 
   app.use(

--- a/tools/backend/src/domain/projects/index.ts
+++ b/tools/backend/src/domain/projects/index.ts
@@ -1,0 +1,39 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { Hono } from 'hono';
+import type { ProjectRegistry } from '../../project-registry.js';
+import { requireRole } from '../../middleware/auth.js';
+import { UserRole } from '../../types.js';
+
+export function createProjectsRouter(registry: ProjectRegistry) {
+  const router = new Hono();
+
+  /**
+   * @swagger
+   * /api/projects:
+   *   get:
+   *     summary: List available projects
+   *     description: Returns a list of all available projects
+   *     responses:
+   *       200:
+   *         description: List of projects
+   *       401:
+   *         description: Unauthorized
+   */
+  router.get('/', requireRole(UserRole.Reader), (c) => {
+    return c.json(registry.list());
+  });
+
+  return router;
+}

--- a/tools/backend/src/export.ts
+++ b/tools/backend/src/export.ts
@@ -18,6 +18,7 @@ import fs, { readFile } from 'node:fs/promises';
 import type { CommandManager } from '@cyberismo/data-handler';
 import { createApp } from './app.js';
 import { MockAuthProvider } from './auth/mock.js';
+import { ProjectRegistry } from './project-registry.js';
 import { cp, writeFile } from 'node:fs/promises';
 import { staticFrontendDirRelative } from './utils.js';
 import type { QueryResult } from '@cyberismo/data-handler/types/queries';
@@ -95,7 +96,11 @@ export async function exportSite(
     ...options,
   };
 
-  const app = createApp(new MockAuthProvider(), commands, opts);
+  const app = createApp(
+    new MockAuthProvider(),
+    ProjectRegistry.fromCommandManager(commands),
+    opts,
+  );
 
   // copy whole frontend to the same directory
   await cp(staticFrontendDirRelative, exportDir, { recursive: true });

--- a/tools/backend/src/index.ts
+++ b/tools/backend/src/index.ts
@@ -16,14 +16,15 @@ import { Hono } from 'hono';
 import { serveStatic } from '@hono/node-server/serve-static';
 import path from 'node:path';
 import { readFile } from 'node:fs/promises';
-import type { CommandManager } from '@cyberismo/data-handler';
 import { findFreePort } from './utils.js';
 import { createApp } from './app.js';
 import type { AuthProvider } from './auth/types.js';
+import type { ProjectRegistry } from './project-registry.js';
 export { MockAuthProvider } from './auth/mock.js';
 export type { MockUserConfig } from './auth/mock.js';
 export type { AuthProvider } from './auth/types.js';
 export { exportSite } from './export.js';
+export { ProjectRegistry } from './project-registry.js';
 
 const DEFAULT_PORT = 3000;
 const DEFAULT_MAX_PORT = DEFAULT_PORT + 100;
@@ -56,12 +57,12 @@ export async function previewSite(dir: string, findPort: boolean = true) {
 /**
  * Start the server
  * @param authProvider - Authentication provider
- * @param commands - CommandManager instance for the project
+ * @param registry - ProjectRegistry holding all project CommandManagers
  * @param findPort - If true, find a free port
  */
 export async function startServer(
   authProvider: AuthProvider,
-  commands: CommandManager,
+  registry: ProjectRegistry,
   findPort: boolean = true,
 ) {
   let port = parseInt(process.env.PORT || DEFAULT_PORT.toString(), 10);
@@ -69,7 +70,7 @@ export async function startServer(
   if (findPort) {
     port = await findFreePort(port, DEFAULT_MAX_PORT);
   }
-  const app = createApp(authProvider, commands);
+  const app = createApp(authProvider, registry);
   startApp(app, port);
 }
 

--- a/tools/backend/src/main.ts
+++ b/tools/backend/src/main.ts
@@ -10,12 +10,13 @@
   details. You should have received a copy of the GNU Affero General Public
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
-import { CommandManager } from '@cyberismo/data-handler';
+import { CommandManager, scanForProjects } from '@cyberismo/data-handler';
 import { startServer } from './index.js';
 import { exportSite } from './export.js';
 import { MockAuthProvider } from './auth/mock.js';
 import { KeycloakAuthProvider } from './auth/keycloak.js';
 import type { AuthProvider } from './auth/types.js';
+import { ProjectRegistry } from './project-registry.js';
 import dotenv from 'dotenv';
 
 // Load environment variables from .env file
@@ -55,12 +56,47 @@ function createAuthProvider(): AuthProvider {
   process.exit(1);
 }
 
-const projectPath = process.env.npm_config_project_path || '';
-const commands = await CommandManager.getInstance(projectPath);
+const projectPath = process.env.npm_config_project_path || process.cwd();
+let projects;
+try {
+  projects = await scanForProjects(projectPath);
+} catch (error) {
+  console.error(
+    error instanceof Error
+      ? error.message
+      : `Failed to scan for projects in '${projectPath}'`,
+  );
+  process.exit(1);
+}
 
 if (process.argv.includes('--export')) {
+  if (projects.length === 0) {
+    console.error('No projects found to export.');
+    process.exit(1);
+  }
+  if (projects.length > 1) {
+    // TODO: Support multi-project export when mass export is implemented
+    console.error(
+      'Export is not supported with multiple projects. Please specify a directory containing a single project.',
+    );
+    process.exit(1);
+  }
+  const commands = new CommandManager(projects[0].path);
+  await commands.initialize();
   await exportSite(commands);
 } else {
+  if (projects.length === 0) {
+    console.error(
+      `No projects found in "${projectPath}". Cannot start the server without at least one project.`,
+    );
+    process.exit(1);
+  }
+  const registry = new ProjectRegistry();
+  for (const project of projects) {
+    const commands = new CommandManager(project.path);
+    await commands.initialize();
+    registry.add(project.prefix, commands);
+  }
   const authProvider = createAuthProvider();
-  await startServer(authProvider, commands);
+  await startServer(authProvider, registry);
 }

--- a/tools/backend/src/middleware/commandManager.ts
+++ b/tools/backend/src/middleware/commandManager.ts
@@ -13,28 +13,65 @@
 import type { Context, MiddlewareHandler } from 'hono';
 import type { CommandManager } from '@cyberismo/data-handler';
 import { getCurrentUser } from './auth.js';
+import type { ProjectRegistry } from '../project-registry.js';
 
 // Extend Hono Context type to include our custom properties
 declare module 'hono' {
   interface ContextVariableMap {
     commands: CommandManager;
     projectPath: string;
+    registry: ProjectRegistry;
   }
 }
 
+/**
+ * Set CommandManager on context and run the next handler as the authenticated user.
+ */
+async function runWithCommands(
+  c: Context,
+  commands: CommandManager,
+  next: () => Promise<void>,
+) {
+  const user = getCurrentUser(c);
+  if (!user) {
+    throw new Error('CommandManager expects a user');
+  }
+  c.set('commands', commands);
+  c.set('projectPath', commands.project.basePath);
+  await commands.runAsAuthor({ name: user.name, email: user.email }, () =>
+    next(),
+  );
+}
+
+// TODO: Remove once MCP is made project-scoped via attachProjectRegistry
 export const attachCommandManager = (
   commands: CommandManager,
 ): MiddlewareHandler => {
+  return (c, next) => runWithCommands(c, commands, next);
+};
+
+export const attachProjectRegistry = (
+  registry: ProjectRegistry,
+  staticMode?: boolean,
+): MiddlewareHandler => {
   return async (c: Context, next) => {
-    c.set('commands', commands);
-    c.set('projectPath', commands.project.basePath);
-    const user = getCurrentUser(c);
-    if (user) {
-      await commands.runAsAuthor({ name: user.name, email: user.email }, () =>
-        next(),
-      );
-    } else {
-      throw new Error('CommandManager expects a user');
+    c.set('registry', registry);
+    const prefix = c.req.param('prefix');
+    if (!prefix) {
+      if (staticMode) {
+        // Export / static mode: mounted at a concrete prefix, so no
+        // :prefix param exists. Use the single registered project.
+        const fallback = registry.first();
+        if (fallback) {
+          return runWithCommands(c, fallback, next);
+        }
+      }
+      return c.json({ error: 'Project prefix is required' }, 400);
     }
+    const commands = registry.get(prefix);
+    if (!commands) {
+      return c.json({ error: `Project '${prefix}' not found` }, 404);
+    }
+    return runWithCommands(c, commands, next);
   };
 };

--- a/tools/backend/src/project-registry.ts
+++ b/tools/backend/src/project-registry.ts
@@ -1,0 +1,74 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { CommandManager } from '@cyberismo/data-handler';
+
+export type ProjectRegistryEntry = {
+  prefix: string;
+  commands: CommandManager;
+};
+
+export type ProjectListItem = {
+  prefix: string;
+  name: string;
+};
+
+export class ProjectRegistry {
+  private projects: Map<string, CommandManager> = new Map();
+
+  constructor(entries: ProjectRegistryEntry[] = []) {
+    for (const entry of entries) {
+      this.add(entry.prefix, entry.commands);
+    }
+  }
+
+  get(prefix: string): CommandManager | undefined {
+    return this.projects.get(prefix);
+  }
+
+  add(prefix: string, commands: CommandManager): void {
+    if (this.projects.has(prefix)) {
+      throw new Error(`Project '${prefix}' is already registered`);
+    }
+    this.projects.set(prefix, commands);
+  }
+
+  list(): ProjectListItem[] {
+    return Array.from(this.projects.entries()).map(([prefix, commands]) => ({
+      prefix,
+      name: commands.project.configuration.name,
+    }));
+  }
+
+  first(): CommandManager | undefined {
+    const [first] = this.projects.values();
+    return first;
+  }
+
+  dispose(): void {
+    for (const commands of this.projects.values()) {
+      commands.project.dispose();
+    }
+    this.projects.clear();
+  }
+
+  /**
+   * Create a single-project registry from a CommandManager.
+   * Used by export mode and tests where only one project is needed.
+   */
+  static fromCommandManager(commands: CommandManager): ProjectRegistry {
+    return new ProjectRegistry([
+      { prefix: commands.project.configuration.cardKeyPrefix, commands },
+    ]);
+  }
+}

--- a/tools/backend/test/api.test.ts
+++ b/tools/backend/test/api.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, beforeAll, afterAll } from 'vitest';
 import { CommandManager } from '@cyberismo/data-handler';
 import { createApp } from '../src/app.js';
+import { ProjectRegistry } from '../src/project-registry.js';
 import { MockAuthProvider } from '../src/auth/mock.js';
 import { type QueryResult } from '@cyberismo/data-handler/types/queries';
 import type {
@@ -21,7 +22,10 @@ beforeAll(async () => {
   process.argv = [];
   tempTestDataPath = await createTempTestData('decision-records');
   const commands = await CommandManager.getInstance(tempTestDataPath);
-  app = createApp(new MockAuthProvider(), commands);
+  app = createApp(
+    new MockAuthProvider(),
+    ProjectRegistry.fromCommandManager(commands),
+  );
 });
 
 afterAll(async () => {
@@ -41,8 +45,8 @@ type ProjectInfoResponse = {
   cardTypes: CardType[];
 };
 
-test('/api/cards returns a project with a list of cards', async () => {
-  const response = await app.request('/api/cards');
+test('/api/projects/:prefix/cards returns a project with a list of cards', async () => {
+  const response = await app.request('/api/projects/decision/cards');
   expect(response).not.toBe(null);
 
   const result = (await response.json()) as ProjectInfoResponse;
@@ -52,8 +56,8 @@ test('/api/cards returns a project with a list of cards', async () => {
   expect(result.cardTypes.length).toBeGreaterThan(0);
 });
 
-test('/api/cards/decision_5 returns a card object', async () => {
-  const response = await app.request('/api/cards/decision_5');
+test('/api/projects/decision/cards/decision_5 returns a card object', async () => {
+  const response = await app.request('/api/projects/decision/cards/decision_5');
   expect(response).not.toBe(null);
 
   const result = (await response.json()) as CardApiResponse;
@@ -70,8 +74,10 @@ test('/api/cards/decision_5 returns a card object', async () => {
   expect(result.cardType).toBe('decision/cardTypes/simplepage');
 });
 
-test('/api/cards/decision_5?raw=true returns raw card data without calculated extras', async () => {
-  const response = await app.request('/api/cards/decision_5?raw=true');
+test('/api/projects/decision/cards/decision_5?raw=true returns raw card data without calculated extras', async () => {
+  const response = await app.request(
+    '/api/projects/decision/cards/decision_5?raw=true',
+  );
   expect(response).not.toBe(null);
 
   const result = (await response.json()) as CardApiResponse;
@@ -84,8 +90,10 @@ test('/api/cards/decision_5?raw=true returns raw card data without calculated ex
   expect(result.cardTypeDisplayName).toBe('decision/cardTypes/simplepage');
 });
 
-test('/api/cards/decision_1/a/the-needle.heic returns an attachment file', async () => {
-  const response = await app.request('/api/cards/decision_1/a/the-needle.heic');
+test('/api/projects/decision/cards/decision_1/a/the-needle.heic returns an attachment file', async () => {
+  const response = await app.request(
+    '/api/projects/decision/cards/decision_1/a/the-needle.heic',
+  );
   expect(response).not.toBe(null);
   expect(response.status).toBe(200);
   expect(response.headers.get('content-type')).toBe('image/heic');
@@ -93,7 +101,7 @@ test('/api/cards/decision_1/a/the-needle.heic returns an attachment file', async
 });
 
 test('invalid card key returns error', async () => {
-  const response = await app.request('/api/cards/bogus');
+  const response = await app.request('/api/projects/decision/cards/bogus');
   expect(response).not.toBe(null);
   expect(response.status).toBe(400);
 });
@@ -105,13 +113,15 @@ test('test invalid api path returns not found', async () => {
 });
 
 test('non-existing attachment file returns an error', async () => {
-  const response = await app.request('/api/cards/decision_1/a/bogus.gif');
+  const response = await app.request(
+    '/api/projects/decision/cards/decision_1/a/bogus.gif',
+  );
   expect(response).not.toBe(null);
   expect(response.status).toBe(404);
 });
 
 test('fieldTypes endpoint returns proper data', async () => {
-  const response = await app.request('/api/fieldTypes');
+  const response = await app.request('/api/projects/decision/fieldTypes');
   expect(response).not.toBe(null);
 
   const result = (await response.json()) as FieldType[];
@@ -124,7 +134,7 @@ test('fieldTypes endpoint returns proper data', async () => {
 });
 
 test('linkTypes endpoint returns proper data', async () => {
-  const response = await app.request('/api/linkTypes');
+  const response = await app.request('/api/projects/decision/linkTypes');
   expect(response).not.toBe(null);
 
   const result = (await response.json()) as LinkType[];
@@ -138,7 +148,7 @@ test('linkTypes endpoint returns proper data', async () => {
 });
 
 test('templates endpoint returns proper data', async () => {
-  const response = await app.request('/api/templates');
+  const response = await app.request('/api/projects/decision/templates');
   expect(response).not.toBe(null);
 
   const result = (await response.json()) as TemplateConfiguration[];
@@ -151,7 +161,7 @@ test('templates endpoint returns proper data', async () => {
 });
 
 test('tree endpoint returns proper data', async () => {
-  const response = await app.request('/api/tree');
+  const response = await app.request('/api/projects/decision/tree');
   expect(response).not.toBe(null);
 
   const result = (await response.json()) as QueryResult<'tree'>[];
@@ -167,7 +177,7 @@ test('tree endpoint returns proper data', async () => {
 });
 
 test('labels endpoint returns the list of labels', async () => {
-  const response = await app.request('/api/labels');
+  const response = await app.request('/api/projects/decision/labels');
   expect(response).not.toBe(null);
 
   const result = (await response.json()) as string[];
@@ -177,7 +187,7 @@ test('labels endpoint returns the list of labels', async () => {
 });
 
 test('connectors endpoint returns connectors data', async () => {
-  const response = await app.request('/api/connectors');
+  const response = await app.request('/api/projects/decision/connectors');
   const result = (await response.json()) as {
     name: string;
     displayName: string;
@@ -188,39 +198,45 @@ test('connectors endpoint returns connectors data', async () => {
   expect(result).toHaveLength(0);
 });
 
-test('POST /api/cards/:key/links creates a link successfully', async () => {
-  const response = await app.request('/api/cards/decision_5/links', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      toCard: 'decision_6',
-      linkType: 'decision/linkTypes/test',
-      direction: 'outbound',
-    }),
-  });
+test('POST /api/projects/:prefix/cards/:key/links creates a link successfully', async () => {
+  const response = await app.request(
+    '/api/projects/decision/cards/decision_5/links',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        toCard: 'decision_6',
+        linkType: 'decision/linkTypes/test',
+        direction: 'outbound',
+      }),
+    },
+  );
   const result = (await response.json()) as { message: string };
   expect(response.status).toBe(200);
   expect(result.message).toBe('Link created successfully');
 });
 
-test('POST /api/cards/:key/links creates an inbound link successfully', async () => {
+test('POST /api/projects/:prefix/cards/:key/links creates an inbound link successfully', async () => {
   // direction='inbound' means decision_6 links TO decision_5 (key is the destination)
-  const response = await app.request('/api/cards/decision_5/links', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      toCard: 'decision_6',
-      linkType: 'decision/linkTypes/test',
-      direction: 'inbound',
-    }),
-  });
+  const response = await app.request(
+    '/api/projects/decision/cards/decision_5/links',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        toCard: 'decision_6',
+        linkType: 'decision/linkTypes/test',
+        direction: 'inbound',
+      }),
+    },
+  );
   const result = (await response.json()) as { message: string };
   expect(response.status).toBe(200);
   expect(result.message).toBe('Link created successfully');
 });
 
-test('DELETE /api/cards/:key/links removes an inbound link successfully', async () => {
-  await app.request('/api/cards/decision_5/links', {
+test('DELETE /api/projects/:prefix/cards/:key/links removes an inbound link successfully', async () => {
+  await app.request('/api/projects/decision/cards/decision_5/links', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -230,69 +246,81 @@ test('DELETE /api/cards/:key/links removes an inbound link successfully', async 
     }),
   });
 
-  const response = await app.request('/api/cards/decision_5/links', {
-    method: 'DELETE',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      toCard: 'decision_6',
-      linkType: 'decision/linkTypes/test',
-      direction: 'inbound',
-    }),
-  });
+  const response = await app.request(
+    '/api/projects/decision/cards/decision_5/links',
+    {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        toCard: 'decision_6',
+        linkType: 'decision/linkTypes/test',
+        direction: 'inbound',
+      }),
+    },
+  );
   const result = (await response.json()) as { message: string };
   expect(response.status).toBe(200);
   expect(result.message).toBe('Link removed successfully');
 });
 
-test('DELETE /api/cards/:key/links removes a link successfully', async () => {
-  const response = await app.request('/api/cards/decision_5/links', {
-    method: 'DELETE',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      toCard: 'decision_6',
-      linkType: 'decision/linkTypes/test',
-      direction: 'outbound',
-    }),
-  });
+test('DELETE /api/projects/:prefix/cards/:key/links removes a link successfully', async () => {
+  const response = await app.request(
+    '/api/projects/decision/cards/decision_5/links',
+    {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        toCard: 'decision_6',
+        linkType: 'decision/linkTypes/test',
+        direction: 'outbound',
+      }),
+    },
+  );
   const result = (await response.json()) as { message: string };
   expect(response.status).toBe(200);
   expect(result.message).toBe('Link removed successfully');
 });
 
-test('POST /api/cards/:key/links creates external link successfully', async () => {
-  const response = await app.request('/api/cards/decision_5/links', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      toCard: 'jira:TEST-123',
-      linkType: 'decision/linkTypes/test',
-      direction: 'outbound',
-    }),
-  });
+test('POST /api/projects/:prefix/cards/:key/links creates external link successfully', async () => {
+  const response = await app.request(
+    '/api/projects/decision/cards/decision_5/links',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        toCard: 'jira:TEST-123',
+        linkType: 'decision/linkTypes/test',
+        direction: 'outbound',
+      }),
+    },
+  );
   const result = (await response.json()) as { message: string };
   expect(response.status).toBe(200);
   expect(result.message).toBe('Link created successfully');
 });
 
-test('DELETE /api/cards/:key/links removes external link successfully', async () => {
-  const response = await app.request('/api/cards/decision_5/links', {
-    method: 'DELETE',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      toCard: 'jira:TEST-123',
-      linkType: 'decision/linkTypes/test',
-      direction: 'outbound',
-    }),
-  });
+test('DELETE /api/projects/:prefix/cards/:key/links removes external link successfully', async () => {
+  const response = await app.request(
+    '/api/projects/decision/cards/decision_5/links',
+    {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        toCard: 'jira:TEST-123',
+        linkType: 'decision/linkTypes/test',
+        direction: 'outbound',
+      }),
+    },
+  );
   const result = (await response.json()) as { message: string };
   expect(response.status).toBe(200);
   expect(result.message).toBe('Link removed successfully');
 });
 
-test('PUT /api/cards/:key/links changes link type', async () => {
+test('PUT /api/projects/:prefix/cards/:key/links changes link type', async () => {
   // testTypes requires source=decision cardType, destination=simplepage cardType
   // decision_6 is 'decision' cardType, decision_5 is 'simplepage' cardType
-  await app.request('/api/cards/decision_6/links', {
+  await app.request('/api/projects/decision/cards/decision_6/links', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -302,24 +330,27 @@ test('PUT /api/cards/:key/links changes link type', async () => {
     }),
   });
 
-  const response = await app.request('/api/cards/decision_6/links', {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      toCard: 'decision_5',
-      linkType: 'decision/linkTypes/testTypes',
-      direction: 'outbound',
-      previousToCard: 'decision_5',
-      previousLinkType: 'decision/linkTypes/test',
-      previousDirection: 'outbound',
-    }),
-  });
+  const response = await app.request(
+    '/api/projects/decision/cards/decision_6/links',
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        toCard: 'decision_5',
+        linkType: 'decision/linkTypes/testTypes',
+        direction: 'outbound',
+        previousToCard: 'decision_5',
+        previousLinkType: 'decision/linkTypes/test',
+        previousDirection: 'outbound',
+      }),
+    },
+  );
   const result = (await response.json()) as { message: string };
   expect(response.status).toBe(200);
   expect(result.message).toBe('Link updated successfully');
 
   // Cleanup
-  await app.request('/api/cards/decision_6/links', {
+  await app.request('/api/projects/decision/cards/decision_6/links', {
     method: 'DELETE',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -330,9 +361,9 @@ test('PUT /api/cards/:key/links changes link type', async () => {
   });
 });
 
-test('PUT /api/cards/:key/links changes link direction', async () => {
+test('PUT /api/projects/:prefix/cards/:key/links changes link direction', async () => {
   // Create initial outbound link
-  await app.request('/api/cards/decision_5/links', {
+  await app.request('/api/projects/decision/cards/decision_5/links', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -342,24 +373,27 @@ test('PUT /api/cards/:key/links changes link direction', async () => {
     }),
   });
 
-  const response = await app.request('/api/cards/decision_5/links', {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      toCard: 'decision_6',
-      linkType: 'decision/linkTypes/test',
-      direction: 'inbound',
-      previousToCard: 'decision_6',
-      previousLinkType: 'decision/linkTypes/test',
-      previousDirection: 'outbound',
-    }),
-  });
+  const response = await app.request(
+    '/api/projects/decision/cards/decision_5/links',
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        toCard: 'decision_6',
+        linkType: 'decision/linkTypes/test',
+        direction: 'inbound',
+        previousToCard: 'decision_6',
+        previousLinkType: 'decision/linkTypes/test',
+        previousDirection: 'outbound',
+      }),
+    },
+  );
   const result = (await response.json()) as { message: string };
   expect(response.status).toBe(200);
   expect(result.message).toBe('Link updated successfully');
 
   // Cleanup
-  await app.request('/api/cards/decision_5/links', {
+  await app.request('/api/projects/decision/cards/decision_5/links', {
     method: 'DELETE',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -370,9 +404,9 @@ test('PUT /api/cards/:key/links changes link direction', async () => {
   });
 });
 
-test('PUT /api/cards/:key/links changes link description', async () => {
+test('PUT /api/projects/:prefix/cards/:key/links changes link description', async () => {
   // Create initial link without description
-  await app.request('/api/cards/decision_5/links', {
+  await app.request('/api/projects/decision/cards/decision_5/links', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -382,25 +416,28 @@ test('PUT /api/cards/:key/links changes link description', async () => {
     }),
   });
 
-  const response = await app.request('/api/cards/decision_5/links', {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      toCard: 'decision_6',
-      linkType: 'decision/linkTypes/test',
-      direction: 'outbound',
-      description: 'new description',
-      previousToCard: 'decision_6',
-      previousLinkType: 'decision/linkTypes/test',
-      previousDirection: 'outbound',
-    }),
-  });
+  const response = await app.request(
+    '/api/projects/decision/cards/decision_5/links',
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        toCard: 'decision_6',
+        linkType: 'decision/linkTypes/test',
+        direction: 'outbound',
+        description: 'new description',
+        previousToCard: 'decision_6',
+        previousLinkType: 'decision/linkTypes/test',
+        previousDirection: 'outbound',
+      }),
+    },
+  );
   const result = (await response.json()) as { message: string };
   expect(response.status).toBe(200);
   expect(result.message).toBe('Link updated successfully');
 
   // Cleanup
-  await app.request('/api/cards/decision_5/links', {
+  await app.request('/api/projects/decision/cards/decision_5/links', {
     method: 'DELETE',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -412,15 +449,18 @@ test('PUT /api/cards/:key/links changes link description', async () => {
   });
 });
 
-test('PUT /api/cards/:key/links returns 400 when required fields are missing', async () => {
-  const response = await app.request('/api/cards/decision_5/links', {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      toCard: 'decision_6',
-      linkType: 'decision/linkTypes/test',
-      // missing direction, previousToCard, previousLinkType, previousDirection
-    }),
-  });
+test('PUT /api/projects/:prefix/cards/:key/links returns 400 when required fields are missing', async () => {
+  const response = await app.request(
+    '/api/projects/decision/cards/decision_5/links',
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        toCard: 'decision_6',
+        linkType: 'decision/linkTypes/test',
+        // missing direction, previousToCard, previousLinkType, previousDirection
+      }),
+    },
+  );
   expect(response.status).toBe(400);
 });

--- a/tools/backend/test/calculations.test.ts
+++ b/tools/backend/test/calculations.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, beforeEach, afterEach } from 'vitest';
 import { CommandManager } from '@cyberismo/data-handler';
 import { createApp } from '../src/app.js';
+import { ProjectRegistry } from '../src/project-registry.js';
 import { MockAuthProvider } from '../src/auth/mock.js';
 import { createTempTestData, cleanupTempTestData } from './test-utils.js';
 
@@ -10,7 +11,10 @@ let tempTestDataPath: string;
 beforeEach(async () => {
   tempTestDataPath = await createTempTestData('decision-records');
   const commands = await CommandManager.getInstance(tempTestDataPath);
-  app = createApp(new MockAuthProvider(), commands);
+  app = createApp(
+    new MockAuthProvider(),
+    ProjectRegistry.fromCommandManager(commands),
+  );
 });
 
 afterEach(async () => {
@@ -18,7 +22,7 @@ afterEach(async () => {
 });
 
 test('POST /api/calculations creates a calculation successfully', async () => {
-  const response = await app.request('/api/calculations', {
+  const response = await app.request('/api/projects/decision/calculations', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/tools/backend/test/cardTypes.test.ts
+++ b/tools/backend/test/cardTypes.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, describe, beforeEach, afterEach } from 'vitest';
 import { CommandManager } from '@cyberismo/data-handler';
 import { createApp } from '../src/app.js';
+import { ProjectRegistry } from '../src/project-registry.js';
 import { MockAuthProvider } from '../src/auth/mock.js';
 import { createTempTestData, cleanupTempTestData } from './test-utils.js';
 
@@ -18,7 +19,10 @@ interface CardTypeResponse {
 beforeEach(async () => {
   tempTestDataPath = await createTempTestData('decision-records');
   const commands = await CommandManager.getInstance(tempTestDataPath);
-  app = createApp(new MockAuthProvider(), commands);
+  app = createApp(
+    new MockAuthProvider(),
+    ProjectRegistry.fromCommandManager(commands),
+  );
 });
 
 afterEach(async () => {
@@ -26,7 +30,7 @@ afterEach(async () => {
 });
 
 async function getCardType(name: string): Promise<CardTypeResponse> {
-  const response = await app.request('/api/cardTypes');
+  const response = await app.request('/api/projects/decision/cardTypes');
   expect(response.status).toBe(200);
   const cardTypes = (await response.json()) as CardTypeResponse[];
   const cardType = cardTypes.find((ct) => ct.name === name);
@@ -34,8 +38,8 @@ async function getCardType(name: string): Promise<CardTypeResponse> {
   return cardType;
 }
 
-test('POST /api/cardTypes creates a card type successfully', async () => {
-  const response = await app.request('/api/cardTypes', {
+test('POST /api/projects/:prefix/cardTypes creates a card type successfully', async () => {
+  const response = await app.request('/api/projects/decision/cardTypes', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -55,8 +59,8 @@ test('POST /api/cardTypes creates a card type successfully', async () => {
   expect(result.message).toBe('Card type created successfully');
 });
 
-test('POST /api/cardTypes returns error for non-existent workflow', async () => {
-  const response = await app.request('/api/cardTypes', {
+test('POST /api/projects/:prefix/cardTypes returns error for non-existent workflow', async () => {
+  const response = await app.request('/api/projects/decision/cardTypes', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -74,7 +78,7 @@ test('POST /api/cardTypes returns error for non-existent workflow', async () => 
   expect(result).toHaveProperty('error');
 });
 
-describe('PATCH /api/cardTypes/:cardTypeName/field-visibility', () => {
+describe('PATCH /api/projects/:prefix/cardTypes/:cardTypeName/field-visibility', () => {
   const cardTypeName = 'decision/cardTypes/decision';
   const fieldInAlways = 'decision/fieldTypes/admins';
   const fieldInHidden = 'decision/fieldTypes/responsible';
@@ -87,7 +91,7 @@ describe('PATCH /api/cardTypes/:cardTypeName/field-visibility', () => {
 
     // Move field
     const response = await app.request(
-      `/api/cardTypes/${encodeURIComponent(cardTypeName)}/field-visibility`,
+      `/api/projects/decision/cardTypes/${encodeURIComponent(cardTypeName)}/field-visibility`,
       {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
@@ -112,7 +116,7 @@ describe('PATCH /api/cardTypes/:cardTypeName/field-visibility', () => {
   test('moves field from optional to hidden', async () => {
     // First move a field to optional
     await app.request(
-      `/api/cardTypes/${encodeURIComponent(cardTypeName)}/field-visibility`,
+      `/api/projects/decision/cardTypes/${encodeURIComponent(cardTypeName)}/field-visibility`,
       {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
@@ -129,7 +133,7 @@ describe('PATCH /api/cardTypes/:cardTypeName/field-visibility', () => {
 
     // Move to hidden
     const response = await app.request(
-      `/api/cardTypes/${encodeURIComponent(cardTypeName)}/field-visibility`,
+      `/api/projects/decision/cardTypes/${encodeURIComponent(cardTypeName)}/field-visibility`,
       {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
@@ -156,7 +160,7 @@ describe('PATCH /api/cardTypes/:cardTypeName/field-visibility', () => {
 
     // Move to always
     const response = await app.request(
-      `/api/cardTypes/${encodeURIComponent(cardTypeName)}/field-visibility`,
+      `/api/projects/decision/cardTypes/${encodeURIComponent(cardTypeName)}/field-visibility`,
       {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
@@ -183,7 +187,7 @@ describe('PATCH /api/cardTypes/:cardTypeName/field-visibility', () => {
     // Move the second field to index 0
     const fieldToMove = initialAlways[1];
     const response = await app.request(
-      `/api/cardTypes/${encodeURIComponent(cardTypeName)}/field-visibility`,
+      `/api/projects/decision/cardTypes/${encodeURIComponent(cardTypeName)}/field-visibility`,
       {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
@@ -205,7 +209,7 @@ describe('PATCH /api/cardTypes/:cardTypeName/field-visibility', () => {
   test('moves field to group with specific index', async () => {
     // Move a field from hidden to always at index 0
     const response = await app.request(
-      `/api/cardTypes/${encodeURIComponent(cardTypeName)}/field-visibility`,
+      `/api/projects/decision/cardTypes/${encodeURIComponent(cardTypeName)}/field-visibility`,
       {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
@@ -226,7 +230,7 @@ describe('PATCH /api/cardTypes/:cardTypeName/field-visibility', () => {
 
   test('returns 404 for non-existent field', async () => {
     const response = await app.request(
-      `/api/cardTypes/${encodeURIComponent(cardTypeName)}/field-visibility`,
+      `/api/projects/decision/cardTypes/${encodeURIComponent(cardTypeName)}/field-visibility`,
       {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
@@ -245,7 +249,7 @@ describe('PATCH /api/cardTypes/:cardTypeName/field-visibility', () => {
 
   test('returns 404 for non-existent card type', async () => {
     const response = await app.request(
-      `/api/cardTypes/${encodeURIComponent('nonexistent/cardTypes/fake')}/field-visibility`,
+      `/api/projects/decision/cardTypes/${encodeURIComponent('nonexistent/cardTypes/fake')}/field-visibility`,
       {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
@@ -261,7 +265,7 @@ describe('PATCH /api/cardTypes/:cardTypeName/field-visibility', () => {
 
   test('returns 400 for invalid group value', async () => {
     const response = await app.request(
-      `/api/cardTypes/${encodeURIComponent(cardTypeName)}/field-visibility`,
+      `/api/projects/decision/cardTypes/${encodeURIComponent(cardTypeName)}/field-visibility`,
       {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
@@ -277,7 +281,7 @@ describe('PATCH /api/cardTypes/:cardTypeName/field-visibility', () => {
 
   test('returns 400 for missing fieldName', async () => {
     const response = await app.request(
-      `/api/cardTypes/${encodeURIComponent(cardTypeName)}/field-visibility`,
+      `/api/projects/decision/cardTypes/${encodeURIComponent(cardTypeName)}/field-visibility`,
       {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
@@ -292,7 +296,7 @@ describe('PATCH /api/cardTypes/:cardTypeName/field-visibility', () => {
 
   test('returns 400 for missing group', async () => {
     const response = await app.request(
-      `/api/cardTypes/${encodeURIComponent(cardTypeName)}/field-visibility`,
+      `/api/projects/decision/cardTypes/${encodeURIComponent(cardTypeName)}/field-visibility`,
       {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
@@ -308,7 +312,7 @@ describe('PATCH /api/cardTypes/:cardTypeName/field-visibility', () => {
   test('no-op when moving hidden field to hidden', async () => {
     // This should succeed without error
     const response = await app.request(
-      `/api/cardTypes/${encodeURIComponent(cardTypeName)}/field-visibility`,
+      `/api/projects/decision/cardTypes/${encodeURIComponent(cardTypeName)}/field-visibility`,
       {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },

--- a/tools/backend/test/fieldTypes.test.ts
+++ b/tools/backend/test/fieldTypes.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, beforeEach, afterEach } from 'vitest';
 import { CommandManager } from '@cyberismo/data-handler';
 import { createApp } from '../src/app.js';
+import { ProjectRegistry } from '../src/project-registry.js';
 import { MockAuthProvider } from '../src/auth/mock.js';
 import { createTempTestData, cleanupTempTestData } from './test-utils.js';
 
@@ -10,7 +11,10 @@ let tempTestDataPath: string;
 beforeEach(async () => {
   tempTestDataPath = await createTempTestData('decision-records');
   const commands = await CommandManager.getInstance(tempTestDataPath);
-  app = createApp(new MockAuthProvider(), commands);
+  app = createApp(
+    new MockAuthProvider(),
+    ProjectRegistry.fromCommandManager(commands),
+  );
 });
 
 afterEach(async () => {
@@ -18,7 +22,7 @@ afterEach(async () => {
 });
 
 test('POST /api/fieldTypes creates a field type successfully', async () => {
-  const response = await app.request('/api/fieldTypes', {
+  const response = await app.request('/api/projects/decision/fieldTypes', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -52,7 +56,7 @@ test('POST /api/fieldTypes creates field type with different data types', async 
   ];
 
   for (const dataType of validDataTypes) {
-    const response = await app.request('/api/fieldTypes', {
+    const response = await app.request('/api/projects/decision/fieldTypes', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/tools/backend/test/graphModels.test.ts
+++ b/tools/backend/test/graphModels.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, beforeEach, afterEach } from 'vitest';
 import { CommandManager } from '@cyberismo/data-handler';
 import { createApp } from '../src/app.js';
+import { ProjectRegistry } from '../src/project-registry.js';
 import { MockAuthProvider } from '../src/auth/mock.js';
 import { createTempTestData, cleanupTempTestData } from './test-utils.js';
 
@@ -10,7 +11,10 @@ let tempTestDataPath: string;
 beforeEach(async () => {
   tempTestDataPath = await createTempTestData('decision-records');
   const commands = await CommandManager.getInstance(tempTestDataPath);
-  app = createApp(new MockAuthProvider(), commands);
+  app = createApp(
+    new MockAuthProvider(),
+    ProjectRegistry.fromCommandManager(commands),
+  );
 });
 
 afterEach(async () => {
@@ -18,7 +22,7 @@ afterEach(async () => {
 });
 
 test('POST /api/graphModels creates a graph model successfully', async () => {
-  const response = await app.request('/api/graphModels', {
+  const response = await app.request('/api/projects/decision/graphModels', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/tools/backend/test/graphViews.test.ts
+++ b/tools/backend/test/graphViews.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, beforeEach, afterEach } from 'vitest';
 import { CommandManager } from '@cyberismo/data-handler';
 import { createApp } from '../src/app.js';
+import { ProjectRegistry } from '../src/project-registry.js';
 import { MockAuthProvider } from '../src/auth/mock.js';
 import { createTempTestData, cleanupTempTestData } from './test-utils.js';
 
@@ -10,7 +11,10 @@ let tempTestDataPath: string;
 beforeEach(async () => {
   tempTestDataPath = await createTempTestData('decision-records');
   const commands = await CommandManager.getInstance(tempTestDataPath);
-  app = createApp(new MockAuthProvider(), commands);
+  app = createApp(
+    new MockAuthProvider(),
+    ProjectRegistry.fromCommandManager(commands),
+  );
 });
 
 afterEach(async () => {
@@ -18,7 +22,7 @@ afterEach(async () => {
 });
 
 test('POST /api/graphViews creates a graph view successfully', async () => {
-  const response = await app.request('/api/graphViews', {
+  const response = await app.request('/api/projects/decision/graphViews', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/tools/backend/test/linkTypes.test.ts
+++ b/tools/backend/test/linkTypes.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, beforeEach, afterEach } from 'vitest';
 import { CommandManager } from '@cyberismo/data-handler';
 import { createApp } from '../src/app.js';
+import { ProjectRegistry } from '../src/project-registry.js';
 import { MockAuthProvider } from '../src/auth/mock.js';
 import { createTempTestData, cleanupTempTestData } from './test-utils.js';
 
@@ -10,7 +11,10 @@ let tempTestDataPath: string;
 beforeEach(async () => {
   tempTestDataPath = await createTempTestData('decision-records');
   const commands = await CommandManager.getInstance(tempTestDataPath);
-  app = createApp(new MockAuthProvider(), commands);
+  app = createApp(
+    new MockAuthProvider(),
+    ProjectRegistry.fromCommandManager(commands),
+  );
 });
 
 afterEach(async () => {
@@ -18,7 +22,7 @@ afterEach(async () => {
 });
 
 test('POST /api/linkTypes creates a link type successfully', async () => {
-  const response = await app.request('/api/linkTypes', {
+  const response = await app.request('/api/projects/decision/linkTypes', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/tools/backend/test/logic-programs.test.ts
+++ b/tools/backend/test/logic-programs.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { CommandManager } from '@cyberismo/data-handler';
 import { createApp } from '../src/app.js';
+import { ProjectRegistry } from '../src/project-registry.js';
 import { MockAuthProvider } from '../src/auth/mock.js';
 
 const fileUrl = fileURLToPath(import.meta.url);
@@ -17,12 +18,15 @@ beforeAll(async () => {
       '../../data-handler/test/test-data/valid/decision-records',
     ),
   );
-  app = createApp(new MockAuthProvider(), commands);
+  app = createApp(
+    new MockAuthProvider(),
+    ProjectRegistry.fromCommandManager(commands),
+  );
 });
 
 test('/api/logicPrograms returns logic program for a valid card', async () => {
   const response = await app.request(
-    '/api/logicPrograms/decision/cards/decision_5',
+    '/api/projects/decision/logicPrograms/decision/cards/decision_5',
   );
   expect(response).not.toBe(null);
   expect(response.status).toBe(200);
@@ -35,7 +39,7 @@ test('/api/logicPrograms returns logic program for a valid card', async () => {
 
 test('/api/logicPrograms returns logic program for a valid card type resource', async () => {
   const response = await app.request(
-    '/api/logicPrograms/decision/cardTypes/decision',
+    '/api/projects/decision/logicPrograms/decision/cardTypes/decision',
   );
   expect(response).not.toBe(null);
   expect(response.status).toBe(200);
@@ -48,7 +52,7 @@ test('/api/logicPrograms returns logic program for a valid card type resource', 
 
 test('/api/logicPrograms returns error for non-existent card', async () => {
   const response = await app.request(
-    '/api/logicPrograms/decision/cards/nonexistent_card',
+    '/api/projects/decision/logicPrograms/decision/cards/nonexistent_card',
   );
   expect(response).not.toBe(null);
   expect(response.status).toBe(500);
@@ -60,7 +64,7 @@ test('/api/logicPrograms returns error for non-existent card', async () => {
 
 test('/api/logicPrograms returns error for non-existent resource', async () => {
   const response = await app.request(
-    '/api/logicPrograms/decision/cardTypes/nonexistent',
+    '/api/projects/decision/logicPrograms/decision/cardTypes/nonexistent',
   );
   expect(response).not.toBe(null);
   expect(response.status).toBe(500);

--- a/tools/backend/test/mcp.test.ts
+++ b/tools/backend/test/mcp.test.ts
@@ -18,6 +18,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { CommandManager } from '@cyberismo/data-handler';
 import { createApp } from '../src/app.js';
+import { ProjectRegistry } from '../src/project-registry.js';
 import { MockAuthProvider } from '../src/auth/mock.js';
 
 const fileUrl = fileURLToPath(import.meta.url);
@@ -34,7 +35,10 @@ beforeAll(async () => {
       '../../data-handler/test/test-data/valid/decision-records',
     ),
   );
-  app = createApp(new MockAuthProvider(), commands);
+  app = createApp(
+    new MockAuthProvider(),
+    ProjectRegistry.fromCommandManager(commands),
+  );
 });
 
 describe('MCP HTTP Endpoint', () => {

--- a/tools/backend/test/middleware/commandManager.test.ts
+++ b/tools/backend/test/middleware/commandManager.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, vi } from 'vitest';
 import { Hono } from 'hono';
-import { attachCommandManager } from '../../src/middleware/commandManager.js';
+import {
+  attachCommandManager,
+  attachProjectRegistry,
+} from '../../src/middleware/commandManager.js';
 import type { CommandManager } from '@cyberismo/data-handler';
 import { UserRole } from '../../src/types.js';
 import type { UserInfo } from '../../src/types.js';
+import { ProjectRegistry } from '../../src/project-registry.js';
 
 const testUser: UserInfo = {
   id: 'user-1',
@@ -38,7 +42,10 @@ describe('attachCommandManager', () => {
 
     const res = await app.request('/test');
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = (await res.json()) as {
+      hasCommands: boolean;
+      projectPath: string;
+    };
     expect(body.hasCommands).toBe(true);
     expect(body.projectPath).toBe('/tmp/test-project');
   });
@@ -73,5 +80,102 @@ describe('attachCommandManager', () => {
     const res = await app.request('/test');
     expect(res.status).toBe(500);
     expect(commands.runAsAuthor).not.toHaveBeenCalled();
+  });
+});
+
+describe('attachProjectRegistry', () => {
+  function createRegistry(entries: { prefix: string }[]) {
+    return new ProjectRegistry(
+      entries.map(({ prefix }) => ({
+        prefix,
+        commands: mockCommands({
+          project: { basePath: `/tmp/${prefix}` },
+        } as Partial<CommandManager>),
+      })),
+    );
+  }
+
+  function createApp(registry: ProjectRegistry, staticMode = false) {
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('user', testUser);
+      await next();
+    });
+    app.use('/projects/:prefix/*', attachProjectRegistry(registry, staticMode));
+    app.get('/projects/:prefix/test', (c) =>
+      c.json({
+        projectPath: c.get('projectPath'),
+        hasRegistry: !!c.get('registry'),
+      }),
+    );
+    // Static mode route (no :prefix param)
+    app.use('/static/*', attachProjectRegistry(registry, staticMode));
+    app.get('/static/test', (c) => c.json({ ok: true }));
+    return app;
+  }
+
+  it('resolves project by prefix and sets commands', async () => {
+    const registry = createRegistry([{ prefix: 'decision' }]);
+    const app = createApp(registry);
+
+    const res = await app.request('/projects/decision/test');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      projectPath: string;
+      hasRegistry: boolean;
+    };
+    expect(body.projectPath).toBe('/tmp/decision');
+    expect(body.hasRegistry).toBe(true);
+  });
+
+  it('selects the correct project from multiple registered projects', async () => {
+    const registry = createRegistry([
+      { prefix: 'decision' },
+      { prefix: 'other' },
+    ]);
+    const app = createApp(registry);
+
+    const res = await app.request('/projects/other/test');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { projectPath: string };
+    expect(body.projectPath).toBe('/tmp/other');
+  });
+
+  it('returns 404 for unknown prefix', async () => {
+    const registry = createRegistry([{ prefix: 'decision' }]);
+    const app = createApp(registry);
+
+    const res = await app.request('/projects/unknown/test');
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Project 'unknown' not found");
+  });
+
+  it('returns 400 when prefix is missing and not in static mode', async () => {
+    const registry = createRegistry([{ prefix: 'decision' }]);
+    const app = createApp(registry, false);
+
+    const res = await app.request('/static/test');
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('Project prefix is required');
+  });
+
+  it('uses first project as fallback in static mode when no prefix param', async () => {
+    const registry = createRegistry([{ prefix: 'decision' }]);
+    const app = createApp(registry, true);
+
+    const res = await app.request('/static/test');
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 400 in static mode when registry is empty', async () => {
+    const registry = createRegistry([]);
+    const app = createApp(registry, true);
+
+    const res = await app.request('/static/test');
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('Project prefix is required');
   });
 });

--- a/tools/backend/test/multi-project.test.ts
+++ b/tools/backend/test/multi-project.test.ts
@@ -1,0 +1,91 @@
+import { expect, test, describe, beforeAll, afterAll } from 'vitest';
+import { CommandManager } from '@cyberismo/data-handler';
+import { createApp } from '../src/app.js';
+import { ProjectRegistry } from '../src/project-registry.js';
+import { MockAuthProvider } from '../src/auth/mock.js';
+import { createTempTestData, cleanupTempTestData } from './test-utils.js';
+
+describe('multi-project routing', () => {
+  let app: ReturnType<typeof createApp>;
+  let tempDecisionPath: string;
+  let tempMinimalPath: string;
+
+  beforeAll(async () => {
+    process.argv = [];
+    tempDecisionPath = await createTempTestData('decision-records');
+    tempMinimalPath = await createTempTestData('minimal');
+
+    const decisionCommands = await CommandManager.getInstance(tempDecisionPath);
+    const minimalCommands = await CommandManager.getInstance(tempMinimalPath);
+
+    const registry = new ProjectRegistry([
+      { prefix: decisionCommands.project.configuration.cardKeyPrefix, commands: decisionCommands },
+      { prefix: minimalCommands.project.configuration.cardKeyPrefix, commands: minimalCommands },
+    ]);
+
+    app = createApp(new MockAuthProvider(), registry);
+  });
+
+  afterAll(async () => {
+    await cleanupTempTestData(tempDecisionPath);
+    await cleanupTempTestData(tempMinimalPath);
+  });
+
+  test('GET /api/projects lists both projects', async () => {
+    const response = await app.request('/api/projects');
+    expect(response.status).toBe(200);
+    const result = (await response.json()) as { prefix: string; name: string }[];
+    expect(result).toHaveLength(2);
+    const prefixes = result.map((p) => p.prefix).sort();
+    expect(prefixes).toContain('decision');
+    expect(prefixes).toContain('mini');
+  });
+
+  test('GET /api/projects/:prefix/cards works for each project', async () => {
+    const decisionRes = await app.request('/api/projects/decision/cards');
+    expect(decisionRes.status).toBe(200);
+    const decisionData = (await decisionRes.json()) as { name: string };
+    expect(decisionData.name).toBe('decision');
+
+    const miniRes = await app.request('/api/projects/mini/cards');
+    expect(miniRes.status).toBe(200);
+    const miniData = (await miniRes.json()) as { name: string };
+    expect(miniData.name).toBe('minimal');
+  });
+
+  test('GET /api/projects/:prefix/tree returns project-specific tree', async () => {
+    const decisionRes = await app.request('/api/projects/decision/tree');
+    expect(decisionRes.status).toBe(200);
+    const decisionTree = (await decisionRes.json()) as { key: string }[];
+    expect(decisionTree.length).toBeGreaterThan(0);
+    expect(decisionTree[0].key).toMatch(/^decision_/);
+
+    const miniRes = await app.request('/api/projects/mini/tree');
+    expect(miniRes.status).toBe(200);
+    const miniTree = (await miniRes.json()) as { key: string }[];
+    // minimal project may have no cards
+    expect(Array.isArray(miniTree)).toBe(true);
+  });
+
+  test('returns 404 for unknown project prefix', async () => {
+    const response = await app.request('/api/projects/nonexistent/cards');
+    expect(response.status).toBe(404);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toContain('nonexistent');
+  });
+
+  test('project data does not leak across prefixes', async () => {
+    // Fetch a card from decision project
+    const decisionCardRes = await app.request(
+      '/api/projects/decision/cards/decision_5',
+    );
+    expect(decisionCardRes.status).toBe(200);
+
+    // The same card key should not exist in the mini project
+    const miniCardRes = await app.request(
+      '/api/projects/mini/cards/decision_5',
+    );
+    // Card not found in this project — returned as 400 (bad request)
+    expect([400, 404]).toContain(miniCardRes.status);
+  });
+});

--- a/tools/backend/test/presence.test.ts
+++ b/tools/backend/test/presence.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
 import { CommandManager } from '@cyberismo/data-handler';
 import { createApp } from '../src/app.js';
+import { ProjectRegistry } from '../src/project-registry.js';
 import { MockAuthProvider } from '../src/auth/mock.js';
 import { presenceStore } from '../src/domain/cards/presence.js';
 import { UserRole } from '../src/types.js';
@@ -14,7 +15,10 @@ beforeAll(async () => {
   process.argv = [];
   tempTestDataPath = await createTempTestData('decision-records');
   const commands = await CommandManager.getInstance(tempTestDataPath);
-  app = createApp(new MockAuthProvider(), commands);
+  app = createApp(
+    new MockAuthProvider(),
+    ProjectRegistry.fromCommandManager(commands),
+  );
 });
 
 afterAll(async () => {
@@ -42,10 +46,10 @@ function parseSSEEvents(
     });
 }
 
-describe('GET /api/cards/:key/presence', () => {
+describe('GET /api/projects/:prefix/cards/:key/presence', () => {
   test('returns 200 with text/event-stream content type', async () => {
     const response = await app.request(
-      '/api/cards/decision_5/presence?mode=viewing',
+      '/api/projects/decision/cards/decision_5/presence?mode=viewing',
     );
     expect(response.status).toBe(200);
     expect(response.headers.get('content-type')).toContain('text/event-stream');
@@ -53,7 +57,7 @@ describe('GET /api/cards/:key/presence', () => {
 
   test('emits an initial presence event with the connected user', async () => {
     const response = await app.request(
-      '/api/cards/decision_5/presence?mode=editing',
+      '/api/projects/decision/cards/decision_5/presence?mode=editing',
     );
     expect(response.status).toBe(200);
 
@@ -88,7 +92,9 @@ describe('GET /api/cards/:key/presence', () => {
   });
 
   test('defaults mode to viewing when not specified', async () => {
-    const response = await app.request('/api/cards/decision_5/presence');
+    const response = await app.request(
+      '/api/projects/decision/cards/decision_5/presence',
+    );
     expect(response.status).toBe(200);
 
     const reader = response.body!.getReader();

--- a/tools/backend/test/project.test.ts
+++ b/tools/backend/test/project.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, afterEach, describe, expect, test } from 'vitest';
 import { CommandManager } from '@cyberismo/data-handler';
 import { createApp } from '../src/app.js';
+import { ProjectRegistry } from '../src/project-registry.js';
 import { MockAuthProvider } from '../src/auth/mock.js';
 import { cleanupTempTestData, createTempTestData } from './test-utils.js';
 
@@ -21,7 +22,10 @@ let tempTestDataPath: string;
 beforeEach(async () => {
   tempTestDataPath = await createTempTestData('module-test');
   const commands = await CommandManager.getInstance(tempTestDataPath);
-  app = createApp(new MockAuthProvider(), commands);
+  app = createApp(
+    new MockAuthProvider(),
+    ProjectRegistry.fromCommandManager(commands),
+  );
 });
 
 afterEach(async () => {
@@ -30,7 +34,7 @@ afterEach(async () => {
 
 describe('Project endpoints', () => {
   test('GET /api/project returns project info', async () => {
-    const response = await app.request('/api/project');
+    const response = await app.request('/api/projects/test/project');
     expect(response.status).toBe(200);
     const result = (await response.json()) as ProjectResponse;
 
@@ -40,7 +44,7 @@ describe('Project endpoints', () => {
   });
 
   test('PATCH /api/project updates name and prefix', async () => {
-    const response = await app.request('/api/project', {
+    const response = await app.request('/api/projects/test/project', {
       method: 'PATCH',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
@@ -56,14 +60,16 @@ describe('Project endpoints', () => {
   });
 
   test('GET /api/project/modules/importable returns the importable modules', async () => {
-    const response = await app.request('/api/project/modules/importable');
+    const response = await app.request(
+      '/api/projects/test/project/modules/importable',
+    );
     expect(response.status).toBe(200);
     const result = await response.json();
     expect(result).toHaveLength(4);
   });
 
   test('POST /api/project/modules returns 400 for missing source', async () => {
-    const response = await app.request('/api/project/modules', {
+    const response = await app.request('/api/projects/test/project/modules', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({}),
@@ -72,7 +78,7 @@ describe('Project endpoints', () => {
   });
 
   test('POST /api/project/modules returns 400 for non-git source', async () => {
-    const response = await app.request('/api/project/modules', {
+    const response = await app.request('/api/projects/test/project/modules', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ source: 'not-a-git-url' }),

--- a/tools/backend/test/projects.test.ts
+++ b/tools/backend/test/projects.test.ts
@@ -1,0 +1,51 @@
+import { expect, test, beforeEach, afterEach } from 'vitest';
+import { CommandManager } from '@cyberismo/data-handler';
+import { createApp } from '../src/app.js';
+import { ProjectRegistry } from '../src/project-registry.js';
+import { MockAuthProvider } from '../src/auth/mock.js';
+import { createTempTestData, cleanupTempTestData } from './test-utils.js';
+
+let app: ReturnType<typeof createApp>;
+let tempTestDataPath: string;
+
+type ProjectsResponse = {
+  prefix: string;
+  name: string;
+}[];
+
+beforeEach(async () => {
+  tempTestDataPath = await createTempTestData('decision-records');
+  const commands = await CommandManager.getInstance(tempTestDataPath);
+  app = createApp(
+    new MockAuthProvider(),
+    ProjectRegistry.fromCommandManager(commands),
+  );
+});
+
+afterEach(async () => {
+  await cleanupTempTestData(tempTestDataPath);
+});
+
+test('GET /api/projects returns a list of projects', async () => {
+  const response = await app.request('/api/projects');
+
+  expect(response.status).toBe(200);
+
+  const result = (await response.json()) as ProjectsResponse;
+  expect(result).toBeInstanceOf(Array);
+  expect(result.length).toBe(1);
+  expect(result[0]).toHaveProperty('prefix', 'decision');
+  expect(result[0]).toHaveProperty('name');
+});
+
+test('GET /api/projects returns empty array when no projects', async () => {
+  const emptyApp = createApp(new MockAuthProvider(), new ProjectRegistry());
+
+  const response = await emptyApp.request('/api/projects');
+
+  expect(response.status).toBe(200);
+
+  const result = (await response.json()) as ProjectsResponse;
+  expect(result).toBeInstanceOf(Array);
+  expect(result.length).toBe(0);
+});

--- a/tools/backend/test/reports.test.ts
+++ b/tools/backend/test/reports.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, beforeEach, afterEach } from 'vitest';
 import { CommandManager } from '@cyberismo/data-handler';
 import { createApp } from '../src/app.js';
+import { ProjectRegistry } from '../src/project-registry.js';
 import { MockAuthProvider } from '../src/auth/mock.js';
 import { createTempTestData, cleanupTempTestData } from './test-utils.js';
 
@@ -10,7 +11,10 @@ let tempTestDataPath: string;
 beforeEach(async () => {
   tempTestDataPath = await createTempTestData('decision-records');
   const commands = await CommandManager.getInstance(tempTestDataPath);
-  app = createApp(new MockAuthProvider(), commands);
+  app = createApp(
+    new MockAuthProvider(),
+    ProjectRegistry.fromCommandManager(commands),
+  );
 });
 
 afterEach(async () => {
@@ -18,7 +22,7 @@ afterEach(async () => {
 });
 
 test('POST /api/reports creates a report successfully', async () => {
-  const response = await app.request('/api/reports', {
+  const response = await app.request('/api/projects/decision/reports', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/tools/backend/test/resources.test.ts
+++ b/tools/backend/test/resources.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, beforeAll, afterAll } from 'vitest';
 import { CommandManager } from '@cyberismo/data-handler';
 import { createApp } from '../src/app.js';
+import { ProjectRegistry } from '../src/project-registry.js';
 import { MockAuthProvider } from '../src/auth/mock.js';
 import { cleanupTempTestData, createTempTestData } from './test-utils.js';
 
@@ -16,7 +17,10 @@ interface CardTypeResponse {
 beforeAll(async () => {
   tempTestDataPath = await createTempTestData('decision-records');
   const commands = await CommandManager.getInstance(tempTestDataPath);
-  app = createApp(new MockAuthProvider(), commands);
+  app = createApp(
+    new MockAuthProvider(),
+    ProjectRegistry.fromCommandManager(commands),
+  );
 });
 
 afterAll(async () => {
@@ -24,7 +28,7 @@ afterAll(async () => {
 });
 
 async function getCardTypeByName(name: string): Promise<CardTypeResponse> {
-  const response = await app.request('/api/cardTypes');
+  const response = await app.request('/api/projects/decision/cardTypes');
   expect(response).not.toBe(null);
   expect(response.status).toBe(200);
 
@@ -39,9 +43,9 @@ async function getCardTypeByName(name: string): Promise<CardTypeResponse> {
   return cardType;
 }
 
-test('/api/resources/decision/fieldTypes/admins/validate returns validation result for valid field type', async () => {
+test('/api/projects/decision/resources/decision/fieldTypes/admins/validate returns validation result for valid field type', async () => {
   const response = await app.request(
-    '/api/resources/decision/fieldTypes/admins/validate',
+    '/api/projects/decision/resources/decision/fieldTypes/admins/validate',
   );
   expect(response).not.toBe(null);
 
@@ -53,9 +57,9 @@ test('/api/resources/decision/fieldTypes/admins/validate returns validation resu
   expect(result.errors.every((error: string) => error === '')).toBe(true);
 });
 
-test('/api/resources/decision/cardTypes/decision/validate returns validation result for valid card type', async () => {
+test('/api/projects/decision/resources/decision/cardTypes/decision/validate returns validation result for valid card type', async () => {
   const response = await app.request(
-    '/api/resources/decision/cardTypes/decision/validate',
+    '/api/projects/decision/resources/decision/cardTypes/decision/validate',
   );
   expect(response).not.toBe(null);
 
@@ -65,7 +69,7 @@ test('/api/resources/decision/cardTypes/decision/validate returns validation res
   expect(result.errors).toEqual([]);
 });
 
-test('/api/resources/decision/cardTypes/decision/operation performs change operation successfully', async () => {
+test('/api/projects/decision/resources/decision/cardTypes/decision/operation performs change operation successfully', async () => {
   const cardTypeBefore = await getCardTypeByName('decision/cardTypes/decision');
   expect(cardTypeBefore.displayName).toBeDefined();
 
@@ -75,7 +79,7 @@ test('/api/resources/decision/cardTypes/decision/operation performs change opera
     : `${originalDisplayName} (test)`;
 
   const response = await app.request(
-    '/api/resources/decision/cardTypes/decision/operation',
+    '/api/projects/decision/resources/decision/cardTypes/decision/operation',
     {
       method: 'POST',
       headers: {
@@ -103,7 +107,7 @@ test('/api/resources/decision/cardTypes/decision/operation performs change opera
   expect(cardTypeAfter.displayName).toBe(updatedDisplayName);
 
   const revertResponse = await app.request(
-    '/api/resources/decision/cardTypes/decision/operation',
+    '/api/projects/decision/resources/decision/cardTypes/decision/operation',
     {
       method: 'POST',
       headers: {
@@ -131,7 +135,7 @@ test('/api/resources/decision/cardTypes/decision/operation performs change opera
   expect(cardTypeRestored.displayName).toBe(originalDisplayName);
 });
 
-test('/api/resources/decision/cardTypes/decision/operation performs add operation successfully', async () => {
+test('/api/projects/decision/resources/decision/cardTypes/decision/operation performs add operation successfully', async () => {
   const targetField = 'decision/fieldTypes/percentageReady';
   const cardTypeBefore = await getCardTypeByName('decision/cardTypes/decision');
   const beforeFields = [...(cardTypeBefore.alwaysVisibleFields ?? [])];
@@ -139,7 +143,7 @@ test('/api/resources/decision/cardTypes/decision/operation performs add operatio
   expect(beforeFields).not.toContain(targetField);
 
   const response = await app.request(
-    '/api/resources/decision/cardTypes/decision/operation',
+    '/api/projects/decision/resources/decision/cardTypes/decision/operation',
     {
       method: 'POST',
       headers: {
@@ -170,7 +174,7 @@ test('/api/resources/decision/cardTypes/decision/operation performs add operatio
   expect(afterFields).to.contain(targetField);
 });
 
-test('/api/resources/decision/cardTypes/decision/operation performs rank operation successfully', async () => {
+test('/api/projects/decision/resources/decision/cardTypes/decision/operation performs rank operation successfully', async () => {
   const targetField = 'decision/fieldTypes/commitDescription';
   const cardTypeBefore = await getCardTypeByName('decision/cardTypes/decision');
   const beforeFields = [...(cardTypeBefore.alwaysVisibleFields ?? [])];
@@ -179,7 +183,7 @@ test('/api/resources/decision/cardTypes/decision/operation performs rank operati
   expect(initialIndex).toBeGreaterThan(-1);
 
   const response = await app.request(
-    '/api/resources/decision/cardTypes/decision/operation',
+    '/api/projects/decision/resources/decision/cardTypes/decision/operation',
     {
       method: 'POST',
       headers: {
@@ -216,7 +220,7 @@ test('/api/resources/decision/cardTypes/decision/operation performs rank operati
   );
 });
 
-test('/api/resources/decision/cardTypes/decision/operation performs remove operation successfully', async () => {
+test('/api/projects/decision/resources/decision/cardTypes/decision/operation performs remove operation successfully', async () => {
   const targetField = 'decision/fieldTypes/commitDescription';
   const cardTypeBefore = await getCardTypeByName('decision/cardTypes/decision');
   const beforeFields = [...(cardTypeBefore.alwaysVisibleFields ?? [])];
@@ -224,7 +228,7 @@ test('/api/resources/decision/cardTypes/decision/operation performs remove opera
   expect(beforeFields).toContain(targetField);
 
   const response = await app.request(
-    '/api/resources/decision/cardTypes/decision/operation',
+    '/api/projects/decision/resources/decision/cardTypes/decision/operation',
     {
       method: 'POST',
       headers: {
@@ -259,9 +263,9 @@ test('/api/resources/decision/cardTypes/decision/operation performs remove opera
   );
 });
 
-test('/api/resources/decision/cardTypes/decision/operation returns 400 for invalid operation', async () => {
+test('/api/projects/decision/resources/decision/cardTypes/decision/operation returns 400 for invalid operation', async () => {
   const response = await app.request(
-    '/api/resources/decision/cardTypes/decision/operation',
+    '/api/projects/decision/resources/decision/cardTypes/decision/operation',
     {
       method: 'POST',
       headers: {
@@ -281,9 +285,9 @@ test('/api/resources/decision/cardTypes/decision/operation returns 400 for inval
   expect(response.status).toBe(400);
 });
 
-test('/api/resources/decision/cardTypes/decision/operation returns 500 for invalid key', async () => {
+test('/api/projects/decision/resources/decision/cardTypes/decision/operation returns 500 for invalid key', async () => {
   const response = await app.request(
-    '/api/resources/decision/cardTypes/decision/operation',
+    '/api/projects/decision/resources/decision/cardTypes/decision/operation',
     {
       method: 'POST',
       headers: {

--- a/tools/backend/test/templates.test.ts
+++ b/tools/backend/test/templates.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, beforeEach, afterEach } from 'vitest';
 import { CommandManager } from '@cyberismo/data-handler';
 import { createApp } from '../src/app.js';
+import { ProjectRegistry } from '../src/project-registry.js';
 import { MockAuthProvider } from '../src/auth/mock.js';
 import { createTempTestData, cleanupTempTestData } from './test-utils.js';
 
@@ -10,7 +11,10 @@ let tempTestDataPath: string;
 beforeEach(async () => {
   tempTestDataPath = await createTempTestData('module-test');
   const commands = await CommandManager.getInstance(tempTestDataPath);
-  app = createApp(new MockAuthProvider(), commands);
+  app = createApp(
+    new MockAuthProvider(),
+    ProjectRegistry.fromCommandManager(commands),
+  );
 });
 
 afterEach(async () => {
@@ -18,7 +22,7 @@ afterEach(async () => {
 });
 
 test('POST /api/templates creates a template successfully', async () => {
-  const response = await app.request('/api/templates', {
+  const response = await app.request('/api/projects/test/templates', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -37,7 +41,7 @@ test('POST /api/templates creates a template successfully', async () => {
 });
 
 test('POST /api/templates/card creates a template card successfully', async () => {
-  const response = await app.request('/api/templates/card', {
+  const response = await app.request('/api/projects/test/templates/card', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -59,23 +63,26 @@ test('POST /api/templates/card creates a template card successfully', async () =
 
 test('POST /api/templates/card creates a template card with parent successfully', async () => {
   // First create a card to use as parent
-  const createResponse = await app.request('/api/templates/card', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
+  const createResponse = await app.request(
+    '/api/projects/test/templates/card',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        template: 'test/templates/page',
+        cardType: 'test/cardTypes/page',
+      }),
     },
-    body: JSON.stringify({
-      template: 'test/templates/page',
-      cardType: 'test/cardTypes/page',
-    }),
-  });
+  );
 
   expect(createResponse.status).toBe(200);
   const createResult = await createResponse.json();
   const parentKey = createResult.cards[0];
 
   // Now create a child card
-  const response = await app.request('/api/templates/card', {
+  const response = await app.request('/api/projects/test/templates/card', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -97,7 +104,7 @@ test('POST /api/templates/card creates a template card with parent successfully'
 });
 
 test('POST /api/templates/card creates multiple template cards with count property', async () => {
-  const response = await app.request('/api/templates/card', {
+  const response = await app.request('/api/projects/test/templates/card', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/tools/backend/test/workflows.test.ts
+++ b/tools/backend/test/workflows.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, beforeEach, afterEach } from 'vitest';
 import { CommandManager } from '@cyberismo/data-handler';
 import { createApp } from '../src/app.js';
+import { ProjectRegistry } from '../src/project-registry.js';
 import { MockAuthProvider } from '../src/auth/mock.js';
 import { createTempTestData, cleanupTempTestData } from './test-utils.js';
 
@@ -10,7 +11,10 @@ let tempTestDataPath: string;
 beforeEach(async () => {
   tempTestDataPath = await createTempTestData('decision-records');
   const commands = await CommandManager.getInstance(tempTestDataPath);
-  app = createApp(new MockAuthProvider(), commands);
+  app = createApp(
+    new MockAuthProvider(),
+    ProjectRegistry.fromCommandManager(commands),
+  );
 });
 
 afterEach(async () => {
@@ -18,7 +22,7 @@ afterEach(async () => {
 });
 
 test('POST /api/workflows creates a workflow successfully', async () => {
-  const response = await app.request('/api/workflows', {
+  const response = await app.request('/api/projects/decision/workflows', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -34,6 +34,7 @@ import {
   CommandManager,
   Commands,
   ExportFormats,
+  scanForProjects,
   validBumps,
   validContexts,
 } from '@cyberismo/data-handler';
@@ -44,6 +45,7 @@ import {
   exportSite,
   previewSite,
   MockAuthProvider,
+  ProjectRegistry,
 } from '@cyberismo/backend';
 import type { MockUserConfig } from '@cyberismo/backend';
 import { simpleGit } from 'simple-git';
@@ -1463,45 +1465,78 @@ const appCmd = new CommandWithPath('app')
   .option('--autocommit', 'Enable git-backed transactional writes');
 program.addCommand(appCmd);
 appCmd.action(async (options: CommandOptions<'start'>) => {
-  // validate project
-  const result = await commandHandler.command(
-    Cmd.validate,
-    [],
-    Object.assign({}, options, program.opts()),
-  );
-  if (!result.message) {
-    program.error('Expected validation result, but got none');
+  const basePath = options.projectPath || process.cwd();
+  let projects: Awaited<ReturnType<typeof scanForProjects>>;
+  try {
+    projects = await scanForProjects(basePath);
+  } catch (error) {
+    program.error(
+      error instanceof Error
+        ? error.message
+        : `Failed to scan for projects in '${basePath}'`,
+    );
     return;
   }
-  if (result.message !== 'Project structure validated') {
-    truncateMessage(result.message).forEach((item) => console.error(item));
-    console.error('\n'); // The output looks nicer with one extra row.
-    result.message = '';
-    const userConfirmation = await confirm(
-      {
-        message: 'There are validation errors. Do you want to continue?',
-      },
-      { signal: AbortSignal.timeout(10000), clearPromptOnDone: true },
-    ).catch((error) => {
-      return error.name === 'AbortPromptError';
-    });
-    if (!userConfirmation) {
-      handleResponse(result);
+
+  if (projects.length === 0) {
+    console.log('No projects found. Starting with empty project collection.');
+  }
+
+  // Validate each discovered project
+  for (const project of projects) {
+    const result = await commandHandler.command(
+      Cmd.validate,
+      [],
+      Object.assign({}, options, program.opts(), {
+        projectPath: project.path,
+      }),
+    );
+    if (!result.message) {
+      program.error(
+        `Expected validation result for project '${project.name}', but got none`,
+      );
       return;
     }
+    if (result.message !== 'Project structure validated') {
+      console.error(`Validation errors in project '${project.name}':`);
+      truncateMessage(result.message).forEach((item) => console.error(item));
+      console.error('\n');
+      result.message = '';
+      const userConfirmation = await confirm(
+        {
+          message: `There are validation errors in '${project.name}'. Do you want to continue?`,
+        },
+        { signal: AbortSignal.timeout(10000), clearPromptOnDone: true },
+      ).catch((error) => {
+        return error.name === 'AbortPromptError';
+      });
+      if (!userConfirmation) {
+        handleResponse(result);
+        return;
+      }
+    }
   }
+
   const gitUser = await getGitUserConfig();
   if (!gitUser.name || !gitUser.email) {
     console.warn(
       'Warning: git user.name or user.email is not configured. Using defaults.',
     );
   }
-  const projectPath = await commandHandler.getProjectPath(options.projectPath);
-  const commands = await CommandManager.getInstance(projectPath, {
-    autocommit: options.autocommit,
-    watchResourceChanges: options.watchResourceChanges,
-  });
-  await startServer(new MockAuthProvider(gitUser), commands);
+
+  // Create a CommandManager for each discovered project
+  const registryEntries = [];
+  for (const project of projects) {
+    const commands = new CommandManager(project.path, {
+      autocommit: options.autocommit,
+      watchResourceChanges: options.watchResourceChanges,
+    });
+    await commands.initialize();
+    registryEntries.push({ prefix: project.prefix, commands });
+  }
+
+  const registry = new ProjectRegistry(registryEntries);
+  await startServer(new MockAuthProvider(gitUser), registry);
 });
 
 // Publish command - creates a git tag from cardsConfig version and pushes

--- a/tools/data-handler/src/index.ts
+++ b/tools/data-handler/src/index.ts
@@ -39,6 +39,7 @@ import {
   resourceNameToString,
 } from './utils/resource-utils.js';
 import { moduleNameFromCardKey } from './utils/card-utils.js';
+import { scanForProjects } from './project-scanner.js';
 
 export {
   Cmd,
@@ -52,6 +53,7 @@ export {
   requestStatus,
   resourceName,
   resourceNameToString,
+  scanForProjects,
   UpdateOperations,
   Validate,
   evaluateMacros,

--- a/tools/data-handler/src/project-scanner.ts
+++ b/tools/data-handler/src/project-scanner.ts
@@ -1,0 +1,123 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { join, resolve } from 'node:path';
+import { readdir } from 'node:fs/promises';
+import { pathExists, resolveTilde } from './utils/file-utils.js';
+import { readJsonFileSync } from './utils/json.js';
+
+export interface ProjectEntry {
+  path: string;
+  prefix: string;
+  name: string;
+}
+
+/**
+ * Check whether a directory is a Cyberismo project (has `.cards/` and `cardRoot/`).
+ */
+function isProjectDirectory(dirPath: string): boolean {
+  return (
+    pathExists(join(dirPath, '.cards')) && pathExists(join(dirPath, 'cardRoot'))
+  );
+}
+
+/**
+ * Read project prefix and name from a project directory's cardsConfig.json.
+ */
+function readProjectMeta(projectPath: string): {
+  prefix: string;
+  name: string;
+} {
+  const configPath = join(projectPath, '.cards', 'local', 'cardsConfig.json');
+  const config = readJsonFileSync(configPath) as {
+    cardKeyPrefix?: string;
+    name?: string;
+  };
+  if (!config?.cardKeyPrefix || !config?.name) {
+    throw new Error(
+      `Invalid project configuration at '${configPath}': missing cardKeyPrefix or name`,
+    );
+  }
+  return { prefix: config.cardKeyPrefix, name: config.name };
+}
+
+/**
+ * Scan for Cyberismo projects starting from `basePath`.
+ *
+ * Detection is strictly binary:
+ * - If `basePath` itself is a project (has `.cards/` + `cardRoot/`), returns a single-entry list.
+ * - Otherwise, treats `basePath` as a collection directory and scans its
+ *   first-level subdirectories for projects. Non-project directories are
+ *   scanned one level deeper. Returns the list of found projects
+ *   (may be empty — an empty collection is valid).
+ */
+export async function scanForProjects(
+  basePath: string,
+): Promise<ProjectEntry[]> {
+  const rootPath = resolve(resolveTilde(basePath));
+
+  // Direct project
+  if (isProjectDirectory(rootPath)) {
+    const meta = readProjectMeta(rootPath);
+    return [{ path: rootPath, ...meta }];
+  }
+
+  // Collection directory — scan subdirectories up to 2 levels deep
+  const projects: ProjectEntry[] = [];
+  const seenPrefixes = new Map<string, string>();
+
+  async function collectProjects(dirPath: string, depth: number) {
+    let entries;
+    try {
+      entries = await readdir(dirPath, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const childPath = join(dirPath, entry.name);
+      if (isProjectDirectory(childPath)) {
+        try {
+          const meta = readProjectMeta(childPath);
+          const existing = seenPrefixes.get(meta.prefix);
+          if (existing) {
+            console.warn(
+              `Skipping project '${childPath}': duplicate prefix '${meta.prefix}' (already registered from '${existing}')`,
+            );
+            continue;
+          }
+          seenPrefixes.set(meta.prefix, childPath);
+          projects.push({ path: childPath, ...meta });
+        } catch (error) {
+          console.warn(
+            `Skipping project directory '${childPath}': ${error instanceof Error ? error.message : error}`,
+          );
+        }
+      } else if (depth > 0) {
+        await collectProjects(childPath, depth - 1);
+      }
+    }
+  }
+
+  try {
+    await readdir(rootPath);
+  } catch {
+    throw new Error(
+      `Cannot scan for projects: '${rootPath}' does not exist or is not a directory`,
+    );
+  }
+
+  await collectProjects(rootPath, 1);
+
+  return projects;
+}

--- a/tools/data-handler/test/project-scanner.test.ts
+++ b/tools/data-handler/test/project-scanner.test.ts
@@ -1,0 +1,151 @@
+import { expect, describe, it, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { scanForProjects } from '../src/project-scanner.js';
+
+describe('scanForProjects', () => {
+  const baseDir = import.meta.dirname;
+  const testDir = join(baseDir, 'tmp-project-scanner-tests');
+
+  function createProject(
+    parentDir: string,
+    dirName: string,
+    prefix: string,
+    name: string,
+  ): string {
+    const projectDir = join(parentDir, dirName);
+    const configDir = join(projectDir, '.cards', 'local');
+    mkdirSync(configDir, { recursive: true });
+    mkdirSync(join(projectDir, 'cardRoot'), { recursive: true });
+    writeFileSync(
+      join(configDir, 'cardsConfig.json'),
+      JSON.stringify({ cardKeyPrefix: prefix, name }),
+    );
+    return projectDir;
+  }
+
+  beforeEach(() => {
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('detects a direct project directory', async () => {
+    createProject(testDir, 'proj', 'TST', 'Test Project');
+    const results = await scanForProjects(join(testDir, 'proj'));
+    expect(results).to.have.length(1);
+    expect(results[0].prefix).to.equal('TST');
+    expect(results[0].name).to.equal('Test Project');
+    expect(results[0].path).to.equal(resolve(testDir, 'proj'));
+  });
+
+  it('scans collection directory for projects', async () => {
+    createProject(testDir, 'alpha', 'AAA', 'Alpha');
+    createProject(testDir, 'beta', 'BBB', 'Beta');
+    const results = await scanForProjects(testDir);
+    expect(results).to.have.length(2);
+    const prefixes = results.map((r) => r.prefix).sort();
+    expect(prefixes).to.deep.equal(['AAA', 'BBB']);
+  });
+
+  it('returns empty array for empty collection directory', async () => {
+    const results = await scanForProjects(testDir);
+    expect(results).to.deep.equal([]);
+  });
+
+  it('skips non-directory entries', async () => {
+    createProject(testDir, 'proj', 'TST', 'Test');
+    writeFileSync(join(testDir, 'readme.txt'), 'not a project');
+    const results = await scanForProjects(testDir);
+    expect(results).to.have.length(1);
+    expect(results[0].prefix).to.equal('TST');
+  });
+
+  it('skips directories without project structure', async () => {
+    mkdirSync(join(testDir, 'not-a-project'), { recursive: true });
+    createProject(testDir, 'real', 'REAL', 'Real Project');
+    const results = await scanForProjects(testDir);
+    expect(results).to.have.length(1);
+    expect(results[0].prefix).to.equal('REAL');
+  });
+
+  it('skips projects with malformed cardsConfig.json', async () => {
+    createProject(testDir, 'good', 'GOOD', 'Good');
+    // Create a project directory structure with invalid config
+    const badDir = join(testDir, 'bad');
+    mkdirSync(join(badDir, '.cards', 'local'), { recursive: true });
+    mkdirSync(join(badDir, 'cardRoot'), { recursive: true });
+    writeFileSync(
+      join(badDir, '.cards', 'local', 'cardsConfig.json'),
+      JSON.stringify({ invalid: true }),
+    );
+    const results = await scanForProjects(testDir);
+    expect(results).to.have.length(1);
+    expect(results[0].prefix).to.equal('GOOD');
+  });
+
+  it('skips duplicate prefixes and keeps the first', async () => {
+    createProject(testDir, 'aaa-first', 'DUP', 'First');
+    createProject(testDir, 'zzz-second', 'DUP', 'Second');
+    const results = await scanForProjects(testDir);
+    expect(results).to.have.length(1);
+    expect(results[0].prefix).to.equal('DUP');
+  });
+
+  it('throws for non-existent path', async () => {
+    await expect(
+      scanForProjects(join(testDir, 'does-not-exist')),
+    ).rejects.toThrow('does not exist or is not a directory');
+  });
+
+  it('finds projects nested one level inside a non-project subdirectory', async () => {
+    const group = join(testDir, 'group');
+    mkdirSync(group, { recursive: true });
+    createProject(group, 'nested', 'NST', 'Nested Project');
+    const results = await scanForProjects(testDir);
+    expect(results).to.have.length(1);
+    expect(results[0].prefix).to.equal('NST');
+    expect(results[0].path).to.equal(resolve(group, 'nested'));
+  });
+
+  it('finds projects at both level 1 and level 2', async () => {
+    createProject(testDir, 'top-proj', 'TOP', 'Top');
+    const group = join(testDir, 'group');
+    mkdirSync(group, { recursive: true });
+    createProject(group, 'deep-proj', 'DEEP', 'Deep');
+    const results = await scanForProjects(testDir);
+    expect(results).to.have.length(2);
+    const prefixes = results.map((r) => r.prefix).sort();
+    expect(prefixes).to.deep.equal(['DEEP', 'TOP']);
+  });
+
+  it('does not scan deeper than 2 levels', async () => {
+    const level1 = join(testDir, 'a');
+    const level2 = join(level1, 'b');
+    mkdirSync(level2, { recursive: true });
+    createProject(level2, 'too-deep', 'NOPE', 'Too Deep');
+    const results = await scanForProjects(testDir);
+    expect(results).to.deep.equal([]);
+  });
+
+  it('does not recurse into project directories', async () => {
+    // A project with a nested project inside should only find the outer one
+    const outer = createProject(testDir, 'outer', 'OUT', 'Outer');
+    createProject(outer, 'inner', 'INN', 'Inner');
+    const results = await scanForProjects(testDir);
+    expect(results).to.have.length(1);
+    expect(results[0].prefix).to.equal('OUT');
+  });
+
+  it('deduplicates across depths', async () => {
+    createProject(testDir, 'first', 'DUP', 'First');
+    const group = join(testDir, 'group');
+    mkdirSync(group, { recursive: true });
+    createProject(group, 'second', 'DUP', 'Second');
+    const results = await scanForProjects(testDir);
+    expect(results).to.have.length(1);
+    expect(results[0].prefix).to.equal('DUP');
+  });
+});


### PR DESCRIPTION
Adds multi-project support. The backend can now serve multiple Cyberismo projects simultaneously under project-scoped API routes (/api/projects/:prefix/...). A new ProjectRegistry maps project prefixes to CommandManager instances, and a scanForProjects utility discovers projects from a directory. The frontend apiPaths were refactored to include the project prefix, and a placeholder project selector was added. Includes new tests for the registry, middleware, projects endpoint, and project scanner. The server and CLI fail fast with clear errors on invalid or empty project paths.

Future work for multiproject support

1. Empty project and project creation support
   Currently starting with an empty directory (no projects) results in a blank page.
   Need a project creation flow and an empty state view.

2. Dedicated project management view
   The project selector in SearchableTreeMenu is a placeholder.
   Replace with a proper project management view for browsing, creating, and managing projects.

3. Multi-project export support
   Export currently rejects multiple projects. Add support for selecting which
   project to export, or exporting all projects.

4. Make MCP project-scoped
   MCP endpoint currently uses registry.first() — hardcoded to the first project.
   Needs multi-project MCP support. Also, the /mcp route is mounted unconditionally;
   if a "no projects" server mode is added, either guard the mount or serve an
   "MCP unavailable" response.