### PR TITLE
INTDEV-1349: remove pre-replay migration log snapshots (PR12)

### DIFF
--- a/tools/assets/src/schema/version.json
+++ b/tools/assets/src/schema/version.json
@@ -1,3 +1,3 @@
 {
-  "schemaVersion": 4
+  "schemaVersion": 5
 }

--- a/tools/data-handler/test/migration-v5.test.ts
+++ b/tools/data-handler/test/migration-v5.test.ts
@@ -1,0 +1,121 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+import { migration as getMigration } from '@cyberismo/migrations';
+
+const testDir = join(import.meta.dirname, 'tmp-migration-v5-tests');
+const cardsConfigPath = join(testDir, '.cards');
+const localDir = join(cardsConfigPath, 'local');
+const migrationsDir = join(localDir, 'migrations');
+const currentDir = join(migrationsDir, 'current');
+
+const oldSnapshot = 'migrationLog_1.0.0.jsonl';
+const lineageSeal = 'migrationLog_0.0.0_1.0.0.jsonl';
+const currentLog = 'migrationLog.jsonl';
+
+describe('migration v5 (remove pre-replay migration log snapshots)', () => {
+  beforeEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+    mkdirSync(currentDir, { recursive: true });
+    writeFileSync(join(migrationsDir, oldSnapshot), '{}\n', 'utf-8');
+    writeFileSync(join(migrationsDir, lineageSeal), '{}\n', 'utf-8');
+    writeFileSync(join(currentDir, currentLog), '{}\n', 'utf-8');
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  const v5 = () => {
+    const m = getMigration(5);
+    if (!m) throw new Error('Migration 5 not registered');
+    return m;
+  };
+
+  const ctx = {
+    cardRootPath: join(testDir, 'cardRoot'),
+    cardsConfigPath,
+    fromVersion: 4,
+    toVersion: 5,
+  };
+
+  it('removes old single-version snapshots only', async () => {
+    const result = await v5().migrate(ctx);
+    expect(result.success).toBe(true);
+
+    expect(existsSync(join(migrationsDir, oldSnapshot))).toBe(false);
+    expect(existsSync(join(migrationsDir, lineageSeal))).toBe(true);
+    expect(existsSync(join(currentDir, currentLog))).toBe(true);
+  });
+
+  it('reports removed files in stepsExecuted', async () => {
+    const result = (await v5().migrate(ctx)) as {
+      success: boolean;
+      stepsExecuted: string[];
+    };
+    expect(
+      result.stepsExecuted.some((step) => step.includes(oldSnapshot)),
+    ).toBe(true);
+  });
+
+  it('removes multiple old snapshots', async () => {
+    writeFileSync(join(migrationsDir, 'migrationLog_0.2.10.jsonl'), '{}\n');
+
+    const result = await v5().migrate(ctx);
+    expect(result.success).toBe(true);
+
+    expect(readdirSync(migrationsDir).sort()).toEqual(['current', lineageSeal]);
+  });
+
+  it('leaves unrelated files untouched', async () => {
+    writeFileSync(join(migrationsDir, 'notes.txt'), 'keep me\n');
+    writeFileSync(join(migrationsDir, 'migrationLog_abc.jsonl'), '{}\n');
+
+    await v5().migrate(ctx);
+
+    expect(existsSync(join(migrationsDir, 'notes.txt'))).toBe(true);
+    expect(existsSync(join(migrationsDir, 'migrationLog_abc.jsonl'))).toBe(
+      true,
+    );
+  });
+
+  it('succeeds when the migrations folder does not exist', async () => {
+    rmSync(migrationsDir, { recursive: true, force: true });
+
+    const result = await v5().migrate(ctx);
+    expect(result.success).toBe(true);
+  });
+
+  it('is idempotent when run twice', async () => {
+    await v5().migrate(ctx);
+    const afterFirst = readdirSync(migrationsDir).sort();
+
+    const result = await v5().migrate(ctx);
+    expect(result.success).toBe(true);
+    expect(readdirSync(migrationsDir).sort()).toEqual(afterFirst);
+    expect(existsSync(join(migrationsDir, lineageSeal))).toBe(true);
+    expect(existsSync(join(currentDir, currentLog))).toBe(true);
+  });
+});

--- a/tools/data-handler/test/test-data/valid/decision-records/.cards/local/cardsConfig.json
+++ b/tools/data-handler/test/test-data/valid/decision-records/.cards/local/cardsConfig.json
@@ -1,5 +1,5 @@
 {
-    "schemaVersion": 4,
+    "schemaVersion": 5,
     "cardKeyPrefix": "decision",
     "name": "decision",
     "modules": [],

--- a/tools/migrations/src/5/index.ts
+++ b/tools/migrations/src/5/index.ts
@@ -1,0 +1,82 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { readdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import type {
+  Migration,
+  MigrationContext,
+  MigrationResult,
+} from '../migration-interfaces.js';
+
+// Pre-replay seals carry a single version (migrationLog_<version>.jsonl).
+// Lineage-named seals (migrationLog_<from>_<to>.jsonl) must not match.
+const OLD_SEAL_NAME = /^migrationLog_\d+\.\d+\.\d+\.jsonl$/;
+
+/**
+ * Migration from schema version 4 to 5
+ *
+ * Changes:
+ * - Removes pre-replay migration log snapshots
+ *   (`.cards/local/migrations/migrationLog_<version>.jsonl`). The replay
+ *   system reads only lineage-named seals
+ *   (`migrationLog_<from>_<to>.jsonl`) and ignores the old single-version
+ *   files, so they are dead data.
+ *
+ * Idempotent: a project without old-format snapshots is left untouched.
+ */
+const migration: Migration = {
+  async migrate(context: MigrationContext): Promise<MigrationResult> {
+    console.log(
+      `Migrating from schema version ${context.fromVersion} to ${context.toVersion}`,
+    );
+
+    const migrationsFolder = join(
+      context.cardsConfigPath,
+      'local',
+      'migrations',
+    );
+
+    let entries: string[] = [];
+    try {
+      entries = await readdir(migrationsFolder);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+    }
+
+    const stepsExecuted: string[] = [];
+    const oldSnapshots = entries.filter((name) => OLD_SEAL_NAME.test(name));
+    for (const name of oldSnapshots) {
+      await rm(join(migrationsFolder, name));
+      console.log(`Removed pre-replay migration log snapshot '${name}'.`);
+      stepsExecuted.push(`Removed pre-replay migration log snapshot ${name}`);
+    }
+    if (oldSnapshots.length === 0) {
+      console.log('No pre-replay migration log snapshots found.');
+    }
+    stepsExecuted.push('Schema version incremented');
+
+    return {
+      success: true,
+      message:
+        'Schema updated to version 5: removed pre-replay migration log snapshots (replay reads only lineage-named seals)',
+      stepsExecuted,
+    };
+  },
+};
+
+export default migration;

--- a/tools/migrations/src/index.ts
+++ b/tools/migrations/src/index.ts
@@ -9,6 +9,7 @@ import type { Migration } from './migration-interfaces.js';
 import migration2 from './2/index.js';
 import migration3 from './3/index.js';
 import migration4 from './4/index.js';
+import migration5 from './5/index.js';
 
 // Re-export migration interfaces and utilities
 export type {
@@ -29,6 +30,7 @@ export const migrations: Record<number, Migration> = {
   2: migration2,
   3: migration3,
   4: migration4,
+  5: migration5,
 };
 
 /**


### PR DESCRIPTION
Bumps the project schema 4 → 5 and cleans up data the replay system no longer reads.

## Changes
- Removes obsolete single-version snapshots (`migrationLog_<version>.jsonl`). The replay system reads only lineage-named seals (`migrationLog_<from>_<to>.jsonl`) and ignores the old files, so they are dead data.
- Idempotent: a project without old-format snapshots is left untouched.