### PR TITLE
feat(mutations): project rename handler (PR6)

### DIFF
--- a/tools/data-handler/src/commands/rename.ts
+++ b/tools/data-handler/src/commands/rename.ts
@@ -16,14 +16,8 @@ import { ResourceMutations } from '../mutations/resource-mutations.js';
 import { write } from '../utils/rw-lock.js';
 
 /**
- * Class that handles the 'rename' command. The project-prefix rename cascade
- * is owned by ProjectRenameHandler; this command is a thin wrapper that routes
- * the request through ResourceMutations.apply.
- *
- * The cascade (resource renames, card-key/reference rewrites, attachments,
- * metadata) and the `project_rename` ConfigurationLogger entry are both
- * produced by the mutations engine, so this command no longer logs — that
- * keeps the log entry written exactly once.
+ * Handles the 'rename' command: routes a project-prefix rename through the
+ * mutations engine, which performs the cascade and records the log entry.
  */
 export class Rename {
   /**

--- a/tools/data-handler/src/commands/rename.ts
+++ b/tools/data-handler/src/commands/rename.ts
@@ -20,11 +20,15 @@ import { write } from '../utils/rw-lock.js';
  * mutations engine, which performs the cascade and records the log entry.
  */
 export class Rename {
+  private readonly mutations: ResourceMutations;
+
   /**
    * Creates an instance of Rename command.
    * @param project Project instance to use.
    */
-  constructor(private project: Project) {}
+  constructor(private project: Project) {
+    this.mutations = new ResourceMutations(project);
+  }
 
   /**
    * Renames project prefix.
@@ -38,7 +42,6 @@ export class Rename {
     if (!to) {
       throw new Error(`Input validation error: empty 'to' is not allowed`);
     }
-    const mutations = new ResourceMutations(this.project);
-    await mutations.apply({ kind: 'project_rename', newPrefix: to });
+    await this.mutations.apply({ kind: 'project_rename', newPrefix: to });
   }
 }

--- a/tools/data-handler/src/commands/rename.ts
+++ b/tools/data-handler/src/commands/rename.ts
@@ -11,283 +11,40 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-// node
-import { assert } from 'node:console';
-import { join } from 'node:path';
-import { rename, readdir, readFile, writeFile } from 'node:fs/promises';
-
-import type { Card } from '../interfaces/project-interfaces.js';
-import { ConfigurationLogger } from '../utils/configuration-logger.js';
-import { isTemplateCard } from '../utils/card-utils.js';
 import { type Project } from '../containers/project.js';
-import { ResourcesFrom } from '../containers/project/resources-from.js';
-import { resourceName } from '../utils/resource-utils.js';
+import { ResourceMutations } from '../mutations/resource-mutations.js';
 import { write } from '../utils/rw-lock.js';
 
-const FILE_TYPES_WITH_PREFIX_REFERENCES = ['adoc', 'hbs', 'json', 'lp'];
-
 /**
- * Class that handles 'rename' command.
+ * Class that handles the 'rename' command. The project-prefix rename cascade
+ * is owned by ProjectRenameHandler; this command is a thin wrapper that routes
+ * the request through ResourceMutations.apply.
+ *
+ * The cascade (resource renames, card-key/reference rewrites, attachments,
+ * metadata) and the `project_rename` ConfigurationLogger entry are both
+ * produced by the mutations engine, so this command no longer logs — that
+ * keeps the log entry written exactly once.
  */
 export class Rename {
-  private from: string = '';
-  private to: string = '';
-
   /**
    * Creates an instance of Rename command.
    * @param project Project instance to use.
    */
   constructor(private project: Project) {}
 
-  // Renames a card and all of its attachments (if it is a project card).
-  private async renameCard(re: RegExp, card: Card): Promise<void> {
-    // Update card's metadata
-    await this.updateCardMetadata(card);
-
-    // Then rename card file.
-    const newCardPath = card.path.replace(re, this.to);
-    await rename(card.path, newCardPath);
-  }
-
-  // Update all the cards in a container.
-  // Sort cards so that cards that deeper in file hierarchy are renamed first.
-  private async renameCards(cards: Card[]): Promise<void> {
-    // Sort cards by path length (so that renaming starts from children)
-    function sortCards(a: Card, b: Card) {
-      if (a.path.length > b.path.length) {
-        return -1;
-      }
-      if (a.path.length < b.path.length) {
-        return 1;
-      }
-      return 0;
-    }
-
-    // Ensure that only last occurrence is replaced, since path can contain "project prefixes" that are not to be touched.
-    //   E.g. /Users/smith/projects/card-projects/smith-project/cardRoot/smith_sdhgsd7; change 'smith' card key to 'miller'
-    //   --> only the last 'smith' should be replaced with 'miller'.
-    const re = new RegExp(`${this.from}(?!.*${this.from})`);
-    const sortedCards = cards.sort((a, b) => sortCards(a, b));
-
-    // Cannot do this parallel, since cards deeper in the hierarchy needs to be renamed first.
-    for (const card of sortedCards) {
-      // Attachments
-      card.content = await this.updateCardAttachments(re, card);
-      await this.renameCard(re, card);
-    }
-  }
-
-  // Checks if file's extension is one that might contain project prefix references.
-  private scanExtensions(fileName: string): boolean {
-    // If file does not contain a dot, then it cannot have extension.
-    // Disqualify all files starting with dot as well.
-    if (!fileName || !fileName.includes('.') || fileName.at(0) === '.') {
-      return false;
-    }
-
-    const extension = fileName.split('.').pop() || '';
-    return FILE_TYPES_WITH_PREFIX_REFERENCES.includes(extension);
-  }
-
-  // Update card's attachments (both the files and the references to them)
-  private async updateCardAttachments(re: RegExp, card: Card) {
-    if (!isTemplateCard(card)) {
-      const attachments = card.attachments ? card.attachments : [];
-      await Promise.all(
-        attachments.map(async (attachment) => {
-          const newAttachmentFileName = attachment.fileName.replace(
-            re,
-            this.to,
-          );
-          await rename(
-            join(attachment.path, attachment.fileName),
-            join(attachment.path, newAttachmentFileName),
-          );
-          // NOTE: content is renamed by updateFiles method
-        }),
-      );
-    }
-    return card.content;
-  }
-
-  // Update card's metadata.
-  private async updateCardMetadata(card: Card) {
-    if (card.metadata?.cardType && card.metadata?.cardType.length > 0) {
-      const { identifier, prefix, type } = resourceName(card.metadata.cardType);
-      if (prefix === this.from) {
-        card.metadata.cardType = `${this.project.configuration.cardKeyPrefix}/${type}/${identifier}`;
-        // Update card' custom fields
-        const keys = Object.keys(card.metadata);
-        for (const oldKey of keys) {
-          if (oldKey.startsWith(`${this.from}/fieldTypes`)) {
-            const newKey = this.updateResourceName(oldKey);
-            // one-liner to remove the old key and add a new one
-            delete Object.assign(card.metadata, {
-              [newKey]: card.metadata[oldKey],
-            })[oldKey];
-          }
-        }
-        await this.project.updateCardMetadata(card, card.metadata);
-      }
-    }
-  }
-
-  private async updateFiles(location: string) {
-    const conversionMap = new Map([
-      [`${this.from}/calculations/`, `${this.to}/calculations/`],
-      [`${this.from}/cardTypes/`, `${this.to}/cardTypes/`],
-      [`${this.from}/fieldTypes/`, `${this.to}/fieldTypes/`],
-      [`${this.from}/linkTypes/`, `${this.to}/linkTypes/`],
-      [`${this.from}/reports/`, `${this.to}/reports/`],
-      [`${this.from}/templates/`, `${this.to}/templates/`],
-      [`${this.from}/workflows/`, `${this.to}/workflows/`],
-      [`${this.from}_`, `${this.to}_`],
-    ]);
-    // Collect all supported file types from the location.
-    const files = (
-      await readdir(location, {
-        recursive: true,
-        withFileTypes: true,
-      })
-    ).filter(
-      (item) =>
-        item.isFile() &&
-        item.name !== '.schema' &&
-        this.scanExtensions(item.name),
-    );
-
-    // Then replace all values that match in the conversion map.
-    await Promise.all(
-      files.map(async (item) => {
-        const target = join(item.parentPath, item.name);
-        let fileContent = await readFile(target, { encoding: 'utf-8' });
-        for (const [key, value] of conversionMap) {
-          // Negative lookbehind prevents matching inside a longer prefix
-          // (e.g. renaming "test" to "projtest" must not re-match the
-          // "test/" substring inside the already-renamed "projtest/").
-          const re = new RegExp(`(?<![a-z])${key}`, 'g');
-          fileContent = fileContent.replace(re, value);
-        }
-        await writeFile(target, fileContent);
-      }),
-    );
-  }
-
-  // Changes the name of a resource to match the new prefix.
-  private updateResourceName(name: string) {
-    const { identifier, prefix, type } = resourceName(name);
-    // do not rename module resources
-    return this.from === prefix
-      ? `${this.project.configuration.cardKeyPrefix}/${type}/${identifier}`
-      : name;
-  }
-
   /**
    * Renames project prefix.
    * @throws if trying to use empty 'to'
-   * @throws if trying to rename with current name
-   * @param to Card id, or template name
+   * @throws if trying to rename with the current name
+   * @throws if the new prefix is not a valid prefix
+   * @param to New project prefix
    */
   @write((to) => `Rename project prefix to ${to}`)
   public async rename(to: string) {
     if (!to) {
       throw new Error(`Input validation error: empty 'to' is not allowed`);
     }
-
-    this.from = this.project.configuration.cardKeyPrefix;
-    this.to = to;
-    assert(this.from !== '');
-    assert(this.to !== '');
-
-    if (this.from === this.to) {
-      throw new Error(`Project prefix is already '${this.from}'`);
-    }
-
-    // Change project prefix to project settings.
-    await this.project.configuration.setCardPrefix(to);
-    console.info(`Rename: New prefix: '${this.project.projectPrefix}'`);
-    // Update the resources collection, since project prefix has changed.
-    this.project.resources.changed();
-
-    // Rename local resources.
-    // It is better to rename the resources in this order: card types, workflows, field types, then the rest
-
-    // Rename all card types and custom fields in them.
-    for (const cardType of this.project.resources.cardTypes(
-      ResourcesFrom.localOnly,
-    )) {
-      const name = this.updateResourceName(cardType.data?.name || '');
-      await cardType.rename(resourceName(name));
-    }
-    console.info('Updated card types');
-
-    for (const workflow of this.project.resources.workflows(
-      ResourcesFrom.localOnly,
-    )) {
-      const name = this.updateResourceName(workflow.data?.name || '');
-      await workflow.rename(resourceName(name));
-    }
-    console.info('Updated workflows');
-
-    for (const fieldType of this.project.resources.fieldTypes(
-      ResourcesFrom.localOnly,
-    )) {
-      const name = this.updateResourceName(fieldType.data?.name || '');
-      await fieldType.rename(resourceName(name));
-    }
-    console.info('Updated field types');
-
-    const restOfResourceTypes = [
-      'graphModels',
-      'graphViews',
-      'linkTypes',
-      'reports',
-      'templates',
-      'calculations',
-    ] as const;
-
-    for (const resourceType of restOfResourceTypes) {
-      for (const resource of this.project.resources.resourceTypes(
-        resourceType,
-        ResourcesFrom.localOnly,
-      )) {
-        const name = this.updateResourceName(resource.data?.name || '');
-        await resource.rename(resourceName(name));
-      }
-    }
-
-    // Rename all local template cards. This must be done after calculations have been renamed.
-    for (const template of this.project.resources.templates(
-      ResourcesFrom.localOnly,
-    )) {
-      const templateObject = template.templateObject();
-      await this.renameCards(templateObject.cards());
-    }
-    console.info('Renamed template cards and updated the content');
-
-    // Rename all project cards.
-    await this.renameCards(
-      this.project.cards(this.project.paths.cardRootFolder),
-    );
-    console.info('Renamed project cards and updated the content');
-
-    await this.updateFiles(this.project.paths.cardRootFolder);
-    console.info('Renamed all remaining references in cardRoot folder');
-    await this.updateFiles(this.project.paths.resourcesFolder);
-    console.info('Renamed all remaining references in .cards folder');
-
-    // It is best that the resources are re-collected after all the renaming has occurred.
-    this.project.resources.changed();
-    console.info('Collected renamed resources');
-
-    // Remove these when operations properly update card cache
-    this.project.cardsCache.clear();
-    await this.project.populateCaches();
-
-    await ConfigurationLogger.log(this.project.basePath, {
-      kind: 'project_rename',
-      target: this.to,
-      payload: { oldPrefix: this.from, newPrefix: this.to },
-    });
+    const mutations = new ResourceMutations(this.project);
+    await mutations.apply({ kind: 'project_rename', newPrefix: to });
   }
 }

--- a/tools/data-handler/src/mutations/dispatcher.ts
+++ b/tools/data-handler/src/mutations/dispatcher.ts
@@ -35,6 +35,7 @@ import { WorkflowRenameStateHandler } from './handlers/workflow-rename-state.js'
 import { WorkflowTransitionHandler } from './handlers/workflow-transition.js';
 import { WorkflowDeleteHandler } from './handlers/workflow-delete.js';
 import { LeafResourceRenameHandler } from './handlers/leaf-resource-rename.js';
+import { ProjectRenameHandler } from './handlers/project-rename.js';
 
 const HANDLERS: Handler[] = [
   new LinkTypeRenameHandler(),
@@ -68,6 +69,7 @@ const HANDLERS: Handler[] = [
   new LeafResourceRenameHandler('reports', 'Report'),
   new LeafResourceRenameHandler('graphModels', 'Graph model'),
   new LeafResourceRenameHandler('graphViews', 'Graph view'),
+  new ProjectRenameHandler(),
   new DefaultNoCascadeHandler(),
 ];
 

--- a/tools/data-handler/src/mutations/handlers/project-rename.ts
+++ b/tools/data-handler/src/mutations/handlers/project-rename.ts
@@ -1,0 +1,263 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { join } from 'node:path';
+import {
+  rename as renameFile,
+  readdir,
+  readFile,
+  writeFile,
+} from 'node:fs/promises';
+
+import type { Handler, MutationContext } from '../handler.js';
+import type { Card } from '../../interfaces/project-interfaces.js';
+import { isTemplateCard } from '../../utils/card-utils.js';
+import { resourceName } from '../../utils/resource-utils.js';
+import { ResourcesFrom } from '../../containers/project/resources-from.js';
+
+const FILE_TYPES_WITH_PREFIX_REFERENCES = ['adoc', 'hbs', 'json', 'lp'];
+
+/**
+ * Renames a project's card-key prefix and the entire cascade that depends on
+ * it: every local resource name, every `<oldPrefix>/<resourceType>/...`
+ * reference, every `<oldPrefix>_*` card key, card metadata, attachments, and
+ * file contents (adoc/hbs/json/lp).
+ *
+ * This is the largest cascade in the system. It was previously owned by
+ * `commands/rename.ts:Rename.rename(to)`; that command is now a thin wrapper
+ * that routes through `ResourceMutations.apply({ kind: 'project_rename' })`,
+ * so this handler is the single owner of the cascade. The whole operation
+ * runs inside `apply`; there is no module-target / local-target split because
+ * a project rename only ever touches the local project.
+ *
+ * `isBreaking` is true: a prefix change rewrites resource names and card keys
+ * across the project, so `ResourceMutations` records a `project_rename`
+ * ConfigurationLogger entry afterwards. The handler itself does NOT log — the
+ * old `Rename` command's `ConfigurationLogger.log` call has been removed so
+ * the entry is written exactly once, by the engine.
+ */
+export class ProjectRenameHandler implements Handler {
+  readonly isBreaking = true;
+
+  matches(ctx: MutationContext): boolean {
+    return ctx.input.kind === 'project_rename';
+  }
+
+  async apply(ctx: MutationContext): Promise<void> {
+    if (ctx.input.kind !== 'project_rename') {
+      throw new Error(
+        'ProjectRenameHandler called with non-project_rename input',
+      );
+    }
+    const from = ctx.project.projectPrefix;
+    const to = ctx.input.newPrefix;
+    if (!to) {
+      throw new Error("Input validation error: empty 'to' is not allowed");
+    }
+    if (from === to) {
+      throw new Error(`Project prefix is already '${from}'`);
+    }
+
+    // (1) Change project prefix and invalidate caches. setCardPrefix validates
+    //     the new prefix format and throws for invalid prefixes.
+    await ctx.project.configuration.setCardPrefix(to);
+    ctx.project.resources.changed();
+
+    // (2) Rename every local resource by category, in dependency order
+    //     (card types, workflows, field types first; then the rest).
+    const orderedCategories = [
+      'cardTypes',
+      'workflows',
+      'fieldTypes',
+      'graphModels',
+      'graphViews',
+      'linkTypes',
+      'reports',
+      'templates',
+      'calculations',
+    ] as const;
+
+    for (const category of orderedCategories) {
+      for (const resource of ctx.project.resources.resourceTypes(
+        category,
+        ResourcesFrom.localOnly,
+      )) {
+        const oldName = resource.data?.name ?? '';
+        if (!oldName) continue;
+        const parsed = resourceName(oldName);
+        // Do not rename module resources.
+        if (parsed.prefix !== from) continue;
+        const newName = `${to}/${parsed.type}/${parsed.identifier}`;
+        await resource.rename(resourceName(newName));
+      }
+    }
+
+    // (3) Rename template cards (deepest first) and rewrite their
+    //     content/attachments. Must run after calculations are renamed.
+    for (const template of ctx.project.resources.templates(
+      ResourcesFrom.localOnly,
+    )) {
+      await renameCards(ctx, template.templateObject().cards(), from, to);
+    }
+
+    // (4) Rename project cards.
+    await renameCards(
+      ctx,
+      ctx.project.cards(ctx.project.paths.cardRootFolder),
+      from,
+      to,
+    );
+
+    // (5) Walk cardRoot and resources, rewriting every prefix-qualified
+    //     reference and every "<prefix>_" card-key prefix.
+    await updateFiles(ctx.project.paths.cardRootFolder, from, to);
+    await updateFiles(ctx.project.paths.resourcesFolder, from, to);
+
+    // (6) Re-collect resources and rebuild card caches.
+    ctx.project.resources.changed();
+    ctx.project.cardsCache.clear();
+    await ctx.project.populateCaches();
+  }
+}
+
+// ---- Helpers extracted from commands/rename.ts (formerly private methods) ----
+
+async function renameCards(
+  ctx: MutationContext,
+  cards: Card[],
+  from: string,
+  to: string,
+): Promise<void> {
+  // Sort cards by path length (deepest first) so children rename before parents.
+  const sortedCards = [...cards].sort((a, b) => b.path.length - a.path.length);
+
+  // Negative lookahead so only the last occurrence in the path is replaced;
+  // the path may contain project prefixes that must not be touched. Matches
+  // the original rename logic in commands/rename.ts.
+  const re = new RegExp(`${from}(?!.*${from})`);
+
+  // Cannot run in parallel: deeper cards must be renamed before their parents.
+  for (const card of sortedCards) {
+    card.content = await updateCardAttachments(re, card, to);
+    await renameOneCard(ctx, re, card, from, to);
+  }
+}
+
+async function updateCardAttachments(
+  re: RegExp,
+  card: Card,
+  to: string,
+): Promise<string | undefined> {
+  if (!isTemplateCard(card)) {
+    const attachments = card.attachments ?? [];
+    await Promise.all(
+      attachments.map(async (attachment) => {
+        const newAttachmentFileName = attachment.fileName.replace(re, to);
+        await renameFile(
+          join(attachment.path, attachment.fileName),
+          join(attachment.path, newAttachmentFileName),
+        );
+        // NOTE: file contents are rewritten by updateFiles.
+      }),
+    );
+  }
+  return card.content;
+}
+
+async function renameOneCard(
+  ctx: MutationContext,
+  re: RegExp,
+  card: Card,
+  from: string,
+  to: string,
+): Promise<void> {
+  await updateCardMetadata(ctx, card, from, to);
+  const newCardPath = card.path.replace(re, to);
+  await renameFile(card.path, newCardPath);
+}
+
+async function updateCardMetadata(
+  ctx: MutationContext,
+  card: Card,
+  from: string,
+  to: string,
+): Promise<void> {
+  if (card.metadata?.cardType && card.metadata.cardType.length > 0) {
+    const { identifier, prefix, type } = resourceName(card.metadata.cardType);
+    if (prefix === from) {
+      card.metadata.cardType = `${to}/${type}/${identifier}`;
+      // Update the card's custom field keys.
+      const keys = Object.keys(card.metadata);
+      for (const oldKey of keys) {
+        if (oldKey.startsWith(`${from}/fieldTypes`)) {
+          const parsed = resourceName(oldKey);
+          const newKey = `${to}/${parsed.type}/${parsed.identifier}`;
+          // One-liner to remove the old key and add the new one.
+          delete Object.assign(card.metadata, {
+            [newKey]: card.metadata[oldKey],
+          })[oldKey];
+        }
+      }
+      await ctx.project.updateCardMetadata(card, card.metadata);
+    }
+  }
+}
+
+function scanExtensions(fileName: string): boolean {
+  // A file with no dot (or a dotfile) cannot carry a relevant extension.
+  if (!fileName || !fileName.includes('.') || fileName.at(0) === '.') {
+    return false;
+  }
+  const extension = fileName.split('.').pop() ?? '';
+  return FILE_TYPES_WITH_PREFIX_REFERENCES.includes(extension);
+}
+
+async function updateFiles(
+  location: string,
+  from: string,
+  to: string,
+): Promise<void> {
+  const conversionMap = new Map([
+    [`${from}/calculations/`, `${to}/calculations/`],
+    [`${from}/cardTypes/`, `${to}/cardTypes/`],
+    [`${from}/fieldTypes/`, `${to}/fieldTypes/`],
+    [`${from}/linkTypes/`, `${to}/linkTypes/`],
+    [`${from}/reports/`, `${to}/reports/`],
+    [`${from}/templates/`, `${to}/templates/`],
+    [`${from}/workflows/`, `${to}/workflows/`],
+    [`${from}_`, `${to}_`],
+  ]);
+
+  const files = (
+    await readdir(location, { recursive: true, withFileTypes: true })
+  ).filter(
+    (item) =>
+      item.isFile() && item.name !== '.schema' && scanExtensions(item.name),
+  );
+
+  await Promise.all(
+    files.map(async (item) => {
+      const target = join(item.parentPath, item.name);
+      let fileContent = await readFile(target, { encoding: 'utf-8' });
+      for (const [key, value] of conversionMap) {
+        // Negative lookbehind prevents matching inside a longer prefix
+        // (e.g. renaming "test" to "projtest" must not re-match the "test/"
+        // substring inside the already-renamed "projtest/").
+        const re = new RegExp(`(?<![a-z])${key}`, 'g');
+        fileContent = fileContent.replace(re, value);
+      }
+      await writeFile(target, fileContent);
+    }),
+  );
+}

--- a/tools/data-handler/src/mutations/handlers/project-rename.ts
+++ b/tools/data-handler/src/mutations/handlers/project-rename.ts
@@ -33,12 +33,6 @@ const FILE_TYPES_WITH_PREFIX_REFERENCES = ['adoc', 'hbs', 'json', 'lp'];
  * it: every local resource name, every `<oldPrefix>/<resourceType>/...`
  * reference, every `<oldPrefix>_*` card key, card metadata, attachments, and
  * file contents (adoc/hbs/json/lp).
- *
- * The whole operation runs in apply(); there is no module-target/local-target
- * split because a project rename only ever touches the local project.
- *
- * isBreaking is true: the engine records the project_rename log entry after
- * apply() succeeds; this handler must not log it itself.
  */
 export class ProjectRenameHandler implements Handler {
   readonly isBreaking = true;
@@ -62,13 +56,13 @@ export class ProjectRenameHandler implements Handler {
       throw new Error(`Project prefix is already '${from}'`);
     }
 
-    // (1) Change project prefix and invalidate caches. setCardPrefix validates
-    //     the new prefix format and throws for invalid prefixes.
+    // The prefix must change first: resource renames are validated against the
+    // current projectPrefix. The cache refresh is also required — local
+    // registry keys are derived from projectPrefix at collection time.
     await ctx.project.configuration.setCardPrefix(to);
     ctx.project.resources.changed();
 
-    // (2) Rename every local resource by category, in dependency order
-    //     (card types, workflows, field types first; then the rest).
+    // Referenced resource families must rename before their referrers.
     const orderedCategories = [
       'cardTypes',
       'workflows',
@@ -89,22 +83,20 @@ export class ProjectRenameHandler implements Handler {
         const oldName = resource.data?.name ?? '';
         if (!oldName) continue;
         const parsed = resourceName(oldName);
-        // Do not rename module resources.
+        // The file's own name field not carrying the old prefix means the
+        // resource was already renamed (e.g. a partially completed run).
         if (parsed.prefix !== from) continue;
         const newName = `${to}/${parsed.type}/${parsed.identifier}`;
         await resource.rename(resourceName(newName));
       }
     }
 
-    // (3) Rename template cards (deepest first) and rewrite their
-    //     content/attachments. Must run after calculations are renamed.
+    // Card renames must run after the resource renames above.
     for (const template of ctx.project.resources.templates(
       ResourcesFrom.localOnly,
     )) {
       await renameCards(ctx, template.templateObject().cards(), from, to);
     }
-
-    // (4) Rename project cards.
     await renameCards(
       ctx,
       ctx.project.cards(ctx.project.paths.cardRootFolder),
@@ -112,19 +104,14 @@ export class ProjectRenameHandler implements Handler {
       to,
     );
 
-    // (5) Walk cardRoot and resources, rewriting every prefix-qualified
-    //     reference and every "<prefix>_" card-key prefix.
     await updateFiles(ctx.project.paths.cardRootFolder, from, to);
     await updateFiles(ctx.project.paths.resourcesFolder, from, to);
 
-    // (6) Re-collect resources and rebuild card caches.
     ctx.project.resources.changed();
     ctx.project.cardsCache.clear();
     await ctx.project.populateCaches();
   }
 }
-
-// ---- Cascade helpers ----
 
 async function renameCards(
   ctx: MutationContext,
@@ -132,14 +119,14 @@ async function renameCards(
   from: string,
   to: string,
 ): Promise<void> {
-  // Sort cards by path length (deepest first) so children rename before parents.
+  // Children must be renamed before their parents, so deepest paths first
+  // and strictly sequentially.
   const sortedCards = [...cards].sort((a, b) => b.path.length - a.path.length);
 
   // Negative lookahead so only the last occurrence in the path is replaced;
   // the path may contain project prefixes that must not be touched.
   const re = new RegExp(`${from}(?!.*${from})`);
 
-  // Cannot run in parallel: deeper cards must be renamed before their parents.
   for (const card of sortedCards) {
     card.content = await updateCardAttachments(re, card, to);
     await renameOneCard(ctx, re, card, from, to);
@@ -189,16 +176,12 @@ async function updateCardMetadata(
     const { identifier, prefix, type } = resourceName(card.metadata.cardType);
     if (prefix === from) {
       card.metadata.cardType = `${to}/${type}/${identifier}`;
-      // Update the card's custom field keys.
-      const keys = Object.keys(card.metadata);
-      for (const oldKey of keys) {
+      for (const oldKey of Object.keys(card.metadata)) {
         if (oldKey.startsWith(`${from}/fieldTypes`)) {
           const parsed = resourceName(oldKey);
           const newKey = `${to}/${parsed.type}/${parsed.identifier}`;
-          // One-liner to remove the old key and add the new one.
-          delete Object.assign(card.metadata, {
-            [newKey]: card.metadata[oldKey],
-          })[oldKey];
+          card.metadata[newKey] = card.metadata[oldKey];
+          delete card.metadata[oldKey];
         }
       }
       await ctx.project.updateCardMetadata(card, card.metadata);
@@ -207,7 +190,6 @@ async function updateCardMetadata(
 }
 
 function scanExtensions(fileName: string): boolean {
-  // A file with no dot (or a dotfile) cannot carry a relevant extension.
   if (!fileName || !fileName.includes('.') || fileName.at(0) === '.') {
     return false;
   }

--- a/tools/data-handler/src/mutations/handlers/project-rename.ts
+++ b/tools/data-handler/src/mutations/handlers/project-rename.ts
@@ -34,18 +34,11 @@ const FILE_TYPES_WITH_PREFIX_REFERENCES = ['adoc', 'hbs', 'json', 'lp'];
  * reference, every `<oldPrefix>_*` card key, card metadata, attachments, and
  * file contents (adoc/hbs/json/lp).
  *
- * This is the largest cascade in the system. It was previously owned by
- * `commands/rename.ts:Rename.rename(to)`; that command is now a thin wrapper
- * that routes through `ResourceMutations.apply({ kind: 'project_rename' })`,
- * so this handler is the single owner of the cascade. The whole operation
- * runs inside `apply`; there is no module-target / local-target split because
- * a project rename only ever touches the local project.
+ * The whole operation runs in apply(); there is no module-target/local-target
+ * split because a project rename only ever touches the local project.
  *
- * `isBreaking` is true: a prefix change rewrites resource names and card keys
- * across the project, so `ResourceMutations` records a `project_rename`
- * ConfigurationLogger entry afterwards. The handler itself does NOT log — the
- * old `Rename` command's `ConfigurationLogger.log` call has been removed so
- * the entry is written exactly once, by the engine.
+ * isBreaking is true: the engine records the project_rename log entry after
+ * apply() succeeds; this handler must not log it itself.
  */
 export class ProjectRenameHandler implements Handler {
   readonly isBreaking = true;
@@ -131,7 +124,7 @@ export class ProjectRenameHandler implements Handler {
   }
 }
 
-// ---- Helpers extracted from commands/rename.ts (formerly private methods) ----
+// ---- Cascade helpers ----
 
 async function renameCards(
   ctx: MutationContext,
@@ -143,8 +136,7 @@ async function renameCards(
   const sortedCards = [...cards].sort((a, b) => b.path.length - a.path.length);
 
   // Negative lookahead so only the last occurrence in the path is replaced;
-  // the path may contain project prefixes that must not be touched. Matches
-  // the original rename logic in commands/rename.ts.
+  // the path may contain project prefixes that must not be touched.
   const re = new RegExp(`${from}(?!.*${from})`);
 
   // Cannot run in parallel: deeper cards must be renamed before their parents.

--- a/tools/data-handler/test/mutations/handlers/project-rename.test.ts
+++ b/tools/data-handler/test/mutations/handlers/project-rename.test.ts
@@ -42,8 +42,8 @@ describe('ProjectRenameHandler', () => {
     expect(
       handler.matches({
         project,
-        // @ts-expect-error wrong input kind on purpose
-        input: { kind: 'rename', newPrefix: 'renamed' },
+        // @ts-expect-error matches() must reject inputs whose kind is not 'project_rename'
+        input: { kind: 'rename' },
       }),
     ).toBe(false);
   });

--- a/tools/data-handler/test/mutations/handlers/project-rename.test.ts
+++ b/tools/data-handler/test/mutations/handlers/project-rename.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { Project } from '../../../src/containers/project.js';
+import { ProjectRenameHandler } from '../../../src/mutations/handlers/project-rename.js';
+import { copyDir } from '../../../src/utils/file-utils.js';
+import { ResourceMutations } from '../../../src/mutations/resource-mutations.js';
+
+const FIXTURE_PATH = join(
+  import.meta.dirname,
+  '..',
+  '..',
+  'test-data',
+  'valid',
+  'decision-records',
+);
+const tmpDir = join(import.meta.dirname, 'tmp-project-rename');
+
+describe('ProjectRenameHandler', () => {
+  let project: Project;
+
+  beforeEach(async () => {
+    const projectPath = join(tmpDir, `proj-${Date.now()}-${Math.random()}`);
+    await mkdir(projectPath, { recursive: true });
+    await copyDir(FIXTURE_PATH, projectPath);
+    project = new Project(projectPath);
+    await project.populateCaches();
+  });
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('matches only project_rename inputs', () => {
+    const handler = new ProjectRenameHandler();
+    expect(
+      handler.matches({
+        project,
+        input: { kind: 'project_rename', newPrefix: 'renamed' },
+      }),
+    ).toBe(true);
+    expect(
+      handler.matches({
+        project,
+        // @ts-expect-error wrong input kind on purpose
+        input: { kind: 'rename', newPrefix: 'renamed' },
+      }),
+    ).toBe(false);
+  });
+
+  it('is breaking', () => {
+    expect(new ProjectRenameHandler().isBreaking).toBe(true);
+  });
+
+  it('apply rewrites cardType references in every card', async () => {
+    const oldPrefix = project.projectPrefix;
+    const newPrefix = 'renamed';
+    const mutations = new ResourceMutations(project);
+
+    await mutations.apply({ kind: 'project_rename', newPrefix });
+
+    expect(project.projectPrefix).toBe(newPrefix);
+
+    for (const card of project.cards(undefined)) {
+      // Cards that referenced cardTypes under oldPrefix must now reference newPrefix.
+      if (card.metadata?.cardType?.startsWith(`${oldPrefix}/`)) {
+        expect.fail(`card '${card.key}' still references old prefix`);
+      }
+    }
+  });
+
+  it('apply rewrites resource references in card content adoc files', async () => {
+    const oldPrefix = project.projectPrefix;
+    const newPrefix = 'renamed';
+    const mutations = new ResourceMutations(project);
+
+    await mutations.apply({ kind: 'project_rename', newPrefix });
+
+    for (const card of project.cards(undefined)) {
+      const adoc = join(card.path, 'index.adoc');
+      let content: string;
+      try {
+        content = await readFile(adoc, 'utf-8');
+      } catch {
+        continue;
+      }
+      // No remaining "<oldPrefix>/<resourceType>/" substring (the strict
+      // cascade pattern that updateFiles uses).
+      for (const type of [
+        'calculations',
+        'cardTypes',
+        'fieldTypes',
+        'linkTypes',
+        'reports',
+        'templates',
+        'workflows',
+      ]) {
+        expect(content).not.toContain(`${oldPrefix}/${type}/`);
+      }
+    }
+  });
+
+  it('apply renames cards whose key starts with the old prefix', async () => {
+    const oldPrefix = project.projectPrefix;
+    const newPrefix = 'renamed';
+    const mutations = new ResourceMutations(project);
+
+    await mutations.apply({ kind: 'project_rename', newPrefix });
+
+    for (const card of project.cards(undefined)) {
+      expect(card.key.startsWith(`${oldPrefix}_`)).toBe(false);
+    }
+  });
+
+  it('throws when renaming to the current prefix', async () => {
+    const mutations = new ResourceMutations(project);
+    const current = project.projectPrefix;
+    await expect(
+      mutations.apply({ kind: 'project_rename', newPrefix: current }),
+    ).rejects.toThrow(`Project prefix is already '${current}'`);
+  });
+
+  it('throws for an invalid prefix', async () => {
+    const mutations = new ResourceMutations(project);
+    // Underscore is not a valid prefix character (setCardPrefix rejects it).
+    await expect(
+      mutations.apply({ kind: 'project_rename', newPrefix: 'bad_prefix' }),
+    ).rejects.toThrow();
+  });
+});

--- a/tools/data-handler/test/mutations/integration-project-rename.test.ts
+++ b/tools/data-handler/test/mutations/integration-project-rename.test.ts
@@ -47,8 +47,7 @@ describe('ProjectRename end-to-end', () => {
 
     expect(project.projectPrefix).toBe('renamed');
 
-    // The engine records the project_rename ConfigurationLogger entry exactly
-    // once. The Rename command no longer logs, so there is no double entry.
+    // Exactly one project_rename entry is recorded per rename.
     const entries = await ConfigurationLogger.entries(project.basePath);
     const projectRenameEntries = entries.filter(
       (e) => e.kind === 'project_rename',

--- a/tools/data-handler/test/mutations/integration-project-rename.test.ts
+++ b/tools/data-handler/test/mutations/integration-project-rename.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { Project } from '../../src/containers/project.js';
+import { ResourceMutations } from '../../src/mutations/resource-mutations.js';
+import { ConfigurationLogger } from '../../src/utils/configuration-logger.js';
+import { copyDir } from '../../src/utils/file-utils.js';
+
+const FIXTURE_PATH = join(
+  import.meta.dirname,
+  '..',
+  'test-data',
+  'valid',
+  'decision-records',
+);
+const tmpDir = join(import.meta.dirname, 'tmp-integration-project-rename');
+
+describe('ProjectRename end-to-end', () => {
+  let project: Project;
+  let projectPath: string;
+  let originalPrefix: string;
+
+  beforeAll(async () => {
+    projectPath = join(tmpDir, `proj-${Date.now()}`);
+    await mkdir(projectPath, { recursive: true });
+    await copyDir(FIXTURE_PATH, projectPath);
+    // Seed an attachment whose file name carries the project prefix so the
+    // attachment-rename step of the cascade has something to assert on.
+    await writeFile(
+      join(projectPath, 'cardRoot', 'decision_5', 'a', 'decision_diagram.png'),
+      'fake-image',
+    );
+    project = new Project(projectPath);
+    await project.populateCaches();
+    originalPrefix = project.projectPrefix;
+  });
+  afterAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('apply renames the prefix and logs a single project_rename entry', async () => {
+    const mutations = new ResourceMutations(project);
+
+    await mutations.apply({ kind: 'project_rename', newPrefix: 'renamed' });
+
+    expect(project.projectPrefix).toBe('renamed');
+
+    // The engine records the project_rename ConfigurationLogger entry exactly
+    // once. The Rename command no longer logs, so there is no double entry.
+    const entries = await ConfigurationLogger.entries(project.basePath);
+    const projectRenameEntries = entries.filter(
+      (e) => e.kind === 'project_rename',
+    );
+    expect(projectRenameEntries).toHaveLength(1);
+    expect(projectRenameEntries[0].target).toBe('renamed');
+    expect(projectRenameEntries[0].payload).toEqual({
+      oldPrefix: originalPrefix,
+      newPrefix: 'renamed',
+    });
+
+    // Attachment files carrying the old prefix are renamed along with the
+    // card directory that contains them.
+    const attachmentDir = join(projectPath, 'cardRoot', 'renamed_5', 'a');
+    expect(existsSync(join(attachmentDir, 'renamed_diagram.png'))).toBe(true);
+    expect(existsSync(join(attachmentDir, 'decision_diagram.png'))).toBe(false);
+  });
+});


### PR DESCRIPTION
Sixth PR of the migration-imp split (follows #1387, sibling of #1443/#1444/#1445). Moves the project-prefix rename cascade out of `commands/rename.ts` into a first-class `ProjectRenameHandler` driven by the mutation engine.

- Unlike the resource handlers (PRs 2–5), the cascade here lived in the command layer, not in a resource class — so the "scaffolding stays" invariant doesn't apply and the cascade moves in full: `rename.ts` shrinks to a thin wrapper (−257 lines) that calls `ResourceMutations.apply({kind: 'project_rename'})`, keeping its `@write` commit-message decorator and public signature (command-handler and backend call sites unchanged).
- Cascade ported 1:1 and verified line-by-line against the old code: prefix validation first, resource renames in the same dependency order, template then project cards deepest-first, identical path/reference regexes, same file-rewrite map, cache rebuild.
- The `project_rename` migration-log entry is now written exactly once, by the engine (the old duplicate log call in `rename.ts` is removed); `oldPrefix` is captured before the cascade mutates state. Integration test asserts the single-entry invariant and payload.
- Attachment files carrying the old prefix are covered by a direct rename assertion.