### PR TITLE
feat(mutations): field type handlers (PR3)

### DIFF
--- a/tools/data-handler/src/commands/remove.ts
+++ b/tools/data-handler/src/commands/remove.ts
@@ -266,7 +266,7 @@ export class Remove {
       );
     }
     if (this.projectResource(type)) {
-      if (type === 'linkType' || type === 'cardType') {
+      if (type === 'linkType' || type === 'cardType' || type === 'fieldType') {
         const target = parseResourceName(targetName);
         const input = { kind: 'delete' as const, target };
         await this.mutations.apply(input);

--- a/tools/data-handler/src/commands/update.ts
+++ b/tools/data-handler/src/commands/update.ts
@@ -60,7 +60,7 @@ export class Update {
     const isRename = updateKey.key === 'name' && operation.name === 'change';
 
     // Only resource families with a dedicated handler are routed through the
-    // engine; the rest use the in-class cascade path. (Do not generalise this
+    // engine; the rest apply their cascade in-class. (Do not generalise this
     // to a blanket Set of types — the dispatcher would route unhandled
     // (type, key, operation) tuples to DefaultNoCascadeHandler and silently
     // drop their cascade.)
@@ -69,8 +69,7 @@ export class Update {
     // linkTypes + fieldTypes route every edit through the engine: dataType /
     // enumValues ops have dedicated handlers, and the remaining shapes (e.g.
     // displayName) fall through to DefaultNoCascadeHandler, which calls
-    // resource.update() — exactly what the legacy path did, with no cascade
-    // and no log entry.
+    // resource.update() with no cascade and no log entry.
     if (type === 'linkTypes' || type === 'fieldTypes') {
       if (isRename) {
         const newIdentifier = parseResourceName(

--- a/tools/data-handler/src/commands/update.ts
+++ b/tools/data-handler/src/commands/update.ts
@@ -66,7 +66,12 @@ export class Update {
     // drop their cascade.)
     const target = parseResourceName(name);
 
-    if (type === 'linkTypes') {
+    // linkTypes + fieldTypes route every edit through the engine: dataType /
+    // enumValues ops have dedicated handlers, and the remaining shapes (e.g.
+    // displayName) fall through to DefaultNoCascadeHandler, which calls
+    // resource.update() — exactly what the legacy path did, with no cascade
+    // and no log entry.
+    if (type === 'linkTypes' || type === 'fieldTypes') {
       if (isRename) {
         const newIdentifier = parseResourceName(
           (operation as ChangeOperation<string>).to,

--- a/tools/data-handler/src/mutations/dispatcher.ts
+++ b/tools/data-handler/src/mutations/dispatcher.ts
@@ -21,6 +21,12 @@ import { CardTypeDeleteHandler } from './handlers/card-type-delete.js';
 import { CardTypeAddCustomFieldHandler } from './handlers/card-type-add-custom-field.js';
 import { CardTypeRemoveCustomFieldHandler } from './handlers/card-type-remove-custom-field.js';
 import { CardTypeWorkflowChangeHandler } from './handlers/card-type-workflow-change.js';
+import { FieldTypeRenameHandler } from './handlers/field-type-rename.js';
+import { FieldTypeDataTypeHandler } from './handlers/field-type-data-type.js';
+import { FieldTypeEnumAddHandler } from './handlers/field-type-enum-add.js';
+import { FieldTypeEnumRemoveHandler } from './handlers/field-type-enum-remove.js';
+import { FieldTypeEnumRenameHandler } from './handlers/field-type-enum-rename.js';
+import { FieldTypeDeleteHandler } from './handlers/field-type-delete.js';
 
 const HANDLERS: Handler[] = [
   new LinkTypeRenameHandler(),
@@ -32,6 +38,15 @@ const HANDLERS: Handler[] = [
   new CardTypeAddCustomFieldHandler(),
   new CardTypeRemoveCustomFieldHandler(),
   new CardTypeWorkflowChangeHandler(),
+  // The field-type handlers below are near-identical thin routers on
+  // purpose: each absorbs its own cascade from FieldTypeResource when the
+  // legacy path is removed, so don't merge them into a shared base.
+  new FieldTypeRenameHandler(),
+  new FieldTypeDataTypeHandler(),
+  new FieldTypeEnumAddHandler(),
+  new FieldTypeEnumRemoveHandler(),
+  new FieldTypeEnumRenameHandler(),
+  new FieldTypeDeleteHandler(),
   new DefaultNoCascadeHandler(),
 ];
 

--- a/tools/data-handler/src/mutations/dispatcher.ts
+++ b/tools/data-handler/src/mutations/dispatcher.ts
@@ -38,9 +38,8 @@ const HANDLERS: Handler[] = [
   new CardTypeAddCustomFieldHandler(),
   new CardTypeRemoveCustomFieldHandler(),
   new CardTypeWorkflowChangeHandler(),
-  // The field-type handlers below are near-identical thin routers on
-  // purpose: each absorbs its own cascade from FieldTypeResource when the
-  // legacy path is removed, so don't merge them into a shared base.
+  // Cascades are operation-specific — keep one handler per edit operation;
+  // don't merge these into a shared base.
   new FieldTypeRenameHandler(),
   new FieldTypeDataTypeHandler(),
   new FieldTypeEnumAddHandler(),

--- a/tools/data-handler/src/mutations/handlers/field-type-data-type.ts
+++ b/tools/data-handler/src/mutations/handlers/field-type-data-type.ts
@@ -1,0 +1,48 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { Handler, MutationContext } from '../handler.js';
+import { resourceNameToString } from '../../utils/resource-utils.js';
+
+/**
+ * Changing a field type's data type is a breaking change: every card carrying
+ * the field has its value converted to the new type. Conversion validation and
+ * the per-card value rewrite still live in FieldTypeResource.update
+ * (isConversionValid + dataTypeChanged), so this handler only routes the
+ * operation and marks it breaking.
+ */
+export class FieldTypeDataTypeHandler implements Handler {
+  readonly isBreaking = true;
+
+  matches(ctx: MutationContext): boolean {
+    return (
+      ctx.input.kind === 'edit' &&
+      ctx.input.target.type === 'fieldTypes' &&
+      ctx.input.updateKey.key === 'dataType' &&
+      ctx.input.operation.name === 'change'
+    );
+  }
+
+  async apply(ctx: MutationContext): Promise<void> {
+    if (ctx.input.kind !== 'edit') {
+      throw new Error('FieldTypeDataTypeHandler: non-edit input');
+    }
+    const fieldName = resourceNameToString(ctx.input.target);
+    const resource = ctx.project.resources.byType(fieldName, 'fieldTypes');
+    if (!resource) {
+      throw new Error(`Field type '${fieldName}' not found`);
+    }
+    await resource.update(ctx.input.updateKey, ctx.input.operation);
+  }
+}

--- a/tools/data-handler/src/mutations/handlers/field-type-data-type.ts
+++ b/tools/data-handler/src/mutations/handlers/field-type-data-type.ts
@@ -18,9 +18,8 @@ import { resourceNameToString } from '../../utils/resource-utils.js';
 /**
  * Changing a field type's data type is a breaking change: every card carrying
  * the field has its value converted to the new type. Conversion validation and
- * the per-card value rewrite still live in FieldTypeResource.update
- * (isConversionValid + dataTypeChanged), so this handler only routes the
- * operation and marks it breaking.
+ * the per-card value rewrite are performed by FieldTypeResource.update, so this
+ * handler only routes the operation and marks it breaking.
  */
 export class FieldTypeDataTypeHandler implements Handler {
   readonly isBreaking = true;

--- a/tools/data-handler/src/mutations/handlers/field-type-delete.ts
+++ b/tools/data-handler/src/mutations/handlers/field-type-delete.ts
@@ -16,12 +16,11 @@ import type { Handler, MutationContext } from '../handler.js';
 import { resourceNameToString } from '../../utils/resource-utils.js';
 
 /**
- * Deleting a field type is a breaking change. On the legacy path a field type
- * has no consumer-side cascade: ResourceObject.delete() refuses (throws) while
- * the field is still referenced by any card or resource (usage() non-empty), so
- * deletion only succeeds once the field is unused. This handler preserves that
- * behavior by delegating to resource.delete(); it only marks the operation
- * breaking so the engine records a log entry.
+ * Deleting a field type is a breaking change. A field type has no consumer-side
+ * cascade: ResourceObject.delete() throws while the field is referenced by any
+ * card or resource (usage() non-empty), so deletion only succeeds once the
+ * field is unused. This handler delegates to resource.delete(); it only marks
+ * the operation breaking so the engine records a log entry.
  */
 export class FieldTypeDeleteHandler implements Handler {
   readonly isBreaking = true;

--- a/tools/data-handler/src/mutations/handlers/field-type-delete.ts
+++ b/tools/data-handler/src/mutations/handlers/field-type-delete.ts
@@ -1,0 +1,46 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { Handler, MutationContext } from '../handler.js';
+import { resourceNameToString } from '../../utils/resource-utils.js';
+
+/**
+ * Deleting a field type is a breaking change. On the legacy path a field type
+ * has no consumer-side cascade: ResourceObject.delete() refuses (throws) while
+ * the field is still referenced by any card or resource (usage() non-empty), so
+ * deletion only succeeds once the field is unused. This handler preserves that
+ * behavior by delegating to resource.delete(); it only marks the operation
+ * breaking so the engine records a log entry.
+ */
+export class FieldTypeDeleteHandler implements Handler {
+  readonly isBreaking = true;
+
+  matches(ctx: MutationContext): boolean {
+    return (
+      ctx.input.kind === 'delete' && ctx.input.target.type === 'fieldTypes'
+    );
+  }
+
+  async apply(ctx: MutationContext): Promise<void> {
+    if (ctx.input.kind !== 'delete') {
+      throw new Error('FieldTypeDeleteHandler: non-delete input');
+    }
+    const fieldName = resourceNameToString(ctx.input.target);
+    const resource = ctx.project.resources.byType(fieldName, 'fieldTypes');
+    if (!resource) {
+      throw new Error(`Field type '${fieldName}' not found`);
+    }
+    await resource.delete();
+  }
+}

--- a/tools/data-handler/src/mutations/handlers/field-type-enum-add.ts
+++ b/tools/data-handler/src/mutations/handlers/field-type-enum-add.ts
@@ -17,10 +17,9 @@ import { resourceNameToString } from '../../utils/resource-utils.js';
 
 /**
  * Adding an enum value has no consumer-side cascade: existing cards keep their
- * current values and are unaffected by the new option. On the legacy path this
- * is a pure resource edit with no card rewrite, so it is NON-breaking and the
- * engine records no log entry. This handler routes the operation to
- * FieldTypeResource.update.
+ * current values and are unaffected by the new option. This is a pure resource
+ * edit with no card rewrite, so it is NON-breaking and the engine records no
+ * log entry. This handler routes the operation to FieldTypeResource.update.
  */
 export class FieldTypeEnumAddHandler implements Handler {
   readonly isBreaking = false;

--- a/tools/data-handler/src/mutations/handlers/field-type-enum-add.ts
+++ b/tools/data-handler/src/mutations/handlers/field-type-enum-add.ts
@@ -1,0 +1,48 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { Handler, MutationContext } from '../handler.js';
+import { resourceNameToString } from '../../utils/resource-utils.js';
+
+/**
+ * Adding an enum value has no consumer-side cascade: existing cards keep their
+ * current values and are unaffected by the new option. On the legacy path this
+ * is a pure resource edit with no card rewrite, so it is NON-breaking and the
+ * engine records no log entry. This handler routes the operation to
+ * FieldTypeResource.update.
+ */
+export class FieldTypeEnumAddHandler implements Handler {
+  readonly isBreaking = false;
+
+  matches(ctx: MutationContext): boolean {
+    return (
+      ctx.input.kind === 'edit' &&
+      ctx.input.target.type === 'fieldTypes' &&
+      ctx.input.updateKey.key === 'enumValues' &&
+      ctx.input.operation.name === 'add'
+    );
+  }
+
+  async apply(ctx: MutationContext): Promise<void> {
+    if (ctx.input.kind !== 'edit') {
+      throw new Error('FieldTypeEnumAddHandler: non-edit input');
+    }
+    const fieldName = resourceNameToString(ctx.input.target);
+    const resource = ctx.project.resources.byType(fieldName, 'fieldTypes');
+    if (!resource) {
+      throw new Error(`Field type '${fieldName}' not found`);
+    }
+    await resource.update(ctx.input.updateKey, ctx.input.operation);
+  }
+}

--- a/tools/data-handler/src/mutations/handlers/field-type-enum-remove.ts
+++ b/tools/data-handler/src/mutations/handlers/field-type-enum-remove.ts
@@ -1,0 +1,50 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { Handler, MutationContext } from '../handler.js';
+import { resourceNameToString } from '../../utils/resource-utils.js';
+
+/**
+ * Removing an enum value is a breaking change. The legacy cascade lives in
+ * FieldTypeResource.update → handleEnumValueReplacements: when the operation
+ * carries a replacementValue, every card holding the removed value is rewritten
+ * to the replacement; with no replacement the value is dropped from the enum
+ * definition only (cards keep their now-orphaned value — the legacy path does
+ * NOT null them). This handler routes the operation unchanged and marks it
+ * breaking.
+ */
+export class FieldTypeEnumRemoveHandler implements Handler {
+  readonly isBreaking = true;
+
+  matches(ctx: MutationContext): boolean {
+    return (
+      ctx.input.kind === 'edit' &&
+      ctx.input.target.type === 'fieldTypes' &&
+      ctx.input.updateKey.key === 'enumValues' &&
+      ctx.input.operation.name === 'remove'
+    );
+  }
+
+  async apply(ctx: MutationContext): Promise<void> {
+    if (ctx.input.kind !== 'edit') {
+      throw new Error('FieldTypeEnumRemoveHandler: non-edit input');
+    }
+    const fieldName = resourceNameToString(ctx.input.target);
+    const resource = ctx.project.resources.byType(fieldName, 'fieldTypes');
+    if (!resource) {
+      throw new Error(`Field type '${fieldName}' not found`);
+    }
+    await resource.update(ctx.input.updateKey, ctx.input.operation);
+  }
+}

--- a/tools/data-handler/src/mutations/handlers/field-type-enum-remove.ts
+++ b/tools/data-handler/src/mutations/handlers/field-type-enum-remove.ts
@@ -16,13 +16,12 @@ import type { Handler, MutationContext } from '../handler.js';
 import { resourceNameToString } from '../../utils/resource-utils.js';
 
 /**
- * Removing an enum value is a breaking change. The legacy cascade lives in
- * FieldTypeResource.update → handleEnumValueReplacements: when the operation
- * carries a replacementValue, every card holding the removed value is rewritten
- * to the replacement; with no replacement the value is dropped from the enum
- * definition only (cards keep their now-orphaned value — the legacy path does
- * NOT null them). This handler routes the operation unchanged and marks it
- * breaking.
+ * Removing an enum value is a breaking change. The cascade is performed by
+ * FieldTypeResource.update: with a replacementValue, every card holding the
+ * removed value is rewritten to the replacement; without one, the value is
+ * removed from the enum definition only and cards keep their orphaned value
+ * (they are NOT nulled). This handler routes the operation unchanged and marks
+ * it breaking.
  */
 export class FieldTypeEnumRemoveHandler implements Handler {
   readonly isBreaking = true;

--- a/tools/data-handler/src/mutations/handlers/field-type-enum-rename.ts
+++ b/tools/data-handler/src/mutations/handlers/field-type-enum-rename.ts
@@ -1,0 +1,59 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { Handler, MutationContext } from '../handler.js';
+import { resourceNameToString } from '../../utils/resource-utils.js';
+import type { ChangeOperation } from '../../resources/resource-object.js';
+import type { EnumDefinition } from '../../interfaces/resource-interfaces.js';
+
+/**
+ * Renaming an enum value (a 'change' on enumValues where the enumValue itself
+ * differs) is a breaking change. On the legacy path FieldTypeResource.update
+ * applies the change to the enum definition array only; it does NOT rewrite the
+ * value carried by existing cards, so cards keep their old value. This handler
+ * routes the operation unchanged and marks it breaking. A change that only edits
+ * enumDisplayValue (same enumValue) is not a rename and falls through to the
+ * default no-cascade handler, matching the legacy definition-only update.
+ */
+export class FieldTypeEnumRenameHandler implements Handler {
+  readonly isBreaking = true;
+
+  matches(ctx: MutationContext): boolean {
+    if (
+      ctx.input.kind !== 'edit' ||
+      ctx.input.target.type !== 'fieldTypes' ||
+      ctx.input.updateKey.key !== 'enumValues' ||
+      ctx.input.operation.name !== 'change'
+    ) {
+      return false;
+    }
+    const op = ctx.input.operation as ChangeOperation<EnumDefinition>;
+    return (
+      (op.target as EnumDefinition).enumValue !==
+      (op.to as EnumDefinition).enumValue
+    );
+  }
+
+  async apply(ctx: MutationContext): Promise<void> {
+    if (ctx.input.kind !== 'edit') {
+      throw new Error('FieldTypeEnumRenameHandler: non-edit input');
+    }
+    const fieldName = resourceNameToString(ctx.input.target);
+    const resource = ctx.project.resources.byType(fieldName, 'fieldTypes');
+    if (!resource) {
+      throw new Error(`Field type '${fieldName}' not found`);
+    }
+    await resource.update(ctx.input.updateKey, ctx.input.operation);
+  }
+}

--- a/tools/data-handler/src/mutations/handlers/field-type-enum-rename.ts
+++ b/tools/data-handler/src/mutations/handlers/field-type-enum-rename.ts
@@ -19,12 +19,12 @@ import type { EnumDefinition } from '../../interfaces/resource-interfaces.js';
 
 /**
  * Renaming an enum value (a 'change' on enumValues where the enumValue itself
- * differs) is a breaking change. On the legacy path FieldTypeResource.update
- * applies the change to the enum definition array only; it does NOT rewrite the
- * value carried by existing cards, so cards keep their old value. This handler
- * routes the operation unchanged and marks it breaking. A change that only edits
+ * differs) is a breaking change. FieldTypeResource.update applies the change to
+ * the enum definition array only; it does NOT rewrite the value carried by
+ * existing cards, so cards keep their old value. This handler routes the
+ * operation unchanged and marks it breaking. A change that only edits
  * enumDisplayValue (same enumValue) is not a rename and falls through to the
- * default no-cascade handler, matching the legacy definition-only update.
+ * default no-cascade handler, which updates the definition only.
  */
 export class FieldTypeEnumRenameHandler implements Handler {
   readonly isBreaking = true;

--- a/tools/data-handler/src/mutations/handlers/field-type-rename.ts
+++ b/tools/data-handler/src/mutations/handlers/field-type-rename.ts
@@ -1,0 +1,52 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { Handler, MutationContext } from '../handler.js';
+import {
+  resourceName,
+  resourceNameToString,
+} from '../../utils/resource-utils.js';
+
+/**
+ * Renaming a field type is a breaking change: card-content references,
+ * calculations, handlebars and the customFields[].name entries on every
+ * referencing card type are rewritten. The whole cascade still lives in
+ * FieldTypeResource.rename → onNameChange (updateCardTypes +
+ * updateCardContentReferences + updateCalculations + updateHandleBars), so this
+ * handler is a thin router: it delegates to resource.rename() and only marks the
+ * operation breaking so the engine records a log entry.
+ */
+export class FieldTypeRenameHandler implements Handler {
+  readonly isBreaking = true;
+
+  matches(ctx: MutationContext): boolean {
+    return (
+      ctx.input.kind === 'rename' && ctx.input.target.type === 'fieldTypes'
+    );
+  }
+
+  async apply(ctx: MutationContext): Promise<void> {
+    if (ctx.input.kind !== 'rename') {
+      throw new Error('FieldTypeRenameHandler called with non-rename input');
+    }
+    const oldName = resourceNameToString(ctx.input.target);
+    const newName = `${ctx.input.target.prefix}/fieldTypes/${ctx.input.newIdentifier}`;
+
+    const resource = ctx.project.resources.byType(oldName, 'fieldTypes');
+    if (!resource) {
+      throw new Error(`Field type '${oldName}' not found`);
+    }
+    await resource.rename(resourceName(newName));
+  }
+}

--- a/tools/data-handler/src/mutations/handlers/field-type-rename.ts
+++ b/tools/data-handler/src/mutations/handlers/field-type-rename.ts
@@ -21,11 +21,9 @@ import {
 /**
  * Renaming a field type is a breaking change: card-content references,
  * calculations, handlebars and the customFields[].name entries on every
- * referencing card type are rewritten. The whole cascade still lives in
- * FieldTypeResource.rename → onNameChange (updateCardTypes +
- * updateCardContentReferences + updateCalculations + updateHandleBars), so this
- * handler is a thin router: it delegates to resource.rename() and only marks the
- * operation breaking so the engine records a log entry.
+ * referencing card type are rewritten. The cascade is performed by
+ * FieldTypeResource.rename; this handler delegates to resource.rename() and
+ * marks the operation breaking so the engine records a log entry.
  */
 export class FieldTypeRenameHandler implements Handler {
   readonly isBreaking = true;

--- a/tools/data-handler/test/mutations/handlers/field-type-data-type.test.ts
+++ b/tools/data-handler/test/mutations/handlers/field-type-data-type.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { copyDir } from '../../../src/utils/file-utils.js';
+import type { Project } from '../../../src/containers/project.js';
+import { getTestProject } from '../../helpers/test-utils.js';
+import { FieldTypeDataTypeHandler } from '../../../src/mutations/handlers/field-type-data-type.js';
+import { resourceName } from '../../../src/utils/resource-utils.js';
+import { ResourceMutations } from '../../../src/mutations/resource-mutations.js';
+
+const baseDir = import.meta.dirname;
+const testDir = join(baseDir, 'tmp-field-type-data-type');
+const decisionRecordsPath = join(testDir, 'valid/decision-records');
+let project: Project;
+
+const fieldName = () => `${project.projectPrefix}/fieldTypes/finished`;
+
+describe('FieldTypeDataTypeHandler', () => {
+  beforeEach(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir(join(baseDir, '..', '..', 'test-data'), testDir);
+    project = getTestProject(decisionRecordsPath);
+    await project.populateCaches();
+
+    // Ensure at least one card carries 'finished' with a non-null boolean value.
+    const cards = project
+      .cards(undefined)
+      .filter((c) => c.metadata && fieldName() in c.metadata);
+    if (cards.length > 0 && cards[0].metadata) {
+      cards[0].metadata[fieldName()] = true;
+      await project.updateCardMetadata(cards[0], cards[0].metadata);
+    }
+  });
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('matches an edit with key=dataType on a field type', () => {
+    const handler = new FieldTypeDataTypeHandler();
+    const ctx = {
+      project,
+      input: {
+        kind: 'edit' as const,
+        target: resourceName(fieldName()),
+        updateKey: { key: 'dataType' as const },
+        operation: {
+          name: 'change' as const,
+          target: 'boolean',
+          to: 'shortText',
+        },
+      },
+    };
+    expect(handler.matches(ctx)).toBe(true);
+    expect(handler.isBreaking).toBe(true);
+  });
+
+  it('does not match a displayName change', () => {
+    const handler = new FieldTypeDataTypeHandler();
+    const ctx = {
+      project,
+      input: {
+        kind: 'edit' as const,
+        target: resourceName(fieldName()),
+        updateKey: { key: 'displayName' as const },
+        operation: { name: 'change' as const, target: 'Finished', to: 'Done' },
+      },
+    };
+    expect(handler.matches(ctx)).toBe(false);
+  });
+
+  it('converts values on every affected card and updates the field definition', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit' as const,
+      target: resourceName(fieldName()),
+      updateKey: { key: 'dataType' as const },
+      operation: {
+        name: 'change' as const,
+        target: 'boolean',
+        to: 'shortText',
+      },
+    });
+
+    const updated = project.resources.byType(fieldName(), 'fieldTypes').show();
+    expect(updated.dataType).toBe('shortText');
+    for (const card of project.cards(undefined)) {
+      const value = card.metadata?.[fieldName()];
+      if (value === undefined || value === null) continue;
+      expect(typeof value).toBe('string');
+    }
+  });
+
+  it('rejects a conversion that is not allowed', async () => {
+    const mutations = new ResourceMutations(project);
+    await expect(
+      mutations.apply({
+        kind: 'edit' as const,
+        target: resourceName(fieldName()),
+        updateKey: { key: 'dataType' as const },
+        operation: { name: 'change' as const, target: 'boolean', to: 'date' },
+      }),
+    ).rejects.toThrow(/Cannot change data type/);
+  });
+});

--- a/tools/data-handler/test/mutations/handlers/field-type-delete.test.ts
+++ b/tools/data-handler/test/mutations/handlers/field-type-delete.test.ts
@@ -52,7 +52,7 @@ describe('FieldTypeDeleteHandler', () => {
     expect(project.resources.exists(name)).toBe(false);
   });
 
-  it('refuses to delete a field type still used by a card type (legacy usage guard)', async () => {
+  it('refuses to delete a field type used by a card type', async () => {
     // 'finished' is referenced by the decision card type's customFields.
     const name = `${project.projectPrefix}/fieldTypes/finished`;
     const mutations = new ResourceMutations(project);

--- a/tools/data-handler/test/mutations/handlers/field-type-delete.test.ts
+++ b/tools/data-handler/test/mutations/handlers/field-type-delete.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { copyDir } from '../../../src/utils/file-utils.js';
+import type { Project } from '../../../src/containers/project.js';
+import { getTestProject } from '../../helpers/test-utils.js';
+import { FieldTypeDeleteHandler } from '../../../src/mutations/handlers/field-type-delete.js';
+import { resourceName } from '../../../src/utils/resource-utils.js';
+import { ResourceMutations } from '../../../src/mutations/resource-mutations.js';
+
+const baseDir = import.meta.dirname;
+const testDir = join(baseDir, 'tmp-field-type-delete');
+const decisionRecordsPath = join(testDir, 'valid/decision-records');
+let project: Project;
+
+describe('FieldTypeDeleteHandler', () => {
+  beforeEach(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir(join(baseDir, '..', '..', 'test-data'), testDir);
+    project = getTestProject(decisionRecordsPath);
+    await project.populateCaches();
+  });
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('matches a FieldType delete input', () => {
+    const handler = new FieldTypeDeleteHandler();
+    expect(
+      handler.matches({
+        project,
+        input: {
+          kind: 'delete',
+          target: resourceName(`${project.projectPrefix}/fieldTypes/finished`),
+        },
+      }),
+    ).toBe(true);
+    expect(handler.isBreaking).toBe(true);
+  });
+
+  it('deletes an unused field type resource from disk', async () => {
+    const name = `${project.projectPrefix}/fieldTypes/unusedField`;
+    await project.resources
+      .byType(name, 'fieldTypes')
+      .createFieldType('shortText');
+    expect(project.resources.exists(name)).toBe(true);
+
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({ kind: 'delete', target: resourceName(name) });
+
+    expect(project.resources.exists(name)).toBe(false);
+  });
+
+  it('refuses to delete a field type still used by a card type (legacy usage guard)', async () => {
+    // 'finished' is referenced by the decision card type's customFields.
+    const name = `${project.projectPrefix}/fieldTypes/finished`;
+    const mutations = new ResourceMutations(project);
+    await expect(
+      mutations.apply({ kind: 'delete', target: resourceName(name) }),
+    ).rejects.toThrow(/used by/);
+    expect(project.resources.exists(name)).toBe(true);
+  });
+});

--- a/tools/data-handler/test/mutations/handlers/field-type-enum-add.test.ts
+++ b/tools/data-handler/test/mutations/handlers/field-type-enum-add.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { copyDir } from '../../../src/utils/file-utils.js';
+import type { Project } from '../../../src/containers/project.js';
+import { getTestProject } from '../../helpers/test-utils.js';
+import { FieldTypeEnumAddHandler } from '../../../src/mutations/handlers/field-type-enum-add.js';
+import { resourceName } from '../../../src/utils/resource-utils.js';
+import { ResourceMutations } from '../../../src/mutations/resource-mutations.js';
+
+const baseDir = import.meta.dirname;
+const testDir = join(baseDir, 'tmp-field-type-enum-add');
+const decisionRecordsPath = join(testDir, 'valid/decision-records');
+let project: Project;
+
+const fieldName = () => `${project.projectPrefix}/fieldTypes/testEnum`;
+
+function seedEnumField() {
+  const enumFieldPath = join(
+    decisionRecordsPath,
+    '.cards',
+    'local',
+    'fieldTypes',
+    'testEnum.json',
+  );
+  writeFileSync(
+    enumFieldPath,
+    JSON.stringify(
+      {
+        name: 'decision/fieldTypes/testEnum',
+        displayName: 'Test Enum',
+        description: 'A seeded enum field type for handler tests',
+        dataType: 'enum',
+        enumValues: [
+          { enumValue: 'low' },
+          { enumValue: 'medium' },
+          { enumValue: 'high' },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+describe('FieldTypeEnumAddHandler', () => {
+  beforeEach(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir(join(baseDir, '..', '..', 'test-data'), testDir);
+    seedEnumField();
+    project = getTestProject(decisionRecordsPath);
+    await project.populateCaches();
+  });
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('matches add operation on enumValues', () => {
+    const handler = new FieldTypeEnumAddHandler();
+    const ctx = {
+      project,
+      input: {
+        kind: 'edit' as const,
+        target: resourceName(fieldName()),
+        updateKey: { key: 'enumValues' as const },
+        operation: { name: 'add' as const, target: { enumValue: 'fresh' } },
+      },
+    };
+    expect(handler.matches(ctx)).toBe(true);
+  });
+
+  it('does not match remove on enumValues', () => {
+    const handler = new FieldTypeEnumAddHandler();
+    const ctx = {
+      project,
+      input: {
+        kind: 'edit' as const,
+        target: resourceName(fieldName()),
+        updateKey: { key: 'enumValues' as const },
+        operation: { name: 'remove' as const, target: { enumValue: 'low' } },
+      },
+    };
+    expect(handler.matches(ctx)).toBe(false);
+  });
+
+  it('is non-breaking', () => {
+    expect(new FieldTypeEnumAddHandler().isBreaking).toBe(false);
+  });
+
+  it('adds the new value to the field definition', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit' as const,
+      target: resourceName(fieldName()),
+      updateKey: { key: 'enumValues' as const },
+      operation: { name: 'add' as const, target: { enumValue: 'critical' } },
+    });
+    const updated = project.resources.byType(fieldName(), 'fieldTypes').show();
+    const values = (updated.enumValues ?? []).map((e) => e.enumValue);
+    expect(values).toContain('critical');
+  });
+});

--- a/tools/data-handler/test/mutations/handlers/field-type-enum-remove.test.ts
+++ b/tools/data-handler/test/mutations/handlers/field-type-enum-remove.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { copyDir } from '../../../src/utils/file-utils.js';
+import type { Project } from '../../../src/containers/project.js';
+import { getTestProject } from '../../helpers/test-utils.js';
+import { FieldTypeEnumRemoveHandler } from '../../../src/mutations/handlers/field-type-enum-remove.js';
+import { resourceName } from '../../../src/utils/resource-utils.js';
+import { ResourceMutations } from '../../../src/mutations/resource-mutations.js';
+import type { Operation } from '../../../src/resources/resource-object.js';
+
+const baseDir = import.meta.dirname;
+const testDir = join(baseDir, 'tmp-field-type-enum-remove');
+const decisionRecordsPath = join(testDir, 'valid/decision-records');
+let project: Project;
+
+const fieldName = () => `${project.projectPrefix}/fieldTypes/testEnum`;
+
+function seedEnumField() {
+  const enumFieldPath = join(
+    decisionRecordsPath,
+    '.cards',
+    'local',
+    'fieldTypes',
+    'testEnum.json',
+  );
+  writeFileSync(
+    enumFieldPath,
+    JSON.stringify(
+      {
+        name: 'decision/fieldTypes/testEnum',
+        displayName: 'Test Enum',
+        description: 'A seeded enum field type for handler tests',
+        dataType: 'enum',
+        enumValues: [
+          { enumValue: 'low' },
+          { enumValue: 'medium' },
+          { enumValue: 'high' },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+// Register the enum field on the decision card type so the legacy replacement
+// cascade (which only touches cards of card types declaring the field) has a
+// reference to follow, then seed the value 'low' onto those cards.
+async function seedCardTypeAndCardValues() {
+  const cardTypeName = `${project.projectPrefix}/cardTypes/decision`;
+  await project.resources
+    .byType(cardTypeName, 'cardTypes')
+    .update({ key: 'customFields' }, {
+      name: 'add',
+      target: { name: fieldName() },
+    } as Operation<{ name: string }>);
+  const cards = project
+    .cards(undefined)
+    .filter((c) => c.metadata?.cardType === cardTypeName);
+  for (const card of cards) {
+    card.metadata![fieldName()] = 'low';
+    await project.updateCardMetadata(card, card.metadata!);
+  }
+}
+
+describe('FieldTypeEnumRemoveHandler', () => {
+  beforeEach(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir(join(baseDir, '..', '..', 'test-data'), testDir);
+    seedEnumField();
+    project = getTestProject(decisionRecordsPath);
+    await project.populateCaches();
+    await seedCardTypeAndCardValues();
+  });
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('matches remove on enumValues', () => {
+    const handler = new FieldTypeEnumRemoveHandler();
+    const ctx = {
+      project,
+      input: {
+        kind: 'edit' as const,
+        target: resourceName(fieldName()),
+        updateKey: { key: 'enumValues' as const },
+        operation: { name: 'remove' as const, target: { enumValue: 'low' } },
+      },
+    };
+    expect(handler.matches(ctx)).toBe(true);
+    expect(handler.isBreaking).toBe(true);
+  });
+
+  it('removes the value from the field definition', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit' as const,
+      target: resourceName(fieldName()),
+      updateKey: { key: 'enumValues' as const },
+      operation: { name: 'remove' as const, target: { enumValue: 'low' } },
+    });
+    const updated = project.resources.byType(fieldName(), 'fieldTypes').show();
+    const values = (updated.enumValues ?? []).map((e) => e.enumValue);
+    expect(values).not.toContain('low');
+  });
+
+  it('rewrites card values when a replacementValue is provided', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit' as const,
+      target: resourceName(fieldName()),
+      updateKey: { key: 'enumValues' as const },
+      operation: {
+        name: 'remove' as const,
+        target: { enumValue: 'low' },
+        replacementValue: { enumValue: 'medium' },
+      },
+    });
+    const cards = project
+      .cards(undefined)
+      .filter((c) => c.metadata?.[fieldName()] !== undefined);
+    for (const card of cards) {
+      expect(card.metadata?.[fieldName()]).not.toBe('low');
+    }
+    const anyMedium = cards.some((c) => c.metadata?.[fieldName()] === 'medium');
+    expect(anyMedium).toBe(true);
+  });
+
+  it('leaves card values untouched when no replacement is given (legacy behavior)', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit' as const,
+      target: resourceName(fieldName()),
+      updateKey: { key: 'enumValues' as const },
+      operation: { name: 'remove' as const, target: { enumValue: 'low' } },
+    });
+    // The legacy path only replaces values when a replacementValue is given;
+    // with none, cards keep their now-orphaned value (they are NOT nulled).
+    const cards = project
+      .cards(undefined)
+      .filter((c) => c.metadata?.[fieldName()] !== undefined);
+    const anyStillLow = cards.some((c) => c.metadata?.[fieldName()] === 'low');
+    expect(anyStillLow).toBe(true);
+  });
+});

--- a/tools/data-handler/test/mutations/handlers/field-type-enum-remove.test.ts
+++ b/tools/data-handler/test/mutations/handlers/field-type-enum-remove.test.ts
@@ -8,7 +8,6 @@ import { getTestProject } from '../../helpers/test-utils.js';
 import { FieldTypeEnumRemoveHandler } from '../../../src/mutations/handlers/field-type-enum-remove.js';
 import { resourceName } from '../../../src/utils/resource-utils.js';
 import { ResourceMutations } from '../../../src/mutations/resource-mutations.js';
-import type { Operation } from '../../../src/resources/resource-object.js';
 
 const baseDir = import.meta.dirname;
 const testDir = join(baseDir, 'tmp-field-type-enum-remove');
@@ -45,17 +44,18 @@ function seedEnumField() {
   );
 }
 
-// Register the enum field on the decision card type so the legacy replacement
-// cascade (which only touches cards of card types declaring the field) has a
-// reference to follow, then seed the value 'low' onto those cards.
+// Register the enum field on the decision card type so the replacement cascade
+// (which only touches cards of card types declaring the field) has a reference
+// to follow, then seed the value 'low' onto those cards.
 async function seedCardTypeAndCardValues() {
   const cardTypeName = `${project.projectPrefix}/cardTypes/decision`;
-  await project.resources
-    .byType(cardTypeName, 'cardTypes')
-    .update({ key: 'customFields' }, {
-      name: 'add',
+  await project.resources.byType(cardTypeName, 'cardTypes').update(
+    { key: 'customFields' },
+    {
+      name: 'add' as const,
       target: { name: fieldName() },
-    } as Operation<{ name: string }>);
+    },
+  );
   const cards = project
     .cards(undefined)
     .filter((c) => c.metadata?.cardType === cardTypeName);
@@ -128,7 +128,7 @@ describe('FieldTypeEnumRemoveHandler', () => {
     expect(anyMedium).toBe(true);
   });
 
-  it('leaves card values untouched when no replacement is given (legacy behavior)', async () => {
+  it('leaves card values untouched when no replacement is given', async () => {
     const mutations = new ResourceMutations(project);
     await mutations.apply({
       kind: 'edit' as const,
@@ -136,8 +136,8 @@ describe('FieldTypeEnumRemoveHandler', () => {
       updateKey: { key: 'enumValues' as const },
       operation: { name: 'remove' as const, target: { enumValue: 'low' } },
     });
-    // The legacy path only replaces values when a replacementValue is given;
-    // with none, cards keep their now-orphaned value (they are NOT nulled).
+    // Values are only replaced when a replacementValue is given; with none,
+    // cards keep their orphaned value (they are NOT nulled).
     const cards = project
       .cards(undefined)
       .filter((c) => c.metadata?.[fieldName()] !== undefined);

--- a/tools/data-handler/test/mutations/handlers/field-type-enum-rename.test.ts
+++ b/tools/data-handler/test/mutations/handlers/field-type-enum-rename.test.ts
@@ -122,7 +122,7 @@ describe('FieldTypeEnumRenameHandler', () => {
     expect(values).not.toContain('low');
   });
 
-  it('leaves card values untouched (legacy definition-only behavior)', async () => {
+  it('leaves card values untouched', async () => {
     const mutations = new ResourceMutations(project);
     await mutations.apply({
       kind: 'edit' as const,
@@ -134,8 +134,7 @@ describe('FieldTypeEnumRenameHandler', () => {
         to: { enumValue: 'minor' },
       },
     });
-    // The legacy path updates the enum definition only; existing cards keep
-    // their old value.
+    // The enum definition is updated only; existing cards keep their old value.
     const anyStillLow = project
       .cards(undefined)
       .some((c) => c.metadata?.[fieldName()] === 'low');

--- a/tools/data-handler/test/mutations/handlers/field-type-enum-rename.test.ts
+++ b/tools/data-handler/test/mutations/handlers/field-type-enum-rename.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { copyDir } from '../../../src/utils/file-utils.js';
+import type { Project } from '../../../src/containers/project.js';
+import { getTestProject } from '../../helpers/test-utils.js';
+import { FieldTypeEnumRenameHandler } from '../../../src/mutations/handlers/field-type-enum-rename.js';
+import { resourceName } from '../../../src/utils/resource-utils.js';
+import { ResourceMutations } from '../../../src/mutations/resource-mutations.js';
+
+const baseDir = import.meta.dirname;
+const testDir = join(baseDir, 'tmp-field-type-enum-rename');
+const decisionRecordsPath = join(testDir, 'valid/decision-records');
+let project: Project;
+
+const fieldName = () => `${project.projectPrefix}/fieldTypes/testEnum`;
+
+function seedEnumField() {
+  const enumFieldPath = join(
+    decisionRecordsPath,
+    '.cards',
+    'local',
+    'fieldTypes',
+    'testEnum.json',
+  );
+  writeFileSync(
+    enumFieldPath,
+    JSON.stringify(
+      {
+        name: 'decision/fieldTypes/testEnum',
+        displayName: 'Test Enum',
+        description: 'A seeded enum field type for handler tests',
+        dataType: 'enum',
+        enumValues: [
+          { enumValue: 'low' },
+          { enumValue: 'medium' },
+          { enumValue: 'high' },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+async function seedCardValues() {
+  const cards = project
+    .cards(undefined)
+    .filter((c) => c.metadata && c.metadata.cardType);
+  for (const card of cards) {
+    card.metadata![fieldName()] = 'low';
+    await project.updateCardMetadata(card, card.metadata!);
+  }
+}
+
+describe('FieldTypeEnumRenameHandler', () => {
+  beforeEach(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir(join(baseDir, '..', '..', 'test-data'), testDir);
+    seedEnumField();
+    project = getTestProject(decisionRecordsPath);
+    await project.populateCaches();
+    await seedCardValues();
+  });
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('matches change on enumValues where enumValue differs', () => {
+    const handler = new FieldTypeEnumRenameHandler();
+    const ctx = {
+      project,
+      input: {
+        kind: 'edit' as const,
+        target: resourceName(fieldName()),
+        updateKey: { key: 'enumValues' as const },
+        operation: {
+          name: 'change' as const,
+          target: { enumValue: 'low' },
+          to: { enumValue: 'minor' },
+        },
+      },
+    };
+    expect(handler.matches(ctx)).toBe(true);
+    expect(handler.isBreaking).toBe(true);
+  });
+
+  it('does not match a change that only edits enumDisplayValue', () => {
+    const handler = new FieldTypeEnumRenameHandler();
+    const ctx = {
+      project,
+      input: {
+        kind: 'edit' as const,
+        target: resourceName(fieldName()),
+        updateKey: { key: 'enumValues' as const },
+        operation: {
+          name: 'change' as const,
+          target: { enumValue: 'low' },
+          to: { enumValue: 'low', enumDisplayValue: 'Low priority' },
+        },
+      },
+    };
+    expect(handler.matches(ctx)).toBe(false);
+  });
+
+  it('renames the value in the field definition', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit' as const,
+      target: resourceName(fieldName()),
+      updateKey: { key: 'enumValues' as const },
+      operation: {
+        name: 'change' as const,
+        target: { enumValue: 'low' },
+        to: { enumValue: 'minor' },
+      },
+    });
+    const updated = project.resources.byType(fieldName(), 'fieldTypes').show();
+    const values = (updated.enumValues ?? []).map((e) => e.enumValue);
+    expect(values).toContain('minor');
+    expect(values).not.toContain('low');
+  });
+
+  it('leaves card values untouched (legacy definition-only behavior)', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit' as const,
+      target: resourceName(fieldName()),
+      updateKey: { key: 'enumValues' as const },
+      operation: {
+        name: 'change' as const,
+        target: { enumValue: 'low' },
+        to: { enumValue: 'minor' },
+      },
+    });
+    // The legacy path updates the enum definition only; existing cards keep
+    // their old value.
+    const anyStillLow = project
+      .cards(undefined)
+      .some((c) => c.metadata?.[fieldName()] === 'low');
+    expect(anyStillLow).toBe(true);
+  });
+});

--- a/tools/data-handler/test/mutations/handlers/field-type-rename.test.ts
+++ b/tools/data-handler/test/mutations/handlers/field-type-rename.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { copyDir } from '../../../src/utils/file-utils.js';
+import type { Project } from '../../../src/containers/project.js';
+import { getTestProject } from '../../helpers/test-utils.js';
+import { FieldTypeRenameHandler } from '../../../src/mutations/handlers/field-type-rename.js';
+import { resourceName } from '../../../src/utils/resource-utils.js';
+import { ResourceMutations } from '../../../src/mutations/resource-mutations.js';
+
+const baseDir = import.meta.dirname;
+const testDir = join(baseDir, 'tmp-field-type-rename');
+const decisionRecordsPath = join(testDir, 'valid/decision-records');
+let project: Project;
+
+describe('FieldTypeRenameHandler', () => {
+  beforeEach(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir(join(baseDir, '..', '..', 'test-data'), testDir);
+    project = getTestProject(decisionRecordsPath);
+    await project.populateCaches();
+  });
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('matches a field-type rename input', () => {
+    const handler = new FieldTypeRenameHandler();
+    const ctx = {
+      project,
+      input: {
+        kind: 'rename' as const,
+        target: resourceName(`${project.projectPrefix}/fieldTypes/finished`),
+        newIdentifier: 'completed',
+      },
+    };
+    expect(handler.matches(ctx)).toBe(true);
+    expect(handler.isBreaking).toBe(true);
+  });
+
+  it('does not match a link-type rename', () => {
+    const handler = new FieldTypeRenameHandler();
+    const ctx = {
+      project,
+      input: {
+        kind: 'rename' as const,
+        target: resourceName(`${project.projectPrefix}/linkTypes/test`),
+        newIdentifier: 'is-caused-by',
+      },
+    };
+    expect(handler.matches(ctx)).toBe(false);
+  });
+
+  it('renames the resource on disk via the legacy cascade', async () => {
+    // Rename an unused field type. (Renaming a field referenced by a card type
+    // is not supported on the legacy path: FieldTypeResource.rename's
+    // updateCardTypes cascade re-validates the now-removed old field name and
+    // throws — see the rejection test below. The handler faithfully preserves
+    // that behavior, so the happy path renames an unreferenced field.)
+    const oldName = `${project.projectPrefix}/fieldTypes/spare`;
+    const newName = `${project.projectPrefix}/fieldTypes/spareRenamed`;
+    await project.resources
+      .byType(oldName, 'fieldTypes')
+      .createFieldType('shortText');
+
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'rename' as const,
+      target: resourceName(oldName),
+      newIdentifier: 'spareRenamed',
+    });
+
+    const renamed = project.resources.byType(newName, 'fieldTypes').show();
+    expect(renamed.name).toBe(newName);
+    expect(project.resources.exists(oldName)).toBe(false);
+  });
+
+  it('reproduces the legacy rejection when renaming a field referenced by a card type', async () => {
+    // 'finished' is referenced by the decision card type's customFields. The
+    // legacy updateCardTypes cascade re-validates the old name after the
+    // resource is renamed and throws. The handler must not mask this.
+    const oldName = `${project.projectPrefix}/fieldTypes/finished`;
+    const mutations = new ResourceMutations(project);
+    await expect(
+      mutations.apply({
+        kind: 'rename' as const,
+        target: resourceName(oldName),
+        newIdentifier: 'completed',
+      }),
+    ).rejects.toThrow(/does not exist in the project/);
+  });
+});

--- a/tools/data-handler/test/mutations/handlers/field-type-rename.test.ts
+++ b/tools/data-handler/test/mutations/handlers/field-type-rename.test.ts
@@ -52,12 +52,11 @@ describe('FieldTypeRenameHandler', () => {
     expect(handler.matches(ctx)).toBe(false);
   });
 
-  it('renames the resource on disk via the legacy cascade', async () => {
+  it('renames the resource on disk via the cascade', async () => {
     // Rename an unused field type. (Renaming a field referenced by a card type
-    // is not supported on the legacy path: FieldTypeResource.rename's
-    // updateCardTypes cascade re-validates the now-removed old field name and
-    // throws — see the rejection test below. The handler faithfully preserves
-    // that behavior, so the happy path renames an unreferenced field.)
+    // is rejected: FieldTypeResource.rename's updateCardTypes cascade
+    // re-validates the now-removed old field name and throws, so the happy path
+    // renames an unreferenced field.)
     const oldName = `${project.projectPrefix}/fieldTypes/spare`;
     const newName = `${project.projectPrefix}/fieldTypes/spareRenamed`;
     await project.resources
@@ -76,10 +75,10 @@ describe('FieldTypeRenameHandler', () => {
     expect(project.resources.exists(oldName)).toBe(false);
   });
 
-  it('reproduces the legacy rejection when renaming a field referenced by a card type', async () => {
+  it('rejects renaming a field referenced by a card type', async () => {
     // 'finished' is referenced by the decision card type's customFields. The
-    // legacy updateCardTypes cascade re-validates the old name after the
-    // resource is renamed and throws. The handler must not mask this.
+    // updateCardTypes cascade re-validates the old name after the resource is
+    // renamed and throws. The handler must not mask this.
     const oldName = `${project.projectPrefix}/fieldTypes/finished`;
     const mutations = new ResourceMutations(project);
     await expect(

--- a/tools/data-handler/test/mutations/integration-field-type.test.ts
+++ b/tools/data-handler/test/mutations/integration-field-type.test.ts
@@ -42,8 +42,8 @@ describe('FieldType mutation engine end-to-end', () => {
   });
 
   it('apply → log entry for a FieldType rename (unused field)', async () => {
-    // Renaming a field referenced by a card type is unsupported on the legacy
-    // path (see field-type-rename.test.ts), so rename an unused field.
+    // Renaming a field still referenced by a card type is rejected, so rename
+    // an unused field.
     const name = `${project.projectPrefix}/fieldTypes/spare`;
     await project.resources
       .byType(name, 'fieldTypes')

--- a/tools/data-handler/test/mutations/integration-field-type.test.ts
+++ b/tools/data-handler/test/mutations/integration-field-type.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { copyDir } from '../../src/utils/file-utils.js';
+import type { Project } from '../../src/containers/project.js';
+import { getTestProject } from '../helpers/test-utils.js';
+import { ResourceMutations } from '../../src/mutations/resource-mutations.js';
+import { ConfigurationLogger } from '../../src/utils/configuration-logger.js';
+import { resourceName } from '../../src/utils/resource-utils.js';
+
+const baseDir = import.meta.dirname;
+const testDir = join(baseDir, 'tmp-field-type-integration');
+const decisionRecordsPath = join(testDir, 'valid/decision-records');
+let project: Project;
+
+describe('FieldType mutation engine end-to-end', () => {
+  beforeEach(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir(join(baseDir, '..', 'test-data'), testDir);
+    project = getTestProject(decisionRecordsPath);
+    await project.populateCaches();
+  });
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('apply → log entry for a FieldType delete (unused field)', async () => {
+    const name = `${project.projectPrefix}/fieldTypes/unusedField`;
+    await project.resources
+      .byType(name, 'fieldTypes')
+      .createFieldType('shortText');
+
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({ kind: 'delete', target: resourceName(name) });
+
+    expect(project.resources.exists(name)).toBe(false);
+    const entries = await ConfigurationLogger.entries(project.basePath);
+    expect(
+      entries.some((e) => e.kind === 'resource_delete' && e.target === name),
+    ).toBe(true);
+  });
+
+  it('apply → log entry for a FieldType rename (unused field)', async () => {
+    // Renaming a field referenced by a card type is unsupported on the legacy
+    // path (see field-type-rename.test.ts), so rename an unused field.
+    const name = `${project.projectPrefix}/fieldTypes/spare`;
+    await project.resources
+      .byType(name, 'fieldTypes')
+      .createFieldType('shortText');
+    const target = resourceName(name);
+    const mutations = new ResourceMutations(project);
+
+    await mutations.apply({
+      kind: 'rename',
+      target,
+      newIdentifier: 'spareRenamed',
+    });
+
+    const entries = await ConfigurationLogger.entries(project.basePath);
+    expect(
+      entries.some((e) => e.kind === 'resource_rename' && e.target === name),
+    ).toBe(true);
+  });
+
+  it('apply → log entry for a FieldType dataType change', async () => {
+    const target = resourceName(`${project.projectPrefix}/fieldTypes/finished`);
+    const mutations = new ResourceMutations(project);
+
+    await mutations.apply({
+      kind: 'edit',
+      target,
+      updateKey: { key: 'dataType' },
+      operation: { name: 'change', target: 'boolean', to: 'shortText' },
+    });
+
+    const entries = await ConfigurationLogger.entries(project.basePath);
+    expect(
+      entries.some(
+        (e) =>
+          e.kind === 'resource_edit' &&
+          e.target === `${project.projectPrefix}/fieldTypes/finished`,
+      ),
+    ).toBe(true);
+  });
+
+  it('adding an enum value is non-breaking (no log entry)', async () => {
+    const enumFieldPath = join(
+      decisionRecordsPath,
+      '.cards',
+      'local',
+      'fieldTypes',
+      'testEnum.json',
+    );
+    writeFileSync(
+      enumFieldPath,
+      JSON.stringify({
+        name: 'decision/fieldTypes/testEnum',
+        displayName: 'Test Enum',
+        dataType: 'enum',
+        enumValues: [{ enumValue: 'low' }, { enumValue: 'high' }],
+      }),
+    );
+    const freshProject = getTestProject(decisionRecordsPath);
+    await freshProject.populateCaches();
+
+    const mutations = new ResourceMutations(freshProject);
+    await mutations.apply({
+      kind: 'edit',
+      target: resourceName(`${freshProject.projectPrefix}/fieldTypes/testEnum`),
+      updateKey: { key: 'enumValues' },
+      operation: { name: 'add', target: { enumValue: 'medium' } },
+    });
+
+    const entries = await ConfigurationLogger.entries(freshProject.basePath);
+    expect(entries).toHaveLength(0);
+  });
+
+  it('display-only changes fall through to DefaultNoCascadeHandler (no log entry)', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit',
+      target: resourceName(`${project.projectPrefix}/fieldTypes/finished`),
+      updateKey: { key: 'displayName' },
+      operation: { name: 'change', target: 'Finished', to: 'Done' },
+    });
+
+    const entries = await ConfigurationLogger.entries(project.basePath);
+    expect(entries).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Third PR of the migration-imp split (follows #1387, sibling of #1443). Extracts the six FieldType mutation handlers into the mutation engine: rename, delete, data-type change, enum add/remove/rename.

- All six handlers are thin routers into the legacy `FieldTypeResource` methods — the in-class cascade (`onNameChange`, `dataTypeChanged`, `handleEnumValueReplacements`) still runs exactly once; each handler absorbs its cascade when the legacy path is deleted in the cleanup PR ("scaffolding stays" invariant).
- isBreaking classification: rename/delete/data-type/enum-remove/enum-rename are breaking (engine writes a migration log entry); enum-add is non-breaking (no entry), matching the old path.
- Routing: all fieldType renames/edits/deletes divert to `ResourceMutations`; unhandled edit shapes (e.g. displayName) fall to `DefaultNoCascadeHandler`, byte-for-byte the legacy no-cascade behavior.
- Behavior matches the old path, not migration-imp's later changes: enum-remove without replacement leaves card values untouched; delete keeps the legacy in-use usage guard; rename does not rewrite card metadata keys.
- A pre-existing baseline bug (renaming a fieldType still referenced by a cardType throws in legacy `onNameChange→updateCardTypes`) is pinned by an explicit test rather than masked.