### PR TITLE
INTDEV-1308 Fix outdated facts in card logic program view

### DIFF
--- a/tools/app/src/components/modals/LogicProgramModal.tsx
+++ b/tools/app/src/components/modals/LogicProgramModal.tsx
@@ -39,8 +39,7 @@ export function LogicProgramModal({
   resourceName,
 }: LogicProgramModalProps) {
   const { t } = useTranslation();
-  // Fetch only while the modal is open so that each open shows up-to-date
-  // facts instead of a logic program cached at page load (INTDEV-1308)
+  // Conditional ensures logic program is refetched after the modal is opened
   const { logicPrograms, error } = useLogicPrograms(open ? resourceName : null);
 
   return (

--- a/tools/app/src/components/modals/LogicProgramModal.tsx
+++ b/tools/app/src/components/modals/LogicProgramModal.tsx
@@ -39,7 +39,9 @@ export function LogicProgramModal({
   resourceName,
 }: LogicProgramModalProps) {
   const { t } = useTranslation();
-  const { logicPrograms, error } = useLogicPrograms(resourceName);
+  // Fetch only while the modal is open so that each open shows up-to-date
+  // facts instead of a logic program cached at page load (INTDEV-1308)
+  const { logicPrograms, error } = useLogicPrograms(open ? resourceName : null);
 
   return (
     <Modal open={open} onClose={onClose}>

--- a/tools/app/src/lib/api/logicPrograms.ts
+++ b/tools/app/src/lib/api/logicPrograms.ts
@@ -17,12 +17,14 @@ import { projectApiPaths } from '../swr';
 import type { SWRConfiguration } from 'swr';
 
 export const useLogicPrograms = (
-  resourceName: string,
+  resourceName: string | null,
   options?: SWRConfiguration,
   projectPrefix?: string,
 ) =>
   useSWRHook<'logicPrograms'>(
-    projectApiPaths(projectPrefix).logicPrograms(resourceName),
+    resourceName
+      ? projectApiPaths(projectPrefix).logicPrograms(resourceName)
+      : null,
     'logicPrograms',
     null,
     options,


### PR DESCRIPTION
`LogicProgramModal` is mounted (closed) as soon as a card page renders, so `useLogicPrograms` fetched the logic program at **page load** — before any field edits. Opening the modal only toggles the `open` prop (no remount, no SWR key change → no revalidation), and `updateCard()` never invalidates the `logicPrograms` SWR key. The modal therefore displayed the facts as they were when the page first rendered, missing custom field values set.


Typically these cases are solved by using accurate mutate statements to tell when resources must be fetched, but logic programs have complex relationships so it's better to just require re-fetch.