### PR TITLE
INTDEV-1292 Skip docker build if already published

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -329,6 +329,11 @@ jobs:
           MAJOR: ${{ steps.docker.outputs.major }}
           MINOR: ${{ steps.docker.outputs.minor }}
         run: |
+          if docker buildx imagetools inspect "${REPO}:${VERSION}" >/dev/null 2>&1; then
+            echo "Tag ${REPO}:${VERSION} already exists; leaving it and the floating tags untouched."
+            exit 0
+          fi
+
           DIGEST_REFS=$(printf "${REPO}@sha256:%s " *)
           docker buildx imagetools create \
             -t "${REPO}:latest" \


### PR DESCRIPTION
This will skip docker build if the version already exists in docker hub. The action still succeeds, following the "skip" on exists  pattern.

Side node: We can't easily tell whether anything was published or not. Created INTDEV-1300 in the "low priority items" section, where this(and other similar steps) would be refactored so that publish steps show up as skipped. However, not worth risking breaking the publish pipeline for that right now.