### PR TITLE
INTDEV-1097 Role based authorization on the frontend

### DIFF
--- a/tools/app/__tests__/permissions.test.tsx
+++ b/tools/app/__tests__/permissions.test.tsx
@@ -1,0 +1,211 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { parseRole, roleSatisfies, UserRole } from '@/lib/auth/roles';
+import { useHasRole } from '@/lib/auth/usePermissions';
+import { Gate } from '@/lib/auth/Gate';
+
+const getConfigMock = vi.fn(() => ({ staticMode: false }));
+const useUserMock = vi.fn(() => ({ user: null as unknown }));
+
+vi.mock('@/lib/utils', async () => {
+  const actual = await vi.importActual('@/lib/utils');
+  return {
+    ...actual,
+    getConfig: () => getConfigMock(),
+  };
+});
+
+vi.mock('@/lib/api', () => ({
+  useUser: () => useUserMock(),
+}));
+
+beforeEach(() => {
+  getConfigMock.mockReset();
+  getConfigMock.mockReturnValue({ staticMode: false });
+  useUserMock.mockReset();
+  useUserMock.mockReturnValue({ user: null });
+});
+
+describe('roleSatisfies', () => {
+  it('returns false when user role is null', () => {
+    expect(roleSatisfies(null, UserRole.Reader)).toBe(false);
+    expect(roleSatisfies(null, UserRole.Editor)).toBe(false);
+    expect(roleSatisfies(null, UserRole.Admin)).toBe(false);
+  });
+
+  it('enforces the reader < editor < admin hierarchy', () => {
+    // Reader satisfies reader only
+    expect(roleSatisfies(UserRole.Reader, UserRole.Reader)).toBe(true);
+    expect(roleSatisfies(UserRole.Reader, UserRole.Editor)).toBe(false);
+    expect(roleSatisfies(UserRole.Reader, UserRole.Admin)).toBe(false);
+
+    // Editor satisfies reader and editor
+    expect(roleSatisfies(UserRole.Editor, UserRole.Reader)).toBe(true);
+    expect(roleSatisfies(UserRole.Editor, UserRole.Editor)).toBe(true);
+    expect(roleSatisfies(UserRole.Editor, UserRole.Admin)).toBe(false);
+
+    // Admin satisfies everything
+    expect(roleSatisfies(UserRole.Admin, UserRole.Reader)).toBe(true);
+    expect(roleSatisfies(UserRole.Admin, UserRole.Editor)).toBe(true);
+    expect(roleSatisfies(UserRole.Admin, UserRole.Admin)).toBe(true);
+  });
+
+  it('admin passes for editor minimum', () => {
+    expect(roleSatisfies(UserRole.Admin, UserRole.Editor)).toBe(true);
+  });
+
+  it('reader fails for editor minimum', () => {
+    expect(roleSatisfies(UserRole.Reader, UserRole.Editor)).toBe(false);
+  });
+});
+
+describe('parseRole', () => {
+  it('parses known role strings', () => {
+    expect(parseRole('reader')).toBe(UserRole.Reader);
+    expect(parseRole('editor')).toBe(UserRole.Editor);
+    expect(parseRole('admin')).toBe(UserRole.Admin);
+  });
+
+  it('returns null for unknown strings', () => {
+    expect(parseRole('superuser')).toBeNull();
+    expect(parseRole('owner')).toBeNull();
+    expect(parseRole('')).toBeNull();
+  });
+
+  it('returns null for null and undefined', () => {
+    expect(parseRole(null)).toBeNull();
+    expect(parseRole(undefined)).toBeNull();
+  });
+
+  it('is case-insensitive', () => {
+    expect(parseRole('READER')).toBe(UserRole.Reader);
+    expect(parseRole('Editor')).toBe(UserRole.Editor);
+    expect(parseRole('ADMIN')).toBe(UserRole.Admin);
+    expect(parseRole('aDmIn')).toBe(UserRole.Admin);
+  });
+});
+
+function Probe({ role }: { role: UserRole }) {
+  const allowed = useHasRole(role);
+  return <span>{allowed ? 'yes' : 'no'}</span>;
+}
+
+function renderProbe(role: UserRole) {
+  const { unmount } = render(<Probe role={role} />);
+  const text = screen.getByText(/^(yes|no)$/).textContent;
+  unmount();
+  return text === 'yes';
+}
+
+describe('useHasRole', () => {
+  it('returns false when staticMode is true regardless of user role', () => {
+    getConfigMock.mockReturnValue({ staticMode: true });
+    useUserMock.mockReturnValue({
+      user: { id: '1', email: 'a@b', name: 'A', role: 'admin' },
+    });
+
+    expect(renderProbe(UserRole.Reader)).toBe(false);
+    expect(renderProbe(UserRole.Editor)).toBe(false);
+    expect(renderProbe(UserRole.Admin)).toBe(false);
+  });
+
+  it('returns false when user is null', () => {
+    useUserMock.mockReturnValue({ user: null });
+
+    expect(renderProbe(UserRole.Reader)).toBe(false);
+    expect(renderProbe(UserRole.Editor)).toBe(false);
+    expect(renderProbe(UserRole.Admin)).toBe(false);
+  });
+
+  it('handles a reader user correctly', () => {
+    useUserMock.mockReturnValue({
+      user: { id: '1', email: 'a@b', name: 'A', role: 'reader' },
+    });
+
+    expect(renderProbe(UserRole.Reader)).toBe(true);
+    expect(renderProbe(UserRole.Editor)).toBe(false);
+    expect(renderProbe(UserRole.Admin)).toBe(false);
+  });
+
+  it('handles an editor user correctly', () => {
+    useUserMock.mockReturnValue({
+      user: { id: '1', email: 'a@b', name: 'A', role: 'editor' },
+    });
+
+    expect(renderProbe(UserRole.Reader)).toBe(true);
+    expect(renderProbe(UserRole.Editor)).toBe(true);
+    expect(renderProbe(UserRole.Admin)).toBe(false);
+  });
+
+  it('handles an admin user correctly', () => {
+    useUserMock.mockReturnValue({
+      user: { id: '1', email: 'a@b', name: 'A', role: 'admin' },
+    });
+
+    expect(renderProbe(UserRole.Reader)).toBe(true);
+    expect(renderProbe(UserRole.Editor)).toBe(true);
+    expect(renderProbe(UserRole.Admin)).toBe(true);
+  });
+});
+
+describe('<Gate>', () => {
+  it('renders children when role is satisfied', () => {
+    useUserMock.mockReturnValue({
+      user: { id: '1', email: 'a@b', name: 'A', role: 'editor' },
+    });
+
+    render(
+      <Gate role={UserRole.Editor} fallback={<span>blocked</span>}>
+        <span>allowed</span>
+      </Gate>,
+    );
+
+    expect(screen.getByText('allowed')).toBeInTheDocument();
+    expect(screen.queryByText('blocked')).not.toBeInTheDocument();
+  });
+
+  it('renders fallback when role is not satisfied', () => {
+    useUserMock.mockReturnValue({
+      user: { id: '1', email: 'a@b', name: 'A', role: 'reader' },
+    });
+
+    render(
+      <Gate role={UserRole.Editor} fallback={<span>blocked</span>}>
+        <span>allowed</span>
+      </Gate>,
+    );
+
+    expect(screen.queryByText('allowed')).not.toBeInTheDocument();
+    expect(screen.getByText('blocked')).toBeInTheDocument();
+  });
+
+  it('renders nothing when no fallback is provided and role is not satisfied', () => {
+    useUserMock.mockReturnValue({
+      user: { id: '1', email: 'a@b', name: 'A', role: 'reader' },
+    });
+
+    const { container } = render(
+      <Gate role={UserRole.Admin}>
+        <span>allowed</span>
+      </Gate>,
+    );
+
+    expect(screen.queryByText('allowed')).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/tools/app/src/components/AppToolbar.tsx
+++ b/tools/app/src/components/AppToolbar.tsx
@@ -32,6 +32,7 @@ import {
   useKeyboardShortcut,
   useConfigTemplateCreationContext,
 } from '@/lib/hooks';
+import { useCanEdit, useCanAdmin } from '@/lib/auth';
 import type { ResourceName } from '@/lib/constants';
 import { RESOURCES } from '@/lib/constants';
 import { ThemeModeToggle } from './ThemeModeToggle';
@@ -116,12 +117,15 @@ export function CreateButton({
 
 export default function AppToolbar({ onCreate }: AppToolbarProps) {
   const inCards = useIsInCards();
+  const canEdit = useCanEdit();
+  const canAdmin = useCanAdmin();
+  const canCreate = inCards ? canEdit : canAdmin;
   useKeyboardShortcut(
     {
       key: 'c',
     },
     () => {
-      if (!getConfig().staticMode) {
+      if (!getConfig().staticMode && canCreate) {
         onCreate();
       }
     },
@@ -149,7 +153,7 @@ export default function AppToolbar({ onCreate }: AppToolbarProps) {
       </Box>
       <Box sx={{ flexGrow: 1 }} />
       <ThemeModeToggle />
-      {!getConfig().staticMode && (
+      {!getConfig().staticMode && canCreate && (
         <CreateButton type={inCards ? 'Card' : 'Resource'} onClick={onCreate} />
       )}
       <UserMenu />

--- a/tools/app/src/components/CardTreeMenu.tsx
+++ b/tools/app/src/components/CardTreeMenu.tsx
@@ -12,6 +12,7 @@
 */
 
 import { useAppRouter } from '@/lib/hooks';
+import { useCanAdmin } from '@/lib/auth';
 import { MoreHoriz } from '@mui/icons-material';
 import { Dropdown, MenuButton, Menu, MenuItem } from '@mui/joy';
 import { useTranslation } from 'react-i18next';
@@ -19,6 +20,8 @@ import { useTranslation } from 'react-i18next';
 export const CardTreeMenu = () => {
   const { t } = useTranslation();
   const router = useAppRouter();
+  const canAdmin = useCanAdmin();
+  if (!canAdmin) return null;
   return (
     <Dropdown>
       <MenuButton variant="plain" size="sm" endDecorator={<MoreHoriz />} />

--- a/tools/app/src/components/ChecksAccordion.tsx
+++ b/tools/app/src/components/ChecksAccordion.tsx
@@ -26,6 +26,7 @@ import { useTranslation } from 'react-i18next';
 import ExpandMore from '@mui/icons-material/ExpandMore';
 import { getConfig } from '@/lib/utils';
 import { useAppRouter } from '../lib/hooks';
+import { useCanEdit } from '@/lib/auth';
 
 // Generic types for check items
 export interface CheckItem {
@@ -78,6 +79,7 @@ export function ChecksAccordion({
     initialFailuresExpanded,
   );
   const router = useAppRouter();
+  const canEdit = useCanEdit();
 
   if (checks.successes.length === 0 && checks.failures.length === 0) {
     return null;
@@ -208,6 +210,7 @@ export function ChecksAccordion({
                       </Typography>
                       {showGoToField &&
                         !getConfig().staticMode &&
+                        canEdit &&
                         failure.fieldName && (
                           <Link
                             level="body-sm"

--- a/tools/app/src/components/ContentArea.tsx
+++ b/tools/app/src/components/ContentArea.tsx
@@ -87,6 +87,7 @@ import { GenericConfirmModal } from './modals';
 import { useCard } from '../lib/api';
 import SvgViewerModal from './modals/svgViewerModal';
 import { SafeRouterLink } from './SafeRouterLink';
+import { useCanEdit } from '@/lib/auth';
 
 export type LinkFormState = 'hidden' | 'add' | 'add-from-toolbar' | 'edit';
 
@@ -569,6 +570,7 @@ export const ContentArea: React.FC<ContentAreaProps> = ({
   onDeleteLink,
 }) => {
   const { isUpdating } = useCard(card.key);
+  const canEdit = useCanEdit();
   const [visibleHeaderIds, setVisibleHeaderIds] = useState<string[] | null>(
     null,
   );
@@ -964,7 +966,8 @@ export const ContentArea: React.FC<ContentAreaProps> = ({
                 </AccordionSummary>
                 {!preview &&
                   linkFormState === 'hidden' &&
-                  !getConfig().staticMode && (
+                  !getConfig().staticMode &&
+                  canEdit && (
                     <IconButton
                       sx={{
                         height: 36,
@@ -1074,7 +1077,8 @@ export const ContentArea: React.FC<ContentAreaProps> = ({
                         </Stack>
                         {link.linkSource === 'user' &&
                           !preview &&
-                          !getConfig().staticMode && (
+                          !getConfig().staticMode &&
+                          canEdit && (
                             <Box
                               gap={1}
                               fontSize={24}

--- a/tools/app/src/components/context-menus/CardContextMenu.tsx
+++ b/tools/app/src/components/context-menus/CardContextMenu.tsx
@@ -32,6 +32,7 @@ import {
 import { useAppSelector, useAppRouter } from '@/lib/hooks';
 import { useCard, useProject } from '@/lib/api';
 import { useParentCard } from '@/lib/hooks';
+import { Gate, UserRole } from '@/lib/auth';
 
 interface CardContextMenuProps {
   cardKey: string;
@@ -82,19 +83,21 @@ export function CardContextMenu({ cardKey }: CardContextMenuProps) {
           </MenuButton>
         </Tooltip>
         <Menu>
-          <MenuItem id="moveCardButton" onClick={openModal('move')}>
-            <Typography>{t('move')}</Typography>
-          </MenuItem>
-          <MenuItem
-            data-cy="addAttachmentButton"
-            onClick={openModal('addAttachment')}
-          >
-            <Typography>{t('addAttachment')}</Typography>
-          </MenuItem>
-          <Divider />
-          <MenuItem data-cy="deleteCardButton" onClick={handleDeleteClick}>
-            <Typography color="danger">{t('deleteCard')}</Typography>
-          </MenuItem>
+          <Gate role={UserRole.Editor}>
+            <MenuItem id="moveCardButton" onClick={openModal('move')}>
+              <Typography>{t('move')}</Typography>
+            </MenuItem>
+            <MenuItem
+              data-cy="addAttachmentButton"
+              onClick={openModal('addAttachment')}
+            >
+              <Typography>{t('addAttachment')}</Typography>
+            </MenuItem>
+            <Divider />
+            <MenuItem data-cy="deleteCardButton" onClick={handleDeleteClick}>
+              <Typography color="danger">{t('deleteCard')}</Typography>
+            </MenuItem>
+          </Gate>
           <MenuItem onClick={openModal('logicProgram')}>
             <Typography>{t('viewLogicProgram')}</Typography>
           </MenuItem>

--- a/tools/app/src/components/macros/CreateCards.tsx
+++ b/tools/app/src/components/macros/CreateCards.tsx
@@ -18,6 +18,7 @@ import { useAppDispatch, useAppRouter } from '@/lib/hooks';
 import { addNotification } from '@/lib/slices/notifications';
 import { useState } from 'react';
 import type { LinkDirection } from '@cyberismo/data-handler/types/queries';
+import { useCanEdit } from '@/lib/auth';
 
 export type CreateCardsProps = {
   buttonLabel: string;
@@ -39,12 +40,15 @@ export default function CreateCards({
   preview,
   link,
 }: CreateCardsProps) {
+  const canEdit = useCanEdit();
   const { t } = useTranslation();
   const { createCard, isUpdating } = useCard(cardKey || macroKey);
   const { createLink } = useCard(link?.cardKey || null);
   const dispatch = useAppDispatch();
   const [loading, setLoading] = useState(false);
   const router = useAppRouter();
+
+  if (!canEdit) return <></>;
 
   return (
     <Button

--- a/tools/app/src/components/macros/CreateCards.tsx
+++ b/tools/app/src/components/macros/CreateCards.tsx
@@ -11,7 +11,7 @@
 */
 
 import { useCard } from '@/lib/api';
-import { Button } from '@mui/joy';
+import { Button, Tooltip } from '@mui/joy';
 import { useTranslation } from 'react-i18next';
 import type { MacroContext } from '.';
 import { useAppDispatch, useAppRouter } from '@/lib/hooks';
@@ -48,102 +48,109 @@ export default function CreateCards({
   const [loading, setLoading] = useState(false);
   const router = useAppRouter();
 
-  if (!canEdit) return <></>;
-
   return (
-    <Button
-      loading={loading}
-      disabled={isUpdating()}
-      onClick={async () => {
-        try {
-          if (preview) {
-            dispatch(
-              addNotification({
-                message: t('createCard.macro.preview'),
-                type: 'success',
-              }),
-            );
-            return;
-          }
-          setLoading(true);
-          const cards = await createCard(template);
-          dispatch(
-            addNotification({
-              message: t('createCard.success'),
-              type: 'success',
-            }),
-          );
-
-          if (cards && cards.length > 0) {
-            if (link) {
-              const rootCards = cards.filter(
-                (card) => card.parent === (cardKey || macroKey),
+    <Tooltip
+      title={t('permissions.editorRequired')}
+      disableHoverListener={canEdit}
+    >
+      <span>
+        <Button
+          loading={loading}
+          disabled={!canEdit || isUpdating()}
+          onClick={async () => {
+            try {
+              if (preview) {
+                dispatch(
+                  addNotification({
+                    message: t('createCard.macro.preview'),
+                    type: 'success',
+                  }),
+                );
+                return;
+              }
+              setLoading(true);
+              const cards = await createCard(template);
+              dispatch(
+                addNotification({
+                  message: t('createCard.success'),
+                  type: 'success',
+                }),
               );
-              if (rootCards.length > 0) {
-                try {
-                  const linkResults = await Promise.allSettled(
-                    rootCards.map((card) =>
-                      createLink(
-                        card.key,
-                        link.linkType,
-                        link.description,
-                        link.direction,
-                      ),
-                    ),
+
+              if (cards && cards.length > 0) {
+                if (link) {
+                  const rootCards = cards.filter(
+                    (card) => card.parent === (cardKey || macroKey),
                   );
+                  if (rootCards.length > 0) {
+                    try {
+                      const linkResults = await Promise.allSettled(
+                        rootCards.map((card) =>
+                          createLink(
+                            card.key,
+                            link.linkType,
+                            link.description,
+                            link.direction,
+                          ),
+                        ),
+                      );
 
-                  const successful = linkResults.filter(
-                    (result) => result.status === 'fulfilled',
-                  ).length;
-                  const failed = linkResults.filter(
-                    (result) => result.status === 'rejected',
-                  ).length;
+                      const successful = linkResults.filter(
+                        (result) => result.status === 'fulfilled',
+                      ).length;
+                      const failed = linkResults.filter(
+                        (result) => result.status === 'rejected',
+                      ).length;
 
-                  if (successful > 0) {
-                    dispatch(
-                      addNotification({
-                        message: t('createLink.success', { count: successful }),
-                        type: 'success',
-                      }),
-                    );
-                  }
+                      if (successful > 0) {
+                        dispatch(
+                          addNotification({
+                            message: t('createLink.success', {
+                              count: successful,
+                            }),
+                            type: 'success',
+                          }),
+                        );
+                      }
 
-                  if (failed > 0) {
-                    dispatch(
-                      addNotification({
-                        message: t('createLink.partialFailure', {
-                          count: failed,
+                      if (failed > 0) {
+                        dispatch(
+                          addNotification({
+                            message: t('createLink.partialFailure', {
+                              count: failed,
+                            }),
+                            type: 'error',
+                          }),
+                        );
+                      }
+                    } catch (e) {
+                      dispatch(
+                        addNotification({
+                          message:
+                            e instanceof Error ? e.message : t('unknownError'),
+                          type: 'error',
                         }),
-                        type: 'error',
-                      }),
-                    );
+                      );
+                    }
                   }
-                } catch (e) {
-                  dispatch(
-                    addNotification({
-                      message:
-                        e instanceof Error ? e.message : t('unknownError'),
-                      type: 'error',
-                    }),
-                  );
                 }
               }
+              router.push(`/cards/${cards[0].key}`);
+            } catch (e) {
+              dispatch(
+                addNotification({
+                  message: e instanceof Error ? e.message : t('unknownError'),
+                  type: 'error',
+                }),
+              );
+            } finally {
+              setLoading(false);
             }
-          }
-          router.push(`/cards/${cards[0].key}`);
-        } catch (e) {
-          dispatch(
-            addNotification({
-              message: e instanceof Error ? e.message : t('unknownError'),
-              type: 'error',
-            }),
-          );
-        } finally {
-          setLoading(false);
-        }
-      }}
-    >
-      {buttonLabel}
-    </Button>
+          }}
+        >
+          {buttonLabel}
+        </Button>
+      </span>
+    </Tooltip>
   );
 }

--- a/tools/app/src/components/toolbar/CardToolbar.tsx
+++ b/tools/app/src/components/toolbar/CardToolbar.tsx
@@ -35,6 +35,7 @@ import { getConfig } from '@/lib/utils';
 import BaseToolbar from './BaseToolbar';
 import { CardContextMenu } from '@/components/context-menus';
 import PresenceIndicator from '@/components/PresenceIndicator';
+import { useCanEdit } from '@/lib/auth';
 
 interface CardToolbarProps {
   cardKey: string;
@@ -67,6 +68,7 @@ export function CardToolbar({
   const presence = usePresence(cardKey, presenceMode);
 
   const dispatch = useAppDispatch();
+  const canEdit = useCanEdit();
 
   const workflow =
     project && card ? findWorkflowForCardType(card.cardType, project) : null;
@@ -93,7 +95,7 @@ export function CardToolbar({
 
   const actions = (
     <>
-      {!getConfig().staticMode && mode === CardMode.VIEW && (
+      {!getConfig().staticMode && mode === CardMode.VIEW && canEdit && (
         <Tooltip title={t('linkTooltip')} placement="top">
           <IconButton
             onClick={onInsertLink}
@@ -120,10 +122,10 @@ export function CardToolbar({
         workflow={workflow}
         onTransition={(transition) => onStateTransition(transition)}
         isLoading={isUpdating('updateState')}
-        disabled={isUpdating() && !isUpdating('updateState')}
+        disabled={!canEdit || (isUpdating() && !isUpdating('updateState'))}
       />
 
-      {!getConfig().staticMode && mode === CardMode.VIEW && (
+      {!getConfig().staticMode && mode === CardMode.VIEW && canEdit && (
         <Button
           variant="solid"
           aria-label="edit"

--- a/tools/app/src/lib/auth/Gate.tsx
+++ b/tools/app/src/lib/auth/Gate.tsx
@@ -1,7 +1,6 @@
 /**
   Cyberismo
   Copyright © Cyberismo Ltd and contributors 2026
-
   This program is free software: you can redistribute it and/or modify it under
   the terms of the GNU Affero General Public License version 3 as published by
   the Free Software Foundation. This program is distributed in the hope that it

--- a/tools/app/src/lib/auth/Gate.tsx
+++ b/tools/app/src/lib/auth/Gate.tsx
@@ -1,0 +1,27 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { ReactNode } from 'react';
+import type { UserRole } from './roles';
+import { useHasRole } from './usePermissions';
+
+interface GateProps {
+  role: UserRole;
+  fallback?: ReactNode;
+  children: ReactNode;
+}
+
+export function Gate({ role, fallback = null, children }: GateProps) {
+  return useHasRole(role) ? <>{children}</> : <>{fallback}</>;
+}

--- a/tools/app/src/lib/auth/index.ts
+++ b/tools/app/src/lib/auth/index.ts
@@ -1,7 +1,6 @@
 /**
   Cyberismo
   Copyright © Cyberismo Ltd and contributors 2026
-
   This program is free software: you can redistribute it and/or modify it under
   the terms of the GNU Affero General Public License version 3 as published by
   the Free Software Foundation. This program is distributed in the hope that it

--- a/tools/app/src/lib/auth/index.ts
+++ b/tools/app/src/lib/auth/index.ts
@@ -1,0 +1,17 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+export { UserRole, parseRole, roleSatisfies } from './roles';
+export { useHasRole, useCanEdit, useCanAdmin } from './usePermissions';
+export { Gate } from './Gate';

--- a/tools/app/src/lib/auth/roles.ts
+++ b/tools/app/src/lib/auth/roles.ts
@@ -1,7 +1,6 @@
 /**
   Cyberismo
   Copyright © Cyberismo Ltd and contributors 2026
-
   This program is free software: you can redistribute it and/or modify it under
   the terms of the GNU Affero General Public License version 3 as published by
   the Free Software Foundation. This program is distributed in the hope that it

--- a/tools/app/src/lib/auth/roles.ts
+++ b/tools/app/src/lib/auth/roles.ts
@@ -1,0 +1,37 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+export enum UserRole {
+  Reader = 0,
+  Editor = 1,
+  Admin = 2,
+}
+
+const ROLE_MAP: Record<string, UserRole> = {
+  reader: UserRole.Reader,
+  editor: UserRole.Editor,
+  admin: UserRole.Admin,
+};
+
+export function parseRole(raw: string | undefined | null): UserRole | null {
+  if (!raw) return null;
+  return ROLE_MAP[raw.toLowerCase()] ?? null;
+}
+
+export function roleSatisfies(
+  userRole: UserRole | null,
+  minRole: UserRole,
+): boolean {
+  return userRole != null && userRole >= minRole;
+}

--- a/tools/app/src/lib/auth/usePermissions.ts
+++ b/tools/app/src/lib/auth/usePermissions.ts
@@ -1,7 +1,6 @@
 /**
   Cyberismo
   Copyright © Cyberismo Ltd and contributors 2026
-
   This program is free software: you can redistribute it and/or modify it under
   the terms of the GNU Affero General Public License version 3 as published by
   the Free Software Foundation. This program is distributed in the hope that it

--- a/tools/app/src/lib/auth/usePermissions.ts
+++ b/tools/app/src/lib/auth/usePermissions.ts
@@ -1,0 +1,27 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { useUser } from '@/lib/api';
+import { getConfig } from '@/lib/utils';
+import { UserRole, parseRole, roleSatisfies } from './roles';
+
+export function useHasRole(minRole: UserRole): boolean {
+  const { user } = useUser();
+  if (getConfig().staticMode) return false;
+  if (!user) return false;
+  return roleSatisfies(parseRole(user.role), minRole);
+}
+
+export const useCanEdit = () => useHasRole(UserRole.Editor);
+export const useCanAdmin = () => useHasRole(UserRole.Admin);

--- a/tools/app/src/locales/en/translation.json
+++ b/tools/app/src/locales/en/translation.json
@@ -340,6 +340,10 @@
     "viewMore": "View more"
   },
   "passedPolicyChecks": "Passed policy checks",
+  "permissions": {
+    "editorRequired": "You need editor permissions to do this",
+    "adminRequired": "You need administrator permissions to do this"
+  },
   "placeholder": {
     "integer": "Enter number (integer)",
     "number": "Enter number (decimal)",

--- a/tools/app/src/locales/en/translation.json
+++ b/tools/app/src/locales/en/translation.json
@@ -341,8 +341,7 @@
   },
   "passedPolicyChecks": "Passed policy checks",
   "permissions": {
-    "editorRequired": "You need editor permissions to do this",
-    "adminRequired": "You need administrator permissions to do this"
+    "editorRequired": "You need editor permissions to do this"
   },
   "placeholder": {
     "integer": "Enter number (integer)",

--- a/tools/app/src/pages/cards/card-edit.tsx
+++ b/tools/app/src/pages/cards/card-edit.tsx
@@ -1,21 +1,27 @@
+import { Navigate } from 'react-router';
 import { useRequiredKeyParam } from '@/lib/hooks';
 import { useTranslation } from 'react-i18next';
 import { useCard } from '@/lib/api';
 import { Box } from '@mui/joy';
 import CardEditor from '@/components/CardEditor';
 import { useAppRouter } from '@/lib/hooks';
+import { useCanEdit } from '@/lib/auth';
 
 export default function CardEdit() {
   const key = useRequiredKeyParam();
   const { t } = useTranslation();
   const cardData = useCard(key);
   const router = useAppRouter();
+  const canEdit = useCanEdit();
 
   if (cardData.isLoading) {
     return <Box>{t('loading')}</Box>;
   }
   if (cardData.error) {
     return <Box>{t('failedToLoad')}</Box>;
+  }
+  if (!canEdit) {
+    return <Navigate to={`/cards/${key}`} replace />;
   }
   return (
     <CardEditor

--- a/tools/app/src/pages/cards/card-view.tsx
+++ b/tools/app/src/pages/cards/card-view.tsx
@@ -30,6 +30,7 @@ import { Box, Stack, Typography } from '@mui/joy';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useRequiredKeyParam } from '@/lib/hooks';
+import { useCanEdit } from '@/lib/auth';
 
 export const dynamic = 'force-dynamic';
 
@@ -74,6 +75,8 @@ export default function Page() {
     }
   }, [listCard, dispatch]);
 
+  const canEdit = useCanEdit();
+
   if (error) {
     let errorMessage = t('unknownError');
     if (error instanceof Error) {
@@ -102,9 +105,10 @@ export default function Page() {
             cards={tree!}
             card={card!}
             connectors={connectors ?? []}
-            onMetadataClick={() =>
-              router.push(`/cards/${key}/edit?expand=true`)
-            }
+            onMetadataClick={() => {
+              if (!canEdit) return;
+              router.push(`/cards/${key}/edit?expand=true`);
+            }}
             linkTypes={expandedLinkTypes}
             onLinkFormSubmit={async (data) => {
               try {

--- a/tools/app/src/pages/cards/layout.tsx
+++ b/tools/app/src/pages/cards/layout.tsx
@@ -26,6 +26,7 @@ import { findParentCard } from '../../lib/utils';
 import { useTree } from '../../lib/api/tree';
 import { useCard } from '../../lib/api/card';
 import { CardTreeMenu } from '@/components/CardTreeMenu';
+import { useCanEdit } from '@/lib/auth';
 
 export default function AppLayout() {
   // Last URL parameter after /cards base is the card key
@@ -33,6 +34,7 @@ export default function AppLayout() {
   const { project, error, isLoading, updateCard } = useProject();
   const { tree, isLoading: isLoadingTree, error: treeError } = useTree();
   const { card } = useCard(key);
+  const canEdit = useCanEdit();
 
   const router = useAppRouter();
 
@@ -83,6 +85,7 @@ export default function AppLayout() {
           tree={tree}
           selectedCardKey={key ?? null}
           onMove={async (cardKey: string, newParent: string, index: number) => {
+            if (!canEdit) return;
             const parent = findParentCard(tree, cardKey);
             await updateCard(cardKey, {
               parent: newParent === parent?.key ? undefined : newParent,

--- a/tools/app/src/pages/configuration/layout.tsx
+++ b/tools/app/src/pages/configuration/layout.tsx
@@ -10,16 +10,18 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Outlet, useParams } from 'react-router';
+import { Navigate, Outlet, useParams } from 'react-router';
 import TwoColumnLayout from '../../components/TwoColumnLayout';
 import ConfigMenu from '../../components/ConfigMenu';
 import { useDocumentTitle } from '../../lib/hooks';
 import { useProject } from '../../lib/api';
+import { useCanAdmin } from '@/lib/auth';
 
 export default function ConfigLayout() {
   // TODO: resource is not implemented yet, might need to change this
   const { resource, resourceType } = useParams();
   const { project } = useProject();
+  const canAdmin = useCanAdmin();
 
   const title =
     resource && project?.name
@@ -28,6 +30,8 @@ export default function ConfigLayout() {
         ? `${resourceType} - ${project.name}`
         : project?.name || 'Cyberismo App';
   useDocumentTitle(title);
+
+  if (!canAdmin) return <Navigate to="/cards" replace />;
 
   return <TwoColumnLayout leftPanel={<ConfigMenu />} rightPanel={<Outlet />} />;
 }

--- a/tools/app/src/pages/layout.tsx
+++ b/tools/app/src/pages/layout.tsx
@@ -38,6 +38,7 @@ import { useModals } from '@/lib/utils';
 import { NewTemplateCardModal } from '../components/modals/resource-forms/NewTemplateCardModal';
 import { useConfigTemplateCreationContext } from '@/lib/hooks';
 import { AppModalsProvider } from '@/lib/contexts/AppModalsProvider';
+import { useCanEdit, useCanAdmin } from '@/lib/auth';
 import type { ResourceName } from '@/lib/constants';
 import { useCallback } from 'react';
 
@@ -48,6 +49,8 @@ const Main = styled('main')(() => ({
 
 export default function Layout() {
   const inCards = useIsInCards();
+  const canEdit = useCanEdit();
+  const canAdmin = useCanAdmin();
   const { templateResource, parentCardKey } =
     useConfigTemplateCreationContext();
   const { modalOpen, openModal, closeModal } = useModals({
@@ -83,8 +86,10 @@ export default function Layout() {
       <AppToolbar
         onCreate={(resourceType) => {
           if (inCards) {
+            if (!canEdit) return;
             openModal('card')();
           } else {
+            if (!canAdmin) return;
             if (!resourceType) {
               console.warn(
                 'No resource type provided when creating a new resource',

--- a/tools/backend/src/app.ts
+++ b/tools/backend/src/app.ts
@@ -40,6 +40,7 @@ import mcpRouter from './domain/mcp/index.js';
 import { createAuthRouter } from './domain/auth/index.js';
 import { createAuthMiddleware } from './middleware/auth.js';
 import type { AuthProvider } from './auth/types.js';
+import { MockAuthProvider, mockRoleCookieMiddleware } from './auth/mock.js';
 
 /**
  * Create the Hono app for the backend
@@ -54,6 +55,11 @@ export function createApp(
   const app = new Hono<{ Variables: AppVars }>();
 
   app.use(treeMiddleware(opts));
+  // Dev-only: let `?role=<reader|editor|admin>` set a persistent mock-role cookie
+  // so role gating can be exercised locally without code changes or a restart.
+  if (authProvider instanceof MockAuthProvider) {
+    app.use(mockRoleCookieMiddleware());
+  }
   // Apply authentication middleware to all API and MCP routes
   app.use('/api/*', createAuthMiddleware(authProvider));
   app.use('/mcp', createAuthMiddleware(authProvider));

--- a/tools/backend/src/auth/index.ts
+++ b/tools/backend/src/auth/index.ts
@@ -12,6 +12,6 @@
 */
 
 export type { AuthProvider } from './types.js';
-export { MockAuthProvider } from './mock.js';
+export { MockAuthProvider, mockRoleCookieMiddleware } from './mock.js';
 export { KeycloakAuthProvider } from './keycloak.js';
 export type { KeycloakConfig } from './keycloak.js';

--- a/tools/backend/src/auth/mock.ts
+++ b/tools/backend/src/auth/mock.ts
@@ -11,6 +11,8 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
+import type { MiddlewareHandler } from 'hono';
+import { setCookie } from 'hono/cookie';
 import { UserRole } from '../types.js';
 import type { UserInfo } from '../types.js';
 import type { AuthProvider } from './types.js';
@@ -20,6 +22,31 @@ export interface MockUserConfig {
   email?: string;
 }
 
+export const MOCK_ROLE_COOKIE = 'mock-role';
+const ROLE_RESET_VALUE = 'default';
+
+const ROLE_ALIASES: Record<string, UserRole> = {
+  reader: UserRole.Reader,
+  editor: UserRole.Editor,
+  admin: UserRole.Admin,
+};
+
+function parseRole(value: string | null | undefined): UserRole | null {
+  if (!value) return null;
+  return ROLE_ALIASES[value.toLowerCase()] ?? null;
+}
+
+function readCookie(header: string | null, name: string): string | undefined {
+  if (!header) return undefined;
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() !== name) continue;
+    return decodeURIComponent(part.slice(eq + 1).trim());
+  }
+  return undefined;
+}
+
 export class MockAuthProvider implements AuthProvider {
   private readonly userConfig: MockUserConfig;
 
@@ -27,12 +54,36 @@ export class MockAuthProvider implements AuthProvider {
     this.userConfig = config ?? {};
   }
 
-  async authenticate(): Promise<UserInfo> {
+  async authenticate(req: Request): Promise<UserInfo> {
+    const cookieRole = parseRole(
+      readCookie(req.headers.get('cookie'), MOCK_ROLE_COOKIE),
+    );
     return {
       id: 'mock-user',
       email: this.userConfig.email ?? 'admin@cyberismo.local',
       name: this.userConfig.name ?? 'Local Admin',
-      role: UserRole.Admin,
+      role: cookieRole ?? UserRole.Admin,
     };
   }
+}
+
+/**
+ * Dev-only middleware that turns `?role=<reader|editor|admin>` into a persistent
+ * `mock-role` cookie, and clears it on `?role=default`.
+ */
+export function mockRoleCookieMiddleware(): MiddlewareHandler {
+  return async (c, next) => {
+    const override = new URL(c.req.url).searchParams.get('role');
+    if (override) {
+      if (override.toLowerCase() === ROLE_RESET_VALUE) {
+        setCookie(c, MOCK_ROLE_COOKIE, '', { path: '/', maxAge: 0 });
+      } else if (parseRole(override)) {
+        setCookie(c, MOCK_ROLE_COOKIE, override.toLowerCase(), {
+          path: '/',
+          sameSite: 'Lax',
+        });
+      }
+    }
+    await next();
+  };
 }

--- a/tools/backend/test/auth/mock.test.ts
+++ b/tools/backend/test/auth/mock.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { MockAuthProvider } from '../../src/auth/mock.js';
+import { Hono } from 'hono';
+import {
+  MOCK_ROLE_COOKIE,
+  MockAuthProvider,
+  mockRoleCookieMiddleware,
+} from '../../src/auth/mock.js';
 import { UserRole } from '../../src/types.js';
 
 describe('MockAuthProvider', () => {
@@ -34,22 +39,87 @@ describe('MockAuthProvider', () => {
     });
   });
 
-  it('always returns Admin role', async () => {
-    const provider = new MockAuthProvider({ name: 'Test' });
+  it('uses the role from the mock-role cookie when present', async () => {
+    const provider = new MockAuthProvider();
     const user = await provider.authenticate(
-      new Request('http://localhost/api/test'),
+      new Request('http://localhost/api/test', {
+        headers: { cookie: `${MOCK_ROLE_COOKIE}=editor` },
+      }),
+    );
+
+    expect(user!.role).toBe(UserRole.Editor);
+  });
+
+  it('falls back to admin for an unrecognized cookie value', async () => {
+    const provider = new MockAuthProvider();
+    const user = await provider.authenticate(
+      new Request('http://localhost/api/test', {
+        headers: { cookie: `${MOCK_ROLE_COOKIE}=superuser` },
+      }),
     );
 
     expect(user!.role).toBe(UserRole.Admin);
   });
 
-  it('works with undefined config', async () => {
-    const provider = new MockAuthProvider(undefined);
+  it('is case-insensitive for the cookie value', async () => {
+    const provider = new MockAuthProvider();
     const user = await provider.authenticate(
-      new Request('http://localhost/api/test'),
+      new Request('http://localhost/api/test', {
+        headers: { cookie: `${MOCK_ROLE_COOKIE}=READER` },
+      }),
     );
 
-    expect(user).not.toBeNull();
-    expect(user!.id).toBe('mock-user');
+    expect(user!.role).toBe(UserRole.Reader);
+  });
+
+  it('ignores unrelated cookies', async () => {
+    const provider = new MockAuthProvider();
+    const user = await provider.authenticate(
+      new Request('http://localhost/api/test', {
+        headers: { cookie: 'session=abc; other=editor' },
+      }),
+    );
+
+    expect(user!.role).toBe(UserRole.Admin);
+  });
+});
+
+describe('mockRoleCookieMiddleware', () => {
+  function appWithMiddleware() {
+    const app = new Hono();
+    app.use(mockRoleCookieMiddleware());
+    app.get('*', (c) => c.text('ok'));
+    return app;
+  }
+
+  it('sets mock-role cookie when a known role is in the query', async () => {
+    const res = await appWithMiddleware().request('/?role=editor');
+    expect(res.headers.get('set-cookie')).toMatch(
+      new RegExp(`^${MOCK_ROLE_COOKIE}=editor`),
+    );
+  });
+
+  it('lowercases the cookie value', async () => {
+    const res = await appWithMiddleware().request('/?role=ADMIN');
+    expect(res.headers.get('set-cookie')).toMatch(
+      new RegExp(`^${MOCK_ROLE_COOKIE}=admin`),
+    );
+  });
+
+  it('clears the cookie when role=default', async () => {
+    const res = await appWithMiddleware().request('/?role=default');
+    const setCookie = res.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain(`${MOCK_ROLE_COOKIE}=`);
+    expect(setCookie.toLowerCase()).toContain('max-age=0');
+  });
+
+  it('does nothing when there is no role query param', async () => {
+    const res = await appWithMiddleware().request('/');
+    expect(res.headers.get('set-cookie')).toBeNull();
+  });
+
+  it('ignores unknown role values', async () => {
+    const res = await appWithMiddleware().request('/?role=superuser');
+    expect(res.headers.get('set-cookie')).toBeNull();
   });
 });


### PR DESCRIPTION
While backend enforces authorization, it is bad UX to not enforce this on the frontend. This PR adds that support.

Also, it used to be hard to test different roles on the app, so I made a simple solution for development: By going to `localhost:3000/?role=admin|editor|reader` you're able to set your role in dev.

Do you think config should be viewable for normal users? Currently only admins can access it. Readers do have access to that anyway, it's just a matter of whether we want to hide it or not.