### PR TITLE
feat(mutations): card type handlers (PR2)

### DIFF
--- a/tools/data-handler/src/commands/remove.ts
+++ b/tools/data-handler/src/commands/remove.ts
@@ -83,41 +83,8 @@ export class Remove {
       await actionGuard.checkPermission('delete', cardKey);
     }
 
-    // Collect all card keys that will be deleted (the card itself and all descendants).
-    const cardsToDelete = new Set<string>();
-    const collectDescendants = (c: typeof card) => {
-      cardsToDelete.add(c.key);
-      for (const childKey of c.children) {
-        try {
-          const childCard = this.project.findCard(childKey);
-          collectDescendants(childCard);
-        } catch {
-          this.logger.debug({ childKey }, 'Child card not found, skipping');
-        }
-      }
-    };
-    collectDescendants(card);
-
-    // If any of the cards to be deleted is a destination of a link, remove the link.
-    const allCards = this.project.cards(this.project.paths.cardRootFolder);
-    const promiseContainer: Promise<void>[] = [];
-
-    for (const item of allCards) {
-      if (cardsToDelete.has(item.key) || !item.metadata) continue;
-      const links = item.metadata.links;
-      const preservedLinks = links.filter((l) => !cardsToDelete.has(l.cardKey));
-      if (preservedLinks.length !== links.length) {
-        promiseContainer.push(
-          this.project.updateCardMetadataKey(item.key, 'links', preservedLinks),
-        );
-      }
-    }
-
-    await Promise.all(promiseContainer);
-
-    if (card) {
-      await this.project.handleCardDeleted(card);
-    }
+    // Descendant cascade and link cleanup live in the project-level primitive.
+    await this.project.deleteCards([card]);
   }
 
   // removes label from project

--- a/tools/data-handler/src/commands/remove.ts
+++ b/tools/data-handler/src/commands/remove.ts
@@ -299,7 +299,7 @@ export class Remove {
       );
     }
     if (this.projectResource(type)) {
-      if (type === 'linkType') {
+      if (type === 'linkType' || type === 'cardType') {
         const target = parseResourceName(targetName);
         const input = { kind: 'delete' as const, target };
         await this.mutations.apply(input);

--- a/tools/data-handler/src/commands/update.ts
+++ b/tools/data-handler/src/commands/update.ts
@@ -59,11 +59,11 @@ export class Update {
     // A rename is encoded as a 'change' on the 'name' updateKey.
     const isRename = updateKey.key === 'name' && operation.name === 'change';
 
-    // linkTypes + cardTypes are routed through the engine. Other resource
-    // families keep their legacy in-class cascade path until their own handler
-    // PR lands. (Do not generalise this to a blanket Set of types — the
-    // dispatcher would route unhandled (type, key, operation) tuples to
-    // DefaultNoCascadeHandler and silently drop their cascade.)
+    // Only resource families with a dedicated handler are routed through the
+    // engine; the rest use the in-class cascade path. (Do not generalise this
+    // to a blanket Set of types — the dispatcher would route unhandled
+    // (type, key, operation) tuples to DefaultNoCascadeHandler and silently
+    // drop their cascade.)
     const target = parseResourceName(name);
 
     if (type === 'linkTypes') {
@@ -97,8 +97,8 @@ export class Update {
       }
 
       // Only the cardType edits with a dedicated handler are routed; all other
-      // cardType edits (e.g. rank, alwaysVisibleFields, displayName) stay on the
-      // legacy path.
+      // cardType edits (e.g. rank, alwaysVisibleFields, displayName) use the
+      // in-class cascade path.
       const routedEdit =
         (updateKey.key === 'workflow' && operation.name === 'change') ||
         (updateKey.key === 'customFields' &&

--- a/tools/data-handler/src/commands/update.ts
+++ b/tools/data-handler/src/commands/update.ts
@@ -59,14 +59,14 @@ export class Update {
     // A rename is encoded as a 'change' on the 'name' updateKey.
     const isRename = updateKey.key === 'name' && operation.name === 'change';
 
-    // PR1 routes ONLY linkTypes through the engine. Other resource families
-    // keep their legacy in-class cascade path until their own handler PR
-    // lands. (Do not generalise this to a Set of types — PR1's dispatcher
-    // would route unhandled types to DefaultNoCascadeHandler and silently
-    // drop their cascade.)
-    if (type === 'linkTypes') {
-      const target = parseResourceName(name);
+    // linkTypes + cardTypes are routed through the engine. Other resource
+    // families keep their legacy in-class cascade path until their own handler
+    // PR lands. (Do not generalise this to a blanket Set of types — the
+    // dispatcher would route unhandled (type, key, operation) tuples to
+    // DefaultNoCascadeHandler and silently drop their cascade.)
+    const target = parseResourceName(name);
 
+    if (type === 'linkTypes') {
       if (isRename) {
         const newIdentifier = parseResourceName(
           (operation as ChangeOperation<string>).to,
@@ -84,6 +84,36 @@ export class Update {
       };
       await this.mutations.apply(input);
       return;
+    }
+
+    if (type === 'cardTypes') {
+      if (isRename) {
+        const newIdentifier = parseResourceName(
+          (operation as ChangeOperation<string>).to,
+        ).identifier;
+        const input = { kind: 'rename' as const, target, newIdentifier };
+        await this.mutations.apply(input);
+        return;
+      }
+
+      // Only the cardType edits with a dedicated handler are routed; all other
+      // cardType edits (e.g. rank, alwaysVisibleFields, displayName) stay on the
+      // legacy path.
+      const routedEdit =
+        (updateKey.key === 'workflow' && operation.name === 'change') ||
+        (updateKey.key === 'customFields' &&
+          (operation.name === 'add' || operation.name === 'remove'));
+
+      if (routedEdit) {
+        const input = {
+          kind: 'edit' as const,
+          target,
+          updateKey,
+          operation,
+        };
+        await this.mutations.apply(input);
+        return;
+      }
     }
 
     const run = () =>

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -651,6 +651,73 @@ export class Project extends CardContainer {
   }
 
   /**
+   * Deletes the given cards together with their descendant subtrees, and
+   * removes any links from surviving cards that point at a deleted card.
+   *
+   * This is the structural card-deletion primitive shared by the `remove`
+   * command and the resource mutation handlers. It performs no permission
+   * checks and assumes the caller already holds the write lock.
+   * @param cards Root cards to delete. Descendants are removed via cascade, so
+   *   passing a card whose ancestor is also in the list is safe.
+   */
+  public async deleteCards(cards: Card[]) {
+    if (cards.length === 0) {
+      return;
+    }
+
+    // Collect every key that will be removed (each card plus its subtree) so
+    // link cleanup can drop links pointing anywhere into the deleted set.
+    const deletedKeys = new Set<string>();
+    const collectDescendants = (cardKey: string) => {
+      if (deletedKeys.has(cardKey)) {
+        return;
+      }
+      let card: Card;
+      try {
+        card = this.findCard(cardKey);
+      } catch {
+        this.logger.debug({ cardKey }, 'Card to delete not found, skipping');
+        return;
+      }
+      deletedKeys.add(cardKey);
+      for (const childKey of card.children) {
+        collectDescendants(childKey);
+      }
+    };
+    for (const card of cards) {
+      collectDescendants(card.key);
+    }
+
+    // Strip links from surviving cards that point at any card being removed.
+    const linkUpdates: Promise<void>[] = [];
+    for (const item of this.cards(this.paths.cardRootFolder)) {
+      if (deletedKeys.has(item.key) || !item.metadata) {
+        continue;
+      }
+      const links = item.metadata.links;
+      const preservedLinks = links.filter((l) => !deletedKeys.has(l.cardKey));
+      if (preservedLinks.length !== links.length) {
+        linkUpdates.push(
+          this.updateCardMetadataKey(item.key, 'links', preservedLinks),
+        );
+      }
+    }
+    await Promise.all(linkUpdates);
+
+    // Remove the subtrees. handleCardDeleted cascades children, so any card
+    // already removed as part of an earlier subtree is skipped here.
+    for (const card of cards) {
+      let fresh: Card;
+      try {
+        fresh = this.findCard(card.key);
+      } catch {
+        continue;
+      }
+      await this.handleCardDeleted(fresh);
+    }
+  }
+
+  /**
    * When card is moved.
    * @param movedCard Card that moved
    * @param newParentCard New parent for the 'movedCard'

--- a/tools/data-handler/src/mutations/dispatcher.ts
+++ b/tools/data-handler/src/mutations/dispatcher.ts
@@ -27,9 +27,8 @@ const HANDLERS: Handler[] = [
   new LinkTypeDeleteHandler(),
   new CardTypeRenameHandler(),
   new CardTypeDeleteHandler(),
-  // The three card-type edit handlers below are near-identical thin routers
-  // on purpose: each absorbs its own cascade from CardTypeResource when the
-  // legacy path is removed, so don't merge them into a shared base.
+  // Cascades are operation-specific — keep one handler per edit operation;
+  // don't merge these into a shared base.
   new CardTypeAddCustomFieldHandler(),
   new CardTypeRemoveCustomFieldHandler(),
   new CardTypeWorkflowChangeHandler(),

--- a/tools/data-handler/src/mutations/dispatcher.ts
+++ b/tools/data-handler/src/mutations/dispatcher.ts
@@ -16,10 +16,23 @@ import type { Handler, MutationContext } from './handler.js';
 import { DefaultNoCascadeHandler } from './handlers/default-no-cascade.js';
 import { LinkTypeDeleteHandler } from './handlers/link-type-delete.js';
 import { LinkTypeRenameHandler } from './handlers/link-type-rename.js';
+import { CardTypeRenameHandler } from './handlers/card-type-rename.js';
+import { CardTypeDeleteHandler } from './handlers/card-type-delete.js';
+import { CardTypeAddCustomFieldHandler } from './handlers/card-type-add-custom-field.js';
+import { CardTypeRemoveCustomFieldHandler } from './handlers/card-type-remove-custom-field.js';
+import { CardTypeWorkflowChangeHandler } from './handlers/card-type-workflow-change.js';
 
 const HANDLERS: Handler[] = [
   new LinkTypeRenameHandler(),
   new LinkTypeDeleteHandler(),
+  new CardTypeRenameHandler(),
+  new CardTypeDeleteHandler(),
+  // The three card-type edit handlers below are near-identical thin routers
+  // on purpose: each absorbs its own cascade from CardTypeResource when the
+  // legacy path is removed, so don't merge them into a shared base.
+  new CardTypeAddCustomFieldHandler(),
+  new CardTypeRemoveCustomFieldHandler(),
+  new CardTypeWorkflowChangeHandler(),
   new DefaultNoCascadeHandler(),
 ];
 

--- a/tools/data-handler/src/mutations/handlers/card-type-add-custom-field.ts
+++ b/tools/data-handler/src/mutations/handlers/card-type-add-custom-field.ts
@@ -18,9 +18,9 @@ import type { Operation } from '../../resources/resource-object.js';
 
 /**
  * Adding a custom field to a card type is a breaking change: every card of the
- * type gains the new field (as null). The cascade itself still lives in
- * CardTypeResource.update (handleCustomFieldsChange → handleAddNewField), so
- * this handler only routes the operation and marks it breaking.
+ * type gains the new field (as null). The cascade is performed by
+ * CardTypeResource.update; this handler routes the operation and marks it
+ * breaking.
  */
 export class CardTypeAddCustomFieldHandler implements Handler {
   readonly isBreaking = true;

--- a/tools/data-handler/src/mutations/handlers/card-type-add-custom-field.ts
+++ b/tools/data-handler/src/mutations/handlers/card-type-add-custom-field.ts
@@ -1,0 +1,51 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { Handler, MutationContext } from '../handler.js';
+import { resourceNameToString } from '../../utils/resource-utils.js';
+import type { Operation } from '../../resources/resource-object.js';
+
+/**
+ * Adding a custom field to a card type is a breaking change: every card of the
+ * type gains the new field (as null). The cascade itself still lives in
+ * CardTypeResource.update (handleCustomFieldsChange → handleAddNewField), so
+ * this handler only routes the operation and marks it breaking.
+ */
+export class CardTypeAddCustomFieldHandler implements Handler {
+  readonly isBreaking = true;
+
+  matches(ctx: MutationContext): boolean {
+    if (ctx.input.kind !== 'edit') return false;
+    if (ctx.input.target.type !== 'cardTypes') return false;
+    return (
+      ctx.input.updateKey.key === 'customFields' &&
+      ctx.input.operation.name === 'add'
+    );
+  }
+
+  async apply(ctx: MutationContext): Promise<void> {
+    if (ctx.input.kind !== 'edit') {
+      throw new Error(
+        'CardTypeAddCustomFieldHandler called with non-edit input',
+      );
+    }
+    const cardTypeName = resourceNameToString(ctx.input.target);
+    const resource = ctx.project.resources.byType(cardTypeName, 'cardTypes');
+    if (!resource) throw new Error(`CardType '${cardTypeName}' not found`);
+    await resource.update(
+      ctx.input.updateKey,
+      ctx.input.operation as Operation<unknown>,
+    );
+  }
+}

--- a/tools/data-handler/src/mutations/handlers/card-type-delete.ts
+++ b/tools/data-handler/src/mutations/handlers/card-type-delete.ts
@@ -17,8 +17,6 @@ import { resourceNameToString } from '../../utils/resource-utils.js';
 import { ResourcesFrom } from '../../containers/project/resources-from.js';
 import type { Card } from '../../interfaces/project-interfaces.js';
 import type { Operation } from '../../resources/resource-object.js';
-import { Remove } from '../../commands/remove.js';
-import { Fetch } from '../../commands/fetch.js';
 
 export class CardTypeDeleteHandler implements Handler {
   readonly isBreaking = true;
@@ -58,23 +56,11 @@ export class CardTypeDeleteHandler implements Handler {
       }
     }
 
-    // 2. Delete every local card of this type. Remove.remove already handles
-    //    child cascades and link cleanup.
-    const remove = new Remove(ctx.project, new Fetch(ctx.project));
+    // 2. Delete every local card of this type, along with their subtrees and
+    //    any links pointing at them. deleteCards handles the cascade; no
+    //    per-card permission check applies to a structural cardType deletion.
     const cards = this.affectedCards(ctx, cardTypeName);
-    // Ensure the calculation engine is ready so ActionGuard can check permissions.
-    await ctx.project.calculationEngine.generate();
-    // Remove cards deeper in the tree first to avoid double-removal attempts.
-    const sorted = [...cards].sort(
-      (a, b) => b.path.split('/').length - a.path.split('/').length,
-    );
-    for (const card of sorted) {
-      try {
-        await remove.remove('card', card.key);
-      } catch {
-        // Some descendants may already be gone via a parent cascade; ignore.
-      }
-    }
+    await ctx.project.deleteCards(cards);
 
     // 3. Delete the card type resource itself. By now usage() is empty.
     const resource = ctx.project.resources.byType(cardTypeName, 'cardTypes');

--- a/tools/data-handler/src/mutations/handlers/card-type-delete.ts
+++ b/tools/data-handler/src/mutations/handlers/card-type-delete.ts
@@ -83,7 +83,7 @@ export class CardTypeDeleteHandler implements Handler {
   }
 
   // Cards using this card type: local project cards plus local template cards
-  // (matches the legacy CardTypeResource collectCards scoping).
+  // (matches CardTypeResource's collectCards scoping).
   private affectedCards(ctx: MutationContext, cardTypeName: string): Card[] {
     return [
       ...ctx.project.cards(undefined),

--- a/tools/data-handler/src/mutations/handlers/card-type-delete.ts
+++ b/tools/data-handler/src/mutations/handlers/card-type-delete.ts
@@ -1,0 +1,95 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { Handler, MutationContext } from '../handler.js';
+import { resourceNameToString } from '../../utils/resource-utils.js';
+import { ResourcesFrom } from '../../containers/project/resources-from.js';
+import type { Card } from '../../interfaces/project-interfaces.js';
+import type { Operation } from '../../resources/resource-object.js';
+import { Remove } from '../../commands/remove.js';
+import { Fetch } from '../../commands/fetch.js';
+
+export class CardTypeDeleteHandler implements Handler {
+  readonly isBreaking = true;
+
+  matches(ctx: MutationContext): boolean {
+    return ctx.input.kind === 'delete' && ctx.input.target.type === 'cardTypes';
+  }
+
+  async apply(ctx: MutationContext): Promise<void> {
+    if (ctx.input.kind !== 'delete') {
+      throw new Error('CardTypeDeleteHandler: non-delete input');
+    }
+    const cardTypeName = resourceNameToString(ctx.input.target);
+
+    // Interactive deletion of a module-owned card type is not allowed.
+    if (ctx.input.target.prefix !== ctx.project.projectPrefix) {
+      throw new Error(
+        `Cannot delete resource ${cardTypeName}: It is a module resource`,
+      );
+    }
+
+    // 1. Strip the card type from every local link type.
+    const linkTypes = ctx.project.resources.linkTypes(ResourcesFrom.localOnly);
+    for (const lt of linkTypes) {
+      const data = lt.data;
+      if (!data) continue;
+      for (const field of [
+        'sourceCardTypes',
+        'destinationCardTypes',
+      ] as const) {
+        if (data[field].includes(cardTypeName)) {
+          await lt.update({ key: field }, {
+            name: 'remove',
+            target: cardTypeName,
+          } as Operation<string>);
+        }
+      }
+    }
+
+    // 2. Delete every local card of this type. Remove.remove already handles
+    //    child cascades and link cleanup.
+    const remove = new Remove(ctx.project, new Fetch(ctx.project));
+    const cards = this.affectedCards(ctx, cardTypeName);
+    // Ensure the calculation engine is ready so ActionGuard can check permissions.
+    await ctx.project.calculationEngine.generate();
+    // Remove cards deeper in the tree first to avoid double-removal attempts.
+    const sorted = [...cards].sort(
+      (a, b) => b.path.split('/').length - a.path.split('/').length,
+    );
+    for (const card of sorted) {
+      try {
+        await remove.remove('card', card.key);
+      } catch {
+        // Some descendants may already be gone via a parent cascade; ignore.
+      }
+    }
+
+    // 3. Delete the card type resource itself. By now usage() is empty.
+    const resource = ctx.project.resources.byType(cardTypeName, 'cardTypes');
+    if (!resource) throw new Error(`CardType '${cardTypeName}' not found`);
+    await resource.delete();
+  }
+
+  // Cards using this card type: local project cards plus local template cards
+  // (matches the legacy CardTypeResource collectCards scoping).
+  private affectedCards(ctx: MutationContext, cardTypeName: string): Card[] {
+    return [
+      ...ctx.project.cards(undefined),
+      ...ctx.project.resources
+        .templates(ResourcesFrom.localOnly)
+        .flatMap((t) => t.templateObject().cards()),
+    ].filter((c) => c.metadata?.cardType === cardTypeName);
+  }
+}

--- a/tools/data-handler/src/mutations/handlers/card-type-remove-custom-field.ts
+++ b/tools/data-handler/src/mutations/handlers/card-type-remove-custom-field.ts
@@ -19,9 +19,8 @@ import type { Operation } from '../../resources/resource-object.js';
 /**
  * Removing a custom field from a card type is a breaking change (data loss):
  * the field key is dropped from every card of the type and from the card type's
- * alwaysVisibleFields / optionallyVisibleFields. The cascade itself still lives
- * in CardTypeResource.update (removeValueFromOtherArrays + handleCustomFieldsChange
- * → handleRemoveField), so this handler only routes the operation and marks it
+ * alwaysVisibleFields / optionallyVisibleFields. The cascade is performed by
+ * CardTypeResource.update; this handler routes the operation and marks it
  * breaking.
  */
 export class CardTypeRemoveCustomFieldHandler implements Handler {

--- a/tools/data-handler/src/mutations/handlers/card-type-remove-custom-field.ts
+++ b/tools/data-handler/src/mutations/handlers/card-type-remove-custom-field.ts
@@ -1,0 +1,53 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { Handler, MutationContext } from '../handler.js';
+import { resourceNameToString } from '../../utils/resource-utils.js';
+import type { Operation } from '../../resources/resource-object.js';
+
+/**
+ * Removing a custom field from a card type is a breaking change (data loss):
+ * the field key is dropped from every card of the type and from the card type's
+ * alwaysVisibleFields / optionallyVisibleFields. The cascade itself still lives
+ * in CardTypeResource.update (removeValueFromOtherArrays + handleCustomFieldsChange
+ * → handleRemoveField), so this handler only routes the operation and marks it
+ * breaking.
+ */
+export class CardTypeRemoveCustomFieldHandler implements Handler {
+  readonly isBreaking = true;
+
+  matches(ctx: MutationContext): boolean {
+    if (ctx.input.kind !== 'edit') return false;
+    if (ctx.input.target.type !== 'cardTypes') return false;
+    return (
+      ctx.input.updateKey.key === 'customFields' &&
+      ctx.input.operation.name === 'remove'
+    );
+  }
+
+  async apply(ctx: MutationContext): Promise<void> {
+    if (ctx.input.kind !== 'edit') {
+      throw new Error(
+        'CardTypeRemoveCustomFieldHandler called with non-edit input',
+      );
+    }
+    const cardTypeName = resourceNameToString(ctx.input.target);
+    const resource = ctx.project.resources.byType(cardTypeName, 'cardTypes');
+    if (!resource) throw new Error(`CardType '${cardTypeName}' not found`);
+    await resource.update(
+      ctx.input.updateKey,
+      ctx.input.operation as Operation<unknown>,
+    );
+  }
+}

--- a/tools/data-handler/src/mutations/handlers/card-type-rename.ts
+++ b/tools/data-handler/src/mutations/handlers/card-type-rename.ts
@@ -57,7 +57,7 @@ export class CardTypeRenameHandler implements Handler {
   }
 
   // Cards using this card type: local project cards plus local template cards
-  // (matches the legacy CardTypeResource collectCards scoping).
+  // (matches CardTypeResource's collectCards scoping).
   private affectedCards(ctx: MutationContext, oldName: string): Card[] {
     const project = [...ctx.project.cards(undefined)];
     const templates = ctx.project.resources

--- a/tools/data-handler/src/mutations/handlers/card-type-rename.ts
+++ b/tools/data-handler/src/mutations/handlers/card-type-rename.ts
@@ -1,0 +1,70 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { Handler, MutationContext } from '../handler.js';
+import {
+  resourceName,
+  resourceNameToString,
+} from '../../utils/resource-utils.js';
+import { ResourcesFrom } from '../../containers/project/resources-from.js';
+import type { Card } from '../../interfaces/project-interfaces.js';
+
+export class CardTypeRenameHandler implements Handler {
+  readonly isBreaking = true;
+
+  matches(ctx: MutationContext): boolean {
+    return ctx.input.kind === 'rename' && ctx.input.target.type === 'cardTypes';
+  }
+
+  async apply(ctx: MutationContext): Promise<void> {
+    if (ctx.input.kind !== 'rename') {
+      throw new Error('CardTypeRenameHandler called with non-rename input');
+    }
+    const oldName = resourceNameToString(ctx.input.target);
+    const newName = `${ctx.input.target.prefix}/cardTypes/${ctx.input.newIdentifier}`;
+
+    // 1. Rewrite metadata.cardType on every affected card BEFORE renaming the
+    //    resource on disk. CardTypeResource.rename() (onNameChange) cascades the
+    //    calculation / handlebar / card-content / link-type references and the
+    //    self-prefix rewrites, but it does NOT touch each card's
+    //    metadata.cardType — so that rewrite lives here.
+    const cards = this.affectedCards(ctx, oldName);
+    for (const card of cards) {
+      const metadata = card.metadata!;
+      metadata.cardType = newName;
+      await ctx.project.updateCardMetadata(card, metadata);
+    }
+
+    // 2. Rename the resource itself. CardTypeResource.rename handles the
+    //    cascading reference rewrites (calculations, handlebars, card content,
+    //    link-type source/destination card types).
+    const resource = ctx.project.resources.byType(oldName, 'cardTypes');
+    if (!resource) {
+      throw new Error(`CardType '${oldName}' not found`);
+    }
+    await resource.rename(resourceName(newName));
+  }
+
+  // Cards using this card type: local project cards plus local template cards
+  // (matches the legacy CardTypeResource collectCards scoping).
+  private affectedCards(ctx: MutationContext, oldName: string): Card[] {
+    const project = [...ctx.project.cards(undefined)];
+    const templates = ctx.project.resources
+      .templates(ResourcesFrom.localOnly)
+      .flatMap((t) => t.templateObject().cards());
+    return [...project, ...templates].filter(
+      (c) => c.metadata?.cardType === oldName,
+    );
+  }
+}

--- a/tools/data-handler/src/mutations/handlers/card-type-workflow-change.ts
+++ b/tools/data-handler/src/mutations/handlers/card-type-workflow-change.ts
@@ -18,10 +18,9 @@ import type { Operation } from '../../resources/resource-object.js';
 
 /**
  * Changing a card type's workflow is a breaking change: cards of the type get
- * their workflowState re-mapped to the new workflow. State-mapping validation
- * and the per-card state rewrite still live in CardTypeResource.update
- * (handleWorkflowChange → verifyStateMapping), so this handler only routes the
- * operation (mapping intact) and marks it breaking.
+ * their workflowState re-mapped to the new workflow. The cascade is performed
+ * by CardTypeResource.update; this handler routes the operation and marks it
+ * breaking.
  */
 export class CardTypeWorkflowChangeHandler implements Handler {
   readonly isBreaking = true;

--- a/tools/data-handler/src/mutations/handlers/card-type-workflow-change.ts
+++ b/tools/data-handler/src/mutations/handlers/card-type-workflow-change.ts
@@ -1,0 +1,52 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { Handler, MutationContext } from '../handler.js';
+import { resourceNameToString } from '../../utils/resource-utils.js';
+import type { Operation } from '../../resources/resource-object.js';
+
+/**
+ * Changing a card type's workflow is a breaking change: cards of the type get
+ * their workflowState re-mapped to the new workflow. State-mapping validation
+ * and the per-card state rewrite still live in CardTypeResource.update
+ * (handleWorkflowChange → verifyStateMapping), so this handler only routes the
+ * operation (mapping intact) and marks it breaking.
+ */
+export class CardTypeWorkflowChangeHandler implements Handler {
+  readonly isBreaking = true;
+
+  matches(ctx: MutationContext): boolean {
+    if (ctx.input.kind !== 'edit') return false;
+    if (ctx.input.target.type !== 'cardTypes') return false;
+    return (
+      ctx.input.updateKey.key === 'workflow' &&
+      ctx.input.operation.name === 'change'
+    );
+  }
+
+  async apply(ctx: MutationContext): Promise<void> {
+    if (ctx.input.kind !== 'edit') {
+      throw new Error(
+        'CardTypeWorkflowChangeHandler called with non-edit input',
+      );
+    }
+    const cardTypeName = resourceNameToString(ctx.input.target);
+    const resource = ctx.project.resources.byType(cardTypeName, 'cardTypes');
+    if (!resource) throw new Error(`CardType '${cardTypeName}' not found`);
+    await resource.update(
+      ctx.input.updateKey,
+      ctx.input.operation as Operation<unknown>,
+    );
+  }
+}

--- a/tools/data-handler/test/mutations/handlers/card-type-add-custom-field.test.ts
+++ b/tools/data-handler/test/mutations/handlers/card-type-add-custom-field.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { copyDir } from '../../../src/utils/file-utils.js';
+import type { Project } from '../../../src/containers/project.js';
+import { getTestProject } from '../../helpers/test-utils.js';
+import { CardTypeAddCustomFieldHandler } from '../../../src/mutations/handlers/card-type-add-custom-field.js';
+import { resourceName } from '../../../src/utils/resource-utils.js';
+import { ResourceMutations } from '../../../src/mutations/resource-mutations.js';
+
+const baseDir = import.meta.dirname;
+const testDir = join(baseDir, 'tmp-card-type-add-field');
+const decisionRecordsPath = join(testDir, 'valid/decision-records');
+let project: Project;
+
+describe('CardTypeAddCustomFieldHandler', () => {
+  beforeEach(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir(join(baseDir, '..', '..', 'test-data'), testDir);
+    project = getTestProject(decisionRecordsPath);
+    await project.populateCaches();
+  });
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('matches an add operation on customFields', () => {
+    const handler = new CardTypeAddCustomFieldHandler();
+    const ctx = {
+      project,
+      input: {
+        kind: 'edit' as const,
+        target: resourceName(`${project.projectPrefix}/cardTypes/decision`),
+        updateKey: { key: 'customFields' },
+        operation: {
+          name: 'add' as const,
+          target: { name: `${project.projectPrefix}/fieldTypes/finished` },
+        },
+      },
+    };
+    expect(handler.matches(ctx)).toBe(true);
+    expect(handler.isBreaking).toBe(true);
+  });
+
+  it('writes null for the new field on every affected card', async () => {
+    const newField = `${project.projectPrefix}/fieldTypes/finished`;
+    // 'finished' is not part of the simplepage card type's customFields.
+    const cardTypeName = `${project.projectPrefix}/cardTypes/simplepage`;
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit' as const,
+      target: resourceName(cardTypeName),
+      updateKey: { key: 'customFields' },
+      operation: {
+        name: 'add' as const,
+        target: { name: newField },
+      },
+    });
+    const cards = project
+      .cards(undefined)
+      .filter((c) => c.metadata?.cardType === cardTypeName);
+    for (const card of cards) {
+      expect(card.metadata).toHaveProperty(newField);
+      expect(card.metadata![newField]).toBeNull();
+    }
+  });
+});

--- a/tools/data-handler/test/mutations/handlers/card-type-delete.test.ts
+++ b/tools/data-handler/test/mutations/handlers/card-type-delete.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { copyDir } from '../../../src/utils/file-utils.js';
+import type { Project } from '../../../src/containers/project.js';
+import { getTestProject } from '../../helpers/test-utils.js';
+import { CardTypeDeleteHandler } from '../../../src/mutations/handlers/card-type-delete.js';
+import { resourceName } from '../../../src/utils/resource-utils.js';
+import { ResourceMutations } from '../../../src/mutations/resource-mutations.js';
+
+const baseDir = import.meta.dirname;
+const testDir = join(baseDir, 'tmp-card-type-delete');
+const decisionRecordsPath = join(testDir, 'valid/decision-records');
+let project: Project;
+
+describe('CardTypeDeleteHandler', () => {
+  beforeEach(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir(join(baseDir, '..', '..', 'test-data'), testDir);
+    project = getTestProject(decisionRecordsPath);
+    await project.populateCaches();
+  });
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  const cardTypeName = () => `${project.projectPrefix}/cardTypes/decision`;
+
+  it('matches a CardType delete input', () => {
+    const handler = new CardTypeDeleteHandler();
+    expect(
+      handler.matches({
+        project,
+        input: {
+          kind: 'delete',
+          target: resourceName(cardTypeName()),
+        },
+      }),
+    ).toBe(true);
+    expect(handler.isBreaking).toBe(true);
+  });
+
+  it('deletes every card of this type', async () => {
+    const before = project
+      .cards(undefined)
+      .filter((c) => c.metadata?.cardType === cardTypeName());
+    expect(before.length).toBeGreaterThan(0);
+
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'delete',
+      target: resourceName(cardTypeName()),
+    });
+    // Re-read after apply (caches were invalidated by removeCard calls).
+    await project.populateCaches();
+    const after = project
+      .cards(undefined)
+      .filter((c) => c.metadata?.cardType === cardTypeName());
+    expect(after).toHaveLength(0);
+  });
+
+  it('strips the card type from every link type sourceCardTypes/destinationCardTypes', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'delete',
+      target: resourceName(cardTypeName()),
+    });
+    for (const lt of project.resources.linkTypes()) {
+      const data = lt.data!;
+      expect(data.sourceCardTypes).not.toContain(cardTypeName());
+      expect(data.destinationCardTypes).not.toContain(cardTypeName());
+    }
+  });
+
+  it('deletes the card type resource file from disk', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'delete',
+      target: resourceName(cardTypeName()),
+    });
+    expect(project.resources.exists(cardTypeName())).toBe(false);
+  });
+});

--- a/tools/data-handler/test/mutations/handlers/card-type-remove-custom-field.test.ts
+++ b/tools/data-handler/test/mutations/handlers/card-type-remove-custom-field.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { copyDir } from '../../../src/utils/file-utils.js';
+import type { Project } from '../../../src/containers/project.js';
+import { getTestProject } from '../../helpers/test-utils.js';
+import { CardTypeRemoveCustomFieldHandler } from '../../../src/mutations/handlers/card-type-remove-custom-field.js';
+import { resourceName } from '../../../src/utils/resource-utils.js';
+import { ResourceMutations } from '../../../src/mutations/resource-mutations.js';
+
+const baseDir = import.meta.dirname;
+const testDir = join(baseDir, 'tmp-card-type-remove-field');
+const decisionRecordsPath = join(testDir, 'valid/decision-records');
+let project: Project;
+
+describe('CardTypeRemoveCustomFieldHandler', () => {
+  beforeEach(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir(join(baseDir, '..', '..', 'test-data'), testDir);
+    project = getTestProject(decisionRecordsPath);
+    await project.populateCaches();
+  });
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  const cardTypeName = () => `${project.projectPrefix}/cardTypes/decision`;
+  const fieldName = () => `${project.projectPrefix}/fieldTypes/finished`;
+
+  it('matches a remove operation on customFields', () => {
+    const handler = new CardTypeRemoveCustomFieldHandler();
+    expect(
+      handler.matches({
+        project,
+        input: {
+          kind: 'edit',
+          target: resourceName(cardTypeName()),
+          updateKey: { key: 'customFields' },
+          operation: { name: 'remove', target: { name: fieldName() } },
+        },
+      }),
+    ).toBe(true);
+    expect(handler.isBreaking).toBe(true);
+  });
+
+  it('removes the field key from every card of this type', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit',
+      target: resourceName(cardTypeName()),
+      updateKey: { key: 'customFields' },
+      operation: { name: 'remove', target: { name: fieldName() } },
+    });
+    const cards = project
+      .cards(undefined)
+      .filter((c) => c.metadata?.cardType === cardTypeName());
+    for (const card of cards) {
+      expect(card.metadata).not.toHaveProperty(fieldName());
+    }
+  });
+
+  it('strips the field from alwaysVisibleFields and optionallyVisibleFields', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit',
+      target: resourceName(cardTypeName()),
+      updateKey: { key: 'customFields' },
+      operation: { name: 'remove', target: { name: fieldName() } },
+    });
+    const ct = project.resources.byType(cardTypeName(), 'cardTypes').show();
+    expect(ct.alwaysVisibleFields ?? []).not.toContain(fieldName());
+    expect(ct.optionallyVisibleFields ?? []).not.toContain(fieldName());
+  });
+});

--- a/tools/data-handler/test/mutations/handlers/card-type-rename.test.ts
+++ b/tools/data-handler/test/mutations/handlers/card-type-rename.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { copyDir } from '../../../src/utils/file-utils.js';
+import type { Project } from '../../../src/containers/project.js';
+import { getTestProject } from '../../helpers/test-utils.js';
+import { CardTypeRenameHandler } from '../../../src/mutations/handlers/card-type-rename.js';
+import { resourceName } from '../../../src/utils/resource-utils.js';
+import { ResourceMutations } from '../../../src/mutations/resource-mutations.js';
+
+const baseDir = import.meta.dirname;
+const testDir = join(baseDir, 'tmp-card-type-rename');
+const decisionRecordsPath = join(testDir, 'valid/decision-records');
+let project: Project;
+
+describe('CardTypeRenameHandler', () => {
+  beforeEach(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir(join(baseDir, '..', '..', 'test-data'), testDir);
+    project = getTestProject(decisionRecordsPath);
+    await project.populateCaches();
+  });
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('matches a CardType rename input', () => {
+    const handler = new CardTypeRenameHandler();
+    const ctx = {
+      project,
+      input: {
+        kind: 'rename' as const,
+        target: resourceName(`${project.projectPrefix}/cardTypes/decision`),
+        newIdentifier: 'choice',
+      },
+    };
+    expect(handler.matches(ctx)).toBe(true);
+    expect(handler.isBreaking).toBe(true);
+  });
+
+  it('rewrites cardType in every affected card after apply', async () => {
+    const oldName = `${project.projectPrefix}/cardTypes/decision`;
+    const newName = `${project.projectPrefix}/cardTypes/choice`;
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'rename' as const,
+      target: resourceName(oldName),
+      newIdentifier: 'choice',
+    });
+
+    for (const card of project.cards(undefined)) {
+      expect(card.metadata?.cardType).not.toBe(oldName);
+    }
+    // The card type file itself has the new name.
+    const renamed = project.resources.byType(newName, 'cardTypes').show();
+    expect(renamed.name).toBe(newName);
+  });
+
+  it('rewrites occurrences in link-type sourceCardTypes/destinationCardTypes', async () => {
+    const oldName = `${project.projectPrefix}/cardTypes/decision`;
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'rename' as const,
+      target: resourceName(oldName),
+      newIdentifier: 'choice',
+    });
+    for (const lt of project.resources.linkTypes()) {
+      const data = lt.data!;
+      expect(data.sourceCardTypes).not.toContain(oldName);
+      expect(data.destinationCardTypes).not.toContain(oldName);
+    }
+  });
+});

--- a/tools/data-handler/test/mutations/handlers/card-type-workflow-change.test.ts
+++ b/tools/data-handler/test/mutations/handlers/card-type-workflow-change.test.ts
@@ -125,7 +125,7 @@ describe('CardTypeWorkflowChangeHandler', () => {
       .byType(cardTypeName(), 'cardTypes')
       .show();
     expect(updated.workflow).toBe(toWorkflow());
-    // Legacy behavior: with no state mapping, card workflowState is untouched.
+    // With no state mapping, card workflowState is untouched.
     for (const card of project.cards(undefined)) {
       if (card.metadata?.cardType === cardTypeName()) {
         expect(card.metadata.workflowState).toBe(before.get(card.key));

--- a/tools/data-handler/test/mutations/handlers/card-type-workflow-change.test.ts
+++ b/tools/data-handler/test/mutations/handlers/card-type-workflow-change.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { copyDir } from '../../../src/utils/file-utils.js';
+import type { Project } from '../../../src/containers/project.js';
+import { getTestProject } from '../../helpers/test-utils.js';
+import { CardTypeWorkflowChangeHandler } from '../../../src/mutations/handlers/card-type-workflow-change.js';
+import { resourceName } from '../../../src/utils/resource-utils.js';
+import { ResourceMutations } from '../../../src/mutations/resource-mutations.js';
+
+const baseDir = import.meta.dirname;
+const testDir = join(baseDir, 'tmp-card-type-workflow');
+const decisionRecordsPath = join(testDir, 'valid/decision-records');
+let project: Project;
+
+const cardTypeName = () => `${project.projectPrefix}/cardTypes/decision`;
+const fromWorkflow = () => `${project.projectPrefix}/workflows/decision`;
+const toWorkflow = () => `${project.projectPrefix}/workflows/simple`;
+
+describe('CardTypeWorkflowChangeHandler', () => {
+  beforeEach(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir(join(baseDir, '..', '..', 'test-data'), testDir);
+    project = getTestProject(decisionRecordsPath);
+    await project.populateCaches();
+  });
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('matches an edit of cardType.workflow', () => {
+    const handler = new CardTypeWorkflowChangeHandler();
+    const ctx = {
+      project,
+      input: {
+        kind: 'edit' as const,
+        target: resourceName(cardTypeName()),
+        updateKey: { key: 'workflow' },
+        operation: {
+          name: 'change' as const,
+          target: fromWorkflow(),
+          to: toWorkflow(),
+        },
+      },
+    };
+    expect(handler.matches(ctx)).toBe(true);
+    expect(handler.isBreaking).toBe(true);
+  });
+
+  it('rejects incomplete mappings the same way verifyStateMapping does', async () => {
+    const mutations = new ResourceMutations(project);
+    await expect(
+      mutations.apply({
+        kind: 'edit' as const,
+        target: resourceName(cardTypeName()),
+        updateKey: { key: 'workflow' },
+        operation: {
+          name: 'change' as const,
+          target: fromWorkflow(),
+          to: toWorkflow(),
+          mappingTable: {
+            stateMapping: { Draft: 'Created', Approved: 'Approved' },
+          },
+        },
+      }),
+    ).rejects.toThrow(/State mapping validation failed/);
+  });
+
+  it('applies the state mapping when provided', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit' as const,
+      target: resourceName(cardTypeName()),
+      updateKey: { key: 'workflow' },
+      operation: {
+        name: 'change' as const,
+        target: fromWorkflow(),
+        to: toWorkflow(),
+        mappingTable: {
+          stateMapping: {
+            Draft: 'Created',
+            Approved: 'Approved',
+            Rejected: 'Deprecated',
+            Rerejected: 'Deprecated',
+            Deprecated: 'Deprecated',
+          },
+        },
+      },
+    });
+    const updated = project.resources
+      .byType(cardTypeName(), 'cardTypes')
+      .show();
+    expect(updated.workflow).toBe(toWorkflow());
+    for (const card of project.cards(undefined)) {
+      if (card.metadata?.cardType === cardTypeName()) {
+        expect(['Created', 'Approved', 'Deprecated']).toContain(
+          card.metadata.workflowState,
+        );
+      }
+    }
+  });
+
+  it('changes the workflow reference but leaves card states when no mapping is given', async () => {
+    const before = new Map(
+      project
+        .cards(undefined)
+        .filter((c) => c.metadata?.cardType === cardTypeName())
+        .map((c) => [c.key, c.metadata!.workflowState]),
+    );
+
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit' as const,
+      target: resourceName(cardTypeName()),
+      updateKey: { key: 'workflow' },
+      operation: {
+        name: 'change' as const,
+        target: fromWorkflow(),
+        to: toWorkflow(),
+      },
+    });
+
+    const updated = project.resources
+      .byType(cardTypeName(), 'cardTypes')
+      .show();
+    expect(updated.workflow).toBe(toWorkflow());
+    // Legacy behavior: with no state mapping, card workflowState is untouched.
+    for (const card of project.cards(undefined)) {
+      if (card.metadata?.cardType === cardTypeName()) {
+        expect(card.metadata.workflowState).toBe(before.get(card.key));
+      }
+    }
+  });
+});

--- a/tools/data-handler/test/mutations/integration-card-type.test.ts
+++ b/tools/data-handler/test/mutations/integration-card-type.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { copyDir } from '../../src/utils/file-utils.js';
+import type { Project } from '../../src/containers/project.js';
+import { getTestProject } from '../helpers/test-utils.js';
+import { ResourceMutations } from '../../src/mutations/resource-mutations.js';
+import { ConfigurationLogger } from '../../src/utils/configuration-logger.js';
+import { resourceName } from '../../src/utils/resource-utils.js';
+
+const baseDir = import.meta.dirname;
+const testDir = join(baseDir, 'tmp-card-type-integration');
+const decisionRecordsPath = join(testDir, 'valid/decision-records');
+let project: Project;
+
+describe('CardType mutation engine end-to-end', () => {
+  beforeEach(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir(join(baseDir, '..', 'test-data'), testDir);
+    project = getTestProject(decisionRecordsPath);
+    await project.populateCaches();
+  });
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('apply → log entry for a CardType delete with cards', async () => {
+    const mutations = new ResourceMutations(project);
+    const target = resourceName(`${project.projectPrefix}/cardTypes/decision`);
+
+    await mutations.apply({ kind: 'delete', target });
+
+    await project.populateCaches();
+    expect(
+      project.resources.exists(`${project.projectPrefix}/cardTypes/decision`),
+    ).toBe(false);
+    const remaining = project
+      .cards(undefined)
+      .filter(
+        (c) =>
+          c.metadata?.cardType ===
+          `${project.projectPrefix}/cardTypes/decision`,
+      );
+    expect(remaining).toHaveLength(0);
+
+    const entries = await ConfigurationLogger.entries(project.basePath);
+    expect(
+      entries.some(
+        (e) =>
+          e.kind === 'resource_delete' &&
+          e.target === `${project.projectPrefix}/cardTypes/decision`,
+      ),
+    ).toBe(true);
+  });
+
+  it('apply → log entry for a CardType rename', async () => {
+    const mutations = new ResourceMutations(project);
+    const target = resourceName(`${project.projectPrefix}/cardTypes/decision`);
+
+    await mutations.apply({
+      kind: 'rename',
+      target,
+      newIdentifier: 'choice',
+    });
+
+    const entries = await ConfigurationLogger.entries(project.basePath);
+    expect(
+      entries.some(
+        (e) =>
+          e.kind === 'resource_rename' &&
+          e.target === `${project.projectPrefix}/cardTypes/decision`,
+      ),
+    ).toBe(true);
+  });
+
+  it('display-only changes fall through to DefaultNoCascadeHandler (no log entry)', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit',
+      target: resourceName(`${project.projectPrefix}/cardTypes/decision`),
+      updateKey: { key: 'displayName' },
+      operation: { name: 'change', target: 'Decision', to: 'Choice' },
+    });
+
+    const entries = await ConfigurationLogger.entries(project.basePath);
+    expect(entries).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Second PR of the migration-imp split (follows #1387). Extracts the five CardType mutation handlers into the mutation engine: rename, delete, add-custom-field, remove-custom-field, workflow-change.

- Rename/delete carry their cascade (card metadata rewrite, link-type ref stripping, card removal) and delegate the remainder to the still-alive legacy path.
- The three edit handlers are deliberately thin routers into `CardTypeResource.update` — the legacy in-class cascade still runs exactly once; each handler absorbs its cascade when the legacy path is deleted in the cleanup PR ("scaffolding stays" invariant).
- Routing: cardType renames, deletes, and exactly two edit shapes (workflow change, customFields add/remove) divert to `ResourceMutations`; everything else stays on the legacy path.