### PR TITLE
INTDEV-1349 Replay chain computation and seal-set linearity check

### DIFF
--- a/tools/data-handler/src/mutations/replay/chain.ts
+++ b/tools/data-handler/src/mutations/replay/chain.ts
@@ -15,11 +15,7 @@
 import semver from 'semver';
 import type { SealFile } from './seal-files.js';
 
-/**
- * Linearity = the installed tree's seal set is a subset of the target
- * tree's (the consumer's chain is a prefix of the target's chain).
- * @returns file names the target is missing; empty means linear.
- */
+/** @returns installed seals absent from the target; empty means linear. */
 export function checkLinearity(
   installedSeals: SealFile[],
   targetSeals: SealFile[],
@@ -30,23 +26,36 @@ export function checkLinearity(
     .map((s) => s.fileName);
 }
 
+/** Two versions on the same minor line (differ only in patch). */
+function sameMinorLine(a: string, b: string): boolean {
+  return (
+    semver.major(a) === semver.major(b) && semver.minor(a) === semver.minor(b)
+  );
+}
+
 /**
- * Target-tree seals to replay for an update from `from` to `to`:
- * those with `to` in (from, to], ascending, linked end-to-end. The first
- * seal's lower bound may sit at or below `from` (clean releases seal
- * nothing).
- * @throws on a gap — a corrupt module tree.
+ * Seals to replay for `from` → `to`: those with `to` in (from, to], ascending
+ * and contiguous. `from` and `to` need not fall on seal boundaries.
+ * @returns [] when the range crosses no seal boundary (no-op or patch jump).
+ * @throws on a downgrade, a gap, or when the chain falls short of `to`.
  */
 export function computeChain(
   targetSeals: SealFile[],
   from: string,
   to: string,
 ): SealFile[] {
+  if (semver.lt(to, from)) {
+    throw new Error(`Cannot replay a downgrade: ${to} is older than ${from}`);
+  }
+
   const chain = targetSeals
     .filter((s) => semver.gt(s.to, from) && semver.lte(s.to, to))
     .sort((a, b) => semver.compare(a.to, b.to));
 
-  if (chain.length === 0) return [];
+  if (chain.length === 0) {
+    if (sameMinorLine(from, to)) return [];
+    throw new Error(`Migration log gap: no seal bridges ${from} to ${to}`);
+  }
 
   if (semver.gt(chain[0].from, from)) {
     throw new Error(
@@ -59,6 +68,11 @@ export function computeChain(
         `Migration log gap between ${chain[i - 1].fileName} and ${chain[i].fileName}`,
       );
     }
+  }
+  if (!sameMinorLine(chain[chain.length - 1].to, to)) {
+    throw new Error(
+      `Migration log gap: chain ends at ${chain[chain.length - 1].fileName} but the update targets ${to}`,
+    );
   }
   return chain;
 }

--- a/tools/data-handler/src/mutations/replay/chain.ts
+++ b/tools/data-handler/src/mutations/replay/chain.ts
@@ -1,0 +1,64 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import semver from 'semver';
+import type { SealFile } from './seal-files.js';
+
+/**
+ * Linearity = the installed tree's seal set is a subset of the target
+ * tree's (the consumer's chain is a prefix of the target's chain).
+ * @returns file names the target is missing; empty means linear.
+ */
+export function checkLinearity(
+  installedSeals: SealFile[],
+  targetSeals: SealFile[],
+): string[] {
+  const targetNames = new Set(targetSeals.map((s) => s.fileName));
+  return installedSeals
+    .filter((s) => !targetNames.has(s.fileName))
+    .map((s) => s.fileName);
+}
+
+/**
+ * Target-tree seals to replay for an update from `from` to `to`:
+ * those with `to` in (from, to], ascending, linked end-to-end. The first
+ * seal's lower bound may sit at or below `from` (clean releases seal
+ * nothing).
+ * @throws on a gap — a corrupt module tree.
+ */
+export function computeChain(
+  targetSeals: SealFile[],
+  from: string,
+  to: string,
+): SealFile[] {
+  const chain = targetSeals
+    .filter((s) => semver.gt(s.to, from) && semver.lte(s.to, to))
+    .sort((a, b) => semver.compare(a.to, b.to));
+
+  if (chain.length === 0) return [];
+
+  if (semver.gt(chain[0].from, from)) {
+    throw new Error(
+      `Migration log gap: chain starts at ${chain[0].fileName} but the update begins at ${from}`,
+    );
+  }
+  for (let i = 1; i < chain.length; i++) {
+    if (chain[i].from !== chain[i - 1].to) {
+      throw new Error(
+        `Migration log gap between ${chain[i - 1].fileName} and ${chain[i].fileName}`,
+      );
+    }
+  }
+  return chain;
+}

--- a/tools/data-handler/src/mutations/replay/chain.ts
+++ b/tools/data-handler/src/mutations/replay/chain.ts
@@ -54,7 +54,7 @@ export function computeChain(
     );
   }
   for (let i = 1; i < chain.length; i++) {
-    if (chain[i].from !== chain[i - 1].to) {
+    if (!semver.eq(chain[i].from, chain[i - 1].to)) {
       throw new Error(
         `Migration log gap between ${chain[i - 1].fileName} and ${chain[i].fileName}`,
       );

--- a/tools/data-handler/test/mutations/replay/chain.test.ts
+++ b/tools/data-handler/test/mutations/replay/chain.test.ts
@@ -50,73 +50,99 @@ describe('checkLinearity', () => {
 });
 
 describe('computeChain', () => {
+  // Dense, contiguous seal set: every minor/major seals, patches don't.
   const target = [
-    seal('0.0.0', '2.0.0'),
-    seal('2.0.0', '2.6.0'),
-    seal('2.6.0', '3.0.0'),
+    seal('0.0.0', '1.0.0'),
+    seal('1.0.0', '1.1.0'),
+    seal('1.1.0', '2.0.0'),
+    seal('2.0.0', '2.1.0'),
   ];
 
   it('selects seals with to in (from, to], ascending', () => {
-    expect(computeChain(target, '2.0.0', '3.0.0').map((s) => s.to)).toEqual([
-      '2.6.0',
-      '3.0.0',
+    expect(computeChain(target, '1.0.0', '2.0.0').map((s) => s.to)).toEqual([
+      '1.1.0',
+      '2.0.0',
     ]);
-  });
-
-  it('clean release between seals: first seal may start below from', () => {
-    // Consumer at clean 2.7 (never sealed); replaying 2.6→3.0 is correct.
-    expect(computeChain(target, '2.7.0', '3.0.0').map((s) => s.to)).toEqual([
-      '3.0.0',
-    ]);
-  });
-
-  it('empty chain when nothing breaking happened in range', () => {
-    expect(computeChain(target, '3.0.0', '3.4.0')).toEqual([]);
-  });
-
-  it('no-op update yields an empty chain', () => {
-    expect(computeChain(target, '3.0.0', '3.0.0')).toEqual([]);
-  });
-
-  it('downgrade yields an empty chain (caller refuses separately)', () => {
-    expect(computeChain(target, '3.0.0', '2.0.0')).toEqual([]);
-  });
-
-  it('throws on a gap between seals', () => {
-    const gappy = [seal('0.0.0', '1.0.0'), seal('2.0.0', '2.5.0')];
-    expect(() => computeChain(gappy, '0.5.0', '2.5.0')).toThrow(/gap/i);
-  });
-
-  it('throws when the first seal starts above from', () => {
-    expect(() =>
-      computeChain([seal('2.6.0', '3.0.0')], '2.0.0', '3.0.0'),
-    ).toThrow(/gap/i);
   });
 
   it('selects the full chain from 0.0.0', () => {
-    expect(computeChain(target, '0.0.0', '3.0.0').map((s) => s.to)).toEqual([
+    expect(computeChain(target, '0.0.0', '2.1.0').map((s) => s.to)).toEqual([
+      '1.0.0',
+      '1.1.0',
       '2.0.0',
-      '2.6.0',
-      '3.0.0',
+      '2.1.0',
     ]);
   });
 
   it('excludes seals whose to equals from (already applied)', () => {
-    expect(computeChain(target, '2.6.0', '3.0.0').map((s) => s.to)).toEqual([
-      '3.0.0',
+    expect(computeChain(target, '1.1.0', '2.0.0').map((s) => s.to)).toEqual([
+      '2.0.0',
     ]);
   });
 
   it('sorts unordered input ascending before linking', () => {
-    const shuffled = [target[2], target[0], target[1]];
-    expect(computeChain(shuffled, '0.0.0', '3.0.0').map((s) => s.to)).toEqual([
+    const shuffled = [target[3], target[1], target[0], target[2]];
+    expect(computeChain(shuffled, '0.0.0', '2.1.0').map((s) => s.to)).toEqual([
+      '1.0.0',
+      '1.1.0',
       '2.0.0',
-      '2.6.0',
-      '3.0.0',
+      '2.1.0',
     ]);
   });
 
-  it('empty chain when target has no seals at all', () => {
-    expect(computeChain([], '1.0.0', '2.0.0')).toEqual([]);
+  it('installed at a patch: first seal may start below from', () => {
+    // 1.0.3 never sealed; it sits inside the 1.0.0→1.1.0 seal range.
+    expect(computeChain(target, '1.0.3', '1.1.0').map((s) => s.to)).toEqual([
+      '1.1.0',
+    ]);
+  });
+
+  it('patch target: chain reaches the enclosing minor', () => {
+    // Updating to patch 2.1.4 is covered by reaching its minor 2.1.0.
+    expect(computeChain(target, '2.0.0', '2.1.4').map((s) => s.to)).toEqual([
+      '2.1.0',
+    ]);
+  });
+
+  it('empty chain for a patch jump within one minor', () => {
+    expect(computeChain(target, '2.0.0', '2.0.4')).toEqual([]);
+  });
+
+  it('no-op update yields an empty chain', () => {
+    expect(computeChain(target, '2.1.0', '2.1.0')).toEqual([]);
+  });
+
+  it('throws on a downgrade', () => {
+    expect(() => computeChain(target, '2.1.0', '1.0.0')).toThrow(/downgrade/i);
+  });
+
+  it('throws on a patch downgrade within a minor', () => {
+    expect(() => computeChain(target, '1.0.5', '1.0.2')).toThrow(/downgrade/i);
+  });
+
+  it('throws when an unsealed target crosses a minor boundary', () => {
+    expect(() => computeChain([], '1.0.0', '2.0.0')).toThrow(/gap/i);
+  });
+
+  it('throws on a gap between seals', () => {
+    const gappy = [seal('0.0.0', '1.0.0'), seal('1.1.0', '2.0.0')];
+    expect(() => computeChain(gappy, '0.5.0', '2.0.0')).toThrow(/gap/i);
+  });
+
+  it('throws when the first seal starts above from', () => {
+    expect(() =>
+      computeChain([seal('1.1.0', '2.0.0')], '1.0.0', '2.0.0'),
+    ).toThrow(/gap/i);
+  });
+
+  it('throws when the top seal is missing (chain stops below the target)', () => {
+    const partial = [seal('0.0.0', '1.0.0'), seal('1.0.0', '1.1.0')];
+    expect(() => computeChain(partial, '1.0.0', '2.0.0')).toThrow(/gap/i);
+  });
+
+  it('throws when an empty range crosses a minor boundary', () => {
+    expect(() =>
+      computeChain([seal('0.0.0', '1.0.0')], '1.0.0', '2.0.0'),
+    ).toThrow(/gap/i);
   });
 });

--- a/tools/data-handler/test/mutations/replay/chain.test.ts
+++ b/tools/data-handler/test/mutations/replay/chain.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import {
+  checkLinearity,
+  computeChain,
+} from '../../../src/mutations/replay/chain.js';
+import type { SealFile } from '../../../src/mutations/replay/seal-files.js';
+
+const seal = (from: string, to: string): SealFile => ({
+  from,
+  to,
+  fileName: `migrationLog_${from}_${to}.jsonl`,
+});
+
+describe('checkLinearity', () => {
+  it('passes when installed seals are a subset of target seals', () => {
+    const installed = [seal('0.0.0', '2.0.0'), seal('2.0.0', '2.6.0')];
+    const target = [...installed, seal('2.6.0', '3.0.0')];
+    expect(checkLinearity(installed, target)).toEqual([]);
+  });
+
+  it('reports seals the target does not know about (diverged branch)', () => {
+    // Consumer sealed 2.6→2.7; target 3.0 was cut from 2.6 and has 2.6→3.0.
+    const installed = [seal('2.0.0', '2.6.0'), seal('2.6.0', '2.7.0')];
+    const target = [seal('2.0.0', '2.6.0'), seal('2.6.0', '3.0.0')];
+    expect(checkLinearity(installed, target)).toEqual([
+      'migrationLog_2.6.0_2.7.0.jsonl',
+    ]);
+  });
+
+  it('passes trivially with no installed seals (pre-replay era)', () => {
+    expect(checkLinearity([], [seal('0.0.0', '1.0.0')])).toEqual([]);
+  });
+
+  it('reports every missing seal, not just the first', () => {
+    const installed = [
+      seal('1.0.0', '1.1.0'),
+      seal('1.1.0', '1.2.0'),
+      seal('1.2.0', '1.3.0'),
+    ];
+    const target = [seal('1.0.0', '1.1.0')];
+    expect(checkLinearity(installed, target)).toEqual([
+      'migrationLog_1.1.0_1.2.0.jsonl',
+      'migrationLog_1.2.0_1.3.0.jsonl',
+    ]);
+  });
+
+  it('passes with an empty target when nothing is installed', () => {
+    expect(checkLinearity([], [])).toEqual([]);
+  });
+});
+
+describe('computeChain', () => {
+  const target = [
+    seal('0.0.0', '2.0.0'),
+    seal('2.0.0', '2.6.0'),
+    seal('2.6.0', '3.0.0'),
+  ];
+
+  it('selects seals with to in (from, to], ascending', () => {
+    expect(computeChain(target, '2.0.0', '3.0.0').map((s) => s.to)).toEqual([
+      '2.6.0',
+      '3.0.0',
+    ]);
+  });
+
+  it('clean release between seals: first seal may start below from', () => {
+    // Consumer at clean 2.7 (never sealed); replaying 2.6→3.0 is correct.
+    expect(computeChain(target, '2.7.0', '3.0.0').map((s) => s.to)).toEqual([
+      '3.0.0',
+    ]);
+  });
+
+  it('empty chain when nothing breaking happened in range', () => {
+    expect(computeChain(target, '3.0.0', '3.4.0')).toEqual([]);
+  });
+
+  it('throws on a gap between seals', () => {
+    const gappy = [seal('0.0.0', '1.0.0'), seal('2.0.0', '2.5.0')];
+    expect(() => computeChain(gappy, '0.5.0', '2.5.0')).toThrow(/gap/i);
+  });
+
+  it('throws when the first seal starts above from', () => {
+    expect(() =>
+      computeChain([seal('2.6.0', '3.0.0')], '2.0.0', '3.0.0'),
+    ).toThrow(/gap/i);
+  });
+
+  it('selects the full chain from 0.0.0', () => {
+    expect(computeChain(target, '0.0.0', '3.0.0').map((s) => s.to)).toEqual([
+      '2.0.0',
+      '2.6.0',
+      '3.0.0',
+    ]);
+  });
+
+  it('excludes seals whose to equals from (already applied)', () => {
+    expect(computeChain(target, '2.6.0', '3.0.0').map((s) => s.to)).toEqual([
+      '3.0.0',
+    ]);
+  });
+
+  it('sorts unordered input ascending before linking', () => {
+    const shuffled = [target[2], target[0], target[1]];
+    expect(computeChain(shuffled, '0.0.0', '3.0.0').map((s) => s.to)).toEqual([
+      '2.0.0',
+      '2.6.0',
+      '3.0.0',
+    ]);
+  });
+
+  it('empty chain when target has no seals at all', () => {
+    expect(computeChain([], '1.0.0', '2.0.0')).toEqual([]);
+  });
+});

--- a/tools/data-handler/test/mutations/replay/chain.test.ts
+++ b/tools/data-handler/test/mutations/replay/chain.test.ts
@@ -74,6 +74,14 @@ describe('computeChain', () => {
     expect(computeChain(target, '3.0.0', '3.4.0')).toEqual([]);
   });
 
+  it('no-op update yields an empty chain', () => {
+    expect(computeChain(target, '3.0.0', '3.0.0')).toEqual([]);
+  });
+
+  it('downgrade yields an empty chain (caller refuses separately)', () => {
+    expect(computeChain(target, '3.0.0', '2.0.0')).toEqual([]);
+  });
+
   it('throws on a gap between seals', () => {
     const gappy = [seal('0.0.0', '1.0.0'), seal('2.0.0', '2.5.0')];
     expect(() => computeChain(gappy, '0.5.0', '2.5.0')).toThrow(/gap/i);


### PR DESCRIPTION
Adds `chain.ts`, the planning the replay engine relies on. It makes sure the update path between two versions are linear.

Note: Linearity here assumes true linearity, divergent branches are not allowed. Divergent patches are fine, minors are not. Earlier I suggested maybe it would be possible to somehow deduce what are the required migrations from a minor that diverges, but this is probably impossible(it's a 3-way merge and requires lots of thinking so not something should be likely done now).

The follow up PR #1467 depends on this, nothing uses this yet. But it was separate and logic heavy so I thought it would be nice to separate