### PR TITLE
INTDEV-1333: Skill resource type with CLI management

### DIFF
--- a/tools/assets/src/schema/cardTreeDirectorySchema.json
+++ b/tools/assets/src/schema/cardTreeDirectorySchema.json
@@ -34,6 +34,9 @@
                     "reports": {
                       "$ref": "#/$defs/reportResourceSchema"
                     },
+                    "skills": {
+                      "$ref": "#/$defs/skillResourceSchema"
+                    },
                     "templates": {
                       "$ref": "#/$defs/templatesResourceSchema"
                     },
@@ -380,6 +383,52 @@
         }
       }
     },
+    "skillResourceSchema": {
+      "type": "object",
+      "properties": {
+        "additionalProperties": false,
+        "files": {
+          "$comment": "skills folder can contain skill configuration files (<name>.json), or .gitkeep",
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^[A-Za-z0-9-_]+.json$": {
+              "type": "object"
+            },
+            "^.schema$": {
+              "type": "object"
+            },
+            "^.gitkeep$": {
+              "type": "object"
+            }
+          }
+        },
+        "directories": {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            ".+": {
+              "type": "object",
+              "properties": {
+                "files": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "skill.md": {
+                      "type": "object"
+                    },
+                    "query.lp": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["skill.md"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "workflowResourceSchema": {
       "type": "object",
       "allOf": [
@@ -572,6 +621,9 @@
                         },
                         "reports": {
                           "$ref": "#/$defs/reportResourceSchema"
+                        },
+                        "skills": {
+                          "$ref": "#/$defs/skillResourceSchema"
                         },
                         "templates": {
                           "$ref": "#/$defs/templatesResourceSchema"

--- a/tools/assets/src/schema/cardTreeDirectorySchema.json
+++ b/tools/assets/src/schema/cardTreeDirectorySchema.json
@@ -125,7 +125,6 @@
     "calculationResourceSchema": {
       "type": "object",
       "properties": {
-        "additionalProperties": false,
         "directories": {
           "type": "object",
           "additionalProperties": false,
@@ -219,7 +218,6 @@
     "graphViewResourceSchema": {
       "type": "object",
       "properties": {
-        "additionalProperties": false,
         "directories": {
           "type": "object",
           "additionalProperties": false,
@@ -248,7 +246,6 @@
     "graphModelResourceSchema": {
       "type": "object",
       "properties": {
-        "additionalProperties": false,
         "directories": {
           "type": "object",
           "additionalProperties": false,
@@ -334,19 +331,18 @@
     "reportResourceSchema": {
       "type": "object",
       "properties": {
-        "additionalProperties": false,
         "files": {
           "$comment": "reports folder can contain report configuration files (<name>.json), or .gitkeep",
           "type": "object",
           "additionalProperties": false,
           "patternProperties": {
-            "^[A-Za-z0-9-_]+.json$": {
+            "^[A-Za-z0-9-_]+\\.json$": {
               "type": "object"
             },
-            "^.schema$": {
+            "^\\.schema$": {
               "type": "object"
             },
-            "^.gitkeep$": {
+            "^\\.gitkeep$": {
               "type": "object"
             }
           }
@@ -386,19 +382,18 @@
     "skillResourceSchema": {
       "type": "object",
       "properties": {
-        "additionalProperties": false,
         "files": {
           "$comment": "skills folder can contain skill configuration files (<name>.json), or .gitkeep",
           "type": "object",
           "additionalProperties": false,
           "patternProperties": {
-            "^[A-Za-z0-9-_]+.json$": {
+            "^[A-Za-z0-9-_]+\\.json$": {
               "type": "object"
             },
-            "^.schema$": {
+            "^\\.schema$": {
               "type": "object"
             },
-            "^.gitkeep$": {
+            "^\\.gitkeep$": {
               "type": "object"
             }
           }
@@ -407,7 +402,7 @@
           "type": "object",
           "additionalProperties": false,
           "patternProperties": {
-            ".+": {
+            "^[A-Za-z0-9-_]+$": {
               "type": "object",
               "properties": {
                 "files": {
@@ -531,15 +526,15 @@
               "type": "object",
               "additionalProperties": false,
               "patternProperties": {
-                "^[A-Za-z0-9-_]+.json$": {
+                "^[A-Za-z0-9-_]+\\.json$": {
                   "type": "object",
                   "$comment": "Each file needs to be separately validated against 'contentSchema'",
                   "contentSchema": "templateSchema.json"
                 },
-                "^.schema$": {
+                "^\\.schema$": {
                   "type": "object"
                 },
-                "^.gitkeep$": {
+                "^\\.gitkeep$": {
                   "type": "object"
                 }
               }

--- a/tools/assets/src/schema/resources/skillSchema.json
+++ b/tools/assets/src/schema/resources/skillSchema.json
@@ -1,0 +1,35 @@
+{
+  "$id": "skillSchema",
+  "additionalProperties": false,
+  "description": "A skill object provides supplemental information about a skill",
+  "properties": {
+    "name": {
+      "description": "The name of this skill",
+      "minLength": 7,
+      "pattern": "^[A-Za-z0-9/._-]+$",
+      "type": "string"
+    },
+    "displayName": {
+      "description": "The name of the skill as it should be displayed in the user interface. For example, 'Manage Risk Register'.",
+      "type": "string"
+    },
+    "description": {
+      "description": "A brief summary of what the skill does and when it applies.",
+      "type": "string"
+    },
+    "category": {
+      "description": "The grouping category of the skill. For example, 'risk assessment', 'compliance' or 'incident response'.",
+      "type": "string"
+    },
+    "relatedTools": {
+      "description": "The MCP tool names that the skill's instructions reference. Lets AI agents see which tools are relevant without parsing the instructions.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": ["name", "displayName", "relatedTools"],
+  "title": "Skill",
+  "type": "object"
+}

--- a/tools/assets/src/schemas.ts
+++ b/tools/assets/src/schemas.ts
@@ -33,6 +33,7 @@ import reportMacroBaseSchema from './schema/macros/reportMacroBaseSchema.json' w
 import reportSchema from './schema/resources/reportSchema.json' with { type: 'json' };
 import schema from './schema/schema.json' with { type: 'json' };
 import scoreCardMacroSchema from './schema/macros/scoreCardMacroSchema.json' with { type: 'json' };
+import skillSchema from './schema/resources/skillSchema.json' with { type: 'json' };
 import templateSchema from './schema/resources/templateSchema.json' with { type: 'json' };
 import vegaLiteMacroSchema from './schema/macros/vegaLiteMacroSchema.json' with { type: 'json' };
 import vegaMacroSchema from './schema/macros/vegaMacroSchema.json' with { type: 'json' };
@@ -65,6 +66,7 @@ export const schemas = [
   reportSchema,
   schema,
   scoreCardMacroSchema,
+  skillSchema,
   templateSchema,
   vegaLiteMacroSchema,
   vegaMacroSchema,

--- a/tools/assets/src/static/defaultSkill/skill.md
+++ b/tools/assets/src/static/defaultSkill/skill.md
@@ -1,0 +1,3 @@
+# Skill
+
+Describe what this skill does and when an agent should apply it.

--- a/tools/assets/src/static/defaultSkill/skill.md
+++ b/tools/assets/src/static/defaultSkill/skill.md
@@ -1,3 +1,4 @@
 # Skill
 
-Describe what this skill does and when an agent should apply it.
+Write the instructions an agent should follow when applying this skill.
+(When the skill applies is described in its `description`.)

--- a/tools/backend/src/common/validationSchemas.ts
+++ b/tools/backend/src/common/validationSchemas.ts
@@ -21,6 +21,7 @@ export const resourceTypes = [
   'graphViews',
   'linkTypes',
   'reports',
+  'skills',
   'templates',
   'workflows',
 ] as const;

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -696,6 +696,20 @@ createCmd
     handleResponse(result);
   });
 
+// Create skill subcommand
+createCmd
+  .command('skill')
+  .description('Create a new skill')
+  .argument('<name>', `Name for skill. ${nameGuideline}`)
+  .action(async (name: string, options: CommandOptions<'create'>) => {
+    const result = await commandHandler.command(
+      Cmd.create,
+      ['skill', name],
+      Object.assign({}, options, program.opts()),
+    );
+    handleResponse(result);
+  });
+
 // Create template subcommand
 createCmd
   .command('template')

--- a/tools/cli/src/resource-type-parser.ts
+++ b/tools/cli/src/resource-type-parser.ts
@@ -20,6 +20,7 @@ const Resources = [
   'graphView',
   'linkType',
   'report',
+  'skill',
   'template',
   'workflow',
 ];
@@ -33,6 +34,7 @@ const pluralLookUpForResources = new Map([
   ['graphView', 'graphViews'],
   ['linkType', 'linkTypes'],
   ['report', 'reports'],
+  ['skill', 'skills'],
   ['template', 'templates'],
   ['workflow', 'workflows'],
 ]);

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -295,6 +295,9 @@ export class Commands {
         } else if (target === 'report') {
           const [name] = rest;
           await this.commands?.createCmd.createReport(name);
+        } else if (target === 'skill') {
+          const [name] = rest;
+          await this.commands?.createCmd.createSkill(name);
         } else if (target === 'template') {
           const [name, content] = rest;
           await this.commands?.createCmd.createTemplate(name, content);
@@ -846,6 +849,7 @@ export class Commands {
       case 'graphModel':
       case 'linkType':
       case 'report':
+      case 'skill':
       case 'template':
       case 'workflow':
         promise = this.commands!.showCmd.showResource(detail, options.showUse);
@@ -857,6 +861,7 @@ export class Commands {
       case 'graphViews':
       case 'linkTypes':
       case 'reports':
+      case 'skills':
       case 'templates':
       case 'workflows':
         promise = this.commands!.showCmd.showResources(type);

--- a/tools/data-handler/src/commands/create.ts
+++ b/tools/data-handler/src/commands/create.ts
@@ -749,6 +749,15 @@ export class Create {
   }
 
   /**
+   * Creates a skill
+   * @param name name of the skill
+   */
+  @write((name) => `Create skill ${name}`)
+  public async createSkill(name: string) {
+    return this.project.resources.byType(name, 'skills').createSkill();
+  }
+
+  /**
    * Creates a new template to a project.
    * @param templateName Name of the template.
    * @param templateContent JSON content for the template file.

--- a/tools/data-handler/src/commands/remove.ts
+++ b/tools/data-handler/src/commands/remove.ts
@@ -54,6 +54,7 @@ export class Remove {
       type === 'graphView' ||
       type === 'linkType' ||
       type === 'report' ||
+      type === 'skill' ||
       type === 'template' ||
       type === 'workflow'
     );

--- a/tools/data-handler/src/commands/show.ts
+++ b/tools/data-handler/src/commands/show.ts
@@ -75,6 +75,7 @@ export class Show {
     graphViews: (from) => this.resourceNames('graphViews', from),
     linkTypes: (from) => this.resourceNames('linkTypes', from),
     reports: (from) => this.resourceNames('reports', from),
+    skills: (from) => this.resourceNames('skills', from),
     templates: (from) => this.resourceNames('templates', from),
     workflows: (from) => this.resourceNames('workflows', from),
   };

--- a/tools/data-handler/src/containers/project/calculation-engine.ts
+++ b/tools/data-handler/src/containers/project/calculation-engine.ts
@@ -38,6 +38,7 @@ import {
   createModuleFacts,
   createProjectFacts,
   createReportFacts,
+  createSkillFacts,
   createTemplateFacts,
   createWorkflowFacts,
 } from '../../utils/clingo-facts.js';
@@ -47,6 +48,7 @@ import type {
   FieldType,
   LinkType,
   ReportMetadata,
+  SkillMetadata,
   TemplateMetadata,
   Workflow,
 } from '../../interfaces/resource-interfaces.js';
@@ -185,6 +187,16 @@ export class CalculationEngine {
     }
   }
 
+  // Sets individual Skill programs
+  private async setSkillsPrograms() {
+    const skills = this.project.resources.skills();
+    for (const skill of skills) {
+      const skl = skill.show();
+      const skillContent = createSkillFacts(skl);
+      this.clingo.setProgram(skl.name, skillContent, [ALL_CATEGORY]);
+    }
+  }
+
   // Sets individual Template programs
   private async setTemplatesPrograms() {
     const templates = this.project.resources.templates();
@@ -312,6 +324,7 @@ export class CalculationEngine {
     await this.setLinkTypesPrograms();
     await this.setWorkflowsPrograms();
     await this.setReportsPrograms();
+    await this.setSkillsPrograms();
     await this.setTemplatesPrograms();
     await this.setCalculationsPrograms();
 
@@ -418,6 +431,8 @@ export class CalculationEngine {
         return createWorkflowFacts(resource as Workflow);
       case 'reports':
         return createReportFacts(resource as ReportMetadata);
+      case 'skills':
+        return createSkillFacts(resource as SkillMetadata);
       case 'templates':
         return createTemplateFacts(resource as TemplateMetadata);
       default:

--- a/tools/data-handler/src/containers/project/project-paths.ts
+++ b/tools/data-handler/src/containers/project/project-paths.ts
@@ -31,6 +31,7 @@ export class ProjectPaths {
       ['linkTypes', this.linkTypesFolder],
       ['modules', this.modulesFolder],
       ['reports', this.reportsFolder],
+      ['skills', this.skillsFolder],
       ['templates', this.templatesFolder],
       ['workflows', this.workflowsFolder],
     ]);
@@ -118,6 +119,10 @@ export class ProjectPaths {
 
   public get reportsFolder(): string {
     return join(this.resourcesFolder, 'reports');
+  }
+
+  public get skillsFolder(): string {
+    return join(this.resourcesFolder, 'skills');
   }
 
   /**

--- a/tools/data-handler/src/containers/project/resource-cache.ts
+++ b/tools/data-handler/src/containers/project/resource-cache.ts
@@ -31,6 +31,7 @@ import { GraphModelResource } from '../../resources/graph-model-resource.js';
 import { GraphViewResource } from '../../resources/graph-view-resource.js';
 import { LinkTypeResource } from '../../resources/link-type-resource.js';
 import { ReportResource } from '../../resources/report-resource.js';
+import { SkillResource } from '../../resources/skill-resource.js';
 import { TemplateResource } from '../../resources/template-resource.js';
 import { WorkflowResource } from '../../resources/workflow-resource.js';
 
@@ -55,9 +56,16 @@ export type ResourceMap = {
   graphModels: GraphModelResource;
   linkTypes: LinkTypeResource;
   reports: ReportResource;
+  skills: SkillResource;
   templates: TemplateResource;
   workflows: WorkflowResource;
 };
+
+// Constructor signature shared by every resource class.
+type ResourceConstructor = new (
+  project: Project,
+  name: ResourceName,
+) => ResourceMap[keyof ResourceMap];
 
 // Helper for SafeExtract.
 export type ExtractResourceType<T extends string> =
@@ -88,6 +96,7 @@ const FOLDER_RESOURCE_TYPES: ResourceFolderType[] = [
   'graphModels',
   'graphViews',
   'reports',
+  'skills',
   'templates',
 ];
 
@@ -103,6 +112,26 @@ const FOLDER_RESOURCE_TYPES: ResourceFolderType[] = [
  *
  */
 export class ResourceCache {
+  // Maps each resource type to its constructor. The object literal is checked
+  // against ResourceMap for exhaustiveness, then frozen into a Map for lookup.
+  private static readonly resourceConstructors = new Map<
+    string,
+    ResourceConstructor
+  >(
+    Object.entries({
+      calculations: CalculationResource,
+      cardTypes: CardTypeResource,
+      fieldTypes: FieldTypeResource,
+      graphModels: GraphModelResource,
+      graphViews: GraphViewResource,
+      linkTypes: LinkTypeResource,
+      reports: ReportResource,
+      skills: SkillResource,
+      templates: TemplateResource,
+      workflows: WorkflowResource,
+    } satisfies Record<keyof ResourceMap, ResourceConstructor>),
+  );
+
   private resourceRegistry = new Map<string, ResourceMetadata>();
   private instanceCache = new Map<string, unknown>();
 
@@ -130,29 +159,14 @@ export class ResourceCache {
   private createResourceObject(resourceName: ResourceName): unknown {
     const key = resourceNameToString(resourceName);
     const metadata = this.resourceRegistry.get(key);
-    let resource: unknown;
 
-    if (resourceName.type === 'calculations') {
-      resource = new CalculationResource(this.project, resourceName);
-    } else if (resourceName.type === 'cardTypes') {
-      resource = new CardTypeResource(this.project, resourceName);
-    } else if (resourceName.type === 'fieldTypes') {
-      resource = new FieldTypeResource(this.project, resourceName);
-    } else if (resourceName.type === 'graphModels') {
-      resource = new GraphModelResource(this.project, resourceName);
-    } else if (resourceName.type === 'graphViews') {
-      resource = new GraphViewResource(this.project, resourceName);
-    } else if (resourceName.type === 'linkTypes') {
-      resource = new LinkTypeResource(this.project, resourceName);
-    } else if (resourceName.type === 'reports') {
-      resource = new ReportResource(this.project, resourceName);
-    } else if (resourceName.type === 'templates') {
-      resource = new TemplateResource(this.project, resourceName);
-    } else if (resourceName.type === 'workflows') {
-      resource = new WorkflowResource(this.project, resourceName);
-    } else {
+    const resourceConstructor = ResourceCache.resourceConstructors.get(
+      resourceName.type,
+    );
+    if (!resourceConstructor) {
       throw new Error(`Unsupported resource type '${resourceName.type}'`);
     }
+    const resource = new resourceConstructor(this.project, resourceName);
 
     // Populate content files into folder resources
     if (metadata?.contentFiles && this.hasSetContentFiles(resource)) {
@@ -178,6 +192,7 @@ export class ResourceCache {
       'graphViews',
       'linkTypes',
       'reports',
+      'skills',
       'templates',
       'workflows',
     ];

--- a/tools/data-handler/src/containers/project/resource-handler.ts
+++ b/tools/data-handler/src/containers/project/resource-handler.ts
@@ -24,6 +24,7 @@ export const singularToPluralResourceType: Record<string, keyof ResourceMap> = {
   template: 'templates',
   workflow: 'workflows',
   report: 'reports',
+  skill: 'skills',
   calculation: 'calculations',
   cardType: 'cardTypes',
   fieldType: 'fieldTypes',
@@ -215,6 +216,10 @@ export class ResourceHandler {
 
   public reports(from: ResourcesFrom = ResourcesFrom.all) {
     return this.cache.resources('reports', from);
+  }
+
+  public skills(from: ResourcesFrom = ResourcesFrom.all) {
+    return this.cache.resources('skills', from);
   }
 
   public templates(from: ResourcesFrom = ResourcesFrom.all) {

--- a/tools/data-handler/src/interfaces/folder-content-interfaces.ts
+++ b/tools/data-handler/src/interfaces/folder-content-interfaces.ts
@@ -21,7 +21,9 @@ export const ALL_FILE_MAPPINGS = {
   'index.adoc.hbs': 'contentTemplate',
   'model.lp': 'model',
   'parameterSchema.json': 'schema',
+  'query.lp': 'skillQuery',
   'query.lp.hbs': 'queryTemplate',
+  'skill.md': 'skillContent',
   'view.lp.hbs': 'viewTemplate',
 } as const;
 
@@ -32,6 +34,8 @@ export const CONTENT_FILES = {
   model: 'model.lp',
   queryTemplate: 'query.lp.hbs',
   schema: 'parameterSchema.json',
+  skillContent: 'skill.md',
+  skillQuery: 'query.lp',
   viewTemplate: 'view.lp.hbs',
 } as const;
 
@@ -61,11 +65,18 @@ export interface ReportContent {
   schema?: Schema;
 }
 
+// Content interface for Skill resources
+export interface SkillContent {
+  skillContent: string;
+  skillQuery: string;
+}
+
 export type FolderResourceContent =
   | CalculationContent
   | GraphModelContent
   | GraphViewContent
-  | ReportContent;
+  | ReportContent
+  | SkillContent;
 
 /**
  * Get filename with property name

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -264,6 +264,7 @@ export type RemovableResourceTypes =
   | 'linkType'
   | 'module'
   | 'report'
+  | 'skill'
   | 'template'
   | 'workflow'
   | 'label';
@@ -281,6 +282,7 @@ export type ResourceFolderType =
   | 'linkTypes'
   | 'modules'
   | 'reports'
+  | 'skills'
   | 'templates'
   | 'workflows';
 

--- a/tools/data-handler/src/interfaces/resource-interfaces.ts
+++ b/tools/data-handler/src/interfaces/resource-interfaces.ts
@@ -16,6 +16,7 @@ import type {
   GraphModelContent,
   GraphViewContent,
   ReportContent,
+  SkillContent,
 } from './folder-content-interfaces.js';
 import type { ResourceType } from './project-interfaces.js';
 
@@ -137,6 +138,19 @@ export type ReportContentPropertyName =
 // Metadata for report
 export type ReportMetadata = ResourceBaseMetadata;
 
+// Skill resource.
+export interface Skill extends SkillMetadata {
+  content: SkillContent;
+}
+
+// Resource-specific content names
+export type SkillContentPropertyName = 'skillContent' | 'skillQuery';
+
+// Metadata for skill
+export interface SkillMetadata extends ResourceBaseMetadata {
+  relatedTools: string[];
+}
+
 // Base interface for all resources.
 export interface ResourceBaseMetadata {
   name: string;
@@ -155,6 +169,7 @@ export type AnyResourceContent =
   | GraphView
   | LinkType
   | Report
+  | Skill
   | TemplateMetadata
   | Workflow;
 
@@ -168,6 +183,7 @@ export type ResourceContentMap = {
   graphViews: GraphView;
   linkTypes: LinkType;
   reports: Report;
+  skills: Skill;
   templates: TemplateMetadata;
   workflows: Workflow;
 };

--- a/tools/data-handler/src/mutations/handlers/leaf-resource-rename.ts
+++ b/tools/data-handler/src/mutations/handlers/leaf-resource-rename.ts
@@ -26,11 +26,13 @@ type LeafResourceType =
   | 'reports'
   | 'graphModels'
   | 'graphViews'
+  | 'skills'
   | 'templates';
 
 /**
- * Renames a leaf resource (calculation, report, graph model, graph view or
- * template). The handler performs the reference cascade itself, rewriting
+ * Renames a leaf resource (calculation, report, graph model, graph view,
+ * skill or template). The handler performs the reference cascade itself,
+ * rewriting
  * references to the old name across folder-resource content files and card
  * content before renaming the resource on disk. The operation is marked
  * breaking so a log entry is recorded.

--- a/tools/data-handler/src/mutations/registry.ts
+++ b/tools/data-handler/src/mutations/registry.ts
@@ -146,6 +146,7 @@ const wildcardEditKeys: Record<string, string[]> = {
   reports: ['displayName', 'description', 'category', 'content'],
   graphModels: ['displayName', 'description', 'category', 'content'],
   graphViews: ['displayName', 'description', 'category', 'content'],
+  skills: ['displayName', 'description', 'category', 'relatedTools', 'content'],
 };
 
 export const ROUTES: Registration[] = [
@@ -262,6 +263,11 @@ export const ROUTES: Registration[] = [
     handler: new LeafResourceRenameHandler('graphViews', 'Graph view'),
     breaking: true,
   },
+  {
+    route: { kind: 'rename', type: 'skills' },
+    handler: new LeafResourceRenameHandler('skills', 'Skill'),
+    breaking: true,
+  },
 
   // DELETE rows.
   {
@@ -306,6 +312,11 @@ export const ROUTES: Registration[] = [
   },
   {
     route: { kind: 'delete', type: 'graphViews' },
+    handler: plainDelete,
+    breaking: false,
+  },
+  {
+    route: { kind: 'delete', type: 'skills' },
     handler: plainDelete,
     breaking: false,
   },

--- a/tools/data-handler/src/resources/create-defaults.ts
+++ b/tools/data-handler/src/resources/create-defaults.ts
@@ -23,6 +23,7 @@ import type {
   Link,
   LinkType,
   ReportMetadata,
+  SkillMetadata,
   TemplateMetadata,
   Workflow,
 } from '../interfaces/resource-interfaces.js';
@@ -184,6 +185,19 @@ export abstract class DefaultContent {
     return {
       name: reportName,
       displayName: '',
+    };
+  }
+
+  /**
+   * Default content for skill type.
+   * @param skillName skill name
+   * @returns Default content for skill type.
+   */
+  static skill(skillName: string): SkillMetadata {
+    return {
+      name: skillName,
+      displayName: '',
+      relatedTools: [],
     };
   }
 

--- a/tools/data-handler/src/resources/skill-resource.ts
+++ b/tools/data-handler/src/resources/skill-resource.ts
@@ -1,6 +1,6 @@
 /**
   Cyberismo
-  Copyright © Cyberismo Ltd and contributors 2024
+  Copyright © Cyberismo Ltd and contributors 2026
 
   This program is free software: you can redistribute it and/or modify it under
   the terms of the GNU Affero General Public License version 3 as published by

--- a/tools/data-handler/src/resources/skill-resource.ts
+++ b/tools/data-handler/src/resources/skill-resource.ts
@@ -1,0 +1,83 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2024
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { join } from 'node:path';
+
+import { copyDir } from '../utils/file-utils.js';
+import { DefaultContent } from './create-defaults.js';
+import { FolderResource } from './folder-resource.js';
+import { getStaticDirectoryPath } from '@cyberismo/assets';
+import { resourceNameToString } from '../utils/resource-utils.js';
+import { sortCards } from '../utils/card-utils.js';
+
+import type { Card } from '../interfaces/project-interfaces.js';
+import type { Project } from '../containers/project.js';
+import type { SkillContent } from '../interfaces/folder-content-interfaces.js';
+import type { SkillMetadata } from '../interfaces/resource-interfaces.js';
+import type { ResourceName } from '../utils/resource-utils.js';
+
+/**
+ * Skill resource class.
+ */
+export class SkillResource extends FolderResource<SkillMetadata, SkillContent> {
+  /**
+   * Creates instance of SkillResource
+   * @param project Project to use
+   * @param name Resource name
+   */
+  constructor(project: Project, name: ResourceName) {
+    super(project, name, 'skills');
+
+    this.contentSchemaId = 'skillSchema';
+    this.contentSchema = super.contentSchemaContent(this.contentSchemaId);
+  }
+
+  // Path to content folder.
+  private async getDefaultSkillLocation(): Promise<string> {
+    const staticDirectoryPath = await getStaticDirectoryPath();
+    return join(staticDirectoryPath, 'defaultSkill');
+  }
+
+  /**
+   * Sets new metadata into the skill object.
+   */
+  public async createSkill() {
+    const defaultContent = DefaultContent.skill(
+      resourceNameToString(this.resourceName),
+    );
+
+    await super.create(defaultContent);
+
+    // Copy skill default structure to destination.
+    const defaultSkillLocation = await this.getDefaultSkillLocation();
+    await copyDir(defaultSkillLocation, this.internalFolder);
+    await this.loadContentFiles();
+  }
+
+  /**
+   * List where this resource is used.
+   * Always returns card key references first, then calculation references.
+   *
+   * @param cards Optional. Check these cards for usage of this resource. If undefined, will check all cards.
+   * @returns array of card keys and calculation filenames that refer this resource.
+   */
+  public async usage(cards?: Card[]): Promise<string[]> {
+    const allCards = cards ?? super.cards();
+    const [relevantCards, calculations] = await Promise.all([
+      super.usage(allCards),
+      super.calculations(),
+    ]);
+    return [...relevantCards.sort(sortCards), ...calculations];
+  }
+}

--- a/tools/data-handler/src/utils/clingo-facts.ts
+++ b/tools/data-handler/src/utils/clingo-facts.ts
@@ -28,6 +28,7 @@ import type {
   Link,
   LinkType,
   ReportMetadata,
+  SkillMetadata,
   TemplateMetadata,
   Workflow,
 } from '../interfaces/resource-interfaces.js';
@@ -71,6 +72,11 @@ export namespace Facts {
 
   export enum Report {
     REPORT = 'report',
+  }
+
+  export enum Skill {
+    RELATED_TOOL = 'skillRelatedTool',
+    SKILL = 'skill',
   }
 
   export enum Template {
@@ -614,6 +620,37 @@ export const createReportFacts = (report: ReportMetadata) => {
       'category',
       report.category,
     );
+  return builder.buildAll();
+};
+
+/**
+ * Creates clingo facts for a skill.
+ * @param skill Skill metadata
+ * @returns clingo facts as a string
+ */
+export const createSkillFacts = (skill: SkillMetadata) => {
+  const builder = new ClingoProgramBuilder();
+  builder.addFact(Facts.Skill.SKILL, skill.name);
+
+  if (skill.displayName)
+    builder.addFact(
+      Facts.Common.FIELD,
+      skill.name,
+      'displayName',
+      skill.displayName,
+    );
+  if (skill.description)
+    builder.addFact(
+      Facts.Common.FIELD,
+      skill.name,
+      'description',
+      skill.description,
+    );
+  if (skill.category)
+    builder.addFact(Facts.Common.FIELD, skill.name, 'category', skill.category);
+  for (const relatedTool of skill.relatedTools) {
+    builder.addFact(Facts.Skill.RELATED_TOOL, skill.name, relatedTool);
+  }
   return builder.buildAll();
 };
 

--- a/tools/data-handler/src/utils/constants.ts
+++ b/tools/data-handler/src/utils/constants.ts
@@ -36,6 +36,8 @@ export const VALID_FOLDER_RESOURCE_FILES = [
   'view.lp.hbs',
   'model.lp',
   'calculation.lp',
+  'skill.md',
+  'query.lp',
 ];
 
 /**

--- a/tools/data-handler/src/utils/report.ts
+++ b/tools/data-handler/src/utils/report.ts
@@ -46,12 +46,15 @@ export async function generateReportContent(
   const handlebars = Handlebars.create();
   registerComparisonHelpers(handlebars);
 
-  // Compile and execute the query template
-  const template = handlebars.compile(queryTemplate, {
-    strict: true,
-  });
-
-  const result = await calculate.runLogicProgram(template(options), context);
+  // When the query is empty, skip the logic program entirely and render the
+  // content template using only the parameter context.
+  const result =
+    (queryTemplate ?? '').trim() === ''
+      ? { results: [], error: null }
+      : await calculate.runLogicProgram(
+          handlebars.compile(queryTemplate, { strict: true })(options),
+          context,
+        );
 
   if (result.error) {
     throw new Error(result.error);

--- a/tools/data-handler/src/utils/resource-utils.ts
+++ b/tools/data-handler/src/utils/resource-utils.ts
@@ -34,6 +34,7 @@ const RESOURCE_FOLDER_TYPES = [
   'graphModels',
   'graphViews',
   'reports',
+  'skills',
   'templates',
 ];
 

--- a/tools/data-handler/test/0_validate.test.ts
+++ b/tools/data-handler/test/0_validate.test.ts
@@ -1,8 +1,10 @@
-import { readdir } from 'node:fs/promises';
+import { mkdirSync, rmSync } from 'node:fs';
+import { readdir, writeFile } from 'node:fs/promises';
 import { join, resolve, sep } from 'node:path';
 
 import { expect, describe, it, beforeAll } from 'vitest';
 
+import { copyDir } from '../src/utils/file-utils.js';
 import { readJsonFile } from '../src/utils/json.js';
 import { Validate } from '../src/commands/index.js';
 import type { Project } from '../src/containers/project.js';
@@ -94,6 +96,18 @@ describe('validate cmd tests', () => {
   it('try to validate() - no-.schema-in-cardRoot', async () => {
     const path = 'test/test-data/invalid/o-.schema-in-cardRoot';
     const valid = await validateCmd.validate(path, () => getTestProject(path));
+    expect(valid.length).toBeGreaterThan(0);
+  });
+  it('try to validate() - stray file matching only via an unescaped dot (fschema)', async () => {
+    // The directory-schema patterns escape the dot in `\.schema`/`\.gitkeep`/
+    // `<name>\.json`. With an unescaped dot, `^.schema$` also matched "fschema".
+    const tmp = join(baseDir, 'tmp-stray-schema-file');
+    rmSync(tmp, { recursive: true, force: true });
+    mkdirSync(tmp, { recursive: true });
+    await copyDir('test/test-data/valid/decision-records', tmp);
+    await writeFile(join(tmp, '.cards/local/reports/fschema'), '', 'utf-8');
+    const valid = await validateCmd.validate(tmp, () => getTestProject(tmp));
+    rmSync(tmp, { recursive: true, force: true });
     expect(valid.length).toBeGreaterThan(0);
   });
   it('try to validate() - invalid-empty', async () => {

--- a/tools/data-handler/test/command-skill.test.ts
+++ b/tools/data-handler/test/command-skill.test.ts
@@ -1,0 +1,150 @@
+// testing
+import { expect, it, describe, beforeAll, afterAll } from 'vitest';
+
+// node
+import { access } from 'node:fs/promises';
+import { constants as fsConstants, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+// cyberismo
+import { Cmd, Commands } from '../src/command-handler.js';
+import { copyDir } from '../src/utils/file-utils.js';
+import { generateReportContent } from '../src/utils/report.js';
+
+import type { CreateCommandOptions } from '../src/interfaces/command-options.js';
+
+// Create test artifacts in a temp folder.
+const baseDir = import.meta.dirname;
+const testDir = join(baseDir, 'tmp-command-handler-skill-tests');
+
+const minimalPath = join(testDir, 'valid/minimal');
+
+const commandHandler: Commands = new Commands();
+const optionsMini: CreateCommandOptions = { projectPath: minimalPath };
+
+// Helper to get current number of skills.
+async function skillCount(): Promise<number> {
+  const resources = await commandHandler.command(
+    Cmd.show,
+    ['skills'],
+    optionsMini,
+  );
+  return resources.payload ? (resources.payload as object[]).length : 0;
+}
+
+describe('skill command', () => {
+  beforeAll(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir('test/test-data', testDir);
+  });
+
+  afterAll(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('create skill (success)', async () => {
+    const before = await skillCount();
+    const result = await commandHandler.command(
+      Cmd.create,
+      ['skill', 'skill-name'],
+      optionsMini,
+    );
+    expect(result.statusCode).toBe(200);
+    expect(before + 1).toBe(await skillCount());
+
+    // Default content files are copied into the skill folder.
+    const skillFolder = join(minimalPath, '.cards/local/skills/skill-name');
+    await expect(
+      access(join(skillFolder, 'skill.md'), fsConstants.F_OK),
+    ).resolves.toBeUndefined();
+    await expect(
+      access(join(skillFolder, 'query.lp'), fsConstants.F_OK),
+    ).resolves.toBeUndefined();
+  });
+
+  it('create skill with full name (success)', async () => {
+    const before = await skillCount();
+    const result = await commandHandler.command(
+      Cmd.create,
+      ['skill', 'mini/skills/another-skill'],
+      optionsMini,
+    );
+    expect(result.statusCode).toBe(200);
+    expect(before + 1).toBe(await skillCount());
+  });
+
+  it('create skill and validate the project', async () => {
+    const result = await commandHandler.command(
+      Cmd.create,
+      ['skill', 'skill-to-validate'],
+      optionsMini,
+    );
+    expect(result.statusCode).toBe(200);
+    const validation = await commandHandler.command(
+      Cmd.validate,
+      [],
+      optionsMini,
+    );
+    expect(validation.statusCode).toBe(200);
+    expect(validation.message).toBe('Project structure validated');
+  });
+
+  it('show a single skill', async () => {
+    const result = await commandHandler.command(
+      Cmd.show,
+      ['skill', 'mini/skills/skill-name'],
+      optionsMini,
+    );
+    expect(result.statusCode).toBe(200);
+    expect(result.payload).toBeDefined();
+  });
+
+  it('try to create skill with same name', async () => {
+    await commandHandler.command(
+      Cmd.create,
+      ['skill', 'duplicate-skill'],
+      optionsMini,
+    );
+    const result = await commandHandler.command(
+      Cmd.create,
+      ['skill', 'duplicate-skill'],
+      optionsMini,
+    );
+    expect(result.statusCode).toBe(400);
+  });
+
+  it('remove skill (success)', async () => {
+    await commandHandler.command(
+      Cmd.create,
+      ['skill', 'skill-to-remove'],
+      optionsMini,
+    );
+    const before = await skillCount();
+    const result = await commandHandler.command(
+      Cmd.remove,
+      ['skill', 'mini/skills/skill-to-remove'],
+      optionsMini,
+    );
+    expect(result.statusCode).toBe(200);
+    expect(before - 1).toBe(await skillCount());
+  });
+
+  it('renders a content-only skill without running a query', async () => {
+    // A skill with an empty query must not invoke the logic program engine.
+    const calculate = {
+      runLogicProgram: () => {
+        throw new Error('logic program should not run for an empty query');
+      },
+    };
+    const rendered = await generateReportContent({
+      // Only runLogicProgram is used by generateReportContent.
+      calculate: calculate as never,
+      contentTemplate: '# {{title}}\n\nApplies to {{cardKey}}.',
+      queryTemplate: '',
+      options: { title: 'Risk register', cardKey: 'mini_1' },
+      context: 'localApp',
+    });
+    expect(rendered).toContain('# Risk register');
+    expect(rendered).toContain('Applies to mini_1.');
+  });
+});

--- a/tools/data-handler/test/mutations/handlers/leaf-resource-rename.test.ts
+++ b/tools/data-handler/test/mutations/handlers/leaf-resource-rename.test.ts
@@ -206,3 +206,69 @@ describe('LeafResourceRenameHandler (graphModels) own model.lp cascade', () => {
     expect(after).not.toContain(`"${oldName}"`);
   });
 });
+
+// Skill-specific: skills are leaf folder resources too. The fixture has no
+// skills, so seed one (metadata + content folder) before the caches load, then
+// verify the rename moves both the metadata file and the content folder.
+describe('LeafResourceRenameHandler (skills)', () => {
+  let project: Project;
+  const tmpDir = join(import.meta.dirname, 'tmp-skills-rename');
+  const oldName = 'decision/skills/testSkill';
+  const newName = 'decision/skills/testSkillV2';
+
+  beforeEach(async () => {
+    const projectPath = join(tmpDir, `proj-${Date.now()}-${Math.random()}`);
+    await mkdir(projectPath, { recursive: true });
+    await copyDir(FIXTURE_PATH, projectPath);
+
+    const skillsFolder = join(projectPath, '.cards', 'local', 'skills');
+    await mkdir(join(skillsFolder, 'testSkill'), { recursive: true });
+    await writeFile(
+      join(skillsFolder, '.schema'),
+      JSON.stringify([{ version: 1, id: 'skillSchema' }]),
+      'utf-8',
+    );
+    await writeFile(
+      join(skillsFolder, 'testSkill.json'),
+      JSON.stringify({
+        name: oldName,
+        displayName: 'Test skill',
+        relatedTools: [],
+      }),
+      'utf-8',
+    );
+    await writeFile(
+      join(skillsFolder, 'testSkill', 'skill.md'),
+      '# Test skill\n',
+      'utf-8',
+    );
+    await writeFile(join(skillsFolder, 'testSkill', 'query.lp'), '', 'utf-8');
+
+    project = new Project(projectPath);
+    await project.populateCaches();
+  });
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('apply renames the skill metadata and content folder', async () => {
+    const mutations = new ResourceMutations(project);
+    await mutations.apply({
+      kind: 'rename',
+      target: resourceName(oldName),
+      newIdentifier: 'testSkillV2',
+    });
+
+    expect(project.resources.exists(oldName)).toBe(false);
+    expect(project.resources.exists(newName)).toBe(true);
+
+    // The content folder moved with the metadata.
+    const newSkillContent = join(
+      project.paths.resourcesFolder,
+      'skills',
+      'testSkillV2',
+      'skill.md',
+    );
+    expect(await readFile(newSkillContent, 'utf-8')).toContain('# Test skill');
+  });
+});

--- a/tools/data-handler/test/mutations/registry-coverage.test.ts
+++ b/tools/data-handler/test/mutations/registry-coverage.test.ts
@@ -36,6 +36,7 @@ const RESOURCE_SCHEMAS: Record<string, string> = {
   reports: 'reportSchema.json',
   graphModels: 'graphModelSchema.json',
   graphViews: 'graphViewSchema.json',
+  skills: 'skillSchema.json',
 };
 
 // Edit keys that are intentionally NOT schema `properties`. `content` is a

--- a/tools/data-handler/test/utils/clingo-facts.test.ts
+++ b/tools/data-handler/test/utils/clingo-facts.test.ts
@@ -1,10 +1,12 @@
 import { expect, it, describe } from 'vitest';
 import {
   createContextFacts,
+  createSkillFacts,
   createWorkflowFacts,
 } from '../../src/utils/clingo-facts.js';
 import {
   WorkflowCategory,
+  type SkillMetadata,
   type Workflow,
 } from '../../src/interfaces/resource-interfaces.js';
 
@@ -53,6 +55,34 @@ describe('clingo-facts', () => {
       expect(createWorkflowFacts(workflow)).toContain(
         'workflowState("mod/workflows/wf", "Draft", "none").',
       );
+    });
+  });
+
+  describe('createSkillFacts', () => {
+    it('emits one skillRelatedTool fact per related tool', () => {
+      const skill: SkillMetadata = {
+        name: 'mod/skills/risk',
+        displayName: 'Risk',
+        relatedTools: ['search_cards', 'create_card'],
+      };
+
+      const facts = createSkillFacts(skill);
+      expect(facts).toContain(
+        'skillRelatedTool("mod/skills/risk", "search_cards").',
+      );
+      expect(facts).toContain(
+        'skillRelatedTool("mod/skills/risk", "create_card").',
+      );
+    });
+
+    it('emits no skillRelatedTool facts when relatedTools is empty', () => {
+      const skill: SkillMetadata = {
+        name: 'mod/skills/risk',
+        displayName: 'Risk',
+        relatedTools: [],
+      };
+
+      expect(createSkillFacts(skill)).not.toContain('skillRelatedTool(');
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds a new **skill** resource type (INTDEV-1333), stored in `.cards/local/skills` and manageable through the CLI like every other resource.

## Changes

- **`SkillResource` + CLI**: `create` / `show` / `list` / `remove`, plus `rename` / `edit` / `delete` rows in the mutation registry.
- **Files**: `query.lp` (optional) + `skill.md` (Markdown), via a `defaultSkill` static template.
- **Metadata**: `name`, `displayName`, `description`, `category`, and a required `relatedTools: string[]` (defaults to `[]`), emitted as `skillRelatedTool(skill, tool)` clingo facts.
- **`cardTreeDirectorySchema.json`**: allow the `skills/` folder under local and modules so `validate` passes.
- **`generateReportContent`**: skip clingo when the query is empty, so content-only skills (and reports) render without running a logic program.
- **Refactor**: replaced the 10-branch type→constructor `if/else` in `ResourceCache.createResourceObject` with a `satisfies`-checked dispatch `Map` (compile-time exhaustiveness).
