### PR TITLE
Potential fix for code scanning alert no. 248: Useless conditional

### DIFF
--- a/tools/data-handler/test/command-move.test.ts
+++ b/tools/data-handler/test/command-move.test.ts
@@ -26,7 +26,7 @@ async function createSimilarCard(
   while (!descendant && attempts < maxAttempts) {
     const done = await commandHandler.command(
       Cmd.create,
-      ['card', template, parent || ''],
+      ['card', template, parent ?? ''],
       options,
     );
     const createdKey = done.affectsCards?.at(0);


### PR DESCRIPTION
Potential fix for [https://github.com/CyberismoCom/cyberismo/security/code-scanning/248](https://github.com/CyberismoCom/cyberismo/security/code-scanning/248)

Use nullish coalescing instead of a truthy/falsy conditional when building the command args in `createSimilarCard`.

- General fix: replace useless truthiness checks (`x || default`) with explicit null/undefined handling (`x ?? default`) when the value is typed optional and empty-string should not be treated as absent.
- Best fix here: in `tools/data-handler/test/command-move.test.ts`, line region around the `Cmd.create` call in `createSimilarCard`, change `parent || ''` to `parent ?? ''`.
- No imports, new methods, or new definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
