### PR TITLE
INTDEV-1310 Clear error when shortText value exceeds length limit

### DIFF
--- a/tools/data-handler/src/commands/validate.ts
+++ b/tools/data-handler/src/commands/validate.ts
@@ -811,6 +811,17 @@ export class Validate {
           );
           continue;
         }
+        if (
+          fieldType.dataType === 'shortText' &&
+          typeOfValue === 'string' &&
+          this.length(card.metadata[field.name] as string) >
+            SHORT_TEXT_MAX_LENGTH
+        ) {
+          validationErrors.push(
+            `In card '${card.key}' field '${field.name}' value exceeds the maximum length for 'shortText': ${SHORT_TEXT_MAX_LENGTH} characters allowed, but value has ${this.length(card.metadata[field.name] as string)} characters\n`,
+          );
+          continue;
+        }
         validationErrors.push(
           `In card '${card.key}' field '${field.name}' is defined as '${fieldType.dataType}', but it is '${typeOfValue}' with value of ${fieldValue}\n`,
         );

--- a/tools/data-handler/test/command-edit.test.ts
+++ b/tools/data-handler/test/command-edit.test.ts
@@ -113,6 +113,45 @@ describe('edit card', () => {
 
     rmSync(freshTestDir, { recursive: true, force: true });
   });
+  it('shortText value over the length limit reports the length, not a type error', async () => {
+    // Isolated project: this test adds a custom field to a card type.
+    const freshTestDir = join(baseDir, 'tmp-edit-shorttext-test');
+    mkdirSync(freshTestDir, { recursive: true });
+    await copyDir('test/test-data/', freshTestDir);
+    const freshCommands = new CommandManager(
+      join(freshTestDir, 'valid/decision-records'),
+      { autoSaveConfiguration: false },
+    );
+    await freshCommands.initialize();
+
+    await freshCommands.createCmd.createFieldType('myShort', 'shortText');
+    await freshCommands.updateCmd.updateValue(
+      'decision/cardTypes/decision.json',
+      'add',
+      'customFields',
+      { name: 'decision/fieldTypes/myShort' },
+    );
+
+    const longValue = 'x'.repeat(120);
+    await expect(
+      freshCommands.editCmd.editCardMetadata(
+        'decision_6',
+        'decision/fieldTypes/myShort',
+        longValue,
+      ),
+    ).rejects.toThrow(
+      /value exceeds the maximum length for 'shortText': 80 characters allowed, but value has 120 characters/,
+    );
+    await expect(
+      freshCommands.editCmd.editCardMetadata(
+        'decision_6',
+        'decision/fieldTypes/myShort',
+        longValue,
+      ),
+    ).rejects.not.toThrow(/but it is 'string'/);
+
+    rmSync(freshTestDir, { recursive: true, force: true });
+  });
   it('try to edit card metadata - incorrect field name', async () => {
     const cards = commands.project.cards();
     const firstCard = cards.at(0) as Card;


### PR DESCRIPTION
## Root cause
Setting a `shortText` field value longer than 80 characters fails validation in `Validate.validateCustomFields` (`tools/data-handler/src/commands/validate.ts`). `validType()` rejects the value because it exceeds `SHORT_TEXT_MAX_LENGTH` (80), but the message builder had no `shortText`-specific branch — so a too-long *string* fell through to the generic type-mismatch message:

> `In card 'test_z9h94s81' field 'test/fieldTypes/shortText' is defined as 'shortText', but it is 'string' with value of "…"`

This is misleading: the value **is** a string; it's just over the length limit. The 80-char limit and this message both live entirely in our own code — no JSON schema / AJV / Zod validates `shortText` value length.

## Fix
Add a `shortText` branch alongside the existing `enum`/`person` cases that reports the allowed and actual lengths when a string value exceeds `SHORT_TEXT_MAX_LENGTH`:

> `In card '…' field '…' value exceeds the maximum length for 'shortText': 80 characters allowed, but value has 120 characters`

Validation behaviour is unchanged — only the error message improves.

## Verification
- New regression test in `command-edit.test.ts` reproduces the bug via the real `editCardMetadata` path; confirmed it **fails** against current code with the old misleading message, and **passes** with the fix.
- Full `data-handler` suite green: 1409 passed, 1 skipped.
- `eslint`, `prettier --check`, and `tsc --noEmit` clean on the changed package.

Ticket: INTDEV-1310 — https://cyberismo.atlassian.net/browse/INTDEV-1310

🤖 Generated with [Claude Code](https://claude.com/claude-code)