### PR TITLE
Add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code owners — automatically requested for review on matching changes.
+# Last matching pattern wins. See https://docs.github.com/articles/about-code-owners
+
+# Default owners for everything in the repo
+*       @samutoljamo @CyberJML @tminkkinen


### PR DESCRIPTION
Happened bump into this github feature that allows defining "Code owners" so I thought I'd just make a suggestion via a PR. Basically it just means that who gets called for automatic review. It could be tied to branch protection, but I don't think we need it for that.