### PR TITLE
INTDEV-1251 Stay in configuration editor after deleting a template card

### DIFF
--- a/tools/app/src/components/CardEditor.tsx
+++ b/tools/app/src/components/CardEditor.tsx
@@ -234,12 +234,14 @@ function AttachmentPreviewCard({
 export default function CardEditor({
   cardKey,
   afterSave,
+  afterDelete,
   cardData,
   readOnly = false,
   onCancel,
 }: {
   cardKey: string;
   afterSave?: () => void;
+  afterDelete?: () => void;
   cardData: CardData;
   readOnly?: boolean;
   onCancel?: () => void;
@@ -598,6 +600,7 @@ export default function CardEditor({
             mode={CardMode.EDIT}
             onUpdate={() => handleSubmit(handleSave)()}
             onCancel={handleCancel}
+            afterDelete={afterDelete}
             linkButtonDisabled={true}
             readOnly={readOnly}
           />

--- a/tools/app/src/components/config-editors/ConfigCardEditor.tsx
+++ b/tools/app/src/components/config-editors/ConfigCardEditor.tsx
@@ -11,14 +11,17 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { useRawCard } from '@/lib/api';
+import { useRawCard, useResourceTree } from '@/lib/api';
 import CardEditor from '../CardEditor';
 import type { AnyNode } from '@/lib/api/types';
 import { useTranslation } from 'react-i18next';
-import { getConfig } from '@/lib/utils';
+import { findCardParentInResourceTree, getConfig } from '@/lib/utils';
+import { useAppRouter } from '@/lib/hooks';
 
 export function ConfigCardEditor({ node }: { node: AnyNode }) {
   const card = useRawCard(node.id);
+  const { resourceTree } = useResourceTree();
+  const router = useAppRouter();
   const { t } = useTranslation();
   if (card.isLoading) {
     return <div>{t('loading')}</div>;
@@ -26,11 +29,17 @@ export function ConfigCardEditor({ node }: { node: AnyNode }) {
   if (card.error) {
     return <div>{card.error.message}</div>;
   }
+  const parent = resourceTree
+    ? findCardParentInResourceTree(resourceTree, node.id)
+    : null;
   return (
     <CardEditor
       cardKey={node.id}
       cardData={card}
       afterSave={() => {}}
+      afterDelete={() =>
+        router.push(parent ? `/configuration/${parent.name}` : '/configuration')
+      }
       readOnly={node?.readOnly || getConfig().staticMode}
     />
   );

--- a/tools/app/src/components/context-menus/CardContextMenu.tsx
+++ b/tools/app/src/components/context-menus/CardContextMenu.tsx
@@ -29,15 +29,18 @@ import {
   AddAttachmentModal,
   LogicProgramModal,
 } from '@/components/modals';
-import { useAppSelector, useAppRouter } from '@/lib/hooks';
+import { useAppSelector } from '@/lib/hooks';
 import { useCard, useProject } from '@/lib/api';
-import { useParentCard } from '@/lib/hooks';
 
 interface CardContextMenuProps {
   cardKey: string;
+  afterDelete?: () => void;
 }
 
-export function CardContextMenu({ cardKey }: CardContextMenuProps) {
+export function CardContextMenu({
+  cardKey,
+  afterDelete,
+}: CardContextMenuProps) {
   const { modalOpen, openModal, closeModal } = useModals({
     delete: false,
     move: false,
@@ -48,20 +51,14 @@ export function CardContextMenu({ cardKey }: CardContextMenuProps) {
 
   const { project } = useProject();
   const { t } = useTranslation();
-  const router = useAppRouter();
   const { deleteCard } = useCard(cardKey);
-  const parent = useParentCard(cardKey);
   const recentlyCreated = useAppSelector((state) => state.card.recentlyCreated);
 
   const handleDeleteClick = async () => {
     if (recentlyCreated.includes(cardKey)) {
       const success = await deleteCard();
       if (success) {
-        if (parent) {
-          router.push(`/cards/${parent.key}`);
-        } else {
-          router.push('/cards');
-        }
+        afterDelete?.();
       }
     } else {
       openModal('delete')();
@@ -110,6 +107,7 @@ export function CardContextMenu({ cardKey }: CardContextMenuProps) {
         open={modalOpen.delete}
         onClose={closeModal('delete')}
         cardKey={cardKey}
+        afterDelete={afterDelete}
       />
       <AddAttachmentModal
         open={modalOpen.addAttachment}

--- a/tools/app/src/components/modals/Delete/DeleteModal.tsx
+++ b/tools/app/src/components/modals/Delete/DeleteModal.tsx
@@ -12,7 +12,7 @@
 */
 
 import { useCard } from '../../../lib/api';
-import { useChildAmount, useParentCard, useAppRouter } from '@/lib/hooks';
+import { useChildAmount } from '@/lib/hooks';
 import { useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { Typography } from '@mui/joy';
@@ -22,14 +22,18 @@ export interface DeleteModalProps {
   open: boolean;
   onClose: () => void;
   cardKey: string;
+  afterDelete?: () => void;
 }
 
-export function DeleteModal({ open, onClose, cardKey }: DeleteModalProps) {
+export function DeleteModal({
+  open,
+  onClose,
+  cardKey,
+  afterDelete,
+}: DeleteModalProps) {
   const { t } = useTranslation();
   const { deleteCard, isUpdating } = useCard(cardKey);
   const childAmount = useChildAmount(cardKey);
-  const parent = useParentCard(cardKey);
-  const router = useAppRouter();
 
   const warning = useMemo((): string | undefined => {
     if (childAmount > 1) {
@@ -58,11 +62,7 @@ export function DeleteModal({ open, onClose, cardKey }: DeleteModalProps) {
     const result = await deleteCard();
     if (result) {
       onClose();
-      if (parent) {
-        router.push(`/cards/${parent.key}`);
-      } else {
-        router.push('/cards');
-      }
+      afterDelete?.();
     }
   };
 

--- a/tools/app/src/components/toolbar/CardToolbar.tsx
+++ b/tools/app/src/components/toolbar/CardToolbar.tsx
@@ -43,6 +43,7 @@ interface CardToolbarProps {
   onUpdate?: () => void;
   onInsertLink?: () => void;
   onCancel?: () => void;
+  afterDelete?: () => void;
   readOnly?: boolean;
 }
 
@@ -52,6 +53,7 @@ export function CardToolbar({
   onUpdate,
   onInsertLink,
   onCancel,
+  afterDelete,
   linkButtonDisabled,
   readOnly,
 }: CardToolbarProps) {
@@ -179,7 +181,7 @@ export function CardToolbar({
         !getConfig().staticMode && (
           <>
             <PresenceIndicator presence={presence} currentUserId={user?.id} />
-            <CardContextMenu cardKey={cardKey} />
+            <CardContextMenu cardKey={cardKey} afterDelete={afterDelete} />
           </>
         )
       }

--- a/tools/app/src/lib/utils.ts
+++ b/tools/app/src/lib/utils.ts
@@ -288,6 +288,33 @@ export function findResourceNodeByName(
 }
 
 /**
+ * Finds the parent of a template card in the resource tree. The parent is
+ * either another card node (when the deleted card was nested) or the owning
+ * templates node (when the deleted card was at the top level of a template).
+ * @param nodes: resource tree
+ * @param cardKey: id of the card whose parent should be found
+ * @returns the parent node if found, otherwise null
+ */
+export function findCardParentInResourceTree(
+  nodes: AnyNode[] | undefined,
+  cardKey: string,
+): AnyNode | null {
+  if (!nodes) return null;
+  for (const node of nodes) {
+    if (
+      node.children?.some(
+        (child) => child.type === 'card' && child.id === cardKey,
+      )
+    ) {
+      return node;
+    }
+    const found = findCardParentInResourceTree(node.children, cardKey);
+    if (found) return found;
+  }
+  return null;
+}
+
+/**
  * Finds the correct workflow for the card, if exists
  * @param cardType: cardType to search for
  * @param project: project object

--- a/tools/app/src/pages/cards/card-edit.tsx
+++ b/tools/app/src/pages/cards/card-edit.tsx
@@ -1,4 +1,4 @@
-import { useRequiredKeyParam } from '@/lib/hooks';
+import { useRequiredKeyParam, useParentCard } from '@/lib/hooks';
 import { useTranslation } from 'react-i18next';
 import { useCard } from '@/lib/api';
 import { Box } from '@mui/joy';
@@ -10,6 +10,7 @@ export default function CardEdit() {
   const { t } = useTranslation();
   const cardData = useCard(key);
   const router = useAppRouter();
+  const parent = useParentCard(key);
 
   if (cardData.isLoading) {
     return <Box>{t('loading')}</Box>;
@@ -23,6 +24,9 @@ export default function CardEdit() {
       afterSave={() => {
         router.push(`/cards/${key}`);
       }}
+      afterDelete={() =>
+        router.push(parent ? `/cards/${parent.key}` : '/cards')
+      }
       onCancel={() => router.safePush(`/cards/${key}`)}
       cardData={cardData}
     />

--- a/tools/app/src/pages/cards/card-view.tsx
+++ b/tools/app/src/pages/cards/card-view.tsx
@@ -23,6 +23,7 @@ import {
   useListCard,
   useAppRouter,
   useKeyboardShortcut,
+  useParentCard,
 } from '@/lib/hooks';
 import { addNotification } from '@/lib/slices/notifications';
 import { expandLinkTypes } from '@/lib/utils';
@@ -40,6 +41,8 @@ export default function Page() {
   const { card, error, createLink, deleteLink, editLink } = useCard(key);
 
   const { tree } = useTree();
+
+  const parent = useParentCard(key);
 
   const listCard = useListCard(key);
 
@@ -94,6 +97,9 @@ export default function Page() {
         mode={CardMode.VIEW}
         onUpdate={() => {}}
         onInsertLink={() => setLinkFormState('add-from-toolbar')}
+        afterDelete={() =>
+          router.push(parent ? `/cards/${parent.key}` : '/cards')
+        }
         linkButtonDisabled={expandedLinkTypes.length === 0}
       />
       <Box flexGrow={1} minHeight={0}>


### PR DESCRIPTION
 - Deleting a template card in the configuration editor previously dropped the user back to the project cards view. It now   
  stays in the configuration editor and lands on the deleted card's parent — either the parent template card (when nested) or 
  the owning template (when top-level).                                                                                       
  - Refactor (first commit): post-delete navigation is no longer hardcoded inside `DeleteModal` and `CardContextMenu`. An     
  `afterDelete` callback is threaded `CardEditor` → `CardToolbar` → `CardContextMenu` → `DeleteModal`, mirroring the existing 
  `afterSave` pattern. Each page now owns its own post-delete routing.
  - Fix (second commit): `ConfigCardEditor` resolves the parent in the resource tree and provides an `afterDelete` that pushes
   to `/configuration/${parent.name}`. The cards pages keep their existing `/cards`-based behavior.