### PR TITLE
Fix github-release job missing repo context

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -436,6 +436,7 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ needs.version.outputs.tag }}
           VERSION: ${{ needs.version.outputs.version }}
         run: |


### PR DESCRIPTION
The github-release job has no checkout step, so gh CLI fails with "fatal: not a git repository" when trying to infer the target repo from git remotes. Set GH_REPO so gh queries the API directly.