### PR TITLE
Simplify enum and list definitions

### DIFF
--- a/tools/assets/src/calculations/common/queryLanguage.lp
+++ b/tools/assets/src/calculations/common/queryLanguage.lp
@@ -106,94 +106,49 @@ resultField(Key, Field, Value, DataType) :-
     showField(Key, Field).
 
 % list
-childResult(Key, (Key, Field, Value), Field) :-
-    DataType = "list",
-    resultField(Key, Field, Value, DataType).
+listField(Key, Field, Value) :-
+    resultField(Key, Field, Value, "list").
 
-resultField((Key, Field, Value), "value", Value, "shortText") :-
-    childResult(Key, (Key, Field, Value), Field),
-    resultField(Key, Field, Value, _).
-
-resultField((Key, Field, Value), "index", Index, "integer") :-
-    childResult(Key, (Key, Field, Value), Field),
-    resultField(Key, Field, Value, _),
-    field((Field, Value), "index", Index).
-
-resultField((Key, Field, Value), "displayName", EnumDisplayValue, "shortText") :-
-    childResult(Key, (Key, Field, Value), Field),
-    resultField(Key, Field, Value, _),
-    field((Field, Value), "enumDisplayValue", EnumDisplayValue).
-
-childResult(Key, (Key, Field, Value), Field) :-
+listField(Key, Field, Value) :-
     field(Key, Field, Value),
     dataType(Key, Field, "list"),
     showField(Key, Field).
 
+childResult(Key, (Key, Field, Value), Field) :-
+    listField(Key, Field, Value).
+
 resultField((Key, Field, Value), "value", Value, "shortText") :-
-    childResult(Key, (Key, Field, Value), Field),
-    field(Key, Field, Value),
-    not resultField(Key, Field, Value, "list"),
-    dataType(Key, Field, "list").
+    listField(Key, Field, Value).
 
 resultField((Key, Field, Value), "index", Index, "integer") :-
-    childResult(Key, (Key, Field, Value), Field),
-    field(Key, Field, Value),
-    dataType(Key, Field, "list"),
-    not resultField(Key, Field, Value, "list"),
+    listField(Key, Field, Value),
     field((Field, Value), "index", Index).
 
 resultField((Key, Field, Value), "displayName", EnumDisplayValue, "shortText") :-
-    childResult(Key, (Key, Field, Value), Field),
-    field(Key, Field, Value),
-    dataType(Key, Field, "list"),
-    not resultField(Key, Field, Value, "list"),
+    listField(Key, Field, Value),
     field((Field, Value), "enumDisplayValue", EnumDisplayValue).
 
 % enum
+enumField(Key, Field, Value) :-
+    resultField(Key, Field, Value, "enum").
 
-
-childObject(Key, (Key, Field), Field) :-
-    DataType = "enum",
-    resultField(Key, Field, _, DataType).
-
-resultField((Key, Field), "value", Value, "shortText") :-
-    childObject(Key, (Key, Field), Field),
-    resultField(Key, Field, Value, _).
-
-resultField((Key, Field), "index", Index, "integer") :-
-    childObject(Key, (Key, Field), Field),
-    resultField(Key, Field, Value, _),
-    field((Field, Value), "index", Index).
-
-resultField((Key, Field), "displayValue", EnumDisplayValue, "shortText") :-
-    childObject(Key, (Key, Field), Field),
-    resultField(Key, Field, Value, _),
-    field((Field, Value), "enumDisplayValue", EnumDisplayValue).
-
-
-childObject(Key, (Key, Field), Field) :-
-    field(Key, Field, _),
+enumField(Key, Field, Value) :-
+    field(Key, Field, Value),
     dataType(Key, Field, "enum"),
     showField(Key, Field).
 
+childObject(Key, (Key, Field), Field) :-
+    enumField(Key, Field, _).
+
 resultField((Key, Field), "value", Value, "shortText") :-
-    childObject(Key, (Key, Field), Field),
-    field(Key, Field, Value),
-    not resultField(Key, Field, Value, "enum"),
-    dataType(Key, Field, "enum").
+    enumField(Key, Field, Value).
 
 resultField((Key, Field), "index", Index, "integer") :-
-    childObject(Key, (Key, Field), Field),
-    field(Key, Field, Value),
-    dataType(Key, Field, "enum"),
-    not resultField(Key, Field, Value, "enum"),
+    enumField(Key, Field, Value),
     field((Field, Value), "index", Index).
 
 resultField((Key, Field), "displayValue", EnumDisplayValue, "shortText") :-
-    childObject(Key, (Key, Field), Field),
-    field(Key, Field, Value),
-    dataType(Key, Field, "enum"),
-    not resultField(Key, Field, Value, "enum"),
+    enumField(Key, Field, Value),
     field((Field, Value), "enumDisplayValue", EnumDisplayValue).
 
 % Allow specifying up to 3 fields at the same time

--- a/tools/assets/src/calculations/common/queryLanguage.lp
+++ b/tools/assets/src/calculations/common/queryLanguage.lp
@@ -82,11 +82,6 @@ resultField(Key, Field, Value, DataType) :-
 % "field" of result/child result "key" has value "value",
 % data type of the field is included, if not specified, it is shortText
 % a field term like this is returned for all other fields except enum and list
-%
-% enumField(key, field, value, index, enum display value):
-% listField(key, field, value, index, enum display value):
-% otherwise the same as field, but for enum and list fields,
-% we also need the enum value index and enum display value
 
 #show field(Key, Field, Value, DataType) :
     field(Key, Field, Value),


### PR DESCRIPTION
This gets rid of the complexity in regarding enum and list definitions in the query language. ResultField continues to be slightly awkward with enum and lists as they depend on other fields, such as the enum display name, index or value being generated. However, that is a different problem, the purpose of this is to improve the performance.