### PR TITLE
INTDEV-1307 Fix null Boolean field shown as No

### DIFF
--- a/tools/app/__tests__/FieldRow.test.tsx
+++ b/tools/app/__tests__/FieldRow.test.tsx
@@ -1,22 +1,10 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { FieldRow } from '@/components/card/metadata-section/FieldRow';
 
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => {
-      const translations: Record<string, string> = {
-        yes: 'Yes',
-        no: 'No',
-      };
-      return translations[key] || key;
-    },
-  }),
-}));
-
 describe('FieldRow', () => {
-  it('renders an empty value for a null boolean field (INTDEV-1307)', () => {
+  it('renders an empty value for a null boolean field', () => {
     render(<FieldRow value={null} label="Boolean field" dataType="boolean" />);
 
     expect(screen.getByText('Boolean field')).toBeInTheDocument();

--- a/tools/app/__tests__/FieldRow.test.tsx
+++ b/tools/app/__tests__/FieldRow.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { FieldRow } from '@/components/card/metadata-section/FieldRow';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        yes: 'Yes',
+        no: 'No',
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+describe('FieldRow', () => {
+  it('renders an empty value for a null boolean field (INTDEV-1307)', () => {
+    render(<FieldRow value={null} label="Boolean field" dataType="boolean" />);
+
+    expect(screen.getByText('Boolean field')).toBeInTheDocument();
+    expect(screen.queryByText('No')).not.toBeInTheDocument();
+    expect(screen.queryByText('Yes')).not.toBeInTheDocument();
+  });
+
+  it('renders "No" for a false boolean field', () => {
+    render(<FieldRow value={false} label="Boolean field" dataType="boolean" />);
+
+    expect(screen.getByText('No')).toBeInTheDocument();
+  });
+
+  it('renders "Yes" for a true boolean field', () => {
+    render(<FieldRow value={true} label="Boolean field" dataType="boolean" />);
+
+    expect(screen.getByText('Yes')).toBeInTheDocument();
+  });
+});

--- a/tools/app/src/components/card/metadata-section/FieldRow.tsx
+++ b/tools/app/src/components/card/metadata-section/FieldRow.tsx
@@ -219,7 +219,7 @@ export function FieldRow({
             data-cy="editableFieldRow"
           >
             <EditableField
-              value={value ?? ''}
+              value={value ?? null}
               label={label}
               dataType={dataType}
               description={description}

--- a/tools/app/tsconfig.app.json
+++ b/tools/app/tsconfig.app.json
@@ -25,5 +25,5 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src", "__tests__"]
+  "include": ["src", "__tests__", "vitest-setup.ts"]
 }

--- a/tools/app/vitest-setup.ts
+++ b/tools/app/vitest-setup.ts
@@ -1,6 +1,7 @@
 import { expect, afterEach } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import * as matchers from '@testing-library/jest-dom/matchers';
+import '@/lib/i18n';
 
 expect.extend(matchers);
 


### PR DESCRIPTION
Jira: [INTDEV-1307](https://cyberismo.atlassian.net/browse/INTDEV-1307)

## Root cause
`FieldRow` passed `value ?? ''` to `EditableField` in view mode. A null boolean field value became `''`, which slipped past the `metadata == null` guard in `metadataValueToString` and fell into `metadata ? t('yes') : t('no')` — `''` is falsy, so an unset Boolean field rendered as **"No"**.

## Fix
Pass `value ?? null` instead, so unset fields reach `metadataValueToString` as `null` and render as empty (it already handles `null` correctly for every data type). Added a regression test covering null/false/true boolean rendering in `FieldRow`.

## Verification
- New regression test seen failing before the fix (`<span>No</span>` rendered for null) and passing after
- Full app unit suite: 196/196 passing
- `eslint`, `tsc --noEmit`, prettier: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[INTDEV-1307]: https://cyberismo.atlassian.net/browse/INTDEV-1307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ