### PR TITLE
fix(backend): pre-render workflow graphs for static site export (INTDEV-1302)

### DIFF
--- a/tools/backend/src/domain/resources/index.ts
+++ b/tools/backend/src/domain/resources/index.ts
@@ -12,8 +12,9 @@
 */
 
 import { Hono } from 'hono';
+import { ssgParams } from 'hono/ssg';
 import * as resourceService from './service.js';
-import type { ResourceValidationResponse } from '../../types.js';
+import type { AppContext, ResourceValidationResponse } from '../../types.js';
 import { UserRole } from '../../types.js';
 import { resourceParamsSchema } from '../../common/validationSchemas.js';
 import { zValidator } from '../../middleware/zvalidator.js';
@@ -183,6 +184,10 @@ router.delete(
 router.get(
   '/:prefix/workflows/:identifier/graph',
   requireRole(UserRole.Reader),
+  ssgParams(async (c: AppContext) => {
+    const commands = c.get('commands');
+    return resourceService.listWorkflowGraphParams(commands);
+  }),
   zValidator('param', workflowGraphParamsSchema),
   zValidator('query', workflowGraphQuerySchema),
   async (c) => {

--- a/tools/backend/src/domain/resources/service.ts
+++ b/tools/backend/src/domain/resources/service.ts
@@ -470,6 +470,28 @@ export async function validateResource(
 }
 
 /**
+ * Enumerates the path params (`prefix`, `identifier`) for every workflow
+ * resource in the project, including workflows imported from modules.
+ *
+ * This is used by the workflow graph endpoint's `ssgParams` so that Hono
+ * SSG pre-renders the graph JSON for each workflow during static site
+ * generation. Without it the static site requests a graph route that was
+ * never generated, the request 404s, and the workflow editor shows an
+ * error message in place of the diagram.
+ * @param commands Command manager.
+ * @returns One `{ prefix, identifier }` entry per workflow resource.
+ */
+export async function listWorkflowGraphParams(
+  commands: CommandManager,
+): Promise<{ prefix: string; identifier: string }[]> {
+  const workflows = await commands.showCmd.showResources('workflows');
+  return workflows.map((name) => {
+    const { prefix, identifier } = resourceName(name);
+    return { prefix, identifier };
+  });
+}
+
+/**
  * Renders the built-in state-machine graph for a single workflow.
  * When `cardKey` is provided, the card's current workflowState is
  * highlighted in the diagram. The workflow lookup, card lookup and

--- a/tools/backend/test/workflows.test.ts
+++ b/tools/backend/test/workflows.test.ts
@@ -4,13 +4,15 @@ import { createApp } from '../src/app.js';
 import { ProjectRegistry } from '../src/project-registry.js';
 import { MockAuthProvider } from '../src/auth/mock.js';
 import { createTempTestData, cleanupTempTestData } from './test-utils.js';
+import { listWorkflowGraphParams } from '../src/domain/resources/service.js';
 
 let app: ReturnType<typeof createApp>;
 let tempTestDataPath: string;
+let commands: CommandManager;
 
 beforeEach(async () => {
   tempTestDataPath = await createTempTestData('decision-records');
-  const commands = await CommandManager.getInstance(tempTestDataPath);
+  commands = await CommandManager.getInstance(tempTestDataPath);
   app = createApp(
     new MockAuthProvider(),
     ProjectRegistry.fromCommandManager(commands),
@@ -83,3 +85,25 @@ test('GET /api/projects/:prefix/resources/:prefix/workflows/:identifier/graph?ca
   );
   expect(response.status).toBe(404);
 });
+
+// Regression test for INTDEV-1302: the static site version of the workflow
+// editor showed an error in place of the workflow graph because the graph
+// endpoint was not enumerated for static site generation (no ssgParams), so
+// the pre-rendered JSON the static frontend requests was never produced.
+// listWorkflowGraphParams supplies that enumeration; every entry it returns
+// must resolve to a route that actually renders a graph.
+test('listWorkflowGraphParams enumerates renderable workflow graph routes (INTDEV-1302)', async () => {
+  const params = await listWorkflowGraphParams(commands);
+
+  expect(params.length).toBeGreaterThan(0);
+  expect(params).toContainEqual({ prefix: 'decision', identifier: 'simple' });
+
+  for (const { prefix, identifier } of params) {
+    const response = await app.request(
+      `/api/projects/decision/resources/${prefix}/workflows/${identifier}/graph`,
+    );
+    expect(response.status).toBe(200);
+    const result = (await response.json()) as { svg: string };
+    expect(result.svg).toBeTruthy();
+  }
+}, 20000);


### PR DESCRIPTION
## INTDEV-1302

**Bug:** The static site version of the workflow editor shows an error message in place of the workflow graph.

### Root cause

The workflow graph endpoint `GET /:prefix/workflows/:identifier/graph` (in `tools/backend/src/domain/resources/index.ts`) was **not enumerated for Hono static site generation (SSG)** — it had no `ssgParams` middleware.

During static export (`exportSite` → `toSSG`), only routes that declare `ssgParams` (like `cards/:key`) get their concrete URLs discovered and pre-rendered to `.json` files. Because the workflow graph route had none, no `graph.json` was ever written.

At runtime in static mode the frontend appends `.json` to every API URL (`tools/app/src/lib/swr.ts`). So when the workflow editor (`WorkflowGraph.tsx`) requested `.../graph.json`, it got a 404, and the component fell back to its error state (`workflowGraph.error`).

### Fix

- Add an `ssgParams` middleware to the workflow graph route that enumerates every workflow resource (including module workflows).
- Add a `listWorkflowGraphParams` service helper (`tools/backend/src/domain/resources/service.ts`) that returns `{ prefix, identifier }` for each workflow via `showCmd.showResources('workflows')`.

This mirrors the existing pattern used by the `cards/:key` endpoint.

### Verification

- `tools/backend/test/workflows.test.ts` — added a regression test asserting the enumeration covers every renderable graph route (all backend workflow tests pass).
- End-to-end: ran `exportSite` against the `decision-records` test project and confirmed the static export now produces:
  - `api/projects/decision/resources/decision/workflows/simple/graph.json`
  - `api/projects/decision/resources/decision/workflows/decision/graph.json`
  
  (these files were absent before the fix), with no export errors.
- `pnpm build`, prettier, and eslint all pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)