### PR TITLE
INTDEV-1299 Fix broken xref macro warning rendering in the middle of text

### DIFF
--- a/tools/data-handler/src/macros/index.ts
+++ b/tools/data-handler/src/macros/index.ts
@@ -299,7 +299,8 @@ export function applyMacroResults(
 ) {
   for (const item of tasks) {
     if (item.error) {
-      input = input.replace(
+      input = replaceWithBlock(
+        input,
         item.placeholder,
         handleMacroError(item.error, item.macro, context),
       );
@@ -318,6 +319,29 @@ export function applyMacroResults(
     }
   }
   return input;
+}
+
+/**
+ * Replaces a placeholder with block-level adoc content. Block syntax (e.g.
+ * admonitions) is only recognized at the start of a line preceded by a blank
+ * line, so inline whitespace around the placeholder is stripped and a blank
+ * line is inserted before the block when the placeholder sits mid-paragraph.
+ * @param input - The content containing the placeholder
+ * @param placeholder - The placeholder to replace
+ * @param block - Block-level adoc content (must end with a blank line)
+ * @returns The content with the placeholder replaced
+ */
+function replaceWithBlock(input: string, placeholder: string, block: string) {
+  const index = input.indexOf(placeholder);
+  if (index === -1) {
+    return input;
+  }
+  let before = input.slice(0, index).replace(/[ \t]+$/, '');
+  const after = input.slice(index + placeholder.length).replace(/^[ \t]+/, '');
+  if (before !== '' && !before.endsWith('\n\n')) {
+    before += before.endsWith('\n') ? '\n' : '\n\n';
+  }
+  return before + block + after;
 }
 
 /**

--- a/tools/data-handler/test/macros/index.test.ts
+++ b/tools/data-handler/test/macros/index.test.ts
@@ -950,6 +950,24 @@ Some content here`;
         );
       });
 
+      it('xrefMacro error in the middle of text renders warning as its own block', async () => {
+        const content = `tekstiä {{#xref}}"cardKey": "non-existent-card"{{/xref}} lisää tekstiä`;
+        const result = await evaluateMacros(content, {
+          mode: 'static',
+          project: project,
+          cardKey: '',
+          context: 'localApp',
+        });
+
+        expect(result).toContain('.Macro Error');
+        // The admonition must be separated from the preceding text by a blank
+        // line, otherwise adoc renders '[WARNING]' as literal inline text
+        expect(result).toContain('tekstiä\n\n[WARNING]\n');
+        // The text after the macro must not start with whitespace, otherwise
+        // adoc renders it as a literal block
+        expect(result).toMatch(/====\n+lisää tekstiä/);
+      });
+
       it('xrefMacro with wrong schema should return warning message', async () => {
         const macro = `{{#xref}}"invalidProperty": "test-value"{{/xref}}`;
         const result = await evaluateMacros(macro, {


### PR DESCRIPTION
## Root cause
When an inline macro such as `xref` fails (e.g. the referenced card does not exist), `applyMacroResults` (`tools/data-handler/src/macros/index.ts`) replaced the macro's placeholder verbatim with the block-level admonition produced by `createAdmonition`. If the macro sits in the middle of a paragraph, the admonition gets spliced into the line:

```
tekstiä [WARNING]
.Macro Error
====
…
====

 lisää tekstiä
```

AsciiDoc only recognizes block syntax at the start of a line preceded by a blank line, so this renders as: literal `tekstiä [WARNING]` text, a bare example block, and — because the space that surrounded the placeholder is left at the start of the next line — the trailing text as a literal block.

## Fix
Replace the placeholder with a new `replaceWithBlock` helper that strips inline whitespace around the placeholder and inserts a blank line before the admonition when the placeholder sits mid-paragraph, so the warning renders as a proper standalone admonition block:

```
tekstiä

[WARNING]
.Macro Error
====
…
====

lisää tekstiä
```

## Verification
- New regression test in `test/macros/index.test.ts` reproduces the bug (failed against the old code with `tekstiä [WARNING]…` glued inline, passes with the fix).
- Full `data-handler` suite green: 1416 passed, 1 skipped.
- `prettier --check` clean on the changed package.

Ticket: INTDEV-1299 — https://cyberismo.atlassian.net/browse/INTDEV-1299

🤖 Generated with [Claude Code](https://claude.com/claude-code)