### PR TITLE
Scope card logic program helper to results

### DIFF
--- a/tools/assets/src/calculations/queries/card.lp
+++ b/tools/assets/src/calculations/queries/card.lp
@@ -7,12 +7,14 @@ result(X) :- projectCard(X).
 % a helper term for display names
 
 displayName(Card, (Card, Field), DisplayName) :-
+    result(Card),
     fieldType(Field),
     field(Field, "displayName", DisplayName),
     field(Card, "cardType", CardType),
     not field((CardType, Field), "displayName", _).
 
 displayName(Card, (Card, Field), DisplayName) :-
+    result(Card),
     field(Card, "cardType", CardType),
     fieldType(Field),
     field((CardType, Field), "displayName", DisplayName).


### PR DESCRIPTION
The helper in `card.lp` is not scoped to even cards, which results in lots of unnecessary `displayName` facts to be derived by Clingo. Since card are always the results in `card.lp`, we can safely scope the helpers to take the card id from results. This significantly helps the grounder in larger programs.