### PR TITLE
INTDEV-1311 Fix template card creation in Create menu

### DIFF
--- a/tools/app/__tests__/hooks.utils.test.tsx
+++ b/tools/app/__tests__/hooks.utils.test.tsx
@@ -168,7 +168,7 @@ describe('useConfigTemplateCreationContext', () => {
 
   test('returns template context on templates route', () => {
     mockedResourceTree = [];
-    renderAt('/configuration/test/templates/mytemplate');
+    renderAt('/projects/test/configuration/test/templates/mytemplate');
 
     expect(screen.getByTestId('show').textContent).toBe('true');
     expect(screen.getByTestId('template').textContent).toBe(
@@ -194,7 +194,7 @@ describe('useConfigTemplateCreationContext', () => {
       } as unknown as AnyNode,
     ];
 
-    renderAt('/configuration/test/cards/test_ic2n3e7w');
+    renderAt('/projects/test/configuration/test/cards/test_ic2n3e7w');
 
     expect(screen.getByTestId('show').textContent).toBe('true');
     expect(screen.getByTestId('template').textContent).toBe(
@@ -205,7 +205,7 @@ describe('useConfigTemplateCreationContext', () => {
 
   test('returns false outside configuration', () => {
     mockedResourceTree = [];
-    renderAt('/cards');
+    renderAt('/projects/test/cards');
     expect(screen.getByTestId('show').textContent).toBe('false');
     expect(screen.getByTestId('template').textContent).toBe('');
     expect(screen.getByTestId('parent').textContent).toBe('');
@@ -213,7 +213,7 @@ describe('useConfigTemplateCreationContext', () => {
 
   test('returns false in other resources', () => {
     mockedResourceTree = [];
-    renderAt('/configuration/test/fieldTypes/myfieldtype');
+    renderAt('/projects/test/configuration/test/fieldTypes/myfieldtype');
     expect(screen.getByTestId('show').textContent).toBe('false');
     expect(screen.getByTestId('template').textContent).toBe('');
     expect(screen.getByTestId('parent').textContent).toBe('');
@@ -243,7 +243,7 @@ describe('useConfigTemplateCreationContext', () => {
       } as unknown as AnyNode,
     ];
 
-    renderAt('/configuration/test/cards/nested_card');
+    renderAt('/projects/test/configuration/test/cards/nested_card');
 
     expect(screen.getByTestId('show').textContent).toBe('true');
     expect(screen.getByTestId('template').textContent).toBe(

--- a/tools/app/src/lib/hooks/utils.ts
+++ b/tools/app/src/lib/hooks/utils.ts
@@ -348,18 +348,27 @@ export function useConfigTemplateCreationContext(): {
   const parts = location.pathname.split('/');
   const { resourceTree } = useResourceTree();
 
-  const inConfiguration = parts.length >= 3 && parts[1] === 'configuration';
+  // Routes are nested under /projects/:projectPrefix/, so locate the
+  // configuration segment instead of relying on a fixed index
+  const configIndex = parts.indexOf('configuration');
+  const inConfiguration = configIndex !== -1;
   const isTemplates =
-    inConfiguration && parts.length >= 5 && parts[3] === 'templates';
+    inConfiguration &&
+    parts.length >= configIndex + 4 &&
+    parts[configIndex + 2] === 'templates';
   const isTemplateCard =
-    inConfiguration && parts.length >= 5 && parts[3] === 'cards';
+    inConfiguration &&
+    parts.length >= configIndex + 4 &&
+    parts[configIndex + 2] === 'cards';
 
-  let templateResource = isTemplates ? parts.slice(2, 5).join('/') : '';
-  const parentCardKey = isTemplateCard ? parts[4] : undefined;
+  let templateResource = isTemplates
+    ? parts.slice(configIndex + 1, configIndex + 4).join('/')
+    : '';
+  const parentCardKey = isTemplateCard ? parts[configIndex + 3] : undefined;
 
   // If inside a template card route, try to resolve the owning template from the resource tree
   if (!templateResource && isTemplateCard && resourceTree) {
-    const cardKey = parts[4];
+    const cardKey = parts[configIndex + 3];
     const found = findTemplateForCard(resourceTree, cardKey);
     if (found) {
       templateResource = found;


### PR DESCRIPTION
Jira: [INTDEV-1311](https://cyberismo.atlassian.net/browse/INTDEV-1311)

## Root cause

`useConfigTemplateCreationContext` (`tools/app/src/lib/hooks/utils.ts`) parsed the URL with fixed segment indices from the pre-multiproject routes — it checked `parts[1] === 'configuration'`. Since #1352 nested all routes under `/projects/:projectPrefix/`, `parts[1]` is always `'projects'`, so `showTemplateCard` was always `false` and the "Template card" item in the Create menu was permanently disabled (for all templates, not just new ones). `templateResource` and `parentCardKey` were silently broken the same way.

The hook's unit tests kept passing because they used the old URL shape, which the router now redirects before any component renders.

## Fix

Locate the `configuration` segment with `parts.indexOf('configuration')` and read the template/card segments relative to it, making the hook robust to route-nesting changes. Updated the hook tests to use the real `/projects/<prefix>/...` URL shape.

## Verification

- Red-green: 3 of the updated hook tests fail against the unfixed hook with exactly the ticket's symptom (`showTemplateCard` false), all 13 pass after the fix
- Full app unit suite: 193/193 ✓
- Full Playwright e2e suite: 46/46 ✓
- `pnpm build` (incl. `tsc -b`), `pnpm lint`, prettier: clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[INTDEV-1311]: https://cyberismo.atlassian.net/browse/INTDEV-1311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ