### PR TITLE
Enable ccache in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     make \
     cmake \
+    # Compiler cache so node-gyp rebuilds of node-clingo are near-instant
+    ccache \
     # Ruby for PDF export via asciidoctor-pdf
     ruby-full \
     # C++ formatting (for node-clingo contributions)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,6 +30,7 @@
   "name": "Cyberismo Dev",
   "postCreateCommand": "bash .devcontainer/post-create.sh",
   "remoteEnv": {
+    "PATH": "/usr/lib/ccache:${containerEnv:PATH}",
     "VITE_HOST": "true"
   }
 }


### PR DESCRIPTION
Noticed that ccache was not used in devcontainer, which is why `pnpm install` was annoyingly slow. We want to keep `gyp rebuild`, because it might fail between node versions etc, but ccache won't have these issues.