### PR TITLE
fix(app): hide export project option in exported static site

### DIFF
--- a/tools/app/src/components/CardTreeMenu.tsx
+++ b/tools/app/src/components/CardTreeMenu.tsx
@@ -13,6 +13,7 @@
 
 import React from 'react';
 import { useAppRouter } from '@/lib/hooks';
+import { getConfig } from '@/lib/utils';
 import { MoreHoriz } from '@mui/icons-material';
 import { Dropdown, MenuButton, Menu, MenuItem } from '@mui/joy';
 import { useTranslation } from 'react-i18next';
@@ -30,9 +31,11 @@ export const CardTreeMenu = () => {
           placement="bottom-end"
           sx={{ zIndex: 'calc(var(--joy-zIndex-modal) + 1)' }}
         >
-          <MenuItem onClick={() => setIsOpen(true)}>
-            {t('exportProject')}
-          </MenuItem>
+          {!getConfig().staticMode && (
+            <MenuItem onClick={() => setIsOpen(true)}>
+              {t('exportProject')}
+            </MenuItem>
+          )}
           <MenuItem onClick={() => router.safePush('/configuration')}>
             {t('configuration')}
           </MenuItem>


### PR DESCRIPTION
The "Export project" entry in the card tree "…" menu is meaningless in a statically exported site, since exporting relies on backend endpoints that are unavailable. Hide it when running in static mode, matching the existing staticMode gating used elsewhere in the app.