### PR TITLE
INTDEV-1179 Render workflow state-machine diagram in workflow editor

### DIFF
--- a/tools/app/cypress/e2e/app.cy.ts
+++ b/tools/app/cypress/e2e/app.cy.ts
@@ -206,7 +206,7 @@ describe('Navigation', () => {
     cy.get('[data-cy="cardLinkType"]').contains('Outbound');
     cy.get('[data-cy="cardLinkTitle"]').contains('Untitled page');
 
-    cy.get(':nth-child(5) > :nth-child(2)').should('not.exist'); // checks 2nd link was not created
+    cy.get('[data-cy="cardLinkType"]').should('have.length', 1); // checks 2nd link was not created
 
     // Navigate to Untitled page to check if link has appeared there
     // Use cy.visit because otherwise timing issues with loading content can occur

--- a/tools/app/src/components/StateSelector.tsx
+++ b/tools/app/src/components/StateSelector.tsx
@@ -23,7 +23,9 @@ import {
   Dropdown,
   MenuButton,
   CircularProgress,
+  Stack,
 } from '@mui/joy';
+import ArrowForward from '@mui/icons-material/ArrowForward';
 import { useTranslation } from 'react-i18next';
 import { getStateColor } from '../lib/utils';
 import { getConfig } from '@/lib/utils';
@@ -100,15 +102,35 @@ const StateSelector: React.FC<StateSelectorProps> = ({
         )}
       </MenuButton>
       <Menu>
-        {availableTransitions.map((transition) => (
-          <MenuItem
-            key={transition.name}
-            onClick={() => onTransition(transition)}
-            disabled={disabled}
-          >
-            <ListItemContent>{transition.name}</ListItemContent>
-          </MenuItem>
-        ))}
+        {availableTransitions.map((transition) => {
+          const toState = workflow?.states.find(
+            (state) => state.name === transition.toState,
+          );
+          return (
+            <MenuItem
+              key={transition.name}
+              onClick={() => onTransition(transition)}
+              disabled={disabled}
+            >
+              <ListItemContent>
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <span>{transition.name}</span>
+                  <ArrowForward fontSize="small" sx={{ opacity: 0.6 }} />
+                  <span
+                    style={{
+                      width: 10,
+                      height: 10,
+                      borderRadius: '50%',
+                      backgroundColor: getStateColor(toState?.category),
+                      flexShrink: 0,
+                    }}
+                  />
+                  <span>{transition.toState}</span>
+                </Stack>
+              </ListItemContent>
+            </MenuItem>
+          );
+        })}
       </Menu>
     </Dropdown>
   );

--- a/tools/app/src/components/StateSelector.tsx
+++ b/tools/app/src/components/StateSelector.tsx
@@ -20,6 +20,7 @@ import {
   Menu,
   MenuItem,
   ListItemContent,
+  ListDivider,
   Dropdown,
   MenuButton,
   CircularProgress,
@@ -35,6 +36,7 @@ interface StateSelectorProps {
   currentState: WorkflowState | null;
   workflow: Workflow | null;
   onTransition: (transition: WorkflowTransition) => void;
+  onViewWorkflow?: () => void;
   isLoading?: boolean;
   disabled?: boolean;
 }
@@ -43,6 +45,7 @@ const StateSelector: React.FC<StateSelectorProps> = ({
   currentState,
   workflow,
   onTransition,
+  onViewWorkflow,
   disabled,
   isLoading,
 }) => {
@@ -78,15 +81,17 @@ const StateSelector: React.FC<StateSelectorProps> = ({
     ></span>
   );
 
+  const hasTransitions = availableTransitions.length > 0;
+  const buttonDisabled =
+    (!hasTransitions && !onViewWorkflow) ||
+    (hasTransitions && disabled) ||
+    getConfig().staticMode;
+
   return (
     <Dropdown>
       <MenuButton
         size="sm"
-        disabled={
-          availableTransitions.length === 0 ||
-          disabled ||
-          getConfig().staticMode
-        }
+        disabled={buttonDisabled}
         variant="soft"
         color="neutral"
         endDecorator={!isLoading && statusDot}
@@ -131,6 +136,16 @@ const StateSelector: React.FC<StateSelectorProps> = ({
             </MenuItem>
           );
         })}
+        {onViewWorkflow && (
+          <>
+            {hasTransitions && <ListDivider />}
+            <MenuItem onClick={onViewWorkflow} data-cy="viewWorkflowMenuItem">
+              <ListItemContent>
+                {t('workflowGraph.viewTooltip')}
+              </ListItemContent>
+            </MenuItem>
+          </>
+        )}
       </Menu>
     </Dropdown>
   );

--- a/tools/app/src/components/config-editors/ResourceEditor.tsx
+++ b/tools/app/src/components/config-editors/ResourceEditor.tsx
@@ -28,6 +28,7 @@ import {
   TextareaInput,
   TextInput,
   SelectInput,
+  WorkflowGraph,
   WorkflowStatesEditor,
 } from './fields';
 import type {
@@ -150,6 +151,8 @@ export function ResourceEditor({ node }: { node: ResourceNode }) {
             readOnly={isDisabled}
           />
         );
+      case 'workflowGraph':
+        return <WorkflowGraph workflowName={node.name} />;
       default:
         return null;
     }

--- a/tools/app/src/components/config-editors/fields/WorkflowGraph.tsx
+++ b/tools/app/src/components/config-editors/fields/WorkflowGraph.tsx
@@ -1,0 +1,92 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { useState } from 'react';
+import {
+  Box,
+  CircularProgress,
+  IconButton,
+  Tooltip,
+  Typography,
+} from '@mui/joy';
+import Fullscreen from '@mui/icons-material/Fullscreen';
+import { useTranslation } from 'react-i18next';
+import { useWorkflowGraph } from '@/lib/api';
+import SvgViewerModal from '@/components/modals/svgViewerModal';
+
+export function WorkflowGraph({ workflowName }: { workflowName: string }) {
+  const { t } = useTranslation();
+  const { workflowGraph, isLoading, error } = useWorkflowGraph(workflowName);
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const svgMarkup = workflowGraph?.svg ? atob(workflowGraph.svg) : '';
+
+  const body = isLoading ? (
+    <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+      <CircularProgress size="sm" />
+    </Box>
+  ) : error || !workflowGraph?.svg ? (
+    <Typography level="body-sm" color="danger">
+      {t('workflowGraph.error')}
+    </Typography>
+  ) : (
+    <Box
+      sx={{
+        position: 'relative',
+        display: 'flex',
+        justifyContent: 'center',
+        py: 2,
+      }}
+    >
+      <img
+        src={`data:image/svg+xml;base64,${workflowGraph.svg}`}
+        alt={t('workflowGraph.alt')}
+        style={{
+          maxWidth: '100%',
+          maxHeight: '500px',
+          width: 'auto',
+          height: 'auto',
+          display: 'block',
+        }}
+      />
+      <Tooltip title={t('workflowGraph.viewTooltip')} placement="top">
+        <IconButton
+          size="sm"
+          variant="soft"
+          color="neutral"
+          onClick={() => setModalOpen(true)}
+          sx={{ position: 'absolute', top: 8, right: 8 }}
+          aria-label={t('workflowGraph.viewTooltip')}
+        >
+          <Fullscreen />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+
+  return (
+    <Box>
+      <Typography level="h4" marginTop={6} marginBottom={4}>
+        {t('workflowGraph.title')}
+      </Typography>
+      {body}
+      <SvgViewerModal
+        open={modalOpen && Boolean(svgMarkup)}
+        svgMarkup={svgMarkup}
+        onClose={() => setModalOpen(false)}
+      />
+    </Box>
+  );
+}
+
+export default WorkflowGraph;

--- a/tools/app/src/components/config-editors/fields/WorkflowGraph.tsx
+++ b/tools/app/src/components/config-editors/fields/WorkflowGraph.tsx
@@ -51,12 +51,23 @@ export function WorkflowGraph({ workflowName }: { workflowName: string }) {
       <img
         src={`data:image/svg+xml;base64,${workflowGraph.svg}`}
         alt={t('workflowGraph.alt')}
+        role="button"
+        tabIndex={0}
+        aria-label={t('workflowGraph.viewTooltip')}
+        onClick={() => setModalOpen(true)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            setModalOpen(true);
+          }
+        }}
         style={{
           maxWidth: '100%',
           maxHeight: '500px',
           width: 'auto',
           height: 'auto',
           display: 'block',
+          cursor: 'pointer',
         }}
       />
       <Tooltip title={t('workflowGraph.viewTooltip')} placement="top">

--- a/tools/app/src/components/config-editors/fields/index.ts
+++ b/tools/app/src/components/config-editors/fields/index.ts
@@ -19,6 +19,7 @@ export { default as TextInput } from './TextInput';
 export { default as CardTypeFieldsEditor } from './CardTypeFieldsEditor';
 export { default as EnumValuesEditor } from './EnumValuesEditor';
 export { default as WorkflowStatesEditor } from './WorkflowStatesEditor';
+export { default as WorkflowGraph } from './WorkflowGraph';
 export { EditableRowActions } from './EditableRowActions';
 export { ListRow } from './ListRow';
 export { ReorderButton, ReorderButtonContainer } from './ReorderButtons';

--- a/tools/app/src/components/config-editors/resourceFieldConfigs.ts
+++ b/tools/app/src/components/config-editors/resourceFieldConfigs.ts
@@ -28,7 +28,8 @@ export type FieldType =
   | 'boolean'
   | 'cardFields'
   | 'enumValues'
-  | 'workflowStates';
+  | 'workflowStates'
+  | 'workflowGraph';
 
 export interface FieldConfig {
   key: string;
@@ -151,6 +152,12 @@ export const resourceFieldConfigs: Record<ResourceNode['type'], FieldConfig[]> =
         key: 'states',
         type: 'workflowStates',
         label: 'workflowStates',
+        fullWidth: true,
+      },
+      {
+        key: 'graph',
+        type: 'workflowGraph',
+        label: 'workflowGraph.title',
         fullWidth: true,
       },
     ],

--- a/tools/app/src/components/modals/svgViewerModal.tsx
+++ b/tools/app/src/components/modals/svgViewerModal.tsx
@@ -1,5 +1,11 @@
 import DOMPurify from 'dompurify';
-import React, { useState, useEffect, useMemo, useLayoutEffect, useRef } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useMemo,
+  useLayoutEffect,
+  useRef,
+} from 'react';
 import {
   Modal,
   Box,

--- a/tools/app/src/components/modals/svgViewerModal.tsx
+++ b/tools/app/src/components/modals/svgViewerModal.tsx
@@ -1,11 +1,5 @@
 import DOMPurify from 'dompurify';
-import React, {
-  useState,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-} from 'react';
+import React, { useState, useEffect, useMemo, useLayoutEffect, useRef } from 'react';
 import {
   Modal,
   Box,
@@ -289,8 +283,11 @@ const SvgViewerModal: React.FC<SvgViewerModalProps> = ({
     }
   }, [zoom]);
 
-  /* ---------- fit & center on open ---------- */
-  useEffect(() => {
+  // Apply fit-to-window zoom synchronously before paint so the user never
+  // sees an unsized intermediate frame. naturalSize is derived from the
+  // markup string, so it's already available on the first commit.
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useLayoutEffect(() => {
     if (!open || !naturalSize) return;
 
     const viewW = window.innerWidth - padding * 2;
@@ -301,22 +298,19 @@ const SvgViewerModal: React.FC<SvgViewerModalProps> = ({
       1,
     );
     zoomRef.current = fit;
+    setZoom(fit);
 
-    // Center after initial layout and update zoom state
-    requestAnimationFrame(() => {
-      setZoom(fit);
-      const scroll = scrollRef.current;
-      if (!scroll) return;
-      scroll.scrollLeft = Math.max(
-        0,
-        (naturalSize.width * fit - scroll.clientWidth) / 2,
-      );
-      scroll.scrollTop = Math.max(
-        0,
-        (naturalSize.height * fit - scroll.clientHeight) / 2,
-      );
-    });
+    const scroll = scrollRef.current;
+    if (scroll) {
+      // Queue the centered scroll position; the [zoom] useLayoutEffect
+      // above applies it after the re-render, still before paint.
+      scrollTargetRef.current = {
+        left: Math.max(0, (naturalSize.width * fit - scroll.clientWidth) / 2),
+        top: Math.max(0, (naturalSize.height * fit - scroll.clientHeight) / 2),
+      };
+    }
   }, [open, padding, naturalSize]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   /* ---------- zoom helpers ---------- */
   const applyZoom = (factor: number, localX?: number, localY?: number) => {

--- a/tools/app/src/components/toolbar/CardToolbar.tsx
+++ b/tools/app/src/components/toolbar/CardToolbar.tsx
@@ -12,10 +12,9 @@
 */
 
 import { useCallback, useState } from 'react';
-import { Button, CircularProgress, IconButton, Tooltip } from '@mui/joy';
+import { Button, IconButton, Tooltip } from '@mui/joy';
 import EditIcon from '@mui/icons-material/Edit';
 import InsertLink from '@mui/icons-material/InsertLink';
-import Schema from '@mui/icons-material/Schema';
 import { ProjectBreadcrumbs } from '../ProjectBreadcrumbs';
 import type { WorkflowTransition } from '../../lib/definitions';
 import { CardMode } from '../../lib/definitions';
@@ -79,7 +78,7 @@ export function CardToolbar({
     workflow?.states.find((state) => state.name == card?.workflowState) ?? null;
 
   const [workflowGraphOpen, setWorkflowGraphOpen] = useState(false);
-  const { workflowGraph, isLoading: isWorkflowGraphLoading } = useWorkflowGraph(
+  const { workflowGraph } = useWorkflowGraph(
     workflowGraphOpen ? (workflow?.name ?? null) : null,
     cardKey,
   );
@@ -127,29 +126,11 @@ export function CardToolbar({
         </Tooltip>
       )}
 
-      {workflow && (
-        <Tooltip title={t('workflowGraph.viewTooltip')} placement="top">
-          <IconButton
-            onClick={() => setWorkflowGraphOpen(true)}
-            size="sm"
-            variant="plain"
-            style={{ marginRight: 8, minWidth: 40 }}
-            data-cy="viewWorkflowButton"
-            disabled={isWorkflowGraphLoading}
-          >
-            {isWorkflowGraphLoading ? (
-              <CircularProgress size="sm" />
-            ) : (
-              <Schema />
-            )}
-          </IconButton>
-        </Tooltip>
-      )}
-
       <StatusSelector
         currentState={currentState}
         workflow={workflow}
         onTransition={(transition) => onStateTransition(transition)}
+        onViewWorkflow={workflow ? () => setWorkflowGraphOpen(true) : undefined}
         isLoading={isUpdating('updateState')}
         disabled={isUpdating() && !isUpdating('updateState')}
       />

--- a/tools/app/src/components/toolbar/CardToolbar.tsx
+++ b/tools/app/src/components/toolbar/CardToolbar.tsx
@@ -11,10 +11,11 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { useCallback } from 'react';
-import { Button, IconButton, Tooltip } from '@mui/joy';
+import { useCallback, useState } from 'react';
+import { Button, CircularProgress, IconButton, Tooltip } from '@mui/joy';
 import EditIcon from '@mui/icons-material/Edit';
 import InsertLink from '@mui/icons-material/InsertLink';
+import Schema from '@mui/icons-material/Schema';
 import { ProjectBreadcrumbs } from '../ProjectBreadcrumbs';
 import type { WorkflowTransition } from '../../lib/definitions';
 import { CardMode } from '../../lib/definitions';
@@ -28,6 +29,7 @@ import {
   useProject,
   useTree,
   useUser,
+  useWorkflowGraph,
 } from '../../lib/api';
 import { useAppDispatch } from '../../lib/hooks';
 import { addNotification } from '../../lib/slices/notifications';
@@ -35,6 +37,7 @@ import { getConfig } from '@/lib/utils';
 import BaseToolbar from './BaseToolbar';
 import { CardContextMenu } from '@/components/context-menus';
 import PresenceIndicator from '@/components/PresenceIndicator';
+import SvgViewerModal from '@/components/modals/svgViewerModal';
 
 interface CardToolbarProps {
   cardKey: string;
@@ -74,6 +77,13 @@ export function CardToolbar({
     project && card ? findWorkflowForCardType(card.cardType, project) : null;
   const currentState =
     workflow?.states.find((state) => state.name == card?.workflowState) ?? null;
+
+  const [workflowGraphOpen, setWorkflowGraphOpen] = useState(false);
+  const { workflowGraph, isLoading: isWorkflowGraphLoading } = useWorkflowGraph(
+    workflowGraphOpen ? (workflow?.name ?? null) : null,
+    cardKey,
+  );
+  const workflowGraphMarkup = workflowGraph?.svg ? atob(workflowGraph.svg) : '';
 
   const onStateTransition = useCallback(
     async (transition: WorkflowTransition) => {
@@ -117,12 +127,37 @@ export function CardToolbar({
         </Tooltip>
       )}
 
+      {workflow && (
+        <Tooltip title={t('workflowGraph.viewTooltip')} placement="top">
+          <IconButton
+            onClick={() => setWorkflowGraphOpen(true)}
+            size="sm"
+            variant="plain"
+            style={{ marginRight: 8, minWidth: 40 }}
+            data-cy="viewWorkflowButton"
+            disabled={isWorkflowGraphLoading}
+          >
+            {isWorkflowGraphLoading ? (
+              <CircularProgress size="sm" />
+            ) : (
+              <Schema />
+            )}
+          </IconButton>
+        </Tooltip>
+      )}
+
       <StatusSelector
         currentState={currentState}
         workflow={workflow}
         onTransition={(transition) => onStateTransition(transition)}
         isLoading={isUpdating('updateState')}
         disabled={isUpdating() && !isUpdating('updateState')}
+      />
+
+      <SvgViewerModal
+        open={workflowGraphOpen && Boolean(workflowGraphMarkup)}
+        svgMarkup={workflowGraphMarkup}
+        onClose={() => setWorkflowGraphOpen(false)}
       />
 
       {!getConfig().staticMode && mode === CardMode.VIEW && (

--- a/tools/app/src/lib/api/resources.ts
+++ b/tools/app/src/lib/api/resources.ts
@@ -75,4 +75,5 @@ export const updateResourceWithOperation = async <
   await callApi(apiPaths.resourceOperation(resourceName), 'POST', body);
   mutate(swrKey);
   mutate(apiPaths.resourceTree());
+  mutate((key) => typeof key === 'string' && key.startsWith(`${swrKey}/`));
 };

--- a/tools/app/src/lib/api/types.ts
+++ b/tools/app/src/lib/api/types.ts
@@ -63,6 +63,10 @@ export type Connector = {
   items: ExternalItem[];
 };
 
+export type WorkflowGraphResponse = {
+  svg: string;
+};
+
 export type Resources = {
   project: Project;
   card: CardResponse;
@@ -78,6 +82,7 @@ export type Resources = {
   validateResource: ValidateResourceResponse;
   general: GeneralSettings;
   user: User;
+  workflowGraph: WorkflowGraphResponse;
 };
 
 export type ResourceName = keyof Resources;

--- a/tools/app/src/lib/api/workflow.ts
+++ b/tools/app/src/lib/api/workflow.ts
@@ -11,13 +11,33 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
+import type { SWRConfiguration } from 'swr';
 import { callApi } from '../swr';
 import { apiPaths } from '../swr';
 import { mutate } from 'swr';
 import type { CreateWorkflowData } from '@/lib/definitions';
+import { useSWRHook } from './common';
 
 export const createWorkflow = async (data: CreateWorkflowData) => {
   await callApi(apiPaths.workflows(), 'POST', data);
   mutate(apiPaths.workflows());
   mutate(apiPaths.resourceTree());
+};
+
+/**
+ * Fetches the rendered state-machine graph for a workflow.
+ * When `cardKey` is provided, the diagram highlights that card's
+ * current workflowState.
+ * @param resourceName Full workflow resource name (prefix/workflows/identifier).
+ * @param cardKey Optional card key to highlight the card's current state.
+ */
+export const useWorkflowGraph = (
+  resourceName: string | null | undefined,
+  cardKey?: string | null,
+  options?: SWRConfiguration,
+) => {
+  const swrKey = resourceName
+    ? apiPaths.workflowGraph(resourceName, cardKey ?? undefined)
+    : null;
+  return useSWRHook(swrKey, 'workflowGraph', null, options);
 };

--- a/tools/app/src/lib/swr.ts
+++ b/tools/app/src/lib/swr.ts
@@ -139,6 +139,10 @@ export const apiPaths = {
   linkTypes: () => '/api/linkTypes',
   reports: () => '/api/reports',
   workflows: () => '/api/workflows',
+  workflowGraph: (resourceName: string, cardKey?: string) =>
+    cardKey
+      ? `/api/resources/${resourceName}/graph?card=${encodeURIComponent(cardKey)}`
+      : `/api/resources/${resourceName}/graph`,
   resources: (type: string) => `/api/resources/${type}`,
   resourceTree: () => '/api/resources/tree',
   resource: (resourceName: string) => `/api/resources/${resourceName}`,

--- a/tools/app/src/locales/en/translation.json
+++ b/tools/app/src/locales/en/translation.json
@@ -428,6 +428,12 @@
   "viewedAgo": "Viewed {{time}} ago",
   "visibility": "Visibility",
   "workflow": "Workflow",
+  "workflowGraph": {
+    "title": "Diagram",
+    "alt": "Workflow state-machine diagram",
+    "error": "Failed to render workflow diagram",
+    "viewTooltip": "View workflow"
+  },
   "workflowState": "Workflow state",
   "workflowStates": {
     "states": "States",

--- a/tools/assets/src/index.ts
+++ b/tools/assets/src/index.ts
@@ -16,6 +16,8 @@ import pdfReportIndex from './exportPdfReport/index.adoc.hbs' with { type: 'text
 import pdfReportQuery from './exportPdfReport/query.lp.hbs' with { type: 'text' };
 import graphvizReportIndex from './graphvizReport/index.adoc.hbs' with { type: 'text' };
 import graphvizReportQuery from './graphvizReport/query.lp.hbs' with { type: 'text' };
+import workflowGraphModel from './workflowGraph/model.lp' with { type: 'text' };
+import workflowGraphView from './workflowGraph/view.lp.hbs' with { type: 'text' };
 
 export const graphvizReport = {
   query: graphvizReportQuery,
@@ -25,6 +27,11 @@ export const graphvizReport = {
 export const pdfReport = {
   query: pdfReportQuery,
   content: pdfReportIndex,
+};
+
+export const workflowGraph = {
+  model: workflowGraphModel,
+  view: workflowGraphView,
 };
 
 export const lpFiles = {

--- a/tools/assets/src/workflowGraph/model.lp
+++ b/tools/assets/src/workflowGraph/model.lp
@@ -1,0 +1,86 @@
+graph(toplevelGraph).
+attr(graph, toplevelGraph, rankdir, "TD").
+
+% the "initial node" from where the card is created
+node("", toplevelGraph) :- workflowState(Workflow, State, _), visible(Workflow).
+
+% Let's add a separate "Any state" for every state that has transitions from "*"
+node(("*", To), toplevelGraph) :-
+    workflowTransition(Workflow, _, "*", To),
+    visible(Workflow).
+
+attr(node, ("*", To), label, @concatenate("<<font point-size='11'> Any state </font>>")) :-
+    workflowTransition(Workflow, _, "*", To),
+    visible(Workflow).
+
+node(State, toplevelGraph) :- workflowState(Workflow, State, _), visible(Workflow).
+
+% Regular state label
+attr(node, State, label, @concatenate("<<font point-size='14'> <b>", State, "</b> </font> <br/> <font point-size='10'>", StateCategory, "</font>>")) :-
+    workflowState(Workflow, State, StateCategory),
+    visible(Workflow),
+    not currentState(State),
+    State != "",
+    State != "*".
+
+% Current state label is rendered larger and underlined to stand out
+attr(node, State, label, @concatenate("<<font point-size='16'> <b><u>", State, "</u></b> </font> <br/> <font point-size='10'>", StateCategory, "</font>>")) :-
+    workflowState(Workflow, State, StateCategory),
+    visible(Workflow),
+    currentState(State),
+    State != "",
+    State != "*".
+
+edge((From, To, Transition), toplevelGraph) :-
+    workflowTransition(Workflow, Transition, From, To),
+    visible(Workflow),
+    From != "*".
+
+attr(edge, (From, To, Transition), label, @concatenate("<<font point-size='10'>", Transition, "</font>>")) :-
+    workflowTransition(Workflow, Transition, From, To),
+    visible(Workflow),
+    From != "*".
+
+edge((("*", To), To, Transition), toplevelGraph) :-
+    workflowTransition(Workflow, Transition, "*", To),
+    visible(Workflow).
+
+attr(edge, (("*", To), To, Transition), label, @concatenate("<<font point-size='10'>", Transition, "</font>>")) :-
+    workflowTransition(Workflow, Transition, "*", To),
+    visible(Workflow).
+
+% margins
+attr(graph, toplevelGraph, pad, "0.1").
+attr(graph, toplevelGraph, nodesep, "0.6").
+attr(graph, toplevelGraph, ranksep, "0.7").
+attr(node, X, margin, "0.15") :- node(X, _).
+attr(graph, X, margin, "8") :- graph(X, _).
+
+% penwidth
+attr(graph, X, penwidth, "1") :- graph(X).
+attr(graph, X, penwidth, "1") :- graph(X, _).
+attr(node, X, penwidth, "1") :- node(X, _), X != "", not currentState(X).
+attr(node, X, penwidth, "3") :- node(X, _), currentState(X).
+attr(node, X, penwidth, "2") :- node(X, _), X = "".
+attr(edge, (X, Y, N), penwidth, "1") :- edge((X, Y, N), _).
+attr(edge, (X, Y, N), arrowsize, "0.8") :- edge((X, Y, N), _).
+
+% shapes of nodes
+attr(node, X, shape, rectangle) :- node(X, _), X != "".
+attr(node, X, shape, circle) :- node(X, _), X = "".
+attr(node, X, style, rounded) :- node(X, _).
+
+% node colours
+attr(node, State, color, "#FF9300") :-
+    workflowState(Workflow, State, "active"),
+    visible(Workflow).
+
+attr(node, State, color, "#37E900") :-
+    workflowState(Workflow, State, "closed"),
+    visible(Workflow).
+
+% fonts
+attr(graph, G, fontname, "helvetica") :- graph(G).
+attr(graph, G, fontname, "helvetica") :- graph(G, _).
+attr(node, N, fontname, "helvetica") :- node(N, _).
+attr(edge, (X, Y, N), fontname, "helvetica") :- edge((X, Y, N), _).

--- a/tools/assets/src/workflowGraph/view.lp.hbs
+++ b/tools/assets/src/workflowGraph/view.lp.hbs
@@ -1,0 +1,4 @@
+visible("{{{clingoEscape workflow}}}").
+{{#if currentState}}
+currentState("{{{clingoEscape currentState}}}").
+{{/if}}

--- a/tools/backend/src/domain/resources/index.ts
+++ b/tools/backend/src/domain/resources/index.ts
@@ -20,6 +20,8 @@ import { zValidator } from '../../middleware/zvalidator.js';
 import {
   validateResourceParamsSchema,
   updateOperationBodySchema,
+  workflowGraphParamsSchema,
+  workflowGraphQuerySchema,
 } from './schema.js';
 import { requireRole } from '../../middleware/auth.js';
 
@@ -129,6 +131,78 @@ router.delete(
     return c.json({
       message: 'Resource deleted',
     });
+  },
+);
+
+/**
+ * @swagger
+ * /api/resources/{prefix}/workflows/{identifier}/graph:
+ *   get:
+ *     summary: Render the state-machine graph for a workflow
+ *     description: Returns a base64-encoded sanitized SVG of the workflow's
+ *                  state-machine diagram, rendered with the built-in
+ *                  workflow graph model and view. When the optional `card`
+ *                  query parameter is provided, the diagram highlights
+ *                  that card's current workflowState.
+ *     parameters:
+ *       - in: path
+ *         name: prefix
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: identifier
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: card
+ *         required: false
+ *         schema:
+ *           type: string
+ *         description: Card key whose current workflowState should be
+ *                      highlighted in the rendered diagram.
+ *     responses:
+ *       200:
+ *         description: Rendered diagram
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 svg:
+ *                   type: string
+ *                   description: Base64-encoded SVG document.
+ *       400:
+ *         description: Invalid path parameters
+ *       404:
+ *         description: Workflow or card not found
+ *       500:
+ *         description: Server error
+ */
+router.get(
+  '/:prefix/workflows/:identifier/graph',
+  requireRole(UserRole.Reader),
+  zValidator('param', workflowGraphParamsSchema),
+  zValidator('query', workflowGraphQuerySchema),
+  async (c) => {
+    const commands = c.get('commands');
+    const { prefix, identifier } = c.req.valid('param');
+    const { card } = c.req.valid('query');
+    const workflowName = `${prefix}/workflows/${identifier}`;
+    try {
+      const svg = await resourceService.getWorkflowGraph(
+        commands,
+        workflowName,
+        card,
+      );
+      return c.json({ svg });
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('not found')) {
+        return c.json({ error: error.message }, 404);
+      }
+      throw error;
+    }
   },
 );
 

--- a/tools/backend/src/domain/resources/schema.ts
+++ b/tools/backend/src/domain/resources/schema.ts
@@ -1,8 +1,22 @@
 import { z } from 'zod';
 import {
+  identifierSchema,
   resourceParamsSchema,
   resourceTypes,
 } from '../../common/validationSchemas.js';
+
+export const workflowGraphParamsSchema = z.object({
+  prefix: z.string(),
+  identifier: identifierSchema,
+});
+
+export type WorkflowGraphParams = z.infer<typeof workflowGraphParamsSchema>;
+
+export const workflowGraphQuerySchema = z.object({
+  card: z.string().optional(),
+});
+
+export type WorkflowGraphQuery = z.infer<typeof workflowGraphQuerySchema>;
 
 export const resourceFileParamsSchema = resourceParamsSchema.extend({
   file: z.string(),

--- a/tools/backend/src/domain/resources/service.ts
+++ b/tools/backend/src/domain/resources/service.ts
@@ -468,6 +468,52 @@ export async function validateResource(
 }
 
 /**
+ * Renders the built-in state-machine graph for a single workflow.
+ * When `cardKey` is provided, the card's current workflowState is
+ * highlighted in the diagram. The workflow lookup, card lookup and
+ * graph rendering all run inside the same consistency window so the
+ * highlighted state matches the diagram even if the card is being
+ * transitioned concurrently.
+ * @returns base64-encoded sanitized SVG.
+ * @throws Error with 'not found' in the message when the workflow or
+ *   card cannot be resolved.
+ */
+export async function getWorkflowGraph(
+  commands: CommandManager,
+  workflowName: string,
+  cardKey?: string,
+): Promise<string> {
+  return commands.consistent(async () => {
+    try {
+      await commands.showCmd.showResource(workflowName, 'workflows');
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('does not exist')) {
+        throw new Error(`Workflow '${workflowName}' not found`, {
+          cause: error,
+        });
+      }
+      throw error;
+    }
+    let currentState: string | undefined;
+    if (cardKey) {
+      let card;
+      try {
+        card = await commands.showCmd.showCardDetails(cardKey);
+      } catch (error) {
+        throw new Error(`Card '${cardKey}' not found`, { cause: error });
+      }
+      if (!card?.metadata) {
+        throw new Error(`Card '${cardKey}' not found`);
+      }
+      currentState = card.metadata.workflowState;
+    }
+    return commands.calculateCmd.runWorkflowGraph(workflowName, {
+      currentState,
+    });
+  });
+}
+
+/**
  * Perform an updateOperation on a resource key.
  * This delegates to data-handler Update.applyResourceOperation.
  */

--- a/tools/backend/test/workflows.test.ts
+++ b/tools/backend/test/workflows.test.ts
@@ -35,3 +35,47 @@ test('POST /api/workflows creates a workflow successfully', async () => {
   expect(result).toHaveProperty('message');
   expect(result.message).toBe('Workflow created successfully');
 });
+
+test('GET /api/resources/:prefix/workflows/:identifier/graph renders the workflow graph', async () => {
+  const response = await app.request(
+    '/api/resources/decision/workflows/simple/graph',
+  );
+
+  expect(response.status).toBe(200);
+  const result = (await response.json()) as { svg: string };
+  expect(result.svg).toBeTruthy();
+  const decoded = Buffer.from(result.svg, 'base64').toString('utf-8');
+  expect(decoded).toContain('<svg');
+  expect(decoded).toContain('Created');
+  expect(decoded).toContain('Approved');
+}, 20000);
+
+test('GET /api/resources/:prefix/workflows/:identifier/graph returns 404 for unknown workflow', async () => {
+  const response = await app.request(
+    '/api/resources/decision/workflows/does-not-exist/graph',
+  );
+
+  expect(response.status).toBe(404);
+});
+
+test('GET /api/resources/:prefix/workflows/:identifier/graph?card=... highlights the card state', async () => {
+  const plain = await app.request(
+    '/api/resources/decision/workflows/simple/graph',
+  );
+  const highlighted = await app.request(
+    '/api/resources/decision/workflows/simple/graph?card=decision_5',
+  );
+
+  expect(plain.status).toBe(200);
+  expect(highlighted.status).toBe(200);
+  const plainSvg = ((await plain.json()) as { svg: string }).svg;
+  const highlightedSvg = ((await highlighted.json()) as { svg: string }).svg;
+  expect(plainSvg).not.toBe(highlightedSvg);
+}, 20000);
+
+test('GET /api/resources/:prefix/workflows/:identifier/graph?card=... returns 404 for unknown card', async () => {
+  const response = await app.request(
+    '/api/resources/decision/workflows/simple/graph?card=decision_999',
+  );
+  expect(response.status).toBe(404);
+});

--- a/tools/data-handler/src/commands/calculate.ts
+++ b/tools/data-handler/src/commands/calculate.ts
@@ -11,10 +11,21 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
+import Handlebars from 'handlebars';
+import { workflowGraph } from '@cyberismo/assets';
+
 import type { Context } from '../interfaces/project-interfaces.js';
 import type { Project } from '../containers/project.js';
 import type { QueryName, QueryResult } from '../types/queries.js';
+import { registerClingoHelpers } from '../utils/handlebars-helpers.js';
 import { read } from '../utils/rw-lock.js';
+
+const workflowGraphHandlebars = Handlebars.create();
+registerClingoHelpers(workflowGraphHandlebars);
+const workflowGraphView = workflowGraphHandlebars.compile<{
+  workflow: string;
+  currentState?: string;
+}>(workflowGraph.view);
 
 // Class that calculates with logic program card / project level calculations.
 export class Calculate {
@@ -48,6 +59,28 @@ export class Calculate {
   @read
   public async runGraph(model: string, view: string, context: Context) {
     return this.project.calculationEngine.runGraph(model, view, context);
+  }
+
+  /**
+   * Renders the built-in workflow state-machine graph for a single workflow.
+   * @param workflowName Fully qualified workflow resource name (e.g. "base/workflows/foo").
+   * @param options Optional `currentState` to highlight, and Clingo `context`.
+   * @returns base64-encoded sanitized SVG string.
+   */
+  @read
+  public async runWorkflowGraph(
+    workflowName: string,
+    options: { currentState?: string; context?: Context } = {},
+  ) {
+    const view = workflowGraphView({
+      workflow: workflowName,
+      currentState: options.currentState,
+    });
+    return this.project.calculationEngine.runGraph(
+      workflowGraph.model,
+      view,
+      options.context ?? 'localApp',
+    );
   }
 
   /**

--- a/tools/data-handler/src/utils/clingo-facts.ts
+++ b/tools/data-handler/src/utils/clingo-facts.ts
@@ -125,16 +125,12 @@ export const createWorkflowFacts = (workflow: Workflow) => {
 
   // add states
   for (const state of workflow.states) {
-    if (state.category) {
-      builder.addFact(
-        Facts.Workflow.WORKFLOW_STATE,
-        workflow.name,
-        state.name,
-        state.category,
-      );
-    } else {
-      builder.addFact(Facts.Workflow.WORKFLOW_STATE, workflow.name, state.name);
-    }
+    builder.addFact(
+      Facts.Workflow.WORKFLOW_STATE,
+      workflow.name,
+      state.name,
+      state.category ?? 'none',
+    );
   }
 
   // add transitions

--- a/tools/data-handler/src/utils/handlebars-helpers.ts
+++ b/tools/data-handler/src/utils/handlebars-helpers.ts
@@ -13,6 +13,7 @@ import type Handlebars from 'handlebars';
 import { escapeJsonString } from './json.js';
 import { escapeCsvField } from './csv.js';
 import { resourceName } from './resource-utils.js';
+import { encodeClingoValue } from './clingo-fact-builder.js';
 
 /**
  * Formats a value from a logic program for use in graphviz
@@ -80,6 +81,20 @@ function formatValue(value: unknown): string {
 export function registerComparisonHelpers(instance: typeof Handlebars) {
   instance.registerHelper('eq', (a: unknown, b: unknown) => a === b);
   instance.registerHelper('ne', (a: unknown, b: unknown) => a !== b);
+}
+
+/**
+ * Registers helpers for templating Clingo source.
+ *
+ * `clingoEscape` escapes a string so it is safe to interpolate inside a
+ * Clingo string literal (`"..."`), preserving newlines and quotes.
+ * Use it with the triple-stash form: `"{{{clingoEscape value}}}"`.
+ * @param instance handlebars instance
+ */
+export function registerClingoHelpers(instance: typeof Handlebars) {
+  instance.registerHelper('clingoEscape', (value: unknown) =>
+    typeof value === 'string' ? encodeClingoValue(value) : '',
+  );
 }
 
 /**

--- a/tools/data-handler/test/calculation-engine.test.ts
+++ b/tools/data-handler/test/calculation-engine.test.ts
@@ -6,6 +6,7 @@ import { copyDir } from '../src/utils/file-utils.js';
 import type { Project } from '../src/containers/project.js';
 import type { QueryResult } from '../src/types/queries.js';
 import { lpFiles } from '@cyberismo/assets';
+import { Calculate } from '../src/commands/calculate.js';
 import { getTestProject } from './helpers/test-utils.js';
 
 const expectedTree: QueryResult<'tree'>[] = [
@@ -62,6 +63,30 @@ describe('calculate', () => {
     );
 
     expect(res).not.toBe('');
+  }, 20000);
+
+  it('runWorkflowGraph renders the built-in workflow graph', async () => {
+    const calculate = new Calculate(project);
+    const res = await calculate.runWorkflowGraph('decision/workflows/simple');
+    expect(res).not.toBe('');
+    const decoded = Buffer.from(res, 'base64').toString('utf-8');
+    expect(decoded).toContain('<svg');
+    // Workflow state names should be rendered into the SVG.
+    expect(decoded).toContain('Created');
+    expect(decoded).toContain('Approved');
+  }, 20000);
+
+  it('runWorkflowGraph emphasises the given currentState', async () => {
+    const calculate = new Calculate(project);
+    const plain = await calculate.runWorkflowGraph('decision/workflows/simple');
+    const highlighted = await calculate.runWorkflowGraph(
+      'decision/workflows/simple',
+      { currentState: 'Approved' },
+    );
+    expect(highlighted).not.toBe(plain);
+    const decoded = Buffer.from(highlighted, 'base64').toString('utf-8');
+    expect(decoded).toContain('<svg');
+    expect(decoded).toContain('Approved');
   }, 20000);
 
   describe('python functions', () => {

--- a/tools/data-handler/test/utils/clingo-facts.test.ts
+++ b/tools/data-handler/test/utils/clingo-facts.test.ts
@@ -1,5 +1,12 @@
 import { expect, it, describe } from 'vitest';
-import { createContextFacts } from '../../src/utils/clingo-facts.js';
+import {
+  createContextFacts,
+  createWorkflowFacts,
+} from '../../src/utils/clingo-facts.js';
+import {
+  WorkflowCategory,
+  type Workflow,
+} from '../../src/interfaces/resource-interfaces.js';
 
 const testCases = [
   { context: 'localApp' as const, expectedFact: 'localApp().\n' },
@@ -20,4 +27,32 @@ describe('clingo-facts', () => {
       expect(contextFacts).to.equal(expectedFact);
     },
   );
+
+  describe('createWorkflowFacts', () => {
+    it('emits workflowState with the declared category', () => {
+      const workflow: Workflow = {
+        name: 'mod/workflows/wf',
+        displayName: 'wf',
+        states: [{ name: 'Draft', category: WorkflowCategory.initial }],
+        transitions: [],
+      };
+
+      expect(createWorkflowFacts(workflow)).toContain(
+        'workflowState("mod/workflows/wf", "Draft", "initial").',
+      );
+    });
+
+    it('falls back to "none" when category is missing', () => {
+      const workflow: Workflow = {
+        name: 'mod/workflows/wf',
+        displayName: 'wf',
+        states: [{ name: 'Draft' }],
+        transitions: [],
+      };
+
+      expect(createWorkflowFacts(workflow)).toContain(
+        'workflowState("mod/workflows/wf", "Draft", "none").',
+      );
+    });
+  });
 });

--- a/tools/data-handler/test/utils/handlebars-helpers.test.ts
+++ b/tools/data-handler/test/utils/handlebars-helpers.test.ts
@@ -1,0 +1,46 @@
+import { expect, it, describe, beforeEach } from 'vitest';
+import Handlebars from 'handlebars';
+import { registerClingoHelpers } from '../../src/utils/handlebars-helpers.js';
+
+describe('registerClingoHelpers', () => {
+  let handlebars: typeof Handlebars;
+
+  beforeEach(() => {
+    handlebars = Handlebars.create();
+    registerClingoHelpers(handlebars);
+  });
+
+  const render = (template: string, context: unknown) =>
+    handlebars.compile(template)(context);
+
+  it('passes through plain strings unchanged', () => {
+    expect(render('"{{{clingoEscape value}}}"', { value: 'simple' })).toBe(
+      '"simple"',
+    );
+  });
+
+  it('escapes embedded double quotes', () => {
+    expect(render('"{{{clingoEscape value}}}"', { value: 'has "quote"' })).toBe(
+      '"has \\"quote\\""',
+    );
+  });
+
+  it('escapes backslashes', () => {
+    expect(render('"{{{clingoEscape value}}}"', { value: 'a\\b' })).toBe(
+      '"a\\\\b"',
+    );
+  });
+
+  it('escapes newlines', () => {
+    expect(render('"{{{clingoEscape value}}}"', { value: 'a\nb' })).toBe(
+      '"a\\nb"',
+    );
+  });
+
+  it('returns empty string for non-string values', () => {
+    expect(render('"{{{clingoEscape value}}}"', { value: 42 })).toBe('""');
+    expect(render('"{{{clingoEscape value}}}"', { value: undefined })).toBe(
+      '""',
+    );
+  });
+});


### PR DESCRIPTION
  ## Changes
  - New built-in Clingo asset (`workflowGraph/{model.lp,view.lp.hbs}`) that renders the workflow's states and transitions as a Graphviz state machine.
  - `Calculate.runWorkflowGraph(workflowName)` produces a sanitized, base64-encoded SVG.
  - New endpoint `GET /api/resources/:prefix/workflows/:identifier/graph` returning `{ svg }`.
  - New `WorkflowGraph` field component wired into `ResourceEditor` for workflow resources, fetched via SWR.