### PR TITLE
feat(mutations): workflow handlers (PR4)

### DIFF
--- a/tools/data-handler/src/commands/remove.ts
+++ b/tools/data-handler/src/commands/remove.ts
@@ -266,7 +266,12 @@ export class Remove {
       );
     }
     if (this.projectResource(type)) {
-      if (type === 'linkType' || type === 'cardType' || type === 'fieldType') {
+      if (
+        type === 'linkType' ||
+        type === 'cardType' ||
+        type === 'fieldType' ||
+        type === 'workflow'
+      ) {
         const target = parseResourceName(targetName);
         const input = { kind: 'delete' as const, target };
         await this.mutations.apply(input);

--- a/tools/data-handler/src/commands/update.ts
+++ b/tools/data-handler/src/commands/update.ts
@@ -131,12 +131,11 @@ export class Update {
       }
 
       // ALL workflow edits route through the engine. The dispatched handlers
-      // (add/remove/rename state, transition) are thin routers that delegate
-      // back to WorkflowResource.update — preserving the legacy in-class
-      // cascade — while recording a log entry for the breaking ones. Edit
-      // shapes without a dedicated handler (e.g. displayName change) fall to
-      // DefaultNoCascadeHandler, which runs the same `resource.update` without
-      // a log entry, matching the legacy non-breaking behavior.
+      // (add/remove/rename state, transition) delegate the cascade to
+      // WorkflowResource.update while recording a log entry for the breaking
+      // ones. Edit shapes without a dedicated handler (e.g. displayName change)
+      // fall to DefaultNoCascadeHandler, which runs the same `resource.update`
+      // with no log entry.
       const input = {
         kind: 'edit' as const,
         target,

--- a/tools/data-handler/src/commands/update.ts
+++ b/tools/data-handler/src/commands/update.ts
@@ -120,6 +120,33 @@ export class Update {
       }
     }
 
+    if (type === 'workflows') {
+      if (isRename) {
+        const newIdentifier = parseResourceName(
+          (operation as ChangeOperation<string>).to,
+        ).identifier;
+        const input = { kind: 'rename' as const, target, newIdentifier };
+        await this.mutations.apply(input);
+        return;
+      }
+
+      // ALL workflow edits route through the engine. The dispatched handlers
+      // (add/remove/rename state, transition) are thin routers that delegate
+      // back to WorkflowResource.update — preserving the legacy in-class
+      // cascade — while recording a log entry for the breaking ones. Edit
+      // shapes without a dedicated handler (e.g. displayName change) fall to
+      // DefaultNoCascadeHandler, which runs the same `resource.update` without
+      // a log entry, matching the legacy non-breaking behavior.
+      const input = {
+        kind: 'edit' as const,
+        target,
+        updateKey,
+        operation,
+      };
+      await this.mutations.apply(input);
+      return;
+    }
+
     const run = () =>
       this.project.lock.write(async () => {
         const resource = this.project.resources.byType(name, type);

--- a/tools/data-handler/src/mutations/dispatcher.ts
+++ b/tools/data-handler/src/mutations/dispatcher.ts
@@ -27,6 +27,12 @@ import { FieldTypeEnumAddHandler } from './handlers/field-type-enum-add.js';
 import { FieldTypeEnumRemoveHandler } from './handlers/field-type-enum-remove.js';
 import { FieldTypeEnumRenameHandler } from './handlers/field-type-enum-rename.js';
 import { FieldTypeDeleteHandler } from './handlers/field-type-delete.js';
+import { WorkflowRenameHandler } from './handlers/workflow-rename.js';
+import { WorkflowAddStateHandler } from './handlers/workflow-add-state.js';
+import { WorkflowRemoveStateHandler } from './handlers/workflow-remove-state.js';
+import { WorkflowRenameStateHandler } from './handlers/workflow-rename-state.js';
+import { WorkflowTransitionHandler } from './handlers/workflow-transition.js';
+import { WorkflowDeleteHandler } from './handlers/workflow-delete.js';
 
 const HANDLERS: Handler[] = [
   new LinkTypeRenameHandler(),
@@ -46,6 +52,15 @@ const HANDLERS: Handler[] = [
   new FieldTypeEnumRemoveHandler(),
   new FieldTypeEnumRenameHandler(),
   new FieldTypeDeleteHandler(),
+  // The workflow handlers below are near-identical thin routers on purpose:
+  // each absorbs its own cascade from WorkflowResource when the legacy path
+  // is removed, so don't merge them into a shared base.
+  new WorkflowRenameHandler(),
+  new WorkflowAddStateHandler(),
+  new WorkflowRemoveStateHandler(),
+  new WorkflowRenameStateHandler(),
+  new WorkflowTransitionHandler(),
+  new WorkflowDeleteHandler(),
   new DefaultNoCascadeHandler(),
 ];
 

--- a/tools/data-handler/src/mutations/dispatcher.ts
+++ b/tools/data-handler/src/mutations/dispatcher.ts
@@ -52,9 +52,8 @@ const HANDLERS: Handler[] = [
   new FieldTypeEnumRemoveHandler(),
   new FieldTypeEnumRenameHandler(),
   new FieldTypeDeleteHandler(),
-  // The workflow handlers below are near-identical thin routers on purpose:
-  // each absorbs its own cascade from WorkflowResource when the legacy path
-  // is removed, so don't merge them into a shared base.
+  // Cascades are operation-specific — keep one handler per operation; don't
+  // merge these into a shared base.
   new WorkflowRenameHandler(),
   new WorkflowAddStateHandler(),
   new WorkflowRemoveStateHandler(),

--- a/tools/data-handler/src/mutations/handlers/workflow-add-state.ts
+++ b/tools/data-handler/src/mutations/handlers/workflow-add-state.ts
@@ -17,10 +17,9 @@ import { resourceNameToString } from '../../utils/resource-utils.js';
 
 /**
  * Adding a state to a workflow is a NON-breaking change: it affects no
- * existing cards (no card is in the new state yet). The state insertion lives
- * in WorkflowResource.update (handleArray), so this handler only routes the
- * operation. isBreaking is false, so the engine records no log entry — matching
- * the legacy ConfigurationLogger classification (add is never breaking).
+ * existing cards (no card can be in the new state yet). The state insertion is
+ * performed by WorkflowResource.update; this handler routes the operation.
+ * isBreaking is false, so the engine records no log entry.
  */
 export class WorkflowAddStateHandler implements Handler {
   readonly isBreaking = false;

--- a/tools/data-handler/src/mutations/handlers/workflow-add-state.ts
+++ b/tools/data-handler/src/mutations/handlers/workflow-add-state.ts
@@ -1,0 +1,48 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { Handler, MutationContext } from '../handler.js';
+import { resourceNameToString } from '../../utils/resource-utils.js';
+
+/**
+ * Adding a state to a workflow is a NON-breaking change: it affects no
+ * existing cards (no card is in the new state yet). The state insertion lives
+ * in WorkflowResource.update (handleArray), so this handler only routes the
+ * operation. isBreaking is false, so the engine records no log entry — matching
+ * the legacy ConfigurationLogger classification (add is never breaking).
+ */
+export class WorkflowAddStateHandler implements Handler {
+  readonly isBreaking = false;
+
+  matches(ctx: MutationContext): boolean {
+    return (
+      ctx.input.kind === 'edit' &&
+      ctx.input.target.type === 'workflows' &&
+      ctx.input.updateKey.key === 'states' &&
+      ctx.input.operation.name === 'add'
+    );
+  }
+
+  async apply(ctx: MutationContext): Promise<void> {
+    if (ctx.input.kind !== 'edit') {
+      throw new Error('WorkflowAddStateHandler called with non-edit input');
+    }
+    const name = resourceNameToString(ctx.input.target);
+    const resource = ctx.project.resources.byType(name, 'workflows');
+    if (!resource) {
+      throw new Error(`Workflow '${name}' not found`);
+    }
+    await resource.update(ctx.input.updateKey, ctx.input.operation);
+  }
+}

--- a/tools/data-handler/src/mutations/handlers/workflow-delete.ts
+++ b/tools/data-handler/src/mutations/handlers/workflow-delete.ts
@@ -1,0 +1,44 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { Handler, MutationContext } from '../handler.js';
+import { resourceNameToString } from '../../utils/resource-utils.js';
+
+/**
+ * Deleting a workflow is a breaking change. The legacy path does NOT cascade:
+ * WorkflowResource.delete refuses to delete a workflow that is still in use
+ * (its usage() includes dependent card types and cards). This handler matches
+ * that behavior — it is a thin router that delegates to `resource.delete()`
+ * (which throws if the workflow is still used) and marks the change breaking
+ * so the engine records a log entry.
+ */
+export class WorkflowDeleteHandler implements Handler {
+  readonly isBreaking = true;
+
+  matches(ctx: MutationContext): boolean {
+    return ctx.input.kind === 'delete' && ctx.input.target.type === 'workflows';
+  }
+
+  async apply(ctx: MutationContext): Promise<void> {
+    if (ctx.input.kind !== 'delete') {
+      throw new Error('WorkflowDeleteHandler: non-delete input');
+    }
+    const name = resourceNameToString(ctx.input.target);
+    const resource = ctx.project.resources.byType(name, 'workflows');
+    if (!resource) {
+      throw new Error(`Workflow '${name}' not found`);
+    }
+    await resource.delete();
+  }
+}

--- a/tools/data-handler/src/mutations/handlers/workflow-delete.ts
+++ b/tools/data-handler/src/mutations/handlers/workflow-delete.ts
@@ -16,12 +16,11 @@ import type { Handler, MutationContext } from '../handler.js';
 import { resourceNameToString } from '../../utils/resource-utils.js';
 
 /**
- * Deleting a workflow is a breaking change. The legacy path does NOT cascade:
- * WorkflowResource.delete refuses to delete a workflow that is still in use
- * (its usage() includes dependent card types and cards). This handler matches
- * that behavior — it is a thin router that delegates to `resource.delete()`
- * (which throws if the workflow is still used) and marks the change breaking
- * so the engine records a log entry.
+ * Deleting a workflow is a breaking change. WorkflowResource.delete refuses to
+ * delete a workflow that is still in use (its usage() includes dependent card
+ * types and cards). This handler delegates to `resource.delete()` (which throws
+ * if the workflow is still used) and marks the change breaking so the engine
+ * records a log entry.
  */
 export class WorkflowDeleteHandler implements Handler {
   readonly isBreaking = true;

--- a/tools/data-handler/src/mutations/handlers/workflow-remove-state.ts
+++ b/tools/data-handler/src/mutations/handlers/workflow-remove-state.ts
@@ -1,0 +1,49 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { Handler, MutationContext } from '../handler.js';
+import { resourceNameToString } from '../../utils/resource-utils.js';
+
+/**
+ * Removing a state from a workflow is a breaking change: transitions that
+ * reference the state are rewritten (removed, or re-pointed at the replacement
+ * state) and every card in the removed state is migrated. That whole cascade
+ * still lives in WorkflowResource.update (handleStateRemoval → updateCardStates),
+ * so this handler is a thin router: it delegates to `resource.update()` and
+ * marks the change breaking so the engine records a log entry.
+ */
+export class WorkflowRemoveStateHandler implements Handler {
+  readonly isBreaking = true;
+
+  matches(ctx: MutationContext): boolean {
+    return (
+      ctx.input.kind === 'edit' &&
+      ctx.input.target.type === 'workflows' &&
+      ctx.input.updateKey.key === 'states' &&
+      ctx.input.operation.name === 'remove'
+    );
+  }
+
+  async apply(ctx: MutationContext): Promise<void> {
+    if (ctx.input.kind !== 'edit') {
+      throw new Error('WorkflowRemoveStateHandler: non-edit input');
+    }
+    const name = resourceNameToString(ctx.input.target);
+    const resource = ctx.project.resources.byType(name, 'workflows');
+    if (!resource) {
+      throw new Error(`Workflow '${name}' not found`);
+    }
+    await resource.update(ctx.input.updateKey, ctx.input.operation);
+  }
+}

--- a/tools/data-handler/src/mutations/handlers/workflow-remove-state.ts
+++ b/tools/data-handler/src/mutations/handlers/workflow-remove-state.ts
@@ -16,12 +16,12 @@ import type { Handler, MutationContext } from '../handler.js';
 import { resourceNameToString } from '../../utils/resource-utils.js';
 
 /**
- * Removing a state from a workflow is a breaking change: transitions that
- * reference the state are rewritten (removed, or re-pointed at the replacement
- * state) and every card in the removed state is migrated. That whole cascade
- * still lives in WorkflowResource.update (handleStateRemoval → updateCardStates),
- * so this handler is a thin router: it delegates to `resource.update()` and
- * marks the change breaking so the engine records a log entry.
+ * Removing a state from a workflow is a breaking change. The cascade is
+ * performed by WorkflowResource.update: transitions that reference the state
+ * are rewritten (removed, or re-pointed at the replacementValue) and every
+ * card in the removed state is migrated. This handler delegates to
+ * `resource.update()` and marks the change breaking so the engine records a
+ * log entry.
  */
 export class WorkflowRemoveStateHandler implements Handler {
   readonly isBreaking = true;

--- a/tools/data-handler/src/mutations/handlers/workflow-rename-state.ts
+++ b/tools/data-handler/src/mutations/handlers/workflow-rename-state.ts
@@ -20,14 +20,13 @@ import type { ChangeOperation } from '../../resources/resource-object.js';
  * Renaming a workflow state (a 'change' on 'states' whose target name differs
  * from the new name) is a breaking change: the state name is the array
  * identity, so every transition referencing it and every card in that state
- * must be rewritten. The whole cascade still lives in WorkflowResource.update
- * (handleStateChange → updateCardStates), so this handler is a thin router that
- * delegates to `resource.update()` and marks the change breaking.
+ * must be rewritten. The cascade is performed by WorkflowResource.update: it
+ * rewrites referencing transitions and card states. This handler delegates to
+ * `resource.update()` and marks the change breaking.
  *
  * A 'change' that only edits non-identity state properties (e.g. category) is
  * NOT matched here; it falls through to DefaultNoCascadeHandler, which runs the
- * same legacy update without recording a (non-breaking) log entry — matching
- * the legacy ConfigurationLogger classification.
+ * same update without recording a (non-breaking) log entry.
  */
 export class WorkflowRenameStateHandler implements Handler {
   readonly isBreaking = true;

--- a/tools/data-handler/src/mutations/handlers/workflow-rename-state.ts
+++ b/tools/data-handler/src/mutations/handlers/workflow-rename-state.ts
@@ -1,0 +1,64 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { Handler, MutationContext } from '../handler.js';
+import { resourceNameToString } from '../../utils/resource-utils.js';
+import type { ChangeOperation } from '../../resources/resource-object.js';
+
+/**
+ * Renaming a workflow state (a 'change' on 'states' whose target name differs
+ * from the new name) is a breaking change: the state name is the array
+ * identity, so every transition referencing it and every card in that state
+ * must be rewritten. The whole cascade still lives in WorkflowResource.update
+ * (handleStateChange → updateCardStates), so this handler is a thin router that
+ * delegates to `resource.update()` and marks the change breaking.
+ *
+ * A 'change' that only edits non-identity state properties (e.g. category) is
+ * NOT matched here; it falls through to DefaultNoCascadeHandler, which runs the
+ * same legacy update without recording a (non-breaking) log entry — matching
+ * the legacy ConfigurationLogger classification.
+ */
+export class WorkflowRenameStateHandler implements Handler {
+  readonly isBreaking = true;
+
+  matches(ctx: MutationContext): boolean {
+    if (ctx.input.kind !== 'edit') return false;
+    if (ctx.input.target.type !== 'workflows') return false;
+    if (ctx.input.updateKey.key !== 'states') return false;
+    if (ctx.input.operation.name !== 'change') return false;
+
+    // Only a state rename (identity change) routes here. The discriminator is
+    // that `to.name` differs from `target.name`.
+    const op = ctx.input.operation as ChangeOperation<unknown>;
+    const targetName = (op.target as { name?: string }).name;
+    const toName = (op.to as { name?: string }).name;
+    return (
+      typeof targetName === 'string' &&
+      typeof toName === 'string' &&
+      targetName !== toName
+    );
+  }
+
+  async apply(ctx: MutationContext): Promise<void> {
+    if (ctx.input.kind !== 'edit') {
+      throw new Error('WorkflowRenameStateHandler: non-edit input');
+    }
+    const name = resourceNameToString(ctx.input.target);
+    const resource = ctx.project.resources.byType(name, 'workflows');
+    if (!resource) {
+      throw new Error(`Workflow '${name}' not found`);
+    }
+    await resource.update(ctx.input.updateKey, ctx.input.operation);
+  }
+}

--- a/tools/data-handler/src/mutations/handlers/workflow-rename.ts
+++ b/tools/data-handler/src/mutations/handlers/workflow-rename.ts
@@ -1,0 +1,50 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { Handler, MutationContext } from '../handler.js';
+import {
+  resourceName,
+  resourceNameToString,
+} from '../../utils/resource-utils.js';
+
+/**
+ * Renaming a workflow is a breaking change: dependent card types' workflow
+ * reference and all cross-resource references must be rewritten. The whole
+ * cascade still lives in WorkflowResource.rename (onNameChange →
+ * updateHandleBars / updateCalculations / updateCardContentReferences /
+ * updateCardTypes), so this handler is a thin router: it delegates to
+ * `resource.rename()` and marks the change breaking so the engine records a
+ * log entry.
+ */
+export class WorkflowRenameHandler implements Handler {
+  readonly isBreaking = true;
+
+  matches(ctx: MutationContext): boolean {
+    return ctx.input.kind === 'rename' && ctx.input.target.type === 'workflows';
+  }
+
+  async apply(ctx: MutationContext): Promise<void> {
+    if (ctx.input.kind !== 'rename') {
+      throw new Error('WorkflowRenameHandler called with non-rename input');
+    }
+    const oldName = resourceNameToString(ctx.input.target);
+    const newName = `${ctx.input.target.prefix}/workflows/${ctx.input.newIdentifier}`;
+
+    const resource = ctx.project.resources.byType(oldName, 'workflows');
+    if (!resource) {
+      throw new Error(`Workflow '${oldName}' not found`);
+    }
+    await resource.rename(resourceName(newName));
+  }
+}

--- a/tools/data-handler/src/mutations/handlers/workflow-rename.ts
+++ b/tools/data-handler/src/mutations/handlers/workflow-rename.ts
@@ -20,10 +20,8 @@ import {
 
 /**
  * Renaming a workflow is a breaking change: dependent card types' workflow
- * reference and all cross-resource references must be rewritten. The whole
- * cascade still lives in WorkflowResource.rename (onNameChange →
- * updateHandleBars / updateCalculations / updateCardContentReferences /
- * updateCardTypes), so this handler is a thin router: it delegates to
+ * reference and all cross-resource references must be rewritten. The cascade
+ * is performed by WorkflowResource.rename; this handler delegates to
  * `resource.rename()` and marks the change breaking so the engine records a
  * log entry.
  */

--- a/tools/data-handler/src/mutations/handlers/workflow-transition.ts
+++ b/tools/data-handler/src/mutations/handlers/workflow-transition.ts
@@ -1,0 +1,49 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { Handler, MutationContext } from '../handler.js';
+import { resourceNameToString } from '../../utils/resource-utils.js';
+
+/**
+ * Changing a workflow's transitions (add/remove/change) is a NON-breaking
+ * change: transitions are workflow-internal and no card data references them.
+ * The transition handling lives in WorkflowResource.update (handleArray and
+ * transitionObject), so this handler only routes the operation. isBreaking is
+ * false, so the engine records no log entry — matching the legacy
+ * ConfigurationLogger classification ('transitions' is a NON_BREAKING_KEY).
+ */
+export class WorkflowTransitionHandler implements Handler {
+  readonly isBreaking = false;
+
+  matches(ctx: MutationContext): boolean {
+    return (
+      ctx.input.kind === 'edit' &&
+      ctx.input.target.type === 'workflows' &&
+      ctx.input.updateKey.key === 'transitions' &&
+      ['add', 'remove', 'change'].includes(ctx.input.operation.name)
+    );
+  }
+
+  async apply(ctx: MutationContext): Promise<void> {
+    if (ctx.input.kind !== 'edit') {
+      throw new Error('WorkflowTransitionHandler: non-edit input');
+    }
+    const name = resourceNameToString(ctx.input.target);
+    const resource = ctx.project.resources.byType(name, 'workflows');
+    if (!resource) {
+      throw new Error(`Workflow '${name}' not found`);
+    }
+    await resource.update(ctx.input.updateKey, ctx.input.operation);
+  }
+}

--- a/tools/data-handler/src/mutations/handlers/workflow-transition.ts
+++ b/tools/data-handler/src/mutations/handlers/workflow-transition.ts
@@ -18,10 +18,8 @@ import { resourceNameToString } from '../../utils/resource-utils.js';
 /**
  * Changing a workflow's transitions (add/remove/change) is a NON-breaking
  * change: transitions are workflow-internal and no card data references them.
- * The transition handling lives in WorkflowResource.update (handleArray and
- * transitionObject), so this handler only routes the operation. isBreaking is
- * false, so the engine records no log entry — matching the legacy
- * ConfigurationLogger classification ('transitions' is a NON_BREAKING_KEY).
+ * The transition handling is performed by WorkflowResource.update; this handler
+ * routes the operation. isBreaking is false, so the engine records no log entry.
  */
 export class WorkflowTransitionHandler implements Handler {
   readonly isBreaking = false;

--- a/tools/data-handler/test/mutations/handlers/workflow-add-state.test.ts
+++ b/tools/data-handler/test/mutations/handlers/workflow-add-state.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { Project } from '../../../src/containers/project.js';
+import { WorkflowAddStateHandler } from '../../../src/mutations/handlers/workflow-add-state.js';
+import { resourceName } from '../../../src/utils/resource-utils.js';
+import { copyDir } from '../../../src/utils/file-utils.js';
+import { ResourceMutations } from '../../../src/mutations/resource-mutations.js';
+
+const FIXTURE_PATH = join(
+  import.meta.dirname,
+  '..',
+  '..',
+  'test-data',
+  'valid',
+  'decision-records',
+);
+const tmpDir = join(import.meta.dirname, 'tmp-workflow-add-state');
+
+describe('WorkflowAddStateHandler', () => {
+  let project: Project;
+
+  beforeEach(async () => {
+    const projectPath = join(tmpDir, `proj-${Date.now()}-${Math.random()}`);
+    await mkdir(projectPath, { recursive: true });
+    await copyDir(FIXTURE_PATH, projectPath);
+    project = new Project(projectPath);
+    await project.populateCaches();
+  });
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('matches add on workflow states', () => {
+    expect(
+      new WorkflowAddStateHandler().matches({
+        project,
+        input: {
+          kind: 'edit',
+          target: resourceName('decision/workflows/decision'),
+          updateKey: { key: 'states' },
+          operation: {
+            name: 'add',
+            target: { name: 'Archived', category: 'closed' },
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('is non-breaking', () => {
+    expect(new WorkflowAddStateHandler().isBreaking).toBe(false);
+  });
+
+  it('apply appends the new state to the workflow definition', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit',
+      target: resourceName('decision/workflows/decision'),
+      updateKey: { key: 'states' },
+      operation: {
+        name: 'add',
+        target: { name: 'Archived', category: 'closed' },
+      },
+    });
+    const wf = project.resources.byType(
+      'decision/workflows/decision',
+      'workflows',
+    );
+    expect(wf?.data?.states.map((s) => s.name)).toContain('Archived');
+  });
+});

--- a/tools/data-handler/test/mutations/handlers/workflow-delete.test.ts
+++ b/tools/data-handler/test/mutations/handlers/workflow-delete.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { Project } from '../../../src/containers/project.js';
+import { WorkflowDeleteHandler } from '../../../src/mutations/handlers/workflow-delete.js';
+import { resourceName } from '../../../src/utils/resource-utils.js';
+import { copyDir } from '../../../src/utils/file-utils.js';
+import { ResourceMutations } from '../../../src/mutations/resource-mutations.js';
+
+const FIXTURE_PATH = join(
+  import.meta.dirname,
+  '..',
+  '..',
+  'test-data',
+  'valid',
+  'decision-records',
+);
+const tmpDir = join(import.meta.dirname, 'tmp-workflow-delete');
+
+describe('WorkflowDeleteHandler', () => {
+  let project: Project;
+
+  beforeEach(async () => {
+    const projectPath = join(tmpDir, `proj-${Date.now()}-${Math.random()}`);
+    await mkdir(projectPath, { recursive: true });
+    await copyDir(FIXTURE_PATH, projectPath);
+    project = new Project(projectPath);
+    await project.populateCaches();
+  });
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('matches a workflow delete input', () => {
+    expect(
+      new WorkflowDeleteHandler().matches({
+        project,
+        input: {
+          kind: 'delete',
+          target: resourceName('decision/workflows/decision'),
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('isBreaking is true', () => {
+    expect(new WorkflowDeleteHandler().isBreaking).toBe(true);
+  });
+
+  // OLD behavior: deleting a workflow that is still used (by card types / cards)
+  // is refused. The legacy WorkflowResource.delete throws when usage() is
+  // non-empty; no cascade deletion of dependents takes place.
+  it('refuses to delete a workflow that is still in use', async () => {
+    const mutations = new ResourceMutations(project);
+    await expect(
+      mutations.apply({
+        kind: 'delete',
+        target: resourceName('decision/workflows/decision'),
+      }),
+    ).rejects.toThrow();
+
+    // Workflow and its dependent card type are untouched.
+    expect(project.resources.exists('decision/workflows/decision')).toBe(true);
+    expect(project.resources.exists('decision/cardTypes/decision')).toBe(true);
+  });
+
+  it('deletes an unused workflow', async () => {
+    // Create a fresh workflow that no card type references, so usage() is empty
+    // and the delete is allowed.
+    const unusedName = 'decision/workflows/unused';
+    const wf = project.resources.byType(unusedName, 'workflows');
+    await wf.create();
+    await project.populateCaches();
+    expect(project.resources.exists(unusedName)).toBe(true);
+
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'delete',
+      target: resourceName(unusedName),
+    });
+    await project.populateCaches();
+    expect(project.resources.exists(unusedName)).toBe(false);
+  });
+
+  it('throws when the workflow does not exist', async () => {
+    const mutations = new ResourceMutations(project);
+    await expect(
+      mutations.apply({
+        kind: 'delete',
+        target: resourceName('decision/workflows/does-not-exist'),
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/tools/data-handler/test/mutations/handlers/workflow-delete.test.ts
+++ b/tools/data-handler/test/mutations/handlers/workflow-delete.test.ts
@@ -48,9 +48,9 @@ describe('WorkflowDeleteHandler', () => {
     expect(new WorkflowDeleteHandler().isBreaking).toBe(true);
   });
 
-  // OLD behavior: deleting a workflow that is still used (by card types / cards)
-  // is refused. The legacy WorkflowResource.delete throws when usage() is
-  // non-empty; no cascade deletion of dependents takes place.
+  // Deleting a workflow that is still used (by card types / cards) is refused.
+  // WorkflowResource.delete throws when usage() is non-empty; no cascade
+  // deletion of dependents takes place.
   it('refuses to delete a workflow that is still in use', async () => {
     const mutations = new ResourceMutations(project);
     await expect(

--- a/tools/data-handler/test/mutations/handlers/workflow-remove-state.test.ts
+++ b/tools/data-handler/test/mutations/handlers/workflow-remove-state.test.ts
@@ -84,7 +84,7 @@ describe('WorkflowRemoveStateHandler', () => {
     }
   });
 
-  it('apply with explicit replacementValue migrates cards to that state (legacy behavior)', async () => {
+  it('apply with explicit replacementValue migrates cards to that state', async () => {
     const cardKey = await seedCardInState('Rejected');
 
     const mutations = new ResourceMutations(project);
@@ -103,7 +103,7 @@ describe('WorkflowRemoveStateHandler', () => {
     expect(refetched.metadata?.workflowState).toBe('Approved');
   });
 
-  it('apply without replacementValue does NOT migrate cards (legacy behavior)', async () => {
+  it('apply without replacementValue does NOT migrate cards', async () => {
     const cardKey = await seedCardInState('Rejected');
 
     const mutations = new ResourceMutations(project);
@@ -117,8 +117,8 @@ describe('WorkflowRemoveStateHandler', () => {
       },
     });
 
-    // Legacy handleStateRemoval only migrates cards when a replacementValue is
-    // given; without one, the card keeps its (now-removed) state value.
+    // Cards are only migrated when a replacementValue is given; without one,
+    // the card keeps its (now-removed) state value.
     const refetched = project.cards(undefined).find((c) => c.key === cardKey)!;
     expect(refetched.metadata?.workflowState).toBe('Rejected');
   });

--- a/tools/data-handler/test/mutations/handlers/workflow-remove-state.test.ts
+++ b/tools/data-handler/test/mutations/handlers/workflow-remove-state.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { Project } from '../../../src/containers/project.js';
+import { WorkflowRemoveStateHandler } from '../../../src/mutations/handlers/workflow-remove-state.js';
+import { resourceName } from '../../../src/utils/resource-utils.js';
+import { copyDir } from '../../../src/utils/file-utils.js';
+import { ResourceMutations } from '../../../src/mutations/resource-mutations.js';
+
+const FIXTURE_PATH = join(
+  import.meta.dirname,
+  '..',
+  '..',
+  'test-data',
+  'valid',
+  'decision-records',
+);
+const tmpDir = join(import.meta.dirname, 'tmp-workflow-remove-state');
+
+const WF = 'decision/workflows/decision';
+
+describe('WorkflowRemoveStateHandler', () => {
+  let project: Project;
+
+  beforeEach(async () => {
+    const projectPath = join(tmpDir, `proj-${Date.now()}-${Math.random()}`);
+    await mkdir(projectPath, { recursive: true });
+    await copyDir(FIXTURE_PATH, projectPath);
+    project = new Project(projectPath);
+    await project.populateCaches();
+  });
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  // Helper: put the first decision card into the given state.
+  async function seedCardInState(state: string) {
+    const target = project
+      .cards(undefined)
+      .find((c) => c.metadata?.cardType === 'decision/cardTypes/decision')!;
+    target.metadata!.workflowState = state;
+    await project.updateCardMetadata(target, target.metadata!);
+    return target.key;
+  }
+
+  it('matches remove on workflow states', () => {
+    expect(
+      new WorkflowRemoveStateHandler().matches({
+        project,
+        input: {
+          kind: 'edit',
+          target: resourceName(WF),
+          updateKey: { key: 'states' },
+          operation: {
+            name: 'remove',
+            target: { name: 'Rejected', category: 'closed' },
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('isBreaking is true', () => {
+    expect(new WorkflowRemoveStateHandler().isBreaking).toBe(true);
+  });
+
+  it('apply removes the state and strips transitions referencing it', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit',
+      target: resourceName(WF),
+      updateKey: { key: 'states' },
+      operation: {
+        name: 'remove',
+        target: { name: 'Rejected', category: 'closed' },
+      },
+    });
+    const wf = project.resources.byType(WF, 'workflows')!;
+    expect(wf.data!.states.map((s) => s.name)).not.toContain('Rejected');
+    for (const t of wf.data!.transitions) {
+      expect(t.toState).not.toBe('Rejected');
+      expect(t.fromState).not.toContain('Rejected');
+    }
+  });
+
+  it('apply with explicit replacementValue migrates cards to that state (legacy behavior)', async () => {
+    const cardKey = await seedCardInState('Rejected');
+
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit',
+      target: resourceName(WF),
+      updateKey: { key: 'states' },
+      operation: {
+        name: 'remove',
+        target: { name: 'Rejected', category: 'closed' },
+        replacementValue: { name: 'Approved', category: 'closed' },
+      },
+    });
+
+    const refetched = project.cards(undefined).find((c) => c.key === cardKey)!;
+    expect(refetched.metadata?.workflowState).toBe('Approved');
+  });
+
+  it('apply without replacementValue does NOT migrate cards (legacy behavior)', async () => {
+    const cardKey = await seedCardInState('Rejected');
+
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit',
+      target: resourceName(WF),
+      updateKey: { key: 'states' },
+      operation: {
+        name: 'remove',
+        target: { name: 'Rejected', category: 'closed' },
+      },
+    });
+
+    // Legacy handleStateRemoval only migrates cards when a replacementValue is
+    // given; without one, the card keeps its (now-removed) state value.
+    const refetched = project.cards(undefined).find((c) => c.key === cardKey)!;
+    expect(refetched.metadata?.workflowState).toBe('Rejected');
+  });
+});

--- a/tools/data-handler/test/mutations/handlers/workflow-rename-state.test.ts
+++ b/tools/data-handler/test/mutations/handlers/workflow-rename-state.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { Project } from '../../../src/containers/project.js';
+import { WorkflowRenameStateHandler } from '../../../src/mutations/handlers/workflow-rename-state.js';
+import { resourceName } from '../../../src/utils/resource-utils.js';
+import { copyDir } from '../../../src/utils/file-utils.js';
+import { ResourceMutations } from '../../../src/mutations/resource-mutations.js';
+
+const FIXTURE_PATH = join(
+  import.meta.dirname,
+  '..',
+  '..',
+  'test-data',
+  'valid',
+  'decision-records',
+);
+const tmpDir = join(import.meta.dirname, 'tmp-workflow-rename-state');
+
+const WF = 'decision/workflows/decision';
+
+describe('WorkflowRenameStateHandler', () => {
+  let project: Project;
+
+  beforeEach(async () => {
+    const projectPath = join(tmpDir, `proj-${Date.now()}-${Math.random()}`);
+    await mkdir(projectPath, { recursive: true });
+    await copyDir(FIXTURE_PATH, projectPath);
+    project = new Project(projectPath);
+    await project.populateCaches();
+  });
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('matches a state rename (name identity change)', () => {
+    expect(
+      new WorkflowRenameStateHandler().matches({
+        project,
+        input: {
+          kind: 'edit',
+          target: resourceName(WF),
+          updateKey: { key: 'states' },
+          operation: {
+            name: 'change',
+            target: { name: 'Draft', category: 'initial' },
+            to: { name: 'DraftNew', category: 'initial' },
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('declines a change that keeps the same state name (non-identity change)', () => {
+    // A category-only change is not a state rename; it falls through to the
+    // default handler instead.
+    expect(
+      new WorkflowRenameStateHandler().matches({
+        project,
+        input: {
+          kind: 'edit',
+          target: resourceName(WF),
+          updateKey: { key: 'states' },
+          operation: {
+            name: 'change',
+            target: { name: 'Draft', category: 'initial' },
+            to: { name: 'Draft', category: 'active' },
+          },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('isBreaking is true', () => {
+    expect(new WorkflowRenameStateHandler().isBreaking).toBe(true);
+  });
+
+  it('apply rewrites workflowState on affected cards and transitions', async () => {
+    // Place a card in 'Draft'.
+    const target = project
+      .cards(undefined)
+      .find((c) => c.metadata?.cardType === 'decision/cardTypes/decision')!;
+    target.metadata!.workflowState = 'Draft';
+    await project.updateCardMetadata(target, target.metadata!);
+
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit',
+      target: resourceName(WF),
+      updateKey: { key: 'states' },
+      operation: {
+        name: 'change',
+        target: { name: 'Draft', category: 'initial' },
+        to: { name: 'DraftNew', category: 'initial' },
+      },
+    });
+
+    const refetched = project
+      .cards(undefined)
+      .find((c) => c.key === target.key)!;
+    expect(refetched.metadata?.workflowState).toBe('DraftNew');
+
+    const wf = project.resources.byType(WF, 'workflows')!;
+    expect(wf.data!.states.map((s) => s.name)).toContain('DraftNew');
+    expect(wf.data!.states.map((s) => s.name)).not.toContain('Draft');
+    for (const t of wf.data!.transitions) {
+      expect(t.toState).not.toBe('Draft');
+      expect(t.fromState).not.toContain('Draft');
+    }
+  });
+});

--- a/tools/data-handler/test/mutations/handlers/workflow-rename.test.ts
+++ b/tools/data-handler/test/mutations/handlers/workflow-rename.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { Project } from '../../../src/containers/project.js';
+import { WorkflowRenameHandler } from '../../../src/mutations/handlers/workflow-rename.js';
+import { resourceName } from '../../../src/utils/resource-utils.js';
+import { copyDir } from '../../../src/utils/file-utils.js';
+import { ResourceMutations } from '../../../src/mutations/resource-mutations.js';
+
+const FIXTURE_PATH = join(
+  import.meta.dirname,
+  '..',
+  '..',
+  'test-data',
+  'valid',
+  'decision-records',
+);
+const tmpDir = join(import.meta.dirname, 'tmp-workflow-rename');
+
+describe('WorkflowRenameHandler', () => {
+  let project: Project;
+
+  beforeEach(async () => {
+    const projectPath = join(tmpDir, `proj-${Date.now()}-${Math.random()}`);
+    await mkdir(projectPath, { recursive: true });
+    await copyDir(FIXTURE_PATH, projectPath);
+    project = new Project(projectPath);
+    await project.populateCaches();
+  });
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('matches a workflow rename input', () => {
+    const handler = new WorkflowRenameHandler();
+    expect(
+      handler.matches({
+        project,
+        input: {
+          kind: 'rename',
+          target: resourceName('decision/workflows/decision'),
+          newIdentifier: 'decision-v2',
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('declines a workflow edit input', () => {
+    const handler = new WorkflowRenameHandler();
+    expect(
+      handler.matches({
+        project,
+        input: {
+          kind: 'edit',
+          target: resourceName('decision/workflows/decision'),
+          updateKey: { key: 'displayName' },
+          operation: { name: 'change', target: 'A', to: 'B' },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('isBreaking is true', () => {
+    expect(new WorkflowRenameHandler().isBreaking).toBe(true);
+  });
+
+  it('apply rewrites the workflow reference in dependent card types', async () => {
+    const oldName = 'decision/workflows/decision';
+    const newName = 'decision/workflows/decision-v2';
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'rename',
+      target: resourceName(oldName),
+      newIdentifier: 'decision-v2',
+    });
+
+    // No card type still references the old workflow name; the card type that
+    // used 'decision' now references the new name.
+    for (const ct of project.resources.cardTypes()) {
+      if (ct.data) {
+        expect(ct.data.workflow).not.toBe(oldName);
+      }
+    }
+    const decisionCt = project.resources
+      .byType('decision/cardTypes/decision', 'cardTypes')
+      .show();
+    expect(decisionCt!.workflow).toBe(newName);
+
+    // The workflow file itself has the new name.
+    const renamed = project.resources.byType(newName, 'workflows').show();
+    expect(renamed!.name).toBe(newName);
+  });
+
+  it('throws when the workflow does not exist', async () => {
+    const mutations = new ResourceMutations(project);
+    await expect(
+      mutations.apply({
+        kind: 'rename',
+        target: resourceName('decision/workflows/does-not-exist'),
+        newIdentifier: 'whatever',
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/tools/data-handler/test/mutations/handlers/workflow-transition.test.ts
+++ b/tools/data-handler/test/mutations/handlers/workflow-transition.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { Project } from '../../../src/containers/project.js';
+import { WorkflowTransitionHandler } from '../../../src/mutations/handlers/workflow-transition.js';
+import { resourceName } from '../../../src/utils/resource-utils.js';
+import { copyDir } from '../../../src/utils/file-utils.js';
+import { ResourceMutations } from '../../../src/mutations/resource-mutations.js';
+
+const FIXTURE_PATH = join(
+  import.meta.dirname,
+  '..',
+  '..',
+  'test-data',
+  'valid',
+  'decision-records',
+);
+const tmpDir = join(import.meta.dirname, 'tmp-workflow-transition');
+
+describe('WorkflowTransitionHandler', () => {
+  let project: Project;
+
+  beforeEach(async () => {
+    const projectPath = join(tmpDir, `proj-${Date.now()}-${Math.random()}`);
+    await mkdir(projectPath, { recursive: true });
+    await copyDir(FIXTURE_PATH, projectPath);
+    project = new Project(projectPath);
+    await project.populateCaches();
+  });
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('matches add on transitions', () => {
+    expect(
+      new WorkflowTransitionHandler().matches({
+        project,
+        input: {
+          kind: 'edit',
+          target: resourceName('decision/workflows/decision'),
+          updateKey: { key: 'transitions' },
+          operation: {
+            name: 'add',
+            target: {
+              name: 'Archive',
+              fromState: ['Approved'],
+              toState: 'Deprecated',
+            },
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('matches remove on transitions', () => {
+    expect(
+      new WorkflowTransitionHandler().matches({
+        project,
+        input: {
+          kind: 'edit',
+          target: resourceName('decision/workflows/decision'),
+          updateKey: { key: 'transitions' },
+          operation: { name: 'remove', target: 'Deprecate' },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('matches change on transitions', () => {
+    expect(
+      new WorkflowTransitionHandler().matches({
+        project,
+        input: {
+          kind: 'edit',
+          target: resourceName('decision/workflows/decision'),
+          updateKey: { key: 'transitions' },
+          operation: {
+            name: 'change',
+            target: 'Deprecate',
+            to: 'MarkDeprecated',
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('is non-breaking', () => {
+    expect(new WorkflowTransitionHandler().isBreaking).toBe(false);
+  });
+
+  it('apply add appends the transition to the workflow definition', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit',
+      target: resourceName('decision/workflows/decision'),
+      updateKey: { key: 'transitions' },
+      operation: {
+        name: 'add',
+        target: {
+          name: 'Archive',
+          fromState: ['Approved'],
+          toState: 'Deprecated',
+        },
+      },
+    });
+    const wf = project.resources.byType(
+      'decision/workflows/decision',
+      'workflows',
+    );
+    expect(wf?.data?.transitions.map((t) => t.name)).toContain('Archive');
+  });
+
+  it('apply remove drops the transition from the workflow definition', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit',
+      target: resourceName('decision/workflows/decision'),
+      updateKey: { key: 'transitions' },
+      operation: { name: 'remove', target: 'Deprecate' },
+    });
+    const wf = project.resources.byType(
+      'decision/workflows/decision',
+      'workflows',
+    );
+    expect(wf?.data?.transitions.map((t) => t.name)).not.toContain('Deprecate');
+  });
+});

--- a/tools/data-handler/test/mutations/workflow-integration.test.ts
+++ b/tools/data-handler/test/mutations/workflow-integration.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { copyDir } from '../../src/utils/file-utils.js';
+import type { Project } from '../../src/containers/project.js';
+import { getTestProject } from '../helpers/test-utils.js';
+import { ResourceMutations } from '../../src/mutations/resource-mutations.js';
+import { ConfigurationLogger } from '../../src/utils/configuration-logger.js';
+import { resourceName } from '../../src/utils/resource-utils.js';
+
+const baseDir = import.meta.dirname;
+const testDir = join(baseDir, 'tmp-workflow-integration');
+const decisionRecordsPath = join(testDir, 'valid/decision-records');
+let project: Project;
+
+const WF = 'decision/workflows/decision';
+
+describe('Workflow mutation engine end-to-end', () => {
+  beforeEach(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir(join(baseDir, '..', 'test-data'), testDir);
+    project = getTestProject(decisionRecordsPath);
+    await project.populateCaches();
+  });
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('apply → log entry for a workflow rename, dependent card types rewritten', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'rename',
+      target: resourceName(WF),
+      newIdentifier: 'decision-v2',
+    });
+
+    const newName = 'decision/workflows/decision-v2';
+    expect(project.resources.exists(newName)).toBe(true);
+    const decisionCt = project.resources
+      .byType('decision/cardTypes/decision', 'cardTypes')
+      .show();
+    expect(decisionCt!.workflow).toBe(newName);
+
+    const entries = await ConfigurationLogger.entries(project.basePath);
+    expect(
+      entries.some((e) => e.kind === 'resource_rename' && e.target === WF),
+    ).toBe(true);
+  });
+
+  it('apply → breaking state removal records a log entry', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit',
+      target: resourceName(WF),
+      updateKey: { key: 'states' },
+      operation: {
+        name: 'remove',
+        target: { name: 'Rejected', category: 'closed' },
+      },
+    });
+
+    const wf = project.resources.byType(WF, 'workflows')!;
+    expect(wf.data!.states.map((s) => s.name)).not.toContain('Rejected');
+
+    const entries = await ConfigurationLogger.entries(project.basePath);
+    expect(
+      entries.some(
+        (e) =>
+          e.kind === 'resource_edit' &&
+          e.target === WF &&
+          (e.payload as { key?: string }).key === 'states',
+      ),
+    ).toBe(true);
+  });
+
+  it('apply → breaking state rename records a log entry', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit',
+      target: resourceName(WF),
+      updateKey: { key: 'states' },
+      operation: {
+        name: 'change',
+        target: { name: 'Rejected', category: 'closed' },
+        to: { name: 'Declined', category: 'closed' },
+      },
+    });
+
+    const wf = project.resources.byType(WF, 'workflows')!;
+    expect(wf.data!.states.map((s) => s.name)).toContain('Declined');
+
+    const entries = await ConfigurationLogger.entries(project.basePath);
+    expect(
+      entries.some(
+        (e) =>
+          e.kind === 'resource_edit' &&
+          e.target === WF &&
+          (e.payload as { key?: string }).key === 'states',
+      ),
+    ).toBe(true);
+  });
+
+  it('apply → non-breaking add state records NO log entry', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit',
+      target: resourceName(WF),
+      updateKey: { key: 'states' },
+      operation: {
+        name: 'add',
+        target: { name: 'Archived', category: 'closed' },
+      },
+    });
+
+    const wf = project.resources.byType(WF, 'workflows')!;
+    expect(wf.data!.states.map((s) => s.name)).toContain('Archived');
+
+    const entries = await ConfigurationLogger.entries(project.basePath);
+    expect(entries).toHaveLength(0);
+  });
+
+  it('apply → non-breaking transition change records NO log entry', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit',
+      target: resourceName(WF),
+      updateKey: { key: 'transitions' },
+      operation: { name: 'remove', target: 'Deprecate' },
+    });
+
+    const wf = project.resources.byType(WF, 'workflows')!;
+    expect(wf.data!.transitions.map((t) => t.name)).not.toContain('Deprecate');
+
+    const entries = await ConfigurationLogger.entries(project.basePath);
+    expect(entries).toHaveLength(0);
+  });
+
+  it('display-only changes fall through to DefaultNoCascadeHandler (no log entry)', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'edit',
+      target: resourceName(WF),
+      updateKey: { key: 'displayName' },
+      operation: {
+        name: 'change',
+        target: 'Decision based workflow',
+        to: 'Decision workflow',
+      },
+    });
+
+    const wf = project.resources.byType(WF, 'workflows')!;
+    expect(wf.data!.displayName).toBe('Decision workflow');
+
+    const entries = await ConfigurationLogger.entries(project.basePath);
+    expect(entries).toHaveLength(0);
+  });
+
+  it('apply → deleting an in-use workflow is refused (no log entry)', async () => {
+    const mutations = new ResourceMutations(project);
+    await expect(
+      mutations.apply({ kind: 'delete', target: resourceName(WF) }),
+    ).rejects.toThrow();
+
+    expect(project.resources.exists(WF)).toBe(true);
+    const entries = await ConfigurationLogger.entries(project.basePath);
+    expect(entries).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Fourth PR of the migration-imp split (follows #1387, sibling of #1443/#1444). Extracts the six Workflow mutation handlers into the mutation engine: rename, delete, add-state, remove-state, rename-state, transition.

- All six handlers are thin routers into the legacy `WorkflowResource` methods — the in-class cascade (`onNameChange`, `handleStateChange`, `handleStateRemoval`) still runs exactly once; each handler absorbs its cascade when the legacy path is deleted in the cleanup PR ("scaffolding stays" invariant).
- isBreaking classification mirrors the legacy `ConfigurationLogger` rules: rename/delete/remove-state are breaking; rename-state breaking only when the state name actually changes; add-state and transition edits are non-breaking (no log entry).
- Routing: all workflow renames/edits/deletes divert to `ResourceMutations`; unhandled edit shapes (displayName, category-only changes, rank) fall to `DefaultNoCascadeHandler`, matching legacy behavior exactly.
- Behavior matches the old path, not migration-imp's later changes: deleting an in-use workflow is still refused (no cascade-delete of card types/cards); remove-state without a replacement leaves card states untouched.