### PR TITLE
INTDEV-1332 Seal module configuration logs per minor version

### DIFF
--- a/tools/data-handler/src/commands/version.ts
+++ b/tools/data-handler/src/commands/version.ts
@@ -67,8 +67,9 @@ export class Version {
       );
     }
 
-    // Snapshot the current migration log with the new version
-    if (ConfigurationLogger.hasBreakingChanges(this.project.basePath)) {
+    // Seal on the first version and every minor/major bump. Patches on an
+    // existing version never seal; they must keep a clean log (guarded above).
+    if (!currentVersion || bumpType !== 'patch') {
       await ConfigurationLogger.createVersion(
         this.project.basePath,
         newVersion,

--- a/tools/data-handler/src/commands/version.ts
+++ b/tools/data-handler/src/commands/version.ts
@@ -46,12 +46,13 @@ export class Version {
 
     const currentVersion = this.project.configuration.version;
 
-    // Guard: breaking changes require a major bump.
+    // Guard: breaking changes cannot ship in a patch. Minor and major bumps
+    // seal the log; consumers replay it on module update.
     // Skipped for the first version — there is no predecessor to break against.
-    if (currentVersion && bumpType !== 'major') {
+    if (currentVersion && bumpType === 'patch') {
       if (ConfigurationLogger.hasBreakingChanges(this.project.basePath)) {
         throw new Error(
-          'Cannot publish a patch or minor version: breaking configuration changes detected. Use a major version bump.',
+          'Cannot publish a patch version: breaking configuration changes detected. Use a minor or major version bump.',
         );
       }
     }

--- a/tools/data-handler/src/mutations/replay/seal-files.ts
+++ b/tools/data-handler/src/mutations/replay/seal-files.ts
@@ -1,0 +1,66 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { readdir } from 'node:fs/promises';
+import semver from 'semver';
+
+/** A sealed migration log: covers breaking changes in (from, to]. */
+export interface SealFile {
+  from: string;
+  to: string;
+  fileName: string;
+}
+
+// Old-format migrationLog_<version>.jsonl names predate replay and must not
+// match; requiring two segments (and valid semver below) excludes them.
+const SEAL_NAME = /^migrationLog_(.+)_(.+)\.jsonl$/;
+
+export function parseSealFileName(fileName: string): SealFile | undefined {
+  const match = SEAL_NAME.exec(fileName);
+  if (!match) return undefined;
+  const [, from, to] = match;
+  if (semver.valid(from) === null || semver.valid(to) === null) {
+    return undefined;
+  }
+  return { from, to, fileName };
+}
+
+export function formatSealFileName(from: string, to: string): string {
+  return `migrationLog_${from}_${to}.jsonl`;
+}
+
+/** New-format seals in a migrations folder, ascending by `to`. Missing folder → []. */
+export async function listSealFiles(
+  migrationsFolder: string,
+): Promise<SealFile[]> {
+  let names: string[];
+  try {
+    names = await readdir(migrationsFolder);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
+  }
+  return names
+    .map(parseSealFileName)
+    .filter((seal): seal is SealFile => seal !== undefined)
+    .sort((a, b) => semver.compare(a.to, b.to));
+}
+
+/** Highest sealed `to` version, or 0.0.0 when nothing is sealed. */
+export async function lastSealedVersion(
+  migrationsFolder: string,
+): Promise<string> {
+  const seals = await listSealFiles(migrationsFolder);
+  return seals.at(-1)?.to ?? '0.0.0';
+}

--- a/tools/data-handler/src/utils/configuration-logger.ts
+++ b/tools/data-handler/src/utils/configuration-logger.ts
@@ -16,6 +16,10 @@ import { readFile, rename, unlink } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { getChildLogger } from './log-utils.js';
+import {
+  formatSealFileName,
+  lastSealedVersion,
+} from '../mutations/replay/seal-files.js';
 import { ProjectPaths } from '../containers/project/project-paths.js';
 import { writeFileSafe, pathExists } from './file-utils.js';
 
@@ -67,9 +71,11 @@ export class ConfigurationLogger {
 
   /**
    * Create a versioned snapshot of the current migration log.
-   * Renames current migrationLog.jsonl to migrationLog_<version>.jsonl
+   * Renames current migrationLog.jsonl to migrationLog_<from>_<to>.jsonl,
+   * where <from> is the highest previously sealed version (0.0.0 when none)
+   * and <to> is the version being sealed.
    * @param projectPath Path to the project root
-   * @param version Version identifier (e.g., "1.0.0", "v2")
+   * @param version Version being sealed (e.g., "1.1.0")
    * @returns Path to the versioned log file
    */
   public static async createVersion(
@@ -78,9 +84,10 @@ export class ConfigurationLogger {
   ): Promise<string | null> {
     const paths = new ProjectPaths(projectPath);
     const currentLogPath = paths.configurationChangesLog;
+    const fromVersion = await lastSealedVersion(paths.migrationLogFolder);
     const versionedLogPath = join(
       paths.migrationLogFolder,
-      `migrationLog_${version}.jsonl`,
+      formatSealFileName(fromVersion, version),
     );
 
     if (!pathExists(currentLogPath)) {

--- a/tools/data-handler/src/utils/configuration-logger.ts
+++ b/tools/data-handler/src/utils/configuration-logger.ts
@@ -85,26 +85,13 @@ export class ConfigurationLogger {
   public static async createVersion(
     projectPath: string,
     version: string,
-  ): Promise<string | null> {
+  ): Promise<string> {
     if (!semver.valid(version)) {
       throw new Error(`Invalid seal version: ${version}`);
     }
     const paths = new ProjectPaths(projectPath);
     const currentLogPath = paths.configurationChangesLog;
     const fromVersion = await lastSealedVersion(paths.migrationLogFolder);
-    const versionedLogPath = join(
-      paths.migrationLogFolder,
-      formatSealFileName(fromVersion, version),
-    );
-
-    if (!pathExists(currentLogPath)) {
-      // Empty seal: no log file to rename; the version is sealed with no
-      // breaking changes. Per the spec, replay against a missing log is
-      // a no-op success.
-      const logger = getChildLogger({ module: 'ConfigurationLogger' });
-      logger.info(`Sealed empty migration log for version: ${version}`);
-      return null;
-    }
 
     if (semver.lte(version, fromVersion)) {
       throw new Error(
@@ -112,12 +99,23 @@ export class ConfigurationLogger {
       );
     }
 
-    await rename(currentLogPath, versionedLogPath);
-
-    const logger = getChildLogger({ module: 'ConfigurationLogger' });
-    logger.info(
-      `Created migration to version: ${version} at ${versionedLogPath}`,
+    const versionedLogPath = join(
+      paths.migrationLogFolder,
+      formatSealFileName(fromVersion, version),
     );
+    const logger = getChildLogger({ module: 'ConfigurationLogger' });
+
+    if (pathExists(currentLogPath)) {
+      await rename(currentLogPath, versionedLogPath);
+      logger.info(
+        `Created migration to version: ${version} at ${versionedLogPath}`,
+      );
+    } else {
+      // No pending changes: still write an empty seal so every sealed version
+      // has a log file. writeFileSafe creates the migrations folder if needed.
+      await writeFileSafe(versionedLogPath, '');
+      logger.info(`Sealed empty migration log for version: ${version}`);
+    }
 
     return versionedLogPath;
   }

--- a/tools/data-handler/src/utils/configuration-logger.ts
+++ b/tools/data-handler/src/utils/configuration-logger.ts
@@ -15,6 +15,8 @@
 import { readFile, rename, unlink } from 'node:fs/promises';
 import { join } from 'node:path';
 
+import semver from 'semver';
+
 import { getChildLogger } from './log-utils.js';
 import {
   formatSealFileName,
@@ -74,6 +76,8 @@ export class ConfigurationLogger {
    * Renames current migrationLog.jsonl to migrationLog_<from>_<to>.jsonl,
    * where <from> is the highest previously sealed version (0.0.0 when none)
    * and <to> is the version being sealed.
+   * Callers must serialize calls to this method (the read-then-rename is not
+   * atomic); bumpVersion's @write lock provides this today.
    * @param projectPath Path to the project root
    * @param version Version being sealed (e.g., "1.1.0")
    * @returns Path to the versioned log file
@@ -82,6 +86,9 @@ export class ConfigurationLogger {
     projectPath: string,
     version: string,
   ): Promise<string | null> {
+    if (!semver.valid(version)) {
+      throw new Error(`Invalid seal version: ${version}`);
+    }
     const paths = new ProjectPaths(projectPath);
     const currentLogPath = paths.configurationChangesLog;
     const fromVersion = await lastSealedVersion(paths.migrationLogFolder);
@@ -97,6 +104,12 @@ export class ConfigurationLogger {
       const logger = getChildLogger({ module: 'ConfigurationLogger' });
       logger.info(`Sealed empty migration log for version: ${version}`);
       return null;
+    }
+
+    if (semver.lte(version, fromVersion)) {
+      throw new Error(
+        `Seal version ${version} must be greater than the last sealed version ${fromVersion}`,
+      );
     }
 
     await rename(currentLogPath, versionedLogPath);

--- a/tools/data-handler/test/mutations/replay/seal-files.test.ts
+++ b/tools/data-handler/test/mutations/replay/seal-files.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import {
+  formatSealFileName,
+  lastSealedVersion,
+  listSealFiles,
+  parseSealFileName,
+} from '../../../src/mutations/replay/seal-files.js';
+
+const tmpDir = join(import.meta.dirname, 'tmp-seal-files');
+
+describe('seal file names', () => {
+  it('parses migrationLog_<from>_<to>.jsonl', () => {
+    expect(parseSealFileName('migrationLog_2.6.0_3.0.0.jsonl')).toEqual({
+      from: '2.6.0',
+      to: '3.0.0',
+      fileName: 'migrationLog_2.6.0_3.0.0.jsonl',
+    });
+  });
+  it('rejects the old single-version format', () => {
+    expect(parseSealFileName('migrationLog_2.6.0.jsonl')).toBeUndefined();
+  });
+  it('rejects non-semver segments', () => {
+    expect(parseSealFileName('migrationLog_abc_3.0.0.jsonl')).toBeUndefined();
+  });
+  it('rejects unrelated files', () => {
+    expect(parseSealFileName('current')).toBeUndefined();
+    expect(parseSealFileName('migrationLog.jsonl')).toBeUndefined();
+  });
+  it('formats round-trip', () => {
+    expect(formatSealFileName('1.0.0', '1.1.0')).toBe(
+      'migrationLog_1.0.0_1.1.0.jsonl',
+    );
+  });
+});
+
+describe('listSealFiles / lastSealedVersion', () => {
+  beforeEach(async () => {
+    await mkdir(tmpDir, { recursive: true });
+  });
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('lists new-format seals ascending, ignoring everything else', async () => {
+    for (const f of [
+      'migrationLog_2.0.0_2.6.0.jsonl',
+      'migrationLog_0.0.0_2.0.0.jsonl',
+      'migrationLog_1.5.0.jsonl', // old format: ignored
+      'notes.txt',
+    ]) {
+      await writeFile(join(tmpDir, f), '');
+    }
+    const seals = await listSealFiles(tmpDir);
+    expect(seals.map((s) => s.to)).toEqual(['2.0.0', '2.6.0']);
+  });
+
+  it('returns [] and 0.0.0 for a missing folder', async () => {
+    const missing = join(tmpDir, 'nope');
+    expect(await listSealFiles(missing)).toEqual([]);
+    expect(await lastSealedVersion(missing)).toBe('0.0.0');
+  });
+
+  it('lastSealedVersion returns the highest sealed to', async () => {
+    // listing must not validate chain linkage; the chain here is inconsistent
+    // on purpose to keep that out of scope
+    for (const f of [
+      'migrationLog_0.0.0_1.0.0.jsonl',
+      'migrationLog_1.0.0_1.10.0.jsonl',
+      'migrationLog_1.10.0_1.9.0.jsonl',
+    ]) {
+      await writeFile(join(tmpDir, f), '');
+    }
+    // semver compare: 1.10.0 > 1.9.0 — guards against lexicographic sorting
+    const seals = await listSealFiles(tmpDir);
+    expect(seals.map((s) => s.to)).toEqual(['1.0.0', '1.9.0', '1.10.0']);
+    expect(await lastSealedVersion(tmpDir)).toBe('1.10.0');
+  });
+});

--- a/tools/data-handler/test/utils/configuration-logger.test.ts
+++ b/tools/data-handler/test/utils/configuration-logger.test.ts
@@ -307,6 +307,30 @@ describe('configuration logger', () => {
     expect(result).toBe(expectedPath);
     expect(pathExists(expectedPath)).toBe(true);
   });
+  it('createVersion rejects an invalid seal version', async () => {
+    const projectPath = await freshProject('invalid-version-seal');
+    await expect(
+      ConfigurationLogger.createVersion(projectPath, 'not-a-version'),
+    ).rejects.toThrow(/Invalid seal version/);
+  });
+  it('createVersion rejects a version equal to the last sealed version', async () => {
+    const projectPath = await freshProject('equal-version-seal');
+    const paths = new ProjectPaths(projectPath);
+    await mkdir(paths.migrationLogFolder, { recursive: true });
+    await writeFile(
+      join(paths.migrationLogFolder, 'migrationLog_0.0.0_1.0.0.jsonl'),
+      '',
+    );
+    await ConfigurationLogger.log(projectPath, {
+      operation: 'resource_delete',
+      target: 'some-resource',
+      parameters: {},
+    });
+
+    await expect(
+      ConfigurationLogger.createVersion(projectPath, '1.0.0'),
+    ).rejects.toThrow(/must be greater/);
+  });
   it('accepts and reads project_rename entries', async () => {
     const projectPath = await freshProject('project-rename-log');
     await ConfigurationLogger.log(projectPath, {

--- a/tools/data-handler/test/utils/configuration-logger.test.ts
+++ b/tools/data-handler/test/utils/configuration-logger.test.ts
@@ -255,9 +255,57 @@ describe('configuration logger', () => {
     const paths = new ProjectPaths(projectPath);
     const versionedPath = join(
       paths.migrationLogFolder,
-      'migrationLog_1.0.1.jsonl',
+      'migrationLog_0.0.0_1.0.1.jsonl',
     );
     expect(await pathExists(versionedPath)).toBe(false);
+  });
+  it('createVersion seals continuing the lineage from the last sealed version', async () => {
+    const projectPath = await freshProject('lineage-seal');
+    const paths = new ProjectPaths(projectPath);
+    await mkdir(paths.migrationLogFolder, { recursive: true });
+    await writeFile(
+      join(paths.migrationLogFolder, 'migrationLog_0.0.0_1.0.0.jsonl'),
+      '',
+    );
+    await ConfigurationLogger.log(projectPath, {
+      operation: 'resource_delete',
+      target: 'some-resource',
+      parameters: {},
+    });
+
+    const result = await ConfigurationLogger.createVersion(
+      projectPath,
+      '1.1.0',
+    );
+
+    const expectedPath = join(
+      paths.migrationLogFolder,
+      'migrationLog_1.0.0_1.1.0.jsonl',
+    );
+    expect(result).toBe(expectedPath);
+    expect(pathExists(expectedPath)).toBe(true);
+    expect(pathExists(paths.configurationChangesLog)).toBe(false);
+  });
+  it('createVersion starts the lineage from 0.0.0 on the first seal', async () => {
+    const projectPath = await freshProject('first-seal');
+    await ConfigurationLogger.log(projectPath, {
+      operation: 'resource_delete',
+      target: 'some-resource',
+      parameters: {},
+    });
+
+    const result = await ConfigurationLogger.createVersion(
+      projectPath,
+      '1.0.0',
+    );
+
+    const paths = new ProjectPaths(projectPath);
+    const expectedPath = join(
+      paths.migrationLogFolder,
+      'migrationLog_0.0.0_1.0.0.jsonl',
+    );
+    expect(result).toBe(expectedPath);
+    expect(pathExists(expectedPath)).toBe(true);
   });
   it('accepts and reads project_rename entries', async () => {
     const projectPath = await freshProject('project-rename-log');

--- a/tools/data-handler/test/utils/configuration-logger.test.ts
+++ b/tools/data-handler/test/utils/configuration-logger.test.ts
@@ -222,14 +222,15 @@ describe('configuration logger', () => {
       expect(entries[0].target).toBe('valid');
       expect(entries[1].target).toBe('valid2');
     });
-    it('should return null when creating version from non-existent log (empty seal)', async () => {
+    it('seals an empty log (returns a path, not null) when the current log does not exist', async () => {
       await ConfigurationLogger.clearLog(testProjectPath);
 
       const result = await ConfigurationLogger.createVersion(
         testProjectPath,
         '1.0.0',
       );
-      expect(result).toBeNull();
+      expect(result).not.toBeNull();
+      expect(pathExists(result)).toBe(true);
     });
     it('should check log existence via static method', async () => {
       const testProjectPath2 = join(testDir, 'test-project-static');
@@ -247,17 +248,22 @@ describe('configuration logger', () => {
     });
   });
 
-  it('createVersion succeeds with no current log (empty seal)', async () => {
+  it('createVersion seals an empty log when there is no current log', async () => {
     const projectPath = await freshProject('empty-seal');
     // No entries have been logged; migrationLog.jsonl does not exist.
-    await ConfigurationLogger.createVersion(projectPath, '1.0.1');
-    // The versioned log file should also not exist (empty seal = no file).
+    const result = await ConfigurationLogger.createVersion(
+      projectPath,
+      '1.0.1',
+    );
+    // An empty seal file records the transition (empty seal = empty file).
     const paths = new ProjectPaths(projectPath);
     const versionedPath = join(
       paths.migrationLogFolder,
       'migrationLog_0.0.0_1.0.1.jsonl',
     );
-    expect(await pathExists(versionedPath)).toBe(false);
+    expect(result).toBe(versionedPath);
+    expect(pathExists(versionedPath)).toBe(true);
+    expect(await readFile(versionedPath, 'utf-8')).toBe('');
   });
   it('createVersion seals continuing the lineage from the last sealed version', async () => {
     const projectPath = await freshProject('lineage-seal');

--- a/tools/data-handler/test/version.test.ts
+++ b/tools/data-handler/test/version.test.ts
@@ -241,5 +241,20 @@ describe('Version', () => {
       expect(createVersionStub.calledOnce).toBe(true);
       expect(createVersionStub.calledWith(dir, '1.0.0')).toBe(true);
     });
+
+    it('seals an empty log on a clean minor bump (no breaking changes)', async () => {
+      configuration.version = '1.0.0';
+      await configuration.setVersion('1.0.0');
+      await git.commit('set version');
+      // hasBreakingChangesStub returns false (set in beforeEach)
+
+      const result = await versionCmd.bumpVersion('minor');
+
+      expect(result.newVersion).toBe('1.1.0');
+      const migrationsFolder = join(dir, '.cards', 'local', 'migrations');
+      expect(
+        pathExists(join(migrationsFolder, 'migrationLog_0.0.0_1.1.0.jsonl')),
+      ).toBe(true);
+    });
   });
 });

--- a/tools/data-handler/test/version.test.ts
+++ b/tools/data-handler/test/version.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import sinon from 'sinon';
 
 import { GitManager } from '../src/utils/git-manager.js';
+import { pathExists } from '../src/utils/file-utils.js';
 import { RWLock } from '../src/utils/rw-lock.js';
 import { Version } from '../src/commands/version.js';
 import { ConfigurationLogger } from '../src/utils/configuration-logger.js';
@@ -166,20 +167,31 @@ describe('Version', () => {
       hasBreakingChangesStub.returns(true);
 
       await expect(versionCmd.bumpVersion('patch')).rejects.toThrow(
-        'breaking configuration changes',
+        /Cannot publish a patch version/,
       );
     });
 
-    it('should throw when minor bump attempted with breaking changes', async () => {
+    it('should seal the log when minor bump attempted with breaking changes', async () => {
       configuration.version = '1.0.0';
       await configuration.setVersion('1.0.0');
-      await git.commit('set version');
+      hasBreakingChangesStub.restore();
+      await ConfigurationLogger.log(dir, {
+        operation: 'resource_delete',
+        target: 'some-resource',
+        parameters: {},
+      });
+      await git.commit('set version and dirty log');
 
-      hasBreakingChangesStub.returns(true);
+      const result = await versionCmd.bumpVersion('minor');
 
-      await expect(versionCmd.bumpVersion('minor')).rejects.toThrow(
-        'breaking configuration changes',
-      );
+      expect(result.newVersion).toBe('1.1.0');
+      const migrationsFolder = join(dir, '.cards', 'local', 'migrations');
+      expect(
+        pathExists(join(migrationsFolder, 'migrationLog_0.0.0_1.1.0.jsonl')),
+      ).toBe(true);
+      expect(
+        pathExists(join(migrationsFolder, 'current', 'migrationLog.jsonl')),
+      ).toBe(false);
     });
 
     it('should allow major bump when breaking changes exist', async () => {


### PR DESCRIPTION
Seals a module's configuration-change log on every **minor and major** version bump so consumers can replay those changes on module update.

Previously the seal only had a "target".  This becomes a problem when migration logs have non-linear paths:
If you release v-2.0, it would be impossible to determine whether the migration log covers changes from 1.7 to 2.0 or 1.8 to 2.0. 

This sort of admits that we cannot do non-linear updates, but since we have semvers, we have to make the update paths linear. In theory, nothing prevents from creating manual migration logs for newly released minor versions. In most cases, just appending the updates of say 1.7-1.8 to the migrationlog between 1.7 and 2.0 would likely work. However that does not work always: ie. renaming a resource in both versions requires deducing that the one in the newer version should stay and thus they could combined:
```
1.7-2.0 -> rename A to B
1.7-1.8 -> rename A to C
# likely what we want:
1.8-2.0 -> rename C to B
```
However, even in this simple example, this might not be enough for the full migration, as likely the rename carries not just a name, but also meaning and the template changes are not reflected to cards. However, I think this should be a future consideration, not something to be done in this PR.


NOTE: This is a breaking change, migration added in #1468

