### PR TITLE
INTDEV-1097 frontend role-based permissions

### DIFF
--- a/tools/app/__tests__/components.test.tsx
+++ b/tools/app/__tests__/components.test.tsx
@@ -1,4 +1,5 @@
 import { beforeEach, describe, it } from 'vitest';
+import type * as libHooksModule from '../src/lib/hooks';
 import { TreeMenu } from '../src/components/TreeMenu';
 import { SearchableTreeMenu } from '../src/components/SearchableTreeMenu';
 import { LabelEditorField } from '@/components/LabelEditor';
@@ -13,9 +14,11 @@ import '@testing-library/jest-dom';
 import { BrowserRouter } from 'react-router';
 
 // mock useAppRouter and useResizeObserver
-vi.mock('../src/lib/hooks', async () => {
+vi.mock('../src/lib/hooks', async (importOriginal) => {
+  const actual = await importOriginal<typeof libHooksModule>();
   let callCount = 0;
   return {
+    ...actual,
     useAppRouter: vi.fn(() => ({
       push: vi.fn(),
     })),
@@ -27,6 +30,12 @@ vi.mock('../src/lib/hooks', async () => {
     }),
   };
 });
+
+vi.mock('@/lib/api', () => ({
+  useUser: () => ({
+    user: { id: 'test', email: '', name: '', role: 'editor' },
+  }),
+}));
 
 vi.mock('@/lib/utils', async () => {
   const actual = await import('@/lib/utils');

--- a/tools/app/__tests__/components.test.tsx
+++ b/tools/app/__tests__/components.test.tsx
@@ -1,4 +1,5 @@
 import { beforeEach, describe, it } from 'vitest';
+import type * as libHooksModule from '../src/lib/hooks';
 import { TreeMenu } from '../src/components/TreeMenu';
 import { SearchableTreeMenu } from '../src/components/SearchableTreeMenu';
 import { LabelEditorField } from '@/components/LabelEditor';
@@ -13,10 +14,12 @@ import '@testing-library/jest-dom';
 import { BrowserRouter } from 'react-router';
 
 // mock useAppRouter and useResizeObserver
-vi.mock('../src/lib/hooks', async () => {
+vi.mock('../src/lib/hooks', async (importOriginal) => {
+  const actual = await importOriginal<typeof libHooksModule>();
   const { selectRecentPrefixes } = await import('../src/lib/slices/project');
   let callCount = 0;
   return {
+    ...actual,
     useAppRouter: vi.fn(() => ({
       push: vi.fn(),
     })),
@@ -42,6 +45,12 @@ vi.mock('../src/lib/hooks', async () => {
 
 vi.mock('../src/lib/api/projects', () => ({
   useAvailableProjects: vi.fn(() => ({ data: [] })),
+}));
+
+vi.mock('@/lib/api', () => ({
+  useUser: () => ({
+    user: { id: 'test', email: '', name: '', role: 'editor' },
+  }),
 }));
 
 vi.mock('@/lib/utils', async () => {

--- a/tools/app/__tests__/permissions.test.tsx
+++ b/tools/app/__tests__/permissions.test.tsx
@@ -1,0 +1,199 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { parseRole, roleSatisfies, UserRole } from '@/lib/auth/roles';
+import { useHasRole } from '@/lib/auth/usePermissions';
+import { Gate } from '@/lib/auth/Gate';
+
+const useUserMock = vi.fn(() => ({ user: null as unknown }));
+
+vi.mock('@/lib/api', () => ({
+  useUser: () => useUserMock(),
+}));
+
+beforeEach(() => {
+  useUserMock.mockReset();
+  useUserMock.mockReturnValue({ user: null });
+});
+
+describe('roleSatisfies', () => {
+  it('returns false when user role is null', () => {
+    expect(roleSatisfies(null, UserRole.Reader)).toBe(false);
+    expect(roleSatisfies(null, UserRole.Editor)).toBe(false);
+    expect(roleSatisfies(null, UserRole.Admin)).toBe(false);
+  });
+
+  it('enforces the reader < editor < admin hierarchy', () => {
+    // Reader satisfies reader only
+    expect(roleSatisfies(UserRole.Reader, UserRole.Reader)).toBe(true);
+    expect(roleSatisfies(UserRole.Reader, UserRole.Editor)).toBe(false);
+    expect(roleSatisfies(UserRole.Reader, UserRole.Admin)).toBe(false);
+
+    // Editor satisfies reader and editor
+    expect(roleSatisfies(UserRole.Editor, UserRole.Reader)).toBe(true);
+    expect(roleSatisfies(UserRole.Editor, UserRole.Editor)).toBe(true);
+    expect(roleSatisfies(UserRole.Editor, UserRole.Admin)).toBe(false);
+
+    // Admin satisfies everything
+    expect(roleSatisfies(UserRole.Admin, UserRole.Reader)).toBe(true);
+    expect(roleSatisfies(UserRole.Admin, UserRole.Editor)).toBe(true);
+    expect(roleSatisfies(UserRole.Admin, UserRole.Admin)).toBe(true);
+  });
+
+  it('admin passes for editor minimum', () => {
+    expect(roleSatisfies(UserRole.Admin, UserRole.Editor)).toBe(true);
+  });
+
+  it('reader fails for editor minimum', () => {
+    expect(roleSatisfies(UserRole.Reader, UserRole.Editor)).toBe(false);
+  });
+});
+
+describe('parseRole', () => {
+  it('parses known role strings', () => {
+    expect(parseRole('reader')).toBe(UserRole.Reader);
+    expect(parseRole('editor')).toBe(UserRole.Editor);
+    expect(parseRole('admin')).toBe(UserRole.Admin);
+  });
+
+  it('returns null for unknown strings', () => {
+    expect(parseRole('superuser')).toBeNull();
+    expect(parseRole('owner')).toBeNull();
+    expect(parseRole('')).toBeNull();
+  });
+
+  it('returns null for null and undefined', () => {
+    expect(parseRole(null)).toBeNull();
+    expect(parseRole(undefined)).toBeNull();
+  });
+
+  it('is case-insensitive', () => {
+    expect(parseRole('READER')).toBe(UserRole.Reader);
+    expect(parseRole('Editor')).toBe(UserRole.Editor);
+    expect(parseRole('ADMIN')).toBe(UserRole.Admin);
+    expect(parseRole('aDmIn')).toBe(UserRole.Admin);
+  });
+});
+
+function Probe({ role }: { role: UserRole }) {
+  const allowed = useHasRole(role);
+  return <span>{allowed ? 'yes' : 'no'}</span>;
+}
+
+function renderProbe(role: UserRole) {
+  const { unmount } = render(<Probe role={role} />);
+  const text = screen.getByText(/^(yes|no)$/).textContent;
+  unmount();
+  return text === 'yes';
+}
+
+describe('useHasRole', () => {
+  it('treats a synthetic reader user (static mode) as reader-only', () => {
+    useUserMock.mockReturnValue({
+      user: { id: 'static-reader', email: '', name: '', role: 'reader' },
+    });
+
+    expect(renderProbe(UserRole.Reader)).toBe(true);
+    expect(renderProbe(UserRole.Editor)).toBe(false);
+    expect(renderProbe(UserRole.Admin)).toBe(false);
+  });
+
+  it('returns false when user is null', () => {
+    useUserMock.mockReturnValue({ user: null });
+
+    expect(renderProbe(UserRole.Reader)).toBe(false);
+    expect(renderProbe(UserRole.Editor)).toBe(false);
+    expect(renderProbe(UserRole.Admin)).toBe(false);
+  });
+
+  it('handles a reader user correctly', () => {
+    useUserMock.mockReturnValue({
+      user: { id: '1', email: 'a@b', name: 'A', role: 'reader' },
+    });
+
+    expect(renderProbe(UserRole.Reader)).toBe(true);
+    expect(renderProbe(UserRole.Editor)).toBe(false);
+    expect(renderProbe(UserRole.Admin)).toBe(false);
+  });
+
+  it('handles an editor user correctly', () => {
+    useUserMock.mockReturnValue({
+      user: { id: '1', email: 'a@b', name: 'A', role: 'editor' },
+    });
+
+    expect(renderProbe(UserRole.Reader)).toBe(true);
+    expect(renderProbe(UserRole.Editor)).toBe(true);
+    expect(renderProbe(UserRole.Admin)).toBe(false);
+  });
+
+  it('handles an admin user correctly', () => {
+    useUserMock.mockReturnValue({
+      user: { id: '1', email: 'a@b', name: 'A', role: 'admin' },
+    });
+
+    expect(renderProbe(UserRole.Reader)).toBe(true);
+    expect(renderProbe(UserRole.Editor)).toBe(true);
+    expect(renderProbe(UserRole.Admin)).toBe(true);
+  });
+});
+
+describe('<Gate>', () => {
+  it('renders children when role is satisfied', () => {
+    useUserMock.mockReturnValue({
+      user: { id: '1', email: 'a@b', name: 'A', role: 'editor' },
+    });
+
+    render(
+      <Gate role={UserRole.Editor} fallback={<span>blocked</span>}>
+        <span>allowed</span>
+      </Gate>,
+    );
+
+    expect(screen.getByText('allowed')).toBeInTheDocument();
+    expect(screen.queryByText('blocked')).not.toBeInTheDocument();
+  });
+
+  it('renders fallback when role is not satisfied', () => {
+    useUserMock.mockReturnValue({
+      user: { id: '1', email: 'a@b', name: 'A', role: 'reader' },
+    });
+
+    render(
+      <Gate role={UserRole.Editor} fallback={<span>blocked</span>}>
+        <span>allowed</span>
+      </Gate>,
+    );
+
+    expect(screen.queryByText('allowed')).not.toBeInTheDocument();
+    expect(screen.getByText('blocked')).toBeInTheDocument();
+  });
+
+  it('renders nothing when no fallback is provided and role is not satisfied', () => {
+    useUserMock.mockReturnValue({
+      user: { id: '1', email: 'a@b', name: 'A', role: 'reader' },
+    });
+
+    const { container } = render(
+      <Gate role={UserRole.Admin}>
+        <span>allowed</span>
+      </Gate>,
+    );
+
+    expect(screen.queryByText('allowed')).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/tools/app/__tests__/permissions.test.tsx
+++ b/tools/app/__tests__/permissions.test.tsx
@@ -16,7 +16,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 import { parseRole, roleSatisfies, UserRole } from '@/lib/auth/roles';
-import { useHasRole } from '@/lib/auth/usePermissions';
+import { useHasMinRole } from '@/lib/auth/usePermissions';
 import { Gate } from '@/lib/auth/Gate';
 
 const useUserMock = vi.fn(() => ({ user: null as unknown }));
@@ -90,7 +90,7 @@ describe('parseRole', () => {
 });
 
 function Probe({ role }: { role: UserRole }) {
-  const allowed = useHasRole(role);
+  const allowed = useHasMinRole(role);
   return <span>{allowed ? 'yes' : 'no'}</span>;
 }
 
@@ -101,7 +101,7 @@ function renderProbe(role: UserRole) {
   return text === 'yes';
 }
 
-describe('useHasRole', () => {
+describe('useHasMinRole', () => {
   it('treats a synthetic reader user (static mode) as reader-only', () => {
     useUserMock.mockReturnValue({
       user: { id: 'static-reader', email: '', name: '', role: 'reader' },
@@ -158,7 +158,7 @@ describe('<Gate>', () => {
     });
 
     render(
-      <Gate role={UserRole.Editor} fallback={<span>blocked</span>}>
+      <Gate minRole={UserRole.Editor} fallback={<span>blocked</span>}>
         <span>allowed</span>
       </Gate>,
     );
@@ -173,7 +173,7 @@ describe('<Gate>', () => {
     });
 
     render(
-      <Gate role={UserRole.Editor} fallback={<span>blocked</span>}>
+      <Gate minRole={UserRole.Editor} fallback={<span>blocked</span>}>
         <span>allowed</span>
       </Gate>,
     );
@@ -188,7 +188,7 @@ describe('<Gate>', () => {
     });
 
     const { container } = render(
-      <Gate role={UserRole.Admin}>
+      <Gate minRole={UserRole.Admin}>
         <span>allowed</span>
       </Gate>,
     );

--- a/tools/app/src/components/AppToolbar.tsx
+++ b/tools/app/src/components/AppToolbar.tsx
@@ -26,12 +26,12 @@ import {
   MenuItem,
   Tooltip,
 } from '@mui/joy';
-import { getConfig } from '@/lib/utils';
 import {
   useIsInCards,
   useKeyboardShortcut,
   useConfigTemplateCreationContext,
 } from '@/lib/hooks';
+import { useCanEdit, useCanAdmin } from '@/lib/auth';
 import type { ResourceName } from '@/lib/constants';
 import { RESOURCES } from '@/lib/constants';
 import { ThemeModeToggle } from './ThemeModeToggle';
@@ -116,12 +116,15 @@ export function CreateButton({
 
 export default function AppToolbar({ onCreate }: AppToolbarProps) {
   const inCards = useIsInCards();
+  const canEdit = useCanEdit();
+  const canAdmin = useCanAdmin();
+  const canCreate = inCards ? canEdit : canAdmin;
   useKeyboardShortcut(
     {
       key: 'c',
     },
     () => {
-      if (!getConfig().staticMode) {
+      if (canCreate) {
         onCreate();
       }
     },
@@ -149,7 +152,7 @@ export default function AppToolbar({ onCreate }: AppToolbarProps) {
       </Box>
       <Box sx={{ flexGrow: 1 }} />
       <ThemeModeToggle />
-      {!getConfig().staticMode && (
+      {canCreate && (
         <CreateButton type={inCards ? 'Card' : 'Resource'} onClick={onCreate} />
       )}
       <UserMenu />

--- a/tools/app/src/components/AppToolbar.tsx
+++ b/tools/app/src/components/AppToolbar.tsx
@@ -28,12 +28,12 @@ import {
   MenuItem,
   Tooltip,
 } from '@mui/joy';
-import { getConfig } from '@/lib/utils';
 import {
   useIsInCards,
   useKeyboardShortcut,
   useConfigTemplateCreationContext,
 } from '@/lib/hooks';
+import { useCanEdit, useCanAdmin } from '@/lib/auth';
 import type { ResourceName } from '@/lib/constants';
 import { RESOURCES } from '@/lib/constants';
 import { ThemeModeToggle } from './ThemeModeToggle';
@@ -126,12 +126,15 @@ export function CreateButton({
 export default function AppToolbar({ onCreate, onMenuClick }: AppToolbarProps) {
   const { t } = useTranslation();
   const inCards = useIsInCards();
+  const canEdit = useCanEdit();
+  const canAdmin = useCanAdmin();
+  const canCreate = inCards ? canEdit : canAdmin;
   useKeyboardShortcut(
     {
       key: 'c',
     },
     () => {
-      if (!getConfig().staticMode) {
+      if (canCreate) {
         onCreate();
       }
     },
@@ -173,7 +176,7 @@ export default function AppToolbar({ onCreate, onMenuClick }: AppToolbarProps) {
       <Box sx={{ display: { xs: 'none', sm: 'inline-flex' } }}>
         <ThemeModeToggle />
       </Box>
-      {!getConfig().staticMode && (
+      {canCreate && (
         <CreateButton type={inCards ? 'Card' : 'Resource'} onClick={onCreate} />
       )}
       <UserMenu />

--- a/tools/app/src/components/AppToolbar.tsx
+++ b/tools/app/src/components/AppToolbar.tsx
@@ -33,7 +33,7 @@ import {
   useKeyboardShortcut,
   useConfigTemplateCreationContext,
 } from '@/lib/hooks';
-import { useCanEdit, useIsAdmin } from '@/lib/auth';
+import { UserRole, useHasMinRole } from '@/lib/auth';
 import type { ResourceName } from '@/lib/constants';
 import { RESOURCES } from '@/lib/constants';
 import { ThemeModeToggle } from './ThemeModeToggle';
@@ -126,8 +126,8 @@ export function CreateButton({
 export default function AppToolbar({ onCreate, onMenuClick }: AppToolbarProps) {
   const { t } = useTranslation();
   const inCards = useIsInCards();
-  const canEdit = useCanEdit();
-  const isAdmin = useIsAdmin();
+  const canEdit = useHasMinRole(UserRole.Editor);
+  const isAdmin = useHasMinRole(UserRole.Admin);
   const canCreate = inCards ? canEdit : isAdmin;
   useKeyboardShortcut(
     {

--- a/tools/app/src/components/AppToolbar.tsx
+++ b/tools/app/src/components/AppToolbar.tsx
@@ -33,7 +33,7 @@ import {
   useKeyboardShortcut,
   useConfigTemplateCreationContext,
 } from '@/lib/hooks';
-import { useCanEdit, useCanAdmin } from '@/lib/auth';
+import { useCanEdit, useIsAdmin } from '@/lib/auth';
 import type { ResourceName } from '@/lib/constants';
 import { RESOURCES } from '@/lib/constants';
 import { ThemeModeToggle } from './ThemeModeToggle';
@@ -127,8 +127,8 @@ export default function AppToolbar({ onCreate, onMenuClick }: AppToolbarProps) {
   const { t } = useTranslation();
   const inCards = useIsInCards();
   const canEdit = useCanEdit();
-  const canAdmin = useCanAdmin();
-  const canCreate = inCards ? canEdit : canAdmin;
+  const isAdmin = useIsAdmin();
+  const canCreate = inCards ? canEdit : isAdmin;
   useKeyboardShortcut(
     {
       key: 'c',

--- a/tools/app/src/components/BaseTreeComponent.tsx
+++ b/tools/app/src/components/BaseTreeComponent.tsx
@@ -17,7 +17,7 @@ import type { NodeRendererProps, NodeApi, TreeApi } from 'react-arborist';
 import { Tree } from 'react-arborist';
 import { Link } from 'react-router';
 import { useResizeObserver } from '../lib/hooks';
-import { getConfig } from '@/lib/utils';
+import { useCanEdit } from '@/lib/auth';
 
 export interface BaseTreeProps<T> {
   title?: string;
@@ -51,6 +51,7 @@ export function BaseTreeComponent<T>({
   const treeRef = useRef(null);
   const { width, height, ref } = useResizeObserver();
   const { height: titleHeight, ref: titleRef } = useResizeObserver();
+  const canEdit = useCanEdit();
 
   useEffect(() => {
     const tree = treeRef.current as unknown as TreeApi<T> | null;
@@ -103,7 +104,7 @@ export function BaseTreeComponent<T>({
         ref={treeRef}
         data={data || []}
         openByDefault={openByDefault}
-        disableDrag={getConfig().staticMode}
+        disableDrag={!canEdit}
         idAccessor={idAccessor}
         childrenAccessor={childrenAccessor}
         indent={16}

--- a/tools/app/src/components/BaseTreeComponent.tsx
+++ b/tools/app/src/components/BaseTreeComponent.tsx
@@ -17,7 +17,7 @@ import type { NodeRendererProps, NodeApi, TreeApi } from 'react-arborist';
 import { Tree } from 'react-arborist';
 import { Link } from 'react-router';
 import { useResizeObserver } from '../lib/hooks';
-import { getConfig } from '@/lib/utils';
+import { useCanEdit } from '@/lib/auth';
 
 export interface BaseTreeProps<T> {
   title?: string;
@@ -33,6 +33,8 @@ export interface BaseTreeProps<T> {
   onMove?: (dragIds: string[], parentId: string | null, index: number) => void;
   onNodeClick?: (node: NodeApi<T>) => void;
   openByDefault?: boolean;
+  /** Disable drag & drop regardless of the user's edit role. */
+  readOnly?: boolean;
 }
 
 export function BaseTreeComponent<T>({
@@ -47,10 +49,12 @@ export function BaseTreeComponent<T>({
   onMove,
   onNodeClick,
   openByDefault = false,
+  readOnly = false,
 }: BaseTreeProps<T>) {
   const treeRef = useRef(null);
   const { width, height, ref } = useResizeObserver();
   const { height: titleHeight, ref: titleRef } = useResizeObserver();
+  const canEdit = useCanEdit() && !readOnly;
 
   useEffect(() => {
     const tree = treeRef.current as unknown as TreeApi<T> | null;
@@ -116,12 +120,12 @@ export function BaseTreeComponent<T>({
         data={data || []}
         openByDefault={openByDefault}
         disableDrag={
-          getConfig().staticMode || !onMove
+          !canEdit || !onMove
             ? true
             : (node: T) => (node as { readOnly?: boolean })?.readOnly === true
         }
         disableDrop={
-          getConfig().staticMode || !onMove
+          !canEdit || !onMove
             ? true
             : ({ parentNode }) =>
                 (parentNode?.data as { readOnly?: boolean })?.readOnly === true

--- a/tools/app/src/components/BaseTreeComponent.tsx
+++ b/tools/app/src/components/BaseTreeComponent.tsx
@@ -17,7 +17,7 @@ import type { NodeRendererProps, NodeApi, TreeApi } from 'react-arborist';
 import { Tree } from 'react-arborist';
 import { Link } from 'react-router';
 import { useResizeObserver } from '../lib/hooks';
-import { useCanEdit } from '@/lib/auth';
+import { UserRole, useHasMinRole } from '@/lib/auth';
 
 export interface BaseTreeProps<T> {
   title?: string;
@@ -54,7 +54,7 @@ export function BaseTreeComponent<T>({
   const treeRef = useRef(null);
   const { width, height, ref } = useResizeObserver();
   const { height: titleHeight, ref: titleRef } = useResizeObserver();
-  const canEdit = useCanEdit() && !readOnly;
+  const canEdit = useHasMinRole(UserRole.Editor) && !readOnly;
 
   useEffect(() => {
     const tree = treeRef.current as unknown as TreeApi<T> | null;

--- a/tools/app/src/components/ChecksAccordion.tsx
+++ b/tools/app/src/components/ChecksAccordion.tsx
@@ -24,8 +24,8 @@ import {
 } from '@mui/joy';
 import { useTranslation } from 'react-i18next';
 import ExpandMore from '@mui/icons-material/ExpandMore';
-import { getConfig } from '@/lib/utils';
 import { useAppRouter } from '../lib/hooks';
+import { useCanEdit } from '@/lib/auth';
 
 // Generic types for check items
 export interface CheckItem {
@@ -78,6 +78,7 @@ export function ChecksAccordion({
     initialFailuresExpanded,
   );
   const router = useAppRouter();
+  const canEdit = useCanEdit();
 
   if (checks.successes.length === 0 && checks.failures.length === 0) {
     return null;
@@ -206,20 +207,18 @@ export function ChecksAccordion({
                       <Typography fontSize="xs">
                         {failure.errorMessage}
                       </Typography>
-                      {showGoToField &&
-                        !getConfig().staticMode &&
-                        failure.fieldName && (
-                          <Link
-                            level="body-sm"
-                            component="button"
-                            onClick={() =>
-                              handleGoToField(cardKey, failure.fieldName!)
-                            }
-                            sx={{ mt: 1 }}
-                          >
-                            {goToFieldText || t('goToField')}
-                          </Link>
-                        )}
+                      {showGoToField && canEdit && failure.fieldName && (
+                        <Link
+                          level="body-sm"
+                          component="button"
+                          onClick={() =>
+                            handleGoToField(cardKey, failure.fieldName!)
+                          }
+                          sx={{ mt: 1 }}
+                        >
+                          {goToFieldText || t('goToField')}
+                        </Link>
+                      )}
                     </Box>
                     <Typography level="title-sm" fontWeight="bold">
                       {failureFailText}

--- a/tools/app/src/components/ChecksAccordion.tsx
+++ b/tools/app/src/components/ChecksAccordion.tsx
@@ -25,7 +25,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import ExpandMore from '@mui/icons-material/ExpandMore';
 import { CountBadge } from './CountBadge';
-import { useCanEdit } from '@/lib/auth';
+import { UserRole, useHasMinRole } from '@/lib/auth';
 
 // Generic types for check items
 export interface CheckItem {
@@ -77,7 +77,7 @@ export function ChecksAccordion({
   const [failuresExpanded, setFailuresExpanded] = useState(
     initialFailuresExpanded,
   );
-  const canEdit = useCanEdit();
+  const canEdit = useHasMinRole(UserRole.Editor);
 
   if (checks.successes.length === 0 && checks.failures.length === 0) {
     return null;

--- a/tools/app/src/components/ChecksAccordion.tsx
+++ b/tools/app/src/components/ChecksAccordion.tsx
@@ -24,8 +24,8 @@ import {
 } from '@mui/joy';
 import { useTranslation } from 'react-i18next';
 import ExpandMore from '@mui/icons-material/ExpandMore';
-import { getConfig } from '@/lib/utils';
 import { CountBadge } from './CountBadge';
+import { useCanEdit } from '@/lib/auth';
 
 // Generic types for check items
 export interface CheckItem {
@@ -77,6 +77,7 @@ export function ChecksAccordion({
   const [failuresExpanded, setFailuresExpanded] = useState(
     initialFailuresExpanded,
   );
+  const canEdit = useCanEdit();
 
   if (checks.successes.length === 0 && checks.failures.length === 0) {
     return null;
@@ -140,7 +141,7 @@ export function ChecksAccordion({
               {failure.title}
             </Typography>
             <Typography fontSize="xs">{failure.errorMessage}</Typography>
-            {onGoToField && !getConfig().staticMode && failure.fieldName && (
+            {onGoToField && canEdit && failure.fieldName && (
               <Link
                 data-cy="goToFieldLink"
                 level="body-sm"

--- a/tools/app/src/components/ConfigMenu.tsx
+++ b/tools/app/src/components/ConfigMenu.tsx
@@ -23,7 +23,7 @@ import { findResourceNodeByName } from '@/lib/utils';
 import { useAppRouter } from '@/lib/hooks';
 import { resolveConfigTreeMove } from '@/lib/configTreeMove';
 import { addNotification } from '@/lib/slices/notifications';
-import { useCanAdmin } from '@/lib/auth';
+import { useIsAdmin } from '@/lib/auth';
 import type { NodeApi } from 'react-arborist';
 import type { AnyNode } from '@/lib/api/types';
 import { RESOURCES } from '@/lib/constants';
@@ -61,7 +61,7 @@ export default function ConfigMenu() {
       ? findResourceNodeByName(resourceTree, selectedName)?.id
       : undefined;
   const { safePush } = useAppRouter();
-  const canAdmin = useCanAdmin();
+  const isAdmin = useIsAdmin();
 
   const handleMove = useCallback(
     async (dragIds: string[], parentId: string | null, index: number) => {
@@ -106,7 +106,7 @@ export default function ConfigMenu() {
       idAccessor="id"
       childrenAccessor="children"
       onMove={handleMove}
-      readOnly={!canAdmin}
+      readOnly={!isAdmin}
       onNodeClick={(node) => {
         if (node.data.type === 'general') {
           safePush('/configuration/general');

--- a/tools/app/src/components/ConfigMenu.tsx
+++ b/tools/app/src/components/ConfigMenu.tsx
@@ -23,7 +23,7 @@ import { findResourceNodeByName } from '@/lib/utils';
 import { useAppRouter } from '@/lib/hooks';
 import { resolveConfigTreeMove } from '@/lib/configTreeMove';
 import { addNotification } from '@/lib/slices/notifications';
-import { useIsAdmin } from '@/lib/auth';
+import { UserRole, useHasMinRole } from '@/lib/auth';
 import type { NodeApi } from 'react-arborist';
 import type { AnyNode } from '@/lib/api/types';
 import { RESOURCES } from '@/lib/constants';
@@ -61,7 +61,7 @@ export default function ConfigMenu() {
       ? findResourceNodeByName(resourceTree, selectedName)?.id
       : undefined;
   const { safePush } = useAppRouter();
-  const isAdmin = useIsAdmin();
+  const isAdmin = useHasMinRole(UserRole.Admin);
 
   const handleMove = useCallback(
     async (dragIds: string[], parentId: string | null, index: number) => {

--- a/tools/app/src/components/ConfigMenu.tsx
+++ b/tools/app/src/components/ConfigMenu.tsx
@@ -23,6 +23,7 @@ import { findResourceNodeByName } from '@/lib/utils';
 import { useAppRouter } from '@/lib/hooks';
 import { resolveConfigTreeMove } from '@/lib/configTreeMove';
 import { addNotification } from '@/lib/slices/notifications';
+import { useCanAdmin } from '@/lib/auth';
 import type { NodeApi } from 'react-arborist';
 import type { AnyNode } from '@/lib/api/types';
 import { RESOURCES } from '@/lib/constants';
@@ -60,6 +61,7 @@ export default function ConfigMenu() {
       ? findResourceNodeByName(resourceTree, selectedName)?.id
       : undefined;
   const { safePush } = useAppRouter();
+  const canAdmin = useCanAdmin();
 
   const handleMove = useCallback(
     async (dragIds: string[], parentId: string | null, index: number) => {
@@ -104,6 +106,7 @@ export default function ConfigMenu() {
       idAccessor="id"
       childrenAccessor="children"
       onMove={handleMove}
+      readOnly={!canAdmin}
       onNodeClick={(node) => {
         if (node.data.type === 'general') {
           safePush('/configuration/general');

--- a/tools/app/src/components/ContentArea.tsx
+++ b/tools/app/src/components/ContentArea.tsx
@@ -81,12 +81,12 @@ import type {
   CalculationLink,
   LinkDirection,
 } from '@cyberismo/data-handler/types/queries';
-import { getConfig } from '@/lib/utils';
 import type { CardResponse, Connector } from '../lib/api/types';
 import { GenericConfirmModal } from './modals';
 import { useCard } from '../lib/api';
 import SvgViewerModal from './modals/svgViewerModal';
 import { SafeRouterLink } from './SafeRouterLink';
+import { useCanEdit } from '@/lib/auth';
 
 export type LinkFormState = 'hidden' | 'add' | 'add-from-toolbar' | 'edit';
 
@@ -569,6 +569,7 @@ export const ContentArea: React.FC<ContentAreaProps> = ({
   onDeleteLink,
 }) => {
   const { isUpdating } = useCard(card.key);
+  const canEdit = useCanEdit();
   const [visibleHeaderIds, setVisibleHeaderIds] = useState<string[] | null>(
     null,
   );
@@ -962,23 +963,21 @@ export const ContentArea: React.FC<ContentAreaProps> = ({
                     </Typography>
                   </Stack>
                 </AccordionSummary>
-                {!preview &&
-                  linkFormState === 'hidden' &&
-                  !getConfig().staticMode && (
-                    <IconButton
-                      sx={{
-                        height: 36,
-                        alignSelf: 'center',
-                      }}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-                        onLinkFormChange && onLinkFormChange('add');
-                      }}
-                    >
-                      <Add />
-                    </IconButton>
-                  )}
+                {!preview && linkFormState === 'hidden' && canEdit && (
+                  <IconButton
+                    sx={{
+                      height: 36,
+                      alignSelf: 'center',
+                    }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+                      onLinkFormChange && onLinkFormChange('add');
+                    }}
+                  >
+                    <Add />
+                  </IconButton>
+                )}
               </Stack>
               <AccordionDetails>
                 {!preview &&
@@ -1072,53 +1071,48 @@ export const ContentArea: React.FC<ContentAreaProps> = ({
                             )}
                           </Box>
                         </Stack>
-                        {link.linkSource === 'user' &&
-                          !preview &&
-                          !getConfig().staticMode && (
-                            <Box
-                              gap={1}
-                              fontSize={24}
-                              alignItems="center"
-                              marginRight={2}
+                        {link.linkSource === 'user' && !preview && canEdit && (
+                          <Box
+                            gap={1}
+                            fontSize={24}
+                            alignItems="center"
+                            marginRight={2}
+                          >
+                            <IconButton
+                              className="actionButton"
+                              onClick={() => {
+                                const linkType = linkTypes.find(
+                                  (t) =>
+                                    t.name === link.linkType &&
+                                    t.direction === link.direction,
+                                );
+                                setEditLinkData({
+                                  linkType: linkType?.id ?? NO_LINK_TYPE,
+                                  connector: link.connector ?? 'card',
+                                  cardKey: link.connector ? '' : link.key,
+                                  externalItemKey: link.connector
+                                    ? link.key
+                                    : '',
+                                  linkDescription: link.linkDescription || '',
+                                  linkTypeName: link.linkType,
+                                  direction: link.direction,
+                                });
+                                openModal('editLink')();
+                              }}
                             >
-                              <IconButton
-                                className="actionButton"
-                                onClick={() => {
-                                  const linkType = linkTypes.find(
-                                    (t) =>
-                                      t.name === link.linkType &&
-                                      t.direction === link.direction,
-                                  );
-                                  setEditLinkData({
-                                    linkType: linkType?.id ?? NO_LINK_TYPE,
-                                    connector: link.connector ?? 'card',
-                                    cardKey: link.connector ? '' : link.key,
-                                    externalItemKey: link.connector
-                                      ? link.key
-                                      : '',
-                                    linkDescription: link.linkDescription || '',
-                                    linkTypeName: link.linkType,
-                                    direction: link.direction,
-                                  });
-                                  openModal('editLink')();
-                                }}
-                              >
-                                <Edit fontSize="inherit" />
-                              </IconButton>
-                              <IconButton
-                                className="actionButton"
-                                onClick={() => {
-                                  setDeleteLinkData(link);
-                                  openModal('deleteLink')();
-                                }}
-                              >
-                                <Delete
-                                  fontSize="inherit"
-                                  data-cy="DeleteIcon"
-                                />
-                              </IconButton>
-                            </Box>
-                          )}
+                              <Edit fontSize="inherit" />
+                            </IconButton>
+                            <IconButton
+                              className="actionButton"
+                              onClick={() => {
+                                setDeleteLinkData(link);
+                                openModal('deleteLink')();
+                              }}
+                            >
+                              <Delete fontSize="inherit" data-cy="DeleteIcon" />
+                            </IconButton>
+                          </Box>
+                        )}
                         {link.linkSource === 'calculated' && (
                           <IconButton color="primary">
                             <Tooltip title={t('linkForm.calculatedLink')}>

--- a/tools/app/src/components/StateSelector.tsx
+++ b/tools/app/src/components/StateSelector.tsx
@@ -26,7 +26,6 @@ import {
 } from '@mui/joy';
 import { useTranslation } from 'react-i18next';
 import { getStateColor } from '../lib/utils';
-import { getConfig } from '@/lib/utils';
 import { ANY_STATE } from '@/lib/constants';
 
 interface StateSelectorProps {
@@ -80,11 +79,7 @@ const StateSelector: React.FC<StateSelectorProps> = ({
     <Dropdown>
       <MenuButton
         size="sm"
-        disabled={
-          availableTransitions.length === 0 ||
-          disabled ||
-          getConfig().staticMode
-        }
+        disabled={availableTransitions.length === 0 || disabled}
         variant="soft"
         color="neutral"
         endDecorator={!isLoading && statusDot}

--- a/tools/app/src/components/StateSelector.tsx
+++ b/tools/app/src/components/StateSelector.tsx
@@ -28,8 +28,7 @@ import {
 } from '@mui/joy';
 import ArrowForward from '@mui/icons-material/ArrowForward';
 import { useTranslation } from 'react-i18next';
-import { getStateColor } from '../lib/utils';
-import { getConfig } from '@/lib/utils';
+import { getStateColor, getConfig } from '../lib/utils';
 import { ANY_STATE } from '@/lib/constants';
 
 interface StateSelectorProps {

--- a/tools/app/src/components/card/CardBody.tsx
+++ b/tools/app/src/components/card/CardBody.tsx
@@ -33,7 +33,7 @@ import {
 } from '@mui/joy';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { isAppUrl, parseDataAttributes } from '@/lib/utils';
-import { useCanEdit } from '@/lib/auth';
+import { UserRole, useHasMinRole } from '@/lib/auth';
 import { useLocation } from 'react-router';
 import DownloadIcon from '@mui/icons-material/Download';
 import OpenInFullIcon from '@mui/icons-material/OpenInFull';
@@ -118,7 +118,7 @@ export const CardBody = forwardRef<CardBodyHandle, CardBodyProps>(
     const router = useAppRouter();
     const { t } = useTranslation();
     const isDarkMode = useIsDarkMode();
-    const canEditRole = useCanEdit();
+    const canEditRole = useHasMinRole(UserRole.Editor);
     const location = useLocation();
 
     // Inline editing state

--- a/tools/app/src/components/card/CardBody.tsx
+++ b/tools/app/src/components/card/CardBody.tsx
@@ -32,7 +32,8 @@ import {
   Typography,
 } from '@mui/joy';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { getConfig, isAppUrl, parseDataAttributes } from '@/lib/utils';
+import { isAppUrl, parseDataAttributes } from '@/lib/utils';
+import { useCanEdit } from '@/lib/auth';
 import { useLocation } from 'react-router';
 import DownloadIcon from '@mui/icons-material/Download';
 import OpenInFullIcon from '@mui/icons-material/OpenInFull';
@@ -117,6 +118,7 @@ export const CardBody = forwardRef<CardBodyHandle, CardBodyProps>(
     const router = useAppRouter();
     const { t } = useTranslation();
     const isDarkMode = useIsDarkMode();
+    const canEditRole = useCanEdit();
     const location = useLocation();
 
     // Inline editing state
@@ -127,7 +129,7 @@ export const CardBody = forwardRef<CardBodyHandle, CardBodyProps>(
     const [previewing, setPreviewing] = useState(false);
     const [previewHtml, setPreviewHtml] = useState<string | null>(null);
 
-    const canEdit = !preview && !!onContentSave && !getConfig().staticMode;
+    const canEdit = !preview && !!onContentSave && canEditRole;
 
     useEffect(() => {
       onEditingChange?.(editing);

--- a/tools/app/src/components/card/CardTitle.tsx
+++ b/tools/app/src/components/card/CardTitle.tsx
@@ -20,7 +20,7 @@ import { useTranslation } from 'react-i18next';
 import { useAppDispatch } from '@/lib/hooks';
 import { addNotification } from '@/lib/slices/notifications';
 import { isEdited } from '@/lib/slices/pageState';
-import { getConfig } from '@/lib/utils';
+import { useCanEdit } from '@/lib/auth';
 import type { MetadataValue } from '@/lib/definitions';
 
 type CardTitleProps = {
@@ -40,13 +40,14 @@ export const CardTitle: React.FC<CardTitleProps> = ({
 }) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
+  const canEditRole = useCanEdit();
 
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState(title);
   const editBoxRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  const canEdit = !preview && !!onSave && !disabled && !getConfig().staticMode;
+  const canEdit = !preview && !!onSave && !disabled && canEditRole;
 
   const handleStartEdit = (e: React.MouseEvent) => {
     if (!canEdit) return;

--- a/tools/app/src/components/card/CardTitle.tsx
+++ b/tools/app/src/components/card/CardTitle.tsx
@@ -20,7 +20,7 @@ import { useTranslation } from 'react-i18next';
 import { useAppDispatch } from '@/lib/hooks';
 import { addNotification } from '@/lib/slices/notifications';
 import { isEdited } from '@/lib/slices/pageState';
-import { useCanEdit } from '@/lib/auth';
+import { UserRole, useHasMinRole } from '@/lib/auth';
 import type { MetadataValue } from '@/lib/definitions';
 
 type CardTitleProps = {
@@ -40,7 +40,7 @@ export const CardTitle: React.FC<CardTitleProps> = ({
 }) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
-  const canEditRole = useCanEdit();
+  const canEditRole = useHasMinRole(UserRole.Editor);
 
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState(title);

--- a/tools/app/src/components/card/linked-cards-section/LinkedCardsSection.tsx
+++ b/tools/app/src/components/card/linked-cards-section/LinkedCardsSection.tsx
@@ -25,7 +25,8 @@ import type {
   CalculationLink,
   QueryResult,
 } from '@cyberismo/data-handler/types/queries';
-import { getConfig, useModals } from '@/lib/utils';
+import { useModals } from '@/lib/utils';
+import { useCanEdit } from '@/lib/auth';
 import { useCard } from '@/lib/api';
 import { useAppDispatch, useAppSelector } from '@/lib/hooks/redux';
 import { setLinkedCardsExpanded } from '@/lib/slices/pageState';
@@ -63,6 +64,7 @@ export default function LinkedCardsSection({
   const { t } = useTranslation();
   const { isUpdating } = useCard(card.key);
   const dispatch = useAppDispatch();
+  const canEdit = useCanEdit();
   const expanded = useAppSelector((state) => state.page.linkedCardsExpanded);
   const [editing, setEditing] = useState(false);
   const [deleteLinkData, setDeleteLinkData] = useState<CalculationLink | null>(
@@ -139,7 +141,7 @@ export default function LinkedCardsSection({
             {linkCount > 0 ? t('linkedCards') : t('noLinkedCards')}
           </Typography>
           {!preview &&
-            !getConfig().staticMode &&
+            canEdit &&
             linkCount === 0 &&
             (editing ? (
               <Button
@@ -169,7 +171,7 @@ export default function LinkedCardsSection({
               </IconButton>
             ))}
           {!preview &&
-            !getConfig().staticMode &&
+            canEdit &&
             expanded &&
             linkCount > 0 &&
             (editing ? (

--- a/tools/app/src/components/card/linked-cards-section/LinkedCardsSection.tsx
+++ b/tools/app/src/components/card/linked-cards-section/LinkedCardsSection.tsx
@@ -26,7 +26,7 @@ import type {
   QueryResult,
 } from '@cyberismo/data-handler/types/queries';
 import { useModals } from '@/lib/utils';
-import { useCanEdit } from '@/lib/auth';
+import { UserRole, useHasMinRole } from '@/lib/auth';
 import { useCard } from '@/lib/api';
 import { useAppDispatch, useAppSelector } from '@/lib/hooks/redux';
 import { setLinkedCardsExpanded } from '@/lib/slices/pageState';
@@ -64,7 +64,7 @@ export default function LinkedCardsSection({
   const { t } = useTranslation();
   const { isUpdating } = useCard(card.key);
   const dispatch = useAppDispatch();
-  const canEdit = useCanEdit();
+  const canEdit = useHasMinRole(UserRole.Editor);
   const expanded = useAppSelector((state) => state.page.linkedCardsExpanded);
   const [editing, setEditing] = useState(false);
   const [deleteLinkData, setDeleteLinkData] = useState<CalculationLink | null>(

--- a/tools/app/src/components/card/metadata-section/MetadataSection.tsx
+++ b/tools/app/src/components/card/metadata-section/MetadataSection.tsx
@@ -19,7 +19,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import type { MetadataValue } from '@/lib/definitions';
 import type { CardResponse } from '@/lib/api/types';
 import { getDefaultValue } from '@/lib/utils';
-import { useCanEdit } from '@/lib/auth';
+import { UserRole, useHasMinRole } from '@/lib/auth';
 import { format } from 'date-fns';
 import { FieldRow } from './FieldRow';
 import { LABEL_SPLITTER } from '@/lib/constants';
@@ -50,7 +50,7 @@ export default function MetadataSection({
   const [expanded, setExpanded] = useState(initialExpanded);
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
-  const canEditRole = useCanEdit();
+  const canEditRole = useHasMinRole(UserRole.Editor);
 
   useEffect(() => {
     setEditingFieldKey(null);

--- a/tools/app/src/components/card/metadata-section/MetadataSection.tsx
+++ b/tools/app/src/components/card/metadata-section/MetadataSection.tsx
@@ -18,7 +18,8 @@ import { Box, Button, Stack } from '@mui/joy';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import type { MetadataValue } from '@/lib/definitions';
 import type { CardResponse } from '@/lib/api/types';
-import { getConfig, getDefaultValue } from '@/lib/utils';
+import { getDefaultValue } from '@/lib/utils';
+import { useCanEdit } from '@/lib/auth';
 import { format } from 'date-fns';
 import { FieldRow } from './FieldRow';
 import { LABEL_SPLITTER } from '@/lib/constants';
@@ -49,6 +50,7 @@ export default function MetadataSection({
   const [expanded, setExpanded] = useState(initialExpanded);
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
+  const canEditRole = useCanEdit();
 
   useEffect(() => {
     setEditingFieldKey(null);
@@ -74,7 +76,7 @@ export default function MetadataSection({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [focusFieldKey, card.key]);
 
-  const canEdit = !getConfig().staticMode && !!onUpdate;
+  const canEdit = canEditRole && !!onUpdate;
 
   const notifyError = (error: unknown) => {
     dispatch(

--- a/tools/app/src/components/config-editors/ConfigCardEditor.tsx
+++ b/tools/app/src/components/config-editors/ConfigCardEditor.tsx
@@ -15,11 +15,12 @@ import { useRawCard } from '@/lib/api';
 import CardEditor from '../CardEditor';
 import type { AnyNode } from '@/lib/api/types';
 import { useTranslation } from 'react-i18next';
-import { getConfig } from '@/lib/utils';
+import { useCanAdmin } from '@/lib/auth';
 
 export function ConfigCardEditor({ node }: { node: AnyNode }) {
   const card = useRawCard(node.id);
   const { t } = useTranslation();
+  const canAdmin = useCanAdmin();
   if (card.isLoading) {
     return <div>{t('loading')}</div>;
   }
@@ -31,7 +32,7 @@ export function ConfigCardEditor({ node }: { node: AnyNode }) {
       cardKey={node.id}
       cardData={card}
       afterSave={() => {}}
-      readOnly={node?.readOnly || getConfig().staticMode}
+      readOnly={node?.readOnly || !canAdmin}
     />
   );
 }

--- a/tools/app/src/components/config-editors/ConfigCardEditor.tsx
+++ b/tools/app/src/components/config-editors/ConfigCardEditor.tsx
@@ -17,14 +17,14 @@ import type { AnyNode } from '@/lib/api/types';
 import { useTranslation } from 'react-i18next';
 import { findCardParentInResourceTree } from '@/lib/utils';
 import { useAppRouter } from '@/lib/hooks';
-import { useIsAdmin } from '@/lib/auth';
+import { UserRole, useHasMinRole } from '@/lib/auth';
 
 export function ConfigCardEditor({ node }: { node: AnyNode }) {
   const card = useRawCard(node.id);
   const { resourceTree } = useResourceTree();
   const router = useAppRouter();
   const { t } = useTranslation();
-  const isAdmin = useIsAdmin();
+  const isAdmin = useHasMinRole(UserRole.Admin);
   if (card.isLoading) {
     return <div>{t('loading')}</div>;
   }

--- a/tools/app/src/components/config-editors/ConfigCardEditor.tsx
+++ b/tools/app/src/components/config-editors/ConfigCardEditor.tsx
@@ -17,14 +17,14 @@ import type { AnyNode } from '@/lib/api/types';
 import { useTranslation } from 'react-i18next';
 import { findCardParentInResourceTree } from '@/lib/utils';
 import { useAppRouter } from '@/lib/hooks';
-import { useCanAdmin } from '@/lib/auth';
+import { useIsAdmin } from '@/lib/auth';
 
 export function ConfigCardEditor({ node }: { node: AnyNode }) {
   const card = useRawCard(node.id);
   const { resourceTree } = useResourceTree();
   const router = useAppRouter();
   const { t } = useTranslation();
-  const canAdmin = useCanAdmin();
+  const isAdmin = useIsAdmin();
   if (card.isLoading) {
     return <div>{t('loading')}</div>;
   }
@@ -42,7 +42,7 @@ export function ConfigCardEditor({ node }: { node: AnyNode }) {
       afterDelete={() =>
         router.push(parent ? `/configuration/${parent.name}` : '/configuration')
       }
-      readOnly={node?.readOnly || !canAdmin}
+      readOnly={node?.readOnly || !isAdmin}
     />
   );
 }

--- a/tools/app/src/components/config-editors/ConfigCardEditor.tsx
+++ b/tools/app/src/components/config-editors/ConfigCardEditor.tsx
@@ -15,14 +15,16 @@ import { useRawCard, useResourceTree } from '@/lib/api';
 import CardEditor from '../CardEditor';
 import type { AnyNode } from '@/lib/api/types';
 import { useTranslation } from 'react-i18next';
-import { findCardParentInResourceTree, getConfig } from '@/lib/utils';
+import { findCardParentInResourceTree } from '@/lib/utils';
 import { useAppRouter } from '@/lib/hooks';
+import { useCanAdmin } from '@/lib/auth';
 
 export function ConfigCardEditor({ node }: { node: AnyNode }) {
   const card = useRawCard(node.id);
   const { resourceTree } = useResourceTree();
   const router = useAppRouter();
   const { t } = useTranslation();
+  const canAdmin = useCanAdmin();
   if (card.isLoading) {
     return <div>{t('loading')}</div>;
   }
@@ -40,7 +42,7 @@ export function ConfigCardEditor({ node }: { node: AnyNode }) {
       afterDelete={() =>
         router.push(parent ? `/configuration/${parent.name}` : '/configuration')
       }
-      readOnly={node?.readOnly || getConfig().staticMode}
+      readOnly={node?.readOnly || !canAdmin}
     />
   );
 }

--- a/tools/app/src/components/config-editors/GeneralEditor.tsx
+++ b/tools/app/src/components/config-editors/GeneralEditor.tsx
@@ -29,7 +29,7 @@ import { addNotification } from '@/lib/slices/notifications';
 import BaseEditor from './BaseEditor';
 import FieldRow from './fields/FieldRow';
 import TextInput from './fields/TextInput';
-import { getConfig } from '@/lib/utils';
+import { useCanAdmin } from '@/lib/auth';
 
 type GeneralEditorProps = {
   node: GenericNode<'general'>;
@@ -55,8 +55,9 @@ export function GeneralEditor({ node }: GeneralEditorProps) {
     cardKeyPrefix: string;
   } | null>(null);
   const dispatch = useAppDispatch();
+  const canAdmin = useCanAdmin();
 
-  const isDisabled = Boolean(node.readOnly) || getConfig().staticMode;
+  const isDisabled = Boolean(node.readOnly) || !canAdmin;
 
   const nameField = useEditableField({
     initialValue: general?.name ?? node.data.name ?? '',

--- a/tools/app/src/components/config-editors/GeneralEditor.tsx
+++ b/tools/app/src/components/config-editors/GeneralEditor.tsx
@@ -37,7 +37,7 @@ import { addNotification } from '@/lib/slices/notifications';
 import BaseEditor from './BaseEditor';
 import FieldRow from './fields/FieldRow';
 import TextInput from './fields/TextInput';
-import { getConfig } from '@/lib/utils';
+import { useCanAdmin } from '@/lib/auth';
 
 type GeneralEditorProps = {
   node: GenericNode<'general'>;
@@ -64,8 +64,9 @@ export function GeneralEditor({ node }: GeneralEditorProps) {
     cardKeyPrefix: string;
   } | null>(null);
   const dispatch = useAppDispatch();
+  const canAdmin = useCanAdmin();
 
-  const isDisabled = Boolean(node.readOnly) || getConfig().staticMode;
+  const isDisabled = Boolean(node.readOnly) || !canAdmin;
 
   const nameField = useEditableField({
     initialValue: general?.name ?? node.data.name ?? '',

--- a/tools/app/src/components/config-editors/GeneralEditor.tsx
+++ b/tools/app/src/components/config-editors/GeneralEditor.tsx
@@ -37,7 +37,7 @@ import { addNotification } from '@/lib/slices/notifications';
 import BaseEditor from './BaseEditor';
 import FieldRow from './fields/FieldRow';
 import TextInput from './fields/TextInput';
-import { useIsAdmin } from '@/lib/auth';
+import { UserRole, useHasMinRole } from '@/lib/auth';
 
 type GeneralEditorProps = {
   node: GenericNode<'general'>;
@@ -64,7 +64,7 @@ export function GeneralEditor({ node }: GeneralEditorProps) {
     cardKeyPrefix: string;
   } | null>(null);
   const dispatch = useAppDispatch();
-  const isAdmin = useIsAdmin();
+  const isAdmin = useHasMinRole(UserRole.Admin);
 
   const isDisabled = Boolean(node.readOnly) || !isAdmin;
 

--- a/tools/app/src/components/config-editors/GeneralEditor.tsx
+++ b/tools/app/src/components/config-editors/GeneralEditor.tsx
@@ -37,7 +37,7 @@ import { addNotification } from '@/lib/slices/notifications';
 import BaseEditor from './BaseEditor';
 import FieldRow from './fields/FieldRow';
 import TextInput from './fields/TextInput';
-import { useCanAdmin } from '@/lib/auth';
+import { useIsAdmin } from '@/lib/auth';
 
 type GeneralEditorProps = {
   node: GenericNode<'general'>;
@@ -64,9 +64,9 @@ export function GeneralEditor({ node }: GeneralEditorProps) {
     cardKeyPrefix: string;
   } | null>(null);
   const dispatch = useAppDispatch();
-  const canAdmin = useCanAdmin();
+  const isAdmin = useIsAdmin();
 
-  const isDisabled = Boolean(node.readOnly) || !canAdmin;
+  const isDisabled = Boolean(node.readOnly) || !isAdmin;
 
   const nameField = useEditableField({
     initialValue: general?.name ?? node.data.name ?? '',

--- a/tools/app/src/components/config-editors/ResourceEditor.tsx
+++ b/tools/app/src/components/config-editors/ResourceEditor.tsx
@@ -37,12 +37,13 @@ import type {
 import FieldRow from './fields/FieldRow';
 import { resourceFieldConfigs, type FieldConfig } from './resourceFieldConfigs';
 import { FORM_FIELD_MAX_WIDTH } from '@/lib/constants';
-import { getConfig } from '@/lib/utils';
+import { useCanAdmin } from '@/lib/auth';
 
 export function ResourceEditor({ node }: { node: ResourceNode }) {
   const { t } = useTranslation();
   const { validateResource } = useValidateResource(node.name);
   const editor = useResourceEditorHelpers(node);
+  const canAdmin = useCanAdmin();
 
   if (!isResourceNode(node) || !('data' in node)) {
     return (
@@ -54,7 +55,7 @@ export function ResourceEditor({ node }: { node: ResourceNode }) {
   const constrainedConfigs = fieldConfigs.filter((c) => !c.fullWidth);
   const fullWidthConfigs = fieldConfigs.filter((c) => c.fullWidth);
 
-  const isDisabled = Boolean(node.readOnly) || getConfig().staticMode;
+  const isDisabled = Boolean(node.readOnly) || !canAdmin;
 
   const renderField = (fieldConfig: FieldConfig) => {
     const { key, type, label, options, staticOptions } = fieldConfig;

--- a/tools/app/src/components/config-editors/ResourceEditor.tsx
+++ b/tools/app/src/components/config-editors/ResourceEditor.tsx
@@ -38,12 +38,13 @@ import type {
 import FieldRow from './fields/FieldRow';
 import { resourceFieldConfigs, type FieldConfig } from './resourceFieldConfigs';
 import { FORM_FIELD_MAX_WIDTH } from '@/lib/constants';
-import { getConfig } from '@/lib/utils';
+import { useCanAdmin } from '@/lib/auth';
 
 export function ResourceEditor({ node }: { node: ResourceNode }) {
   const { t } = useTranslation();
   const { validateResource } = useValidateResource(node.name);
   const editor = useResourceEditorHelpers(node);
+  const canAdmin = useCanAdmin();
 
   if (!isResourceNode(node) || !('data' in node)) {
     return (
@@ -55,7 +56,7 @@ export function ResourceEditor({ node }: { node: ResourceNode }) {
   const constrainedConfigs = fieldConfigs.filter((c) => !c.fullWidth);
   const fullWidthConfigs = fieldConfigs.filter((c) => c.fullWidth);
 
-  const isDisabled = Boolean(node.readOnly) || getConfig().staticMode;
+  const isDisabled = Boolean(node.readOnly) || !canAdmin;
 
   const renderField = (fieldConfig: FieldConfig) => {
     const { key, type, label, options, staticOptions } = fieldConfig;

--- a/tools/app/src/components/config-editors/ResourceEditor.tsx
+++ b/tools/app/src/components/config-editors/ResourceEditor.tsx
@@ -38,13 +38,13 @@ import type {
 import FieldRow from './fields/FieldRow';
 import { resourceFieldConfigs, type FieldConfig } from './resourceFieldConfigs';
 import { FORM_FIELD_MAX_WIDTH } from '@/lib/constants';
-import { useCanAdmin } from '@/lib/auth';
+import { useIsAdmin } from '@/lib/auth';
 
 export function ResourceEditor({ node }: { node: ResourceNode }) {
   const { t } = useTranslation();
   const { validateResource } = useValidateResource(node.name);
   const editor = useResourceEditorHelpers(node);
-  const canAdmin = useCanAdmin();
+  const isAdmin = useIsAdmin();
 
   if (!isResourceNode(node) || !('data' in node)) {
     return (
@@ -56,7 +56,7 @@ export function ResourceEditor({ node }: { node: ResourceNode }) {
   const constrainedConfigs = fieldConfigs.filter((c) => !c.fullWidth);
   const fullWidthConfigs = fieldConfigs.filter((c) => c.fullWidth);
 
-  const isDisabled = Boolean(node.readOnly) || !canAdmin;
+  const isDisabled = Boolean(node.readOnly) || !isAdmin;
 
   const renderField = (fieldConfig: FieldConfig) => {
     const { key, type, label, options, staticOptions } = fieldConfig;

--- a/tools/app/src/components/config-editors/ResourceEditor.tsx
+++ b/tools/app/src/components/config-editors/ResourceEditor.tsx
@@ -38,13 +38,13 @@ import type {
 import FieldRow from './fields/FieldRow';
 import { resourceFieldConfigs, type FieldConfig } from './resourceFieldConfigs';
 import { FORM_FIELD_MAX_WIDTH } from '@/lib/constants';
-import { useIsAdmin } from '@/lib/auth';
+import { UserRole, useHasMinRole } from '@/lib/auth';
 
 export function ResourceEditor({ node }: { node: ResourceNode }) {
   const { t } = useTranslation();
   const { validateResource } = useValidateResource(node.name);
   const editor = useResourceEditorHelpers(node);
-  const isAdmin = useIsAdmin();
+  const isAdmin = useHasMinRole(UserRole.Admin);
 
   if (!isResourceNode(node) || !('data' in node)) {
     return (

--- a/tools/app/src/components/config-editors/TextEditor.tsx
+++ b/tools/app/src/components/config-editors/TextEditor.tsx
@@ -22,12 +22,13 @@ import { useTranslation } from 'react-i18next';
 import { CODE_MIRROR_CONFIG_PROPS, CODE_MIRROR_THEMES } from '@/lib/constants';
 import { useResource } from '@/lib/api';
 import { useIsDarkMode } from '@/lib/hooks';
-import { getConfig } from '@/lib/utils';
+import { useCanAdmin } from '@/lib/auth';
 
 export function TextEditor({ node }: { node: FileNode }) {
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
   const isDarkMode = useIsDarkMode();
+  const canAdmin = useCanAdmin();
   const [content, setContent] = useState(node.data.content);
 
   const { update, isUpdating } = useResource(node.resourceName);
@@ -89,7 +90,7 @@ export function TextEditor({ node }: { node: FileNode }) {
       <CodeMirror
         {...CODE_MIRROR_CONFIG_PROPS}
         theme={isDarkMode ? CODE_MIRROR_THEMES.dark : CODE_MIRROR_THEMES.light}
-        readOnly={node.readOnly || getConfig().staticMode}
+        readOnly={node.readOnly || !canAdmin}
         value={content}
         onChange={(value: string) => setContent(value)}
       />

--- a/tools/app/src/components/config-editors/TextEditor.tsx
+++ b/tools/app/src/components/config-editors/TextEditor.tsx
@@ -22,13 +22,13 @@ import { useTranslation } from 'react-i18next';
 import { CODE_MIRROR_CONFIG_PROPS, CODE_MIRROR_THEMES } from '@/lib/constants';
 import { useResource } from '@/lib/api';
 import { useIsDarkMode } from '@/lib/hooks';
-import { useCanAdmin } from '@/lib/auth';
+import { useIsAdmin } from '@/lib/auth';
 
 export function TextEditor({ node }: { node: FileNode }) {
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
   const isDarkMode = useIsDarkMode();
-  const canAdmin = useCanAdmin();
+  const isAdmin = useIsAdmin();
   const [content, setContent] = useState(node.data.content);
 
   const { update, isUpdating } = useResource(node.resourceName);
@@ -90,7 +90,7 @@ export function TextEditor({ node }: { node: FileNode }) {
       <CodeMirror
         {...CODE_MIRROR_CONFIG_PROPS}
         theme={isDarkMode ? CODE_MIRROR_THEMES.dark : CODE_MIRROR_THEMES.light}
-        readOnly={node.readOnly || !canAdmin}
+        readOnly={node.readOnly || !isAdmin}
         value={content}
         onChange={(value: string) => setContent(value)}
       />

--- a/tools/app/src/components/config-editors/TextEditor.tsx
+++ b/tools/app/src/components/config-editors/TextEditor.tsx
@@ -22,13 +22,13 @@ import { useTranslation } from 'react-i18next';
 import { CODE_MIRROR_CONFIG_PROPS, CODE_MIRROR_THEMES } from '@/lib/constants';
 import { useResource } from '@/lib/api';
 import { useIsDarkMode } from '@/lib/hooks';
-import { useIsAdmin } from '@/lib/auth';
+import { UserRole, useHasMinRole } from '@/lib/auth';
 
 export function TextEditor({ node }: { node: FileNode }) {
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
   const isDarkMode = useIsDarkMode();
-  const isAdmin = useIsAdmin();
+  const isAdmin = useHasMinRole(UserRole.Admin);
   const [content, setContent] = useState(node.data.content);
 
   const { update, isUpdating } = useResource(node.resourceName);

--- a/tools/app/src/components/context-menus/CardContextMenu.tsx
+++ b/tools/app/src/components/context-menus/CardContextMenu.tsx
@@ -32,6 +32,7 @@ import {
 import { useAppSelector, useAppRouter } from '@/lib/hooks';
 import { useCard, useProject } from '@/lib/api';
 import { useParentCard } from '@/lib/hooks';
+import { Gate, UserRole } from '@/lib/auth';
 
 interface CardContextMenuProps {
   cardKey: string;
@@ -82,19 +83,21 @@ export function CardContextMenu({ cardKey }: CardContextMenuProps) {
           </MenuButton>
         </Tooltip>
         <Menu>
-          <MenuItem id="moveCardButton" onClick={openModal('move')}>
-            <Typography>{t('move')}</Typography>
-          </MenuItem>
-          <MenuItem
-            data-cy="addAttachmentButton"
-            onClick={openModal('addAttachment')}
-          >
-            <Typography>{t('addAttachment')}</Typography>
-          </MenuItem>
-          <Divider />
-          <MenuItem data-cy="deleteCardButton" onClick={handleDeleteClick}>
-            <Typography color="danger">{t('deleteCard')}</Typography>
-          </MenuItem>
+          <Gate role={UserRole.Editor}>
+            <MenuItem id="moveCardButton" onClick={openModal('move')}>
+              <Typography>{t('move')}</Typography>
+            </MenuItem>
+            <MenuItem
+              data-cy="addAttachmentButton"
+              onClick={openModal('addAttachment')}
+            >
+              <Typography>{t('addAttachment')}</Typography>
+            </MenuItem>
+            <Divider />
+            <MenuItem data-cy="deleteCardButton" onClick={handleDeleteClick}>
+              <Typography color="danger">{t('deleteCard')}</Typography>
+            </MenuItem>
+          </Gate>
           <MenuItem onClick={openModal('logicProgram')}>
             <Typography>{t('viewLogicProgram')}</Typography>
           </MenuItem>

--- a/tools/app/src/components/context-menus/CardContextMenu.tsx
+++ b/tools/app/src/components/context-menus/CardContextMenu.tsx
@@ -32,6 +32,7 @@ import {
 import { useAppSelector } from '@/lib/hooks';
 import { useCard, useProject } from '@/lib/api';
 import { ExportCardModal } from '../modals/ExportCardModal';
+import { Gate, UserRole } from '@/lib/auth';
 
 interface CardContextMenuProps {
   cardKey: string;
@@ -87,18 +88,20 @@ export function CardContextMenu({
           </MenuButton>
         </Tooltip>
         <Menu>
-          {isModuleCard === false && (
-            <MenuItem id="moveCardButton" onClick={openModal('move')}>
-              <Typography>{t('move')}</Typography>
+          <Gate role={UserRole.Editor}>
+            {isModuleCard === false && (
+              <MenuItem id="moveCardButton" onClick={openModal('move')}>
+                <Typography>{t('move')}</Typography>
+              </MenuItem>
+            )}
+            <MenuItem
+              data-cy="addAttachmentButton"
+              onClick={openModal('addAttachment')}
+            >
+              <Typography>{t('addAttachment')}</Typography>
             </MenuItem>
-          )}
-          <MenuItem
-            data-cy="addAttachmentButton"
-            onClick={openModal('addAttachment')}
-          >
-            <Typography>{t('addAttachment')}</Typography>
-          </MenuItem>
-          <Divider />
+            <Divider />
+          </Gate>
           <MenuItem onClick={openModal('logicProgram')}>
             <Typography>{t('viewLogicProgram')}</Typography>
           </MenuItem>
@@ -110,10 +113,12 @@ export function CardContextMenu({
               </MenuItem>
             </>
           )}
-          <Divider />
-          <MenuItem data-cy="deleteCardButton" onClick={handleDeleteClick}>
-            <Typography color="danger">{t('deleteCard')}</Typography>
-          </MenuItem>
+          <Gate role={UserRole.Editor}>
+            <Divider />
+            <MenuItem data-cy="deleteCardButton" onClick={handleDeleteClick}>
+              <Typography color="danger">{t('deleteCard')}</Typography>
+            </MenuItem>
+          </Gate>
         </Menu>
       </Dropdown>
 

--- a/tools/app/src/components/context-menus/CardContextMenu.tsx
+++ b/tools/app/src/components/context-menus/CardContextMenu.tsx
@@ -88,7 +88,7 @@ export function CardContextMenu({
           </MenuButton>
         </Tooltip>
         <Menu>
-          <Gate role={UserRole.Editor}>
+          <Gate minRole={UserRole.Editor}>
             {isModuleCard === false && (
               <MenuItem id="moveCardButton" onClick={openModal('move')}>
                 <Typography>{t('move')}</Typography>
@@ -113,7 +113,7 @@ export function CardContextMenu({
               </MenuItem>
             </>
           )}
-          <Gate role={UserRole.Editor}>
+          <Gate minRole={UserRole.Editor}>
             <Divider />
             <MenuItem data-cy="deleteCardButton" onClick={handleDeleteClick}>
               <Typography color="danger">{t('deleteCard')}</Typography>

--- a/tools/app/src/components/macros/CreateCards.tsx
+++ b/tools/app/src/components/macros/CreateCards.tsx
@@ -11,13 +11,14 @@
 */
 
 import { useCard } from '@/lib/api';
-import { Button } from '@mui/joy';
+import { Button, Tooltip } from '@mui/joy';
 import { useTranslation } from 'react-i18next';
 import type { MacroContext } from '.';
 import { useAppDispatch, useAppRouter } from '@/lib/hooks';
 import { addNotification } from '@/lib/slices/notifications';
 import { useState } from 'react';
 import type { LinkDirection } from '@cyberismo/data-handler/types/queries';
+import { useCanEdit } from '@/lib/auth';
 
 export type CreateCardsProps = {
   buttonLabel: string;
@@ -39,6 +40,7 @@ export default function CreateCards({
   preview,
   link,
 }: CreateCardsProps) {
+  const canEdit = useCanEdit();
   const { t } = useTranslation();
   const { createCard, isUpdating } = useCard(cardKey || macroKey);
   const { createLink } = useCard(link?.cardKey || null);
@@ -47,99 +49,108 @@ export default function CreateCards({
   const router = useAppRouter();
 
   return (
-    <Button
-      loading={loading}
-      disabled={isUpdating()}
-      onClick={async () => {
-        try {
-          if (preview) {
-            dispatch(
-              addNotification({
-                message: t('createCard.macro.preview'),
-                type: 'success',
-              }),
-            );
-            return;
-          }
-          setLoading(true);
-          const cards = await createCard(template);
-          dispatch(
-            addNotification({
-              message: t('createCard.success'),
-              type: 'success',
-            }),
-          );
-
-          if (cards && cards.length > 0) {
-            if (link) {
-              const rootCards = cards.filter(
-                (card) => card.parent === (cardKey || macroKey),
+    <Tooltip
+      title={t('permissions.editorRequired')}
+      disableHoverListener={canEdit}
+    >
+      <span>
+        <Button
+          loading={loading}
+          disabled={!canEdit || isUpdating()}
+          onClick={async () => {
+            try {
+              if (preview) {
+                dispatch(
+                  addNotification({
+                    message: t('createCard.macro.preview'),
+                    type: 'success',
+                  }),
+                );
+                return;
+              }
+              setLoading(true);
+              const cards = await createCard(template);
+              dispatch(
+                addNotification({
+                  message: t('createCard.success'),
+                  type: 'success',
+                }),
               );
-              if (rootCards.length > 0) {
-                try {
-                  const linkResults = await Promise.allSettled(
-                    rootCards.map((card) =>
-                      createLink(
-                        card.key,
-                        link.linkType,
-                        link.description,
-                        link.direction,
-                      ),
-                    ),
+
+              if (cards && cards.length > 0) {
+                if (link) {
+                  const rootCards = cards.filter(
+                    (card) => card.parent === (cardKey || macroKey),
                   );
+                  if (rootCards.length > 0) {
+                    try {
+                      const linkResults = await Promise.allSettled(
+                        rootCards.map((card) =>
+                          createLink(
+                            card.key,
+                            link.linkType,
+                            link.description,
+                            link.direction,
+                          ),
+                        ),
+                      );
 
-                  const successful = linkResults.filter(
-                    (result) => result.status === 'fulfilled',
-                  ).length;
-                  const failed = linkResults.filter(
-                    (result) => result.status === 'rejected',
-                  ).length;
+                      const successful = linkResults.filter(
+                        (result) => result.status === 'fulfilled',
+                      ).length;
+                      const failed = linkResults.filter(
+                        (result) => result.status === 'rejected',
+                      ).length;
 
-                  if (successful > 0) {
-                    dispatch(
-                      addNotification({
-                        message: t('createLink.success', { count: successful }),
-                        type: 'success',
-                      }),
-                    );
-                  }
+                      if (successful > 0) {
+                        dispatch(
+                          addNotification({
+                            message: t('createLink.success', {
+                              count: successful,
+                            }),
+                            type: 'success',
+                          }),
+                        );
+                      }
 
-                  if (failed > 0) {
-                    dispatch(
-                      addNotification({
-                        message: t('createLink.partialFailure', {
-                          count: failed,
+                      if (failed > 0) {
+                        dispatch(
+                          addNotification({
+                            message: t('createLink.partialFailure', {
+                              count: failed,
+                            }),
+                            type: 'error',
+                          }),
+                        );
+                      }
+                    } catch (e) {
+                      dispatch(
+                        addNotification({
+                          message:
+                            e instanceof Error ? e.message : t('unknownError'),
+                          type: 'error',
                         }),
-                        type: 'error',
-                      }),
-                    );
+                      );
+                    }
                   }
-                } catch (e) {
-                  dispatch(
-                    addNotification({
-                      message:
-                        e instanceof Error ? e.message : t('unknownError'),
-                      type: 'error',
-                    }),
-                  );
                 }
               }
+              router.push(`/cards/${cards[0].key}`);
+            } catch (e) {
+              dispatch(
+                addNotification({
+                  message: e instanceof Error ? e.message : t('unknownError'),
+                  type: 'error',
+                }),
+              );
+            } finally {
+              setLoading(false);
             }
-          }
-          router.push(`/cards/${cards[0].key}`);
-        } catch (e) {
-          dispatch(
-            addNotification({
-              message: e instanceof Error ? e.message : t('unknownError'),
-              type: 'error',
-            }),
-          );
-        } finally {
-          setLoading(false);
-        }
-      }}
-    >
-      {buttonLabel}
-    </Button>
+          }}
+        >
+          {buttonLabel}
+        </Button>
+      </span>
+    </Tooltip>
   );
 }

--- a/tools/app/src/components/macros/CreateCards.tsx
+++ b/tools/app/src/components/macros/CreateCards.tsx
@@ -18,7 +18,7 @@ import { useAppDispatch, useAppRouter } from '@/lib/hooks';
 import { addNotification } from '@/lib/slices/notifications';
 import { useState } from 'react';
 import type { LinkDirection } from '@cyberismo/data-handler/types/queries';
-import { useCanEdit } from '@/lib/auth';
+import { UserRole, useHasMinRole } from '@/lib/auth';
 
 export type CreateCardsProps = {
   buttonLabel: string;
@@ -40,7 +40,7 @@ export default function CreateCards({
   preview,
   link,
 }: CreateCardsProps) {
-  const canEdit = useCanEdit();
+  const canEdit = useHasMinRole(UserRole.Editor);
   const { t } = useTranslation();
   const { createCard, isUpdating } = useCard(cardKey || macroKey);
   const { createLink } = useCard(link?.cardKey || null);

--- a/tools/app/src/components/toolbar/CardToolbar.tsx
+++ b/tools/app/src/components/toolbar/CardToolbar.tsx
@@ -31,10 +31,10 @@ import {
 } from '../../lib/api';
 import { useAppDispatch } from '../../lib/hooks';
 import { addNotification } from '../../lib/slices/notifications';
-import { getConfig } from '@/lib/utils';
 import BaseToolbar from './BaseToolbar';
 import { CardContextMenu } from '@/components/context-menus';
 import PresenceIndicator from '@/components/PresenceIndicator';
+import { useCanEdit } from '@/lib/auth';
 
 interface CardToolbarProps {
   cardKey: string;
@@ -67,6 +67,7 @@ export function CardToolbar({
   const presence = usePresence(cardKey, presenceMode);
 
   const dispatch = useAppDispatch();
+  const canEdit = useCanEdit();
 
   const workflow =
     project && card ? findWorkflowForCardType(card.cardType, project) : null;
@@ -93,7 +94,7 @@ export function CardToolbar({
 
   const actions = (
     <>
-      {!getConfig().staticMode && mode === CardMode.VIEW && (
+      {mode === CardMode.VIEW && canEdit && (
         <Tooltip title={t('linkTooltip')} placement="top">
           <IconButton
             onClick={onInsertLink}
@@ -120,10 +121,10 @@ export function CardToolbar({
         workflow={workflow}
         onTransition={(transition) => onStateTransition(transition)}
         isLoading={isUpdating('updateState')}
-        disabled={isUpdating() && !isUpdating('updateState')}
+        disabled={!canEdit || (isUpdating() && !isUpdating('updateState'))}
       />
 
-      {!getConfig().staticMode && mode === CardMode.VIEW && (
+      {mode === CardMode.VIEW && canEdit && (
         <Button
           variant="solid"
           aria-label="edit"
@@ -176,7 +177,7 @@ export function CardToolbar({
     <BaseToolbar
       breadcrumbs={breadcrumbs}
       contextMenu={
-        !getConfig().staticMode && (
+        canEdit && (
           <>
             <PresenceIndicator presence={presence} currentUserId={user?.id} />
             <CardContextMenu cardKey={cardKey} />

--- a/tools/app/src/components/toolbar/CardToolbar.tsx
+++ b/tools/app/src/components/toolbar/CardToolbar.tsx
@@ -33,7 +33,7 @@ import BaseToolbar from './BaseToolbar';
 import { CardContextMenu } from '@/components/context-menus';
 import PresenceIndicator from '@/components/PresenceIndicator';
 import SvgViewerModal from '@/components/modals/svgViewerModal';
-import { useCanEdit } from '@/lib/auth';
+import { UserRole, useHasMinRole } from '@/lib/auth';
 
 interface CardToolbarProps {
   cardKey: string;
@@ -61,7 +61,7 @@ export function CardToolbar({
   const presence = usePresence(cardKey, presenceMode);
 
   const dispatch = useAppDispatch();
-  const canEdit = useCanEdit();
+  const canEdit = useHasMinRole(UserRole.Editor);
 
   const workflow =
     project && card ? findWorkflowForCardType(card.cardType, project) : null;

--- a/tools/app/src/components/toolbar/CardToolbar.tsx
+++ b/tools/app/src/components/toolbar/CardToolbar.tsx
@@ -29,11 +29,11 @@ import {
 } from '../../lib/api';
 import { useAppDispatch } from '../../lib/hooks';
 import { addNotification } from '../../lib/slices/notifications';
-import { getConfig } from '@/lib/utils';
 import BaseToolbar from './BaseToolbar';
 import { CardContextMenu } from '@/components/context-menus';
 import PresenceIndicator from '@/components/PresenceIndicator';
 import SvgViewerModal from '@/components/modals/svgViewerModal';
+import { useCanEdit } from '@/lib/auth';
 
 interface CardToolbarProps {
   cardKey: string;
@@ -61,6 +61,7 @@ export function CardToolbar({
   const presence = usePresence(cardKey, presenceMode);
 
   const dispatch = useAppDispatch();
+  const canEdit = useCanEdit();
 
   const workflow =
     project && card ? findWorkflowForCardType(card.cardType, project) : null;
@@ -94,7 +95,7 @@ export function CardToolbar({
 
   const actions = (
     <>
-      {!getConfig().staticMode && (
+      {canEdit && (
         <Tooltip title={t('linkTooltip')} placement="top">
           <IconButton
             onClick={onInsertLink}
@@ -122,7 +123,7 @@ export function CardToolbar({
         onTransition={(transition) => onStateTransition(transition)}
         onViewWorkflow={workflow ? () => setWorkflowGraphOpen(true) : undefined}
         isLoading={isUpdating('updateState')}
-        disabled={isUpdating() && !isUpdating('updateState')}
+        disabled={!canEdit || (isUpdating() && !isUpdating('updateState'))}
       />
 
       <SvgViewerModal
@@ -137,7 +138,7 @@ export function CardToolbar({
     <BaseToolbar
       breadcrumbs={breadcrumbs}
       contextMenu={
-        !getConfig().staticMode && (
+        canEdit && (
           <>
             <PresenceIndicator presence={presence} currentUserId={user?.id} />
             <CardContextMenu

--- a/tools/app/src/components/toolbar/ConfigToolbar.tsx
+++ b/tools/app/src/components/toolbar/ConfigToolbar.tsx
@@ -16,7 +16,7 @@ import { useTranslation } from 'react-i18next';
 import type { AnyNode } from '../../lib/api/types';
 import BaseToolbar from './BaseToolbar';
 import { ConfigContextMenu } from '../context-menus';
-import { getConfig } from '@/lib/utils';
+import { useCanAdmin } from '@/lib/auth';
 
 interface ConfigToolbarProps {
   node: AnyNode;
@@ -38,6 +38,7 @@ export function ConfigToolbar({
   enabled,
 }: ConfigToolbarProps) {
   const { t } = useTranslation();
+  const canAdmin = useCanAdmin();
 
   // Create breadcrumbs from the node path
   const breadcrumbs = (() => {
@@ -90,7 +91,7 @@ export function ConfigToolbar({
           {t('cancel')}
         </Button>
       )}
-      {onUpdate && !node.readOnly && !getConfig().staticMode && (
+      {onUpdate && !node.readOnly && canAdmin && (
         <Button
           variant="solid"
           size="sm"
@@ -115,8 +116,7 @@ export function ConfigToolbar({
           node={node}
           enabled={{
             ...enabled,
-            delete:
-              enabled?.delete && !node.readOnly && !getConfig().staticMode,
+            delete: enabled?.delete && !node.readOnly && canAdmin,
           }}
         />
       }

--- a/tools/app/src/components/toolbar/ConfigToolbar.tsx
+++ b/tools/app/src/components/toolbar/ConfigToolbar.tsx
@@ -16,7 +16,7 @@ import { useTranslation } from 'react-i18next';
 import type { AnyNode } from '../../lib/api/types';
 import BaseToolbar from './BaseToolbar';
 import { ConfigContextMenu } from '../context-menus';
-import { useIsAdmin } from '@/lib/auth';
+import { UserRole, useHasMinRole } from '@/lib/auth';
 
 interface ConfigToolbarProps {
   node: AnyNode;
@@ -38,7 +38,7 @@ export function ConfigToolbar({
   enabled,
 }: ConfigToolbarProps) {
   const { t } = useTranslation();
-  const isAdmin = useIsAdmin();
+  const isAdmin = useHasMinRole(UserRole.Admin);
 
   // Create breadcrumbs from the node path
   const breadcrumbs = (() => {

--- a/tools/app/src/components/toolbar/ConfigToolbar.tsx
+++ b/tools/app/src/components/toolbar/ConfigToolbar.tsx
@@ -16,7 +16,7 @@ import { useTranslation } from 'react-i18next';
 import type { AnyNode } from '../../lib/api/types';
 import BaseToolbar from './BaseToolbar';
 import { ConfigContextMenu } from '../context-menus';
-import { useCanAdmin } from '@/lib/auth';
+import { useIsAdmin } from '@/lib/auth';
 
 interface ConfigToolbarProps {
   node: AnyNode;
@@ -38,7 +38,7 @@ export function ConfigToolbar({
   enabled,
 }: ConfigToolbarProps) {
   const { t } = useTranslation();
-  const canAdmin = useCanAdmin();
+  const isAdmin = useIsAdmin();
 
   // Create breadcrumbs from the node path
   const breadcrumbs = (() => {
@@ -91,7 +91,7 @@ export function ConfigToolbar({
           {t('cancel')}
         </Button>
       )}
-      {onUpdate && !node.readOnly && canAdmin && (
+      {onUpdate && !node.readOnly && isAdmin && (
         <Button
           variant="solid"
           size="sm"
@@ -116,7 +116,7 @@ export function ConfigToolbar({
           node={node}
           enabled={{
             ...enabled,
-            delete: enabled?.delete && !node.readOnly && canAdmin,
+            delete: enabled?.delete && !node.readOnly && isAdmin,
           }}
         />
       }

--- a/tools/app/src/lib/api/presence.ts
+++ b/tools/app/src/lib/api/presence.ts
@@ -12,8 +12,8 @@
 */
 
 import { useEffect, useState } from 'react';
-import { getConfig } from '@/lib/utils';
 import { apiPaths } from '@/lib/swr.js';
+import { useCanEdit } from '@/lib/auth';
 import { z } from 'zod';
 
 const presenceEntrySchema = z.object({
@@ -39,10 +39,11 @@ export function usePresence(
   cardKey: string | null,
   mode: 'viewing' | 'editing' = 'viewing',
 ): PresenceEntry[] {
+  const canEdit = useCanEdit();
   const [editors, setEditors] = useState<PresenceEntry[]>([]);
 
   useEffect(() => {
-    if (!cardKey || getConfig().staticMode) {
+    if (!cardKey || !canEdit) {
       return;
     }
 
@@ -67,9 +68,9 @@ export function usePresence(
       eventSource.close();
       setEditors([]);
     };
-  }, [cardKey, mode]);
+  }, [cardKey, mode, canEdit]);
 
-  if (!cardKey || getConfig().staticMode) return [];
+  if (!cardKey || !canEdit) return [];
 
   return editors;
 }

--- a/tools/app/src/lib/api/presence.ts
+++ b/tools/app/src/lib/api/presence.ts
@@ -14,7 +14,7 @@
 import { useEffect, useState } from 'react';
 import { getConfig } from '@/lib/utils';
 import { projectApiPaths } from '@/lib/swr.js';
-import { useCanEdit } from '@/lib/auth';
+import { UserRole, useHasMinRole } from '@/lib/auth';
 import { z } from 'zod';
 
 const presenceEntrySchema = z.object({
@@ -41,7 +41,7 @@ export function usePresence(
   mode: 'viewing' | 'editing' = 'viewing',
   projectPrefix?: string,
 ): PresenceEntry[] {
-  const canEdit = useCanEdit();
+  const canEdit = useHasMinRole(UserRole.Editor);
   const [editors, setEditors] = useState<PresenceEntry[]>([]);
   const config = getConfig();
   const isEnabled = !config.staticMode && !!config.presenceEnabled;

--- a/tools/app/src/lib/api/presence.ts
+++ b/tools/app/src/lib/api/presence.ts
@@ -14,6 +14,7 @@
 import { useEffect, useState } from 'react';
 import { getConfig } from '@/lib/utils';
 import { projectApiPaths } from '@/lib/swr.js';
+import { useCanEdit } from '@/lib/auth';
 import { z } from 'zod';
 
 const presenceEntrySchema = z.object({
@@ -40,11 +41,12 @@ export function usePresence(
   mode: 'viewing' | 'editing' = 'viewing',
   projectPrefix?: string,
 ): PresenceEntry[] {
+  const canEdit = useCanEdit();
   const [editors, setEditors] = useState<PresenceEntry[]>([]);
   const config = getConfig();
   const isEnabled = !config.staticMode && !!config.presenceEnabled;
   const url =
-    cardKey && isEnabled
+    cardKey && isEnabled && canEdit
       ? projectApiPaths(projectPrefix).presence(cardKey, mode)
       : null;
 

--- a/tools/app/src/lib/auth/Gate.tsx
+++ b/tools/app/src/lib/auth/Gate.tsx
@@ -11,26 +11,16 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { useSWRHook } from './common';
-import { apiPaths } from '../swr';
-import { getConfig } from '../utils';
-import type { User } from './types';
+import type { ReactNode } from 'react';
+import type { UserRole } from './roles';
+import { useHasRole } from './usePermissions';
 
-import type { SWRConfiguration } from 'swr';
+interface GateProps {
+  role: UserRole;
+  fallback?: ReactNode;
+  children: ReactNode;
+}
 
-const STATIC_READER_USER: User = {
-  id: 'static-reader',
-  email: '',
-  name: '',
-  role: 'reader',
-};
-
-export const useUser = (options?: SWRConfiguration) => {
-  const staticMode = getConfig().staticMode;
-  return useSWRHook<'user', User | null>(
-    staticMode ? null : apiPaths.user(),
-    'user',
-    staticMode ? STATIC_READER_USER : null,
-    options,
-  );
-};
+export function Gate({ role, fallback = null, children }: GateProps) {
+  return useHasRole(role) ? <>{children}</> : <>{fallback}</>;
+}

--- a/tools/app/src/lib/auth/Gate.tsx
+++ b/tools/app/src/lib/auth/Gate.tsx
@@ -13,14 +13,14 @@
 
 import type { ReactNode } from 'react';
 import type { UserRole } from './roles';
-import { useHasRole } from './usePermissions';
+import { useHasMinRole } from './usePermissions';
 
 interface GateProps {
-  role: UserRole;
+  minRole: UserRole;
   fallback?: ReactNode;
   children: ReactNode;
 }
 
-export function Gate({ role, fallback = null, children }: GateProps) {
-  return useHasRole(role) ? <>{children}</> : <>{fallback}</>;
+export function Gate({ minRole, fallback = null, children }: GateProps) {
+  return useHasMinRole(minRole) ? <>{children}</> : <>{fallback}</>;
 }

--- a/tools/app/src/lib/auth/Gate.tsx
+++ b/tools/app/src/lib/auth/Gate.tsx
@@ -11,26 +11,16 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { useSWRHook } from './common';
-import { globalApiPaths } from '../swr';
-import { getConfig } from '../utils';
-import type { User } from './types';
+import type { ReactNode } from 'react';
+import type { UserRole } from './roles';
+import { useHasRole } from './usePermissions';
 
-import type { SWRConfiguration } from 'swr';
+interface GateProps {
+  role: UserRole;
+  fallback?: ReactNode;
+  children: ReactNode;
+}
 
-const STATIC_READER_USER: User = {
-  id: 'static-reader',
-  email: '',
-  name: '',
-  role: 'reader',
-};
-
-export const useUser = (options?: SWRConfiguration) => {
-  const staticMode = getConfig().staticMode;
-  return useSWRHook<'user', User | null>(
-    staticMode ? null : globalApiPaths.user(),
-    'user',
-    staticMode ? STATIC_READER_USER : null,
-    options,
-  );
-};
+export function Gate({ role, fallback = null, children }: GateProps) {
+  return useHasRole(role) ? <>{children}</> : <>{fallback}</>;
+}

--- a/tools/app/src/lib/auth/index.ts
+++ b/tools/app/src/lib/auth/index.ts
@@ -11,26 +11,6 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { useSWRHook } from './common';
-import { apiPaths } from '../swr';
-import { getConfig } from '../utils';
-import type { User } from './types';
-
-import type { SWRConfiguration } from 'swr';
-
-const STATIC_READER_USER: User = {
-  id: 'static-reader',
-  email: '',
-  name: '',
-  role: 'reader',
-};
-
-export const useUser = (options?: SWRConfiguration) => {
-  const staticMode = getConfig().staticMode;
-  return useSWRHook<'user', User | null>(
-    staticMode ? null : apiPaths.user(),
-    'user',
-    staticMode ? STATIC_READER_USER : null,
-    options,
-  );
-};
+export { UserRole, parseRole, roleSatisfies } from './roles';
+export { useHasRole, useCanEdit, useCanAdmin } from './usePermissions';
+export { Gate } from './Gate';

--- a/tools/app/src/lib/auth/index.ts
+++ b/tools/app/src/lib/auth/index.ts
@@ -12,5 +12,5 @@
 */
 
 export { UserRole, parseRole, roleSatisfies } from './roles';
-export { useHasRole, useCanEdit, useCanAdmin } from './usePermissions';
+export { useHasRole, useCanEdit, useIsAdmin } from './usePermissions';
 export { Gate } from './Gate';

--- a/tools/app/src/lib/auth/index.ts
+++ b/tools/app/src/lib/auth/index.ts
@@ -11,26 +11,6 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { useSWRHook } from './common';
-import { globalApiPaths } from '../swr';
-import { getConfig } from '../utils';
-import type { User } from './types';
-
-import type { SWRConfiguration } from 'swr';
-
-const STATIC_READER_USER: User = {
-  id: 'static-reader',
-  email: '',
-  name: '',
-  role: 'reader',
-};
-
-export const useUser = (options?: SWRConfiguration) => {
-  const staticMode = getConfig().staticMode;
-  return useSWRHook<'user', User | null>(
-    staticMode ? null : globalApiPaths.user(),
-    'user',
-    staticMode ? STATIC_READER_USER : null,
-    options,
-  );
-};
+export { UserRole, parseRole, roleSatisfies } from './roles';
+export { useHasRole, useCanEdit, useCanAdmin } from './usePermissions';
+export { Gate } from './Gate';

--- a/tools/app/src/lib/auth/index.ts
+++ b/tools/app/src/lib/auth/index.ts
@@ -12,5 +12,5 @@
 */
 
 export { UserRole, parseRole, roleSatisfies } from './roles';
-export { useHasRole, useCanEdit, useIsAdmin } from './usePermissions';
+export { useHasMinRole } from './usePermissions';
 export { Gate } from './Gate';

--- a/tools/app/src/lib/auth/roles.ts
+++ b/tools/app/src/lib/auth/roles.ts
@@ -11,26 +11,26 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { useSWRHook } from './common';
-import { apiPaths } from '../swr';
-import { getConfig } from '../utils';
-import type { User } from './types';
+export enum UserRole {
+  Reader = 0,
+  Editor = 1,
+  Admin = 2,
+}
 
-import type { SWRConfiguration } from 'swr';
-
-const STATIC_READER_USER: User = {
-  id: 'static-reader',
-  email: '',
-  name: '',
-  role: 'reader',
+const ROLE_MAP: Record<string, UserRole> = {
+  reader: UserRole.Reader,
+  editor: UserRole.Editor,
+  admin: UserRole.Admin,
 };
 
-export const useUser = (options?: SWRConfiguration) => {
-  const staticMode = getConfig().staticMode;
-  return useSWRHook<'user', User | null>(
-    staticMode ? null : apiPaths.user(),
-    'user',
-    staticMode ? STATIC_READER_USER : null,
-    options,
-  );
-};
+export function parseRole(raw: string | undefined | null): UserRole | null {
+  if (!raw) return null;
+  return ROLE_MAP[raw.toLowerCase()] ?? null;
+}
+
+export function roleSatisfies(
+  userRole: UserRole | null,
+  minRole: UserRole,
+): boolean {
+  return userRole != null && userRole >= minRole;
+}

--- a/tools/app/src/lib/auth/roles.ts
+++ b/tools/app/src/lib/auth/roles.ts
@@ -11,26 +11,26 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { useSWRHook } from './common';
-import { globalApiPaths } from '../swr';
-import { getConfig } from '../utils';
-import type { User } from './types';
+export enum UserRole {
+  Reader = 0,
+  Editor = 1,
+  Admin = 2,
+}
 
-import type { SWRConfiguration } from 'swr';
-
-const STATIC_READER_USER: User = {
-  id: 'static-reader',
-  email: '',
-  name: '',
-  role: 'reader',
+const ROLE_MAP: Record<string, UserRole> = {
+  reader: UserRole.Reader,
+  editor: UserRole.Editor,
+  admin: UserRole.Admin,
 };
 
-export const useUser = (options?: SWRConfiguration) => {
-  const staticMode = getConfig().staticMode;
-  return useSWRHook<'user', User | null>(
-    staticMode ? null : globalApiPaths.user(),
-    'user',
-    staticMode ? STATIC_READER_USER : null,
-    options,
-  );
-};
+export function parseRole(raw: string | undefined | null): UserRole | null {
+  if (!raw) return null;
+  return ROLE_MAP[raw.toLowerCase()] ?? null;
+}
+
+export function roleSatisfies(
+  userRole: UserRole | null,
+  minRole: UserRole,
+): boolean {
+  return userRole != null && userRole >= minRole;
+}

--- a/tools/app/src/lib/auth/usePermissions.ts
+++ b/tools/app/src/lib/auth/usePermissions.ts
@@ -11,26 +11,14 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { useSWRHook } from './common';
-import { apiPaths } from '../swr';
-import { getConfig } from '../utils';
-import type { User } from './types';
+import { useUser } from '@/lib/api';
+import { UserRole, parseRole, roleSatisfies } from './roles';
 
-import type { SWRConfiguration } from 'swr';
+export function useHasRole(minRole: UserRole): boolean {
+  const { user } = useUser();
+  if (!user) return false;
+  return roleSatisfies(parseRole(user.role), minRole);
+}
 
-const STATIC_READER_USER: User = {
-  id: 'static-reader',
-  email: '',
-  name: '',
-  role: 'reader',
-};
-
-export const useUser = (options?: SWRConfiguration) => {
-  const staticMode = getConfig().staticMode;
-  return useSWRHook<'user', User | null>(
-    staticMode ? null : apiPaths.user(),
-    'user',
-    staticMode ? STATIC_READER_USER : null,
-    options,
-  );
-};
+export const useCanEdit = () => useHasRole(UserRole.Editor);
+export const useCanAdmin = () => useHasRole(UserRole.Admin);

--- a/tools/app/src/lib/auth/usePermissions.ts
+++ b/tools/app/src/lib/auth/usePermissions.ts
@@ -21,4 +21,4 @@ export function useHasRole(minRole: UserRole): boolean {
 }
 
 export const useCanEdit = () => useHasRole(UserRole.Editor);
-export const useCanAdmin = () => useHasRole(UserRole.Admin);
+export const useIsAdmin = () => useHasRole(UserRole.Admin);

--- a/tools/app/src/lib/auth/usePermissions.ts
+++ b/tools/app/src/lib/auth/usePermissions.ts
@@ -11,26 +11,14 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { useSWRHook } from './common';
-import { globalApiPaths } from '../swr';
-import { getConfig } from '../utils';
-import type { User } from './types';
+import { useUser } from '@/lib/api';
+import { UserRole, parseRole, roleSatisfies } from './roles';
 
-import type { SWRConfiguration } from 'swr';
+export function useHasRole(minRole: UserRole): boolean {
+  const { user } = useUser();
+  if (!user) return false;
+  return roleSatisfies(parseRole(user.role), minRole);
+}
 
-const STATIC_READER_USER: User = {
-  id: 'static-reader',
-  email: '',
-  name: '',
-  role: 'reader',
-};
-
-export const useUser = (options?: SWRConfiguration) => {
-  const staticMode = getConfig().staticMode;
-  return useSWRHook<'user', User | null>(
-    staticMode ? null : globalApiPaths.user(),
-    'user',
-    staticMode ? STATIC_READER_USER : null,
-    options,
-  );
-};
+export const useCanEdit = () => useHasRole(UserRole.Editor);
+export const useCanAdmin = () => useHasRole(UserRole.Admin);

--- a/tools/app/src/lib/auth/usePermissions.ts
+++ b/tools/app/src/lib/auth/usePermissions.ts
@@ -12,13 +12,10 @@
 */
 
 import { useUser } from '@/lib/api';
-import { UserRole, parseRole, roleSatisfies } from './roles';
+import { type UserRole, parseRole, roleSatisfies } from './roles';
 
-export function useHasRole(minRole: UserRole): boolean {
+export function useHasMinRole(minRole: UserRole): boolean {
   const { user } = useUser();
   if (!user) return false;
   return roleSatisfies(parseRole(user.role), minRole);
 }
-
-export const useCanEdit = () => useHasRole(UserRole.Editor);
-export const useIsAdmin = () => useHasRole(UserRole.Admin);

--- a/tools/app/src/locales/en/translation.json
+++ b/tools/app/src/locales/en/translation.json
@@ -340,6 +340,9 @@
     "viewMore": "View more"
   },
   "passedPolicyChecks": "Passed policy checks",
+  "permissions": {
+    "editorRequired": "You need editor permissions to do this"
+  },
   "placeholder": {
     "integer": "Enter number (integer)",
     "number": "Enter number (decimal)",

--- a/tools/app/src/locales/en/translation.json
+++ b/tools/app/src/locales/en/translation.json
@@ -360,6 +360,9 @@
     "viewMore": "View more"
   },
   "passedPolicyChecks": "Passed policy checks",
+  "permissions": {
+    "editorRequired": "You need editor permissions to do this"
+  },
   "placeholder": {
     "integer": "Enter number (integer)",
     "number": "Enter number (decimal)",

--- a/tools/app/src/pages/cards/card-edit.tsx
+++ b/tools/app/src/pages/cards/card-edit.tsx
@@ -1,21 +1,27 @@
+import { Navigate } from 'react-router';
 import { useRequiredKeyParam } from '@/lib/hooks';
 import { useTranslation } from 'react-i18next';
 import { useCard } from '@/lib/api';
 import { Box } from '@mui/joy';
 import CardEditor from '@/components/CardEditor';
 import { useAppRouter } from '@/lib/hooks';
+import { useCanEdit } from '@/lib/auth';
 
 export default function CardEdit() {
   const key = useRequiredKeyParam();
   const { t } = useTranslation();
   const cardData = useCard(key);
   const router = useAppRouter();
+  const canEdit = useCanEdit();
 
   if (cardData.isLoading) {
     return <Box>{t('loading')}</Box>;
   }
   if (cardData.error) {
     return <Box>{t('failedToLoad')}</Box>;
+  }
+  if (!canEdit) {
+    return <Navigate to={`/cards/${key}`} replace />;
   }
   return (
     <CardEditor

--- a/tools/app/src/pages/cards/card-view.tsx
+++ b/tools/app/src/pages/cards/card-view.tsx
@@ -30,6 +30,7 @@ import { Box, Stack, Typography } from '@mui/joy';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useRequiredKeyParam } from '@/lib/hooks';
+import { useCanEdit } from '@/lib/auth';
 
 export const dynamic = 'force-dynamic';
 
@@ -74,6 +75,8 @@ export default function Page() {
     }
   }, [listCard, dispatch]);
 
+  const canEdit = useCanEdit();
+
   if (error) {
     let errorMessage = t('unknownError');
     if (error instanceof Error) {
@@ -102,9 +105,10 @@ export default function Page() {
             cards={tree!}
             card={card!}
             connectors={connectors ?? []}
-            onMetadataClick={() =>
-              router.push(`/cards/${key}/edit?expand=true`)
-            }
+            onMetadataClick={() => {
+              if (!canEdit) return;
+              router.push(`/cards/${key}/edit?expand=true`);
+            }}
             linkTypes={expandedLinkTypes}
             onLinkFormSubmit={async (data) => {
               try {

--- a/tools/app/src/pages/cards/layout.tsx
+++ b/tools/app/src/pages/cards/layout.tsx
@@ -26,6 +26,7 @@ import { findParentCard } from '../../lib/utils';
 import { useTree } from '../../lib/api/tree';
 import { useCard } from '../../lib/api/card';
 import { CardTreeMenu } from '@/components/CardTreeMenu';
+import { useCanEdit } from '@/lib/auth';
 
 export default function AppLayout() {
   // Last URL parameter after /cards base is the card key
@@ -33,6 +34,7 @@ export default function AppLayout() {
   const { project, error, isLoading, updateCard } = useProject();
   const { tree, isLoading: isLoadingTree, error: treeError } = useTree();
   const { card } = useCard(key);
+  const canEdit = useCanEdit();
 
   const router = useAppRouter();
 
@@ -83,6 +85,7 @@ export default function AppLayout() {
           tree={tree}
           selectedCardKey={key ?? null}
           onMove={async (cardKey: string, newParent: string, index: number) => {
+            if (!canEdit) return;
             const parent = findParentCard(tree, cardKey);
             await updateCard(cardKey, {
               parent: newParent === parent?.key ? undefined : newParent,

--- a/tools/app/src/pages/cards/layout.tsx
+++ b/tools/app/src/pages/cards/layout.tsx
@@ -27,6 +27,7 @@ import { useTree } from '../../lib/api/tree';
 import { useCard } from '../../lib/api/card';
 import { CardTreeMenu } from '@/components/CardTreeMenu';
 import type { AppLayoutOutletContext } from '../layout';
+import { useCanEdit } from '@/lib/auth';
 
 /**
  * Delay in milliseconds before hiding the loading overlay after a move operation.
@@ -38,6 +39,7 @@ export default function AppLayout() {
   const { project, error, isLoading, updateCard } = useProject();
   const { tree, isLoading: isLoadingTree, error: treeError } = useTree();
   const { card } = useCard(key);
+  const canEdit = useCanEdit();
   const router = useAppRouter();
   const { drawerOpen, setDrawerOpen } =
     useOutletContext<AppLayoutOutletContext>();
@@ -92,6 +94,7 @@ export default function AppLayout() {
           selectedCardKey={key ?? null}
           onClose={() => setDrawerOpen(false)}
           onMove={async (cardKey: string, newParent: string, index: number) => {
+            if (!canEdit) return;
             const parent = findParentCard(tree, cardKey);
             await updateCard(cardKey, {
               parent: newParent === parent?.key ? undefined : newParent,

--- a/tools/app/src/pages/cards/layout.tsx
+++ b/tools/app/src/pages/cards/layout.tsx
@@ -27,7 +27,7 @@ import { useTree } from '../../lib/api/tree';
 import { useCard } from '../../lib/api/card';
 import { CardTreeMenu } from '@/components/CardTreeMenu';
 import type { AppLayoutOutletContext } from '../layout';
-import { useCanEdit } from '@/lib/auth';
+import { UserRole, useHasMinRole } from '@/lib/auth';
 
 /**
  * Delay in milliseconds before hiding the loading overlay after a move operation.
@@ -39,7 +39,7 @@ export default function AppLayout() {
   const { project, error, isLoading, updateCard } = useProject();
   const { tree, isLoading: isLoadingTree, error: treeError } = useTree();
   const { card } = useCard(key);
-  const canEdit = useCanEdit();
+  const canEdit = useHasMinRole(UserRole.Editor);
   const router = useAppRouter();
   const { drawerOpen, setDrawerOpen } =
     useOutletContext<AppLayoutOutletContext>();

--- a/tools/app/src/pages/configuration/resource-overview.tsx
+++ b/tools/app/src/pages/configuration/resource-overview.tsx
@@ -27,7 +27,7 @@ import {
   ResourceModuleSection,
   ResourceOverviewCard,
 } from '@/components/resource-overview';
-import { getConfig } from '@/lib/utils';
+import { useCanAdmin } from '@/lib/auth';
 
 function identifier(name: string) {
   const parts = name.split('/');
@@ -83,6 +83,7 @@ function ResourceOverviewContent({
 }) {
   const { t } = useTranslation();
   const { openCreateResourceModal } = useAppModals();
+  const canAdmin = useCanAdmin();
   const [expandedModules, setExpandedModules] = useState<
     Record<string, boolean>
   >({});
@@ -154,7 +155,7 @@ function ResourceOverviewContent({
                   gap: 2,
                 }}
               >
-                {isProject && !getConfig().staticMode && (
+                {isProject && canAdmin && (
                   <CreateResourceCard
                     title={t('overview.createNew', {
                       resourceType: t(

--- a/tools/app/src/pages/configuration/resource-overview.tsx
+++ b/tools/app/src/pages/configuration/resource-overview.tsx
@@ -27,7 +27,7 @@ import {
   ResourceModuleSection,
   ResourceOverviewCard,
 } from '@/components/resource-overview';
-import { useIsAdmin } from '@/lib/auth';
+import { UserRole, useHasMinRole } from '@/lib/auth';
 
 function identifier(name: string) {
   const parts = name.split('/');
@@ -83,7 +83,7 @@ function ResourceOverviewContent({
 }) {
   const { t } = useTranslation();
   const { openCreateResourceModal } = useAppModals();
-  const isAdmin = useIsAdmin();
+  const isAdmin = useHasMinRole(UserRole.Admin);
   const [expandedModules, setExpandedModules] = useState<
     Record<string, boolean>
   >({});

--- a/tools/app/src/pages/configuration/resource-overview.tsx
+++ b/tools/app/src/pages/configuration/resource-overview.tsx
@@ -27,7 +27,7 @@ import {
   ResourceModuleSection,
   ResourceOverviewCard,
 } from '@/components/resource-overview';
-import { useCanAdmin } from '@/lib/auth';
+import { useIsAdmin } from '@/lib/auth';
 
 function identifier(name: string) {
   const parts = name.split('/');
@@ -83,7 +83,7 @@ function ResourceOverviewContent({
 }) {
   const { t } = useTranslation();
   const { openCreateResourceModal } = useAppModals();
-  const canAdmin = useCanAdmin();
+  const isAdmin = useIsAdmin();
   const [expandedModules, setExpandedModules] = useState<
     Record<string, boolean>
   >({});
@@ -155,7 +155,7 @@ function ResourceOverviewContent({
                   gap: 2,
                 }}
               >
-                {isProject && canAdmin && (
+                {isProject && isAdmin && (
                   <CreateResourceCard
                     title={t('overview.createNew', {
                       resourceType: t(

--- a/tools/app/src/pages/layout.tsx
+++ b/tools/app/src/pages/layout.tsx
@@ -38,6 +38,7 @@ import { useModals } from '@/lib/utils';
 import { NewTemplateCardModal } from '../components/modals/resource-forms/NewTemplateCardModal';
 import { useConfigTemplateCreationContext } from '@/lib/hooks';
 import { AppModalsProvider } from '@/lib/contexts/AppModalsProvider';
+import { useCanEdit, useCanAdmin } from '@/lib/auth';
 import type { ResourceName } from '@/lib/constants';
 import { useCallback } from 'react';
 
@@ -48,6 +49,8 @@ const Main = styled('main')(() => ({
 
 export default function Layout() {
   const inCards = useIsInCards();
+  const canEdit = useCanEdit();
+  const canAdmin = useCanAdmin();
   const { templateResource, parentCardKey } =
     useConfigTemplateCreationContext();
   const { modalOpen, openModal, closeModal } = useModals({
@@ -83,8 +86,10 @@ export default function Layout() {
       <AppToolbar
         onCreate={(resourceType) => {
           if (inCards) {
+            if (!canEdit) return;
             openModal('card')();
           } else {
+            if (!canAdmin) return;
             if (!resourceType) {
               console.warn(
                 'No resource type provided when creating a new resource',

--- a/tools/app/src/pages/layout.tsx
+++ b/tools/app/src/pages/layout.tsx
@@ -38,6 +38,7 @@ import { useModals } from '@/lib/utils';
 import { NewTemplateCardModal } from '../components/modals/resource-forms/NewTemplateCardModal';
 import { useConfigTemplateCreationContext } from '@/lib/hooks';
 import { AppModalsProvider } from '@/lib/contexts/AppModalsProvider';
+import { useCanEdit, useCanAdmin } from '@/lib/auth';
 import type { ResourceName } from '@/lib/constants';
 import { useCallback, useState } from 'react';
 
@@ -65,6 +66,8 @@ const notificationDurationMap = {
 
 export default function Layout() {
   const inCards = useIsInCards();
+  const canEdit = useCanEdit();
+  const canAdmin = useCanAdmin();
   const { templateResource, parentCardKey } =
     useConfigTemplateCreationContext();
   const { modalOpen, openModal, closeModal } = useModals({
@@ -108,8 +111,10 @@ export default function Layout() {
       <AppToolbar
         onCreate={(resourceType) => {
           if (inCards) {
+            if (!canEdit) return;
             openModal('card')();
           } else {
+            if (!canAdmin) return;
             if (!resourceType) {
               console.warn(
                 'No resource type provided when creating a new resource',

--- a/tools/app/src/pages/layout.tsx
+++ b/tools/app/src/pages/layout.tsx
@@ -38,7 +38,7 @@ import { useModals } from '@/lib/utils';
 import { NewTemplateCardModal } from '../components/modals/resource-forms/NewTemplateCardModal';
 import { useConfigTemplateCreationContext } from '@/lib/hooks';
 import { AppModalsProvider } from '@/lib/contexts/AppModalsProvider';
-import { useCanEdit, useCanAdmin } from '@/lib/auth';
+import { useCanEdit, useIsAdmin } from '@/lib/auth';
 import type { ResourceName } from '@/lib/constants';
 import { useCallback, useState } from 'react';
 
@@ -67,7 +67,7 @@ const notificationDurationMap = {
 export default function Layout() {
   const inCards = useIsInCards();
   const canEdit = useCanEdit();
-  const canAdmin = useCanAdmin();
+  const isAdmin = useIsAdmin();
   const { templateResource, parentCardKey } =
     useConfigTemplateCreationContext();
   const { modalOpen, openModal, closeModal } = useModals({
@@ -114,7 +114,7 @@ export default function Layout() {
             if (!canEdit) return;
             openModal('card')();
           } else {
-            if (!canAdmin) return;
+            if (!isAdmin) return;
             if (!resourceType) {
               console.warn(
                 'No resource type provided when creating a new resource',

--- a/tools/app/src/pages/layout.tsx
+++ b/tools/app/src/pages/layout.tsx
@@ -38,7 +38,7 @@ import { useModals } from '@/lib/utils';
 import { NewTemplateCardModal } from '../components/modals/resource-forms/NewTemplateCardModal';
 import { useConfigTemplateCreationContext } from '@/lib/hooks';
 import { AppModalsProvider } from '@/lib/contexts/AppModalsProvider';
-import { useCanEdit, useIsAdmin } from '@/lib/auth';
+import { UserRole, useHasMinRole } from '@/lib/auth';
 import type { ResourceName } from '@/lib/constants';
 import { useCallback, useState } from 'react';
 
@@ -66,8 +66,8 @@ const notificationDurationMap = {
 
 export default function Layout() {
   const inCards = useIsInCards();
-  const canEdit = useCanEdit();
-  const isAdmin = useIsAdmin();
+  const canEdit = useHasMinRole(UserRole.Editor);
+  const isAdmin = useHasMinRole(UserRole.Admin);
   const { templateResource, parentCardKey } =
     useConfigTemplateCreationContext();
   const { modalOpen, openModal, closeModal } = useModals({

--- a/tools/backend/src/app.ts
+++ b/tools/backend/src/app.ts
@@ -40,6 +40,7 @@ import mcpRouter from './domain/mcp/index.js';
 import { createAuthRouter } from './domain/auth/index.js';
 import { createAuthMiddleware } from './middleware/auth.js';
 import type { AuthProvider } from './auth/types.js';
+import { MockAuthProvider, mockRoleCookieMiddleware } from './auth/mock.js';
 
 /**
  * Create the Hono app for the backend
@@ -54,6 +55,11 @@ export function createApp(
   const app = new Hono<{ Variables: AppVars }>();
 
   app.use(treeMiddleware(opts));
+  // Dev-only: let `?role=<reader|editor|admin>` set a persistent mock-role cookie
+  // so role gating can be exercised locally without code changes or a restart.
+  if (authProvider instanceof MockAuthProvider) {
+    app.use(mockRoleCookieMiddleware());
+  }
   // Apply authentication middleware to all API and MCP routes
   app.use('/api/*', createAuthMiddleware(authProvider));
   app.use('/mcp', createAuthMiddleware(authProvider));

--- a/tools/backend/src/app.ts
+++ b/tools/backend/src/app.ts
@@ -41,6 +41,7 @@ import { createMcpRouter } from './domain/mcp/index.js';
 import { createAuthRouter } from './domain/auth/index.js';
 import { createAuthMiddleware } from './middleware/auth.js';
 import type { AuthProvider } from './auth/types.js';
+import { MockAuthProvider, mockRoleCookieMiddleware } from './auth/mock.js';
 import type { ProjectRegistry } from './project-registry.js';
 import { CommandManager, scanForProjects } from '@cyberismo/data-handler';
 import { createProjectsRouter } from './domain/projects/index.js';
@@ -112,6 +113,12 @@ export function createApp(
       defaultProject: process.env.CYBERISMO_DEFAULT_PROJECT || undefined,
     });
   });
+
+  // Dev-only: let `?role=<reader|editor|admin>` set a persistent mock-role cookie
+  // so role gating can be exercised locally without code changes or a restart.
+  if (authProvider instanceof MockAuthProvider) {
+    app.use(mockRoleCookieMiddleware());
+  }
 
   // Apply authentication middleware to all API and MCP routes
   app.use('/api/*', createAuthMiddleware(authProvider));

--- a/tools/backend/src/auth/index.ts
+++ b/tools/backend/src/auth/index.ts
@@ -12,6 +12,6 @@
 */
 
 export type { AuthProvider } from './types.js';
-export { MockAuthProvider } from './mock.js';
+export { MockAuthProvider, mockRoleCookieMiddleware } from './mock.js';
 export { KeycloakAuthProvider } from './keycloak.js';
 export type { KeycloakConfig } from './keycloak.js';

--- a/tools/backend/src/auth/mock.ts
+++ b/tools/backend/src/auth/mock.ts
@@ -11,6 +11,8 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
+import type { MiddlewareHandler } from 'hono';
+import { setCookie } from 'hono/cookie';
 import { UserRole } from '../types.js';
 import type { UserInfo } from '../types.js';
 import type { AuthProvider } from './types.js';
@@ -20,6 +22,31 @@ export interface MockUserConfig {
   email?: string;
 }
 
+export const MOCK_ROLE_COOKIE = 'mock-role';
+const ROLE_RESET_VALUE = 'default';
+
+const ROLE_ALIASES: Record<string, UserRole> = {
+  reader: UserRole.Reader,
+  editor: UserRole.Editor,
+  admin: UserRole.Admin,
+};
+
+function parseRole(value: string | null | undefined): UserRole | null {
+  if (!value) return null;
+  return ROLE_ALIASES[value.toLowerCase()] ?? null;
+}
+
+function readCookie(header: string | null, name: string): string | undefined {
+  if (!header) return undefined;
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() !== name) continue;
+    return decodeURIComponent(part.slice(eq + 1).trim());
+  }
+  return undefined;
+}
+
 export class MockAuthProvider implements AuthProvider {
   private readonly userConfig: MockUserConfig;
 
@@ -27,12 +54,36 @@ export class MockAuthProvider implements AuthProvider {
     this.userConfig = config ?? {};
   }
 
-  async authenticate(): Promise<UserInfo> {
+  async authenticate(req: Request): Promise<UserInfo> {
+    const cookieRole = parseRole(
+      readCookie(req.headers.get('cookie'), MOCK_ROLE_COOKIE),
+    );
     return {
       id: 'mock-user',
       email: this.userConfig.email ?? 'admin@cyberismo.local',
       name: this.userConfig.name ?? 'Local Admin',
-      role: UserRole.Admin,
+      role: cookieRole ?? UserRole.Admin,
     };
   }
+}
+
+/**
+ * Dev-only middleware that turns `?role=<reader|editor|admin>` into a persistent
+ * `mock-role` cookie, and clears it on `?role=default`.
+ */
+export function mockRoleCookieMiddleware(): MiddlewareHandler {
+  return async (c, next) => {
+    const override = new URL(c.req.url).searchParams.get('role');
+    if (override) {
+      if (override.toLowerCase() === ROLE_RESET_VALUE) {
+        setCookie(c, MOCK_ROLE_COOKIE, '', { path: '/', maxAge: 0 });
+      } else if (parseRole(override)) {
+        setCookie(c, MOCK_ROLE_COOKIE, override.toLowerCase(), {
+          path: '/',
+          sameSite: 'Lax',
+        });
+      }
+    }
+    await next();
+  };
 }

--- a/tools/backend/test/auth/mock.test.ts
+++ b/tools/backend/test/auth/mock.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { MockAuthProvider } from '../../src/auth/mock.js';
+import { Hono } from 'hono';
+import {
+  MOCK_ROLE_COOKIE,
+  MockAuthProvider,
+  mockRoleCookieMiddleware,
+} from '../../src/auth/mock.js';
 import { UserRole } from '../../src/types.js';
 
 describe('MockAuthProvider', () => {
@@ -34,22 +39,87 @@ describe('MockAuthProvider', () => {
     });
   });
 
-  it('always returns Admin role', async () => {
-    const provider = new MockAuthProvider({ name: 'Test' });
+  it('uses the role from the mock-role cookie when present', async () => {
+    const provider = new MockAuthProvider();
     const user = await provider.authenticate(
-      new Request('http://localhost/api/test'),
+      new Request('http://localhost/api/test', {
+        headers: { cookie: `${MOCK_ROLE_COOKIE}=editor` },
+      }),
+    );
+
+    expect(user!.role).toBe(UserRole.Editor);
+  });
+
+  it('falls back to admin for an unrecognized cookie value', async () => {
+    const provider = new MockAuthProvider();
+    const user = await provider.authenticate(
+      new Request('http://localhost/api/test', {
+        headers: { cookie: `${MOCK_ROLE_COOKIE}=superuser` },
+      }),
     );
 
     expect(user!.role).toBe(UserRole.Admin);
   });
 
-  it('works with undefined config', async () => {
-    const provider = new MockAuthProvider(undefined);
+  it('is case-insensitive for the cookie value', async () => {
+    const provider = new MockAuthProvider();
     const user = await provider.authenticate(
-      new Request('http://localhost/api/test'),
+      new Request('http://localhost/api/test', {
+        headers: { cookie: `${MOCK_ROLE_COOKIE}=READER` },
+      }),
     );
 
-    expect(user).not.toBeNull();
-    expect(user!.id).toBe('mock-user');
+    expect(user!.role).toBe(UserRole.Reader);
+  });
+
+  it('ignores unrelated cookies', async () => {
+    const provider = new MockAuthProvider();
+    const user = await provider.authenticate(
+      new Request('http://localhost/api/test', {
+        headers: { cookie: 'session=abc; other=editor' },
+      }),
+    );
+
+    expect(user!.role).toBe(UserRole.Admin);
+  });
+});
+
+describe('mockRoleCookieMiddleware', () => {
+  function appWithMiddleware() {
+    const app = new Hono();
+    app.use(mockRoleCookieMiddleware());
+    app.get('*', (c) => c.text('ok'));
+    return app;
+  }
+
+  it('sets mock-role cookie when a known role is in the query', async () => {
+    const res = await appWithMiddleware().request('/?role=editor');
+    expect(res.headers.get('set-cookie')).toMatch(
+      new RegExp(`^${MOCK_ROLE_COOKIE}=editor`),
+    );
+  });
+
+  it('lowercases the cookie value', async () => {
+    const res = await appWithMiddleware().request('/?role=ADMIN');
+    expect(res.headers.get('set-cookie')).toMatch(
+      new RegExp(`^${MOCK_ROLE_COOKIE}=admin`),
+    );
+  });
+
+  it('clears the cookie when role=default', async () => {
+    const res = await appWithMiddleware().request('/?role=default');
+    const setCookie = res.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain(`${MOCK_ROLE_COOKIE}=`);
+    expect(setCookie.toLowerCase()).toContain('max-age=0');
+  });
+
+  it('does nothing when there is no role query param', async () => {
+    const res = await appWithMiddleware().request('/');
+    expect(res.headers.get('set-cookie')).toBeNull();
+  });
+
+  it('ignores unknown role values', async () => {
+    const res = await appWithMiddleware().request('/?role=superuser');
+    expect(res.headers.get('set-cookie')).toBeNull();
   });
 });


### PR DESCRIPTION
Add auth primitives (UserRole enum, parseRole, roleSatisfies, useHasRole, Gate) and gate card/config UI by role.

Static mode resolves to a synthetic reader user so a single role check drives gating everywhere. Readers and editors can view /configuration; mutations stay admin-only.

Adds a dev-only mock-role cookie middleware so roles can be exercised locally without a restart.