### PR TITLE
INTDEV-1334: Dynamic skill discovery via MCP tools

### DIFF
--- a/tools/assets/src/calculations/queries/enabledSkills.lp
+++ b/tools/assets/src/calculations/queries/enabledSkills.lp
@@ -1,0 +1,18 @@
+% Resolve which skills are enabled for the current request.
+%
+% A skill is enabled either globally (enableSkill/1) or for specific cards
+% (enableSkill/2) — never both. If both are defined for the same skill, the
+% global enablement wins and the per-card terms are ignored.
+%
+% Each enabled skill name is surfaced via result/1; the caller looks up the
+% skill metadata separately. When a cardKey is given, per-card skills are
+% limited to that card; otherwise every per-card skill is included.
+
+globallyEnabled(S) :- enableSkill(S).
+
+result(S) :- globallyEnabled(S).
+{{#if cardKey}}
+result(S) :- enableSkill(S, {{cardKey}}), not globallyEnabled(S).
+{{else}}
+result(S) :- enableSkill(S, _), not globallyEnabled(S).
+{{/if}}

--- a/tools/assets/src/calculations/queries/enabledSkills.lp
+++ b/tools/assets/src/calculations/queries/enabledSkills.lp
@@ -4,15 +4,16 @@
 % (enableSkill/2) — never both. If both are defined for the same skill, the
 % global enablement wins and the per-card terms are ignored.
 %
-% Each enabled skill name is surfaced via result/1; the caller looks up the
-% skill metadata separately. When a cardKey is given, per-card skills are
-% limited to that card; otherwise every per-card skill is included.
+% Each enabled skill name is surfaced via result/1, together with its scope
+% ("global" or "card") via resultField/4. When a cardKey is given, per-card
+% skills are limited to that card; otherwise every per-card skill is included.
 
-globallyEnabled(S) :- enableSkill(S).
-
-result(S) :- globallyEnabled(S).
+result(S) :- enableSkill(S).
 {{#if cardKey}}
-result(S) :- enableSkill(S, {{cardKey}}), not globallyEnabled(S).
+result(S) :- enableSkill(S, {{cardKey}}).
 {{else}}
-result(S) :- enableSkill(S, _), not globallyEnabled(S).
+result(S) :- enableSkill(S, _).
 {{/if}}
+
+resultField(S, "scope", "global", "shortText") :- enableSkill(S).
+resultField(S, "scope", "card", "shortText") :- result(S), not enableSkill(S).

--- a/tools/assets/src/calculations/queries/globalSkills.lp
+++ b/tools/assets/src/calculations/queries/globalSkills.lp
@@ -1,6 +1,0 @@
-% Skills enabled globally via enableSkill/1.
-%
-% Used to tell a globally-enabled skill apart from a card-specific one when no
-% cardKey is supplied — a card-specific skill needs a cardKey to render.
-
-result(S) :- enableSkill(S).

--- a/tools/assets/src/calculations/queries/globalSkills.lp
+++ b/tools/assets/src/calculations/queries/globalSkills.lp
@@ -1,0 +1,6 @@
+% Skills enabled globally via enableSkill/1.
+%
+% Used to tell a globally-enabled skill apart from a card-specific one when no
+% cardKey is supplied — a card-specific skill needs a cardKey to render.
+
+result(S) :- enableSkill(S).

--- a/tools/assets/src/index.ts
+++ b/tools/assets/src/index.ts
@@ -10,7 +10,6 @@ import commonQueryLanguage from './calculations/common/queryLanguage.lp';
 import commonUtils from './calculations/common/utils.lp';
 import queriesCard from './calculations/queries/card.lp';
 import queriesEnabledSkills from './calculations/queries/enabledSkills.lp';
-import queriesGlobalSkills from './calculations/queries/globalSkills.lp';
 import queriesOnCreation from './calculations/queries/onCreation.lp';
 import queriesOnTransition from './calculations/queries/onTransition.lp';
 import queriesConnectors from './calculations/queries/connectors.lp';
@@ -49,7 +48,6 @@ export const lpFiles = {
     card: queriesCard,
     connectors: queriesConnectors,
     enabledSkills: queriesEnabledSkills,
-    globalSkills: queriesGlobalSkills,
     onCreation: queriesOnCreation,
     onTransition: queriesOnTransition,
     tree: queriesTree,

--- a/tools/assets/src/index.ts
+++ b/tools/assets/src/index.ts
@@ -9,6 +9,8 @@ import commonBase from './calculations/common/base.lp';
 import commonQueryLanguage from './calculations/common/queryLanguage.lp';
 import commonUtils from './calculations/common/utils.lp';
 import queriesCard from './calculations/queries/card.lp';
+import queriesEnabledSkills from './calculations/queries/enabledSkills.lp';
+import queriesGlobalSkills from './calculations/queries/globalSkills.lp';
 import queriesOnCreation from './calculations/queries/onCreation.lp';
 import queriesOnTransition from './calculations/queries/onTransition.lp';
 import queriesConnectors from './calculations/queries/connectors.lp';
@@ -46,6 +48,8 @@ export const lpFiles = {
   queries: {
     card: queriesCard,
     connectors: queriesConnectors,
+    enabledSkills: queriesEnabledSkills,
+    globalSkills: queriesGlobalSkills,
     onCreation: queriesOnCreation,
     onTransition: queriesOnTransition,
     tree: queriesTree,

--- a/tools/data-handler/src/commands/show.ts
+++ b/tools/data-handler/src/commands/show.ts
@@ -660,36 +660,25 @@ export class Show {
    * @param context Calculation context.
    * @returns lightweight summaries of the enabled skills, sorted by name.
    */
+  @read
   public async listSkills(
     options: { cardKey?: string; category?: string } = {},
     context: Context = 'localApp',
   ): Promise<SkillSummary[]> {
-    return this.project.lock.read(async () => {
-      const enabled = await this.project.calculationEngine.runQuery(
-        'enabledSkills',
-        context,
-        { cardKey: options.cardKey },
-      );
-      const globallyEnabled = new Set(
-        (
-          await this.project.calculationEngine.runQuery('globalSkills', context)
-        ).map((row) => row.key),
-      );
-      const summaries: SkillSummary[] = [];
-      for (const { key } of enabled) {
-        const resource = this.project.resources.byType(key, 'skills');
-        if (!resource) continue;
-        const skill = resource.show() as Skill;
-        if (options.category && skill.category !== options.category) continue;
-        summaries.push(
-          this.toSkillSummary(
-            skill,
-            globallyEnabled.has(key) ? 'global' : 'card',
-          ),
-        );
-      }
-      return summaries.sort((a, b) => a.name.localeCompare(b.name));
-    });
+    const enabled = await this.project.calculationEngine.runQuery(
+      'enabledSkills',
+      context,
+      { cardKey: options.cardKey },
+    );
+    const summaries: SkillSummary[] = [];
+    for (const { key, scope } of enabled) {
+      const resource = this.project.resources.byType(key, 'skills');
+      if (!resource) continue;
+      const skill = resource.show();
+      if (options.category && skill.category !== options.category) continue;
+      summaries.push(this.toSkillSummary(skill, scope));
+    }
+    return summaries.sort((a, b) => a.name.localeCompare(b.name));
   }
 
   /**
@@ -703,50 +692,42 @@ export class Show {
    * @param context Calculation context.
    * @returns the rendered skill ('ok'), or a marker ('not-enabled' / 'needs-card').
    */
+  @read
   public async getSkill(
     name: string,
     options: { cardKey?: string } = {},
     context: Context = 'localApp',
   ): Promise<SkillLookupResult> {
-    return this.project.lock.read(async () => {
-      const { cardKey } = options;
-      const enabled = (
-        await this.project.calculationEngine.runQuery(
-          'enabledSkills',
-          context,
-          {
-            cardKey,
-          },
-        )
-      ).map((row) => row.key);
-      if (!enabled.includes(name)) {
-        return { status: 'not-enabled' };
-      }
-      const globallyEnabled = (
-        await this.project.calculationEngine.runQuery('globalSkills', context)
-      ).map((row) => row.key);
-      const scope = globallyEnabled.includes(name) ? 'global' : 'card';
-      // A card-specific skill can't be rendered meaningfully without a cardKey.
-      if (scope === 'card' && !cardKey) {
-        return { status: 'needs-card' };
-      }
-      const resource = this.project.resources.byType(name, 'skills');
-      if (!resource) {
-        return { status: 'not-enabled' };
-      }
-      const skill = resource.show() as Skill;
-      const instructions = await generateReportContent({
-        calculate: this.project.calculationEngine,
-        contentTemplate: skill.content.skillContent,
-        queryTemplate: skill.content.skillQuery,
-        options: { cardKey },
-        context,
-      });
-      return {
-        status: 'ok',
-        skill: { ...this.toSkillSummary(skill, scope), instructions },
-      };
+    const { cardKey } = options;
+    const enabled = await this.project.calculationEngine.runQuery(
+      'enabledSkills',
+      context,
+      { cardKey },
+    );
+    const entry = enabled.find((row) => row.key === name);
+    if (!entry) {
+      return { status: 'not-enabled' };
+    }
+    // A card-specific skill can't be rendered meaningfully without a cardKey.
+    if (entry.scope === 'card' && !cardKey) {
+      return { status: 'needs-card' };
+    }
+    const resource = this.project.resources.byType(name, 'skills');
+    if (!resource) {
+      return { status: 'not-enabled' };
+    }
+    const skill = resource.show();
+    const instructions = await generateReportContent({
+      calculate: this.project.calculationEngine,
+      contentTemplate: skill.content.skillContent,
+      queryTemplate: skill.content.skillQuery,
+      options: { cardKey },
+      context,
     });
+    return {
+      status: 'ok',
+      skill: { ...this.toSkillSummary(skill, entry.scope), instructions },
+    };
   }
 
   /**

--- a/tools/data-handler/src/commands/show.ts
+++ b/tools/data-handler/src/commands/show.ts
@@ -43,6 +43,9 @@ import type {
   AnyResourceContent,
   CardType,
   ResourceContent,
+  Skill,
+  SkillLookupResult,
+  SkillSummary,
   TemplateConfiguration,
   Workflow,
 } from '../interfaces/resource-interfaces.js';
@@ -53,6 +56,7 @@ import type { ResourceMap } from '../containers/project/resource-cache.js';
 import { UserPreferences } from '../utils/user-preferences.js';
 import { read, write } from '../utils/rw-lock.js';
 import ReportMacro from '../macros/report/index.js';
+import { generateReportContent } from '../utils/report.js';
 import TaskQueue from '../macros/task-queue.js';
 import { evaluateMacros } from '../macros/index.js';
 import { readJsonFile } from '../utils/json.js';
@@ -624,6 +628,125 @@ export class Show {
       workflows.push(workflow.data);
     }
     return workflows;
+  }
+
+  // Maps a full skill resource to a lightweight discovery summary.
+  private toSkillSummary(
+    skill: Skill,
+    scope: SkillSummary['scope'],
+  ): SkillSummary {
+    const { name, displayName, description, category, relatedTools } = skill;
+
+    return {
+      name,
+      displayName,
+      description,
+      category,
+      relatedTools,
+      scope,
+    };
+  }
+
+  /**
+   * Lists the skills currently enabled by the project's logic programs.
+   *
+   * A skill is enabled either globally (`enableSkill/1`) or for specific cards
+   * (`enableSkill/2`). Without a cardKey, all enabled skills are returned
+   * (global + every card-specific skill); with a cardKey, the result is the
+   * global skills plus those enabled for that card. Enablement is evaluated
+   * against the current project state on every call.
+   * @param options.cardKey Optional card to scope card-specific skills to.
+   * @param options.category Optional category filter.
+   * @param context Calculation context.
+   * @returns lightweight summaries of the enabled skills, sorted by name.
+   */
+  public async listSkills(
+    options: { cardKey?: string; category?: string } = {},
+    context: Context = 'localApp',
+  ): Promise<SkillSummary[]> {
+    return this.project.lock.read(async () => {
+      const enabled = await this.project.calculationEngine.runQuery(
+        'enabledSkills',
+        context,
+        { cardKey: options.cardKey },
+      );
+      const globallyEnabled = new Set(
+        (
+          await this.project.calculationEngine.runQuery('globalSkills', context)
+        ).map((row) => row.key),
+      );
+      const summaries: SkillSummary[] = [];
+      for (const { key } of enabled) {
+        const resource = this.project.resources.byType(key, 'skills');
+        if (!resource) continue;
+        const skill = resource.show() as Skill;
+        if (options.category && skill.category !== options.category) continue;
+        summaries.push(
+          this.toSkillSummary(
+            skill,
+            globallyEnabled.has(key) ? 'global' : 'card',
+          ),
+        );
+      }
+      return summaries.sort((a, b) => a.name.localeCompare(b.name));
+    });
+  }
+
+  /**
+   * Returns a single enabled skill with its rendered instructions.
+   *
+   * The skill must be enabled by the logic programs. A card-specific skill
+   * requested without a cardKey cannot be rendered meaningfully, so a
+   * 'needs-card' marker is returned instead of throwing.
+   * @param name Full skill resource name.
+   * @param options.cardKey Card context for per-card template rendering.
+   * @param context Calculation context.
+   * @returns the rendered skill ('ok'), or a marker ('not-enabled' / 'needs-card').
+   */
+  public async getSkill(
+    name: string,
+    options: { cardKey?: string } = {},
+    context: Context = 'localApp',
+  ): Promise<SkillLookupResult> {
+    return this.project.lock.read(async () => {
+      const { cardKey } = options;
+      const enabled = (
+        await this.project.calculationEngine.runQuery(
+          'enabledSkills',
+          context,
+          {
+            cardKey,
+          },
+        )
+      ).map((row) => row.key);
+      if (!enabled.includes(name)) {
+        return { status: 'not-enabled' };
+      }
+      const globallyEnabled = (
+        await this.project.calculationEngine.runQuery('globalSkills', context)
+      ).map((row) => row.key);
+      const scope = globallyEnabled.includes(name) ? 'global' : 'card';
+      // A card-specific skill can't be rendered meaningfully without a cardKey.
+      if (scope === 'card' && !cardKey) {
+        return { status: 'needs-card' };
+      }
+      const resource = this.project.resources.byType(name, 'skills');
+      if (!resource) {
+        return { status: 'not-enabled' };
+      }
+      const skill = resource.show() as Skill;
+      const instructions = await generateReportContent({
+        calculate: this.project.calculationEngine,
+        contentTemplate: skill.content.skillContent,
+        queryTemplate: skill.content.skillQuery,
+        options: { cardKey },
+        context,
+      });
+      return {
+        status: 'ok',
+        skill: { ...this.toSkillSummary(skill, scope), instructions },
+      };
+    });
   }
 
   /**

--- a/tools/data-handler/src/interfaces/resource-interfaces.ts
+++ b/tools/data-handler/src/interfaces/resource-interfaces.ts
@@ -151,6 +151,28 @@ export interface SkillMetadata extends ResourceBaseMetadata {
   relatedTools: string[];
 }
 
+// Lightweight skill listing entry (list_skills / MCP discovery).
+export interface SkillSummary {
+  name: string;
+  displayName: string;
+  description?: string;
+  category?: string;
+  relatedTools: string[];
+  scope: 'global' | 'card';
+}
+
+// Full skill payload for get_skill: summary plus rendered instructions.
+export interface SkillDetails extends SkillSummary {
+  instructions: string;
+}
+
+// Discriminated result for getSkill: the enabled-and-rendered skill, or the
+// reason it cannot be returned (so callers report it without throwing).
+export type SkillLookupResult =
+  | { status: 'ok'; skill: SkillDetails }
+  | { status: 'not-enabled' }
+  | { status: 'needs-card' };
+
 // Base interface for all resources.
 export interface ResourceBaseMetadata {
   name: string;

--- a/tools/data-handler/src/types/queries.ts
+++ b/tools/data-handler/src/types/queries.ts
@@ -77,6 +77,8 @@ export interface ParseResult<T extends BaseResult> {
 export const queries = [
   'card',
   'connectors',
+  'enabledSkills',
+  'globalSkills',
   'onCreation',
   'onTransition',
   'tree',
@@ -87,6 +89,8 @@ export type QueryName = (typeof queries)[number];
 export type QueryMap = {
   card: CardQueryResult;
   connectors: ConnectorQueryResult;
+  enabledSkills: BaseResult;
+  globalSkills: BaseResult;
   onCreation: FieldsToUpdateQueryResult;
   onTransition: FieldsToUpdateQueryResult;
   tree: TreeQueryResult;

--- a/tools/data-handler/src/types/queries.ts
+++ b/tools/data-handler/src/types/queries.ts
@@ -78,7 +78,6 @@ export const queries = [
   'card',
   'connectors',
   'enabledSkills',
-  'globalSkills',
   'onCreation',
   'onTransition',
   'tree',
@@ -89,8 +88,7 @@ export type QueryName = (typeof queries)[number];
 export type QueryMap = {
   card: CardQueryResult;
   connectors: ConnectorQueryResult;
-  enabledSkills: BaseResult;
-  globalSkills: BaseResult;
+  enabledSkills: EnabledSkillQueryResult;
   onCreation: FieldsToUpdateQueryResult;
   onTransition: FieldsToUpdateQueryResult;
   tree: TreeQueryResult;
@@ -122,6 +120,9 @@ interface ConnectorQueryResult extends BaseResult {
   connector?: string;
   itemKey?: string;
   title?: string;
+}
+interface EnabledSkillQueryResult extends BaseResult {
+  scope: 'global' | 'card';
 }
 interface FieldsToUpdateQueryResult extends BaseResult {
   updateFields: UpdateField[];

--- a/tools/data-handler/test/skill-discovery.test.ts
+++ b/tools/data-handler/test/skill-discovery.test.ts
@@ -1,0 +1,211 @@
+import { expect, it, describe, beforeAll, afterAll } from 'vitest';
+import { mkdirSync, rmSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { CommandManager } from '../src/command-manager.js';
+import { copyDir } from '../src/utils/file-utils.js';
+
+const baseDir = import.meta.dirname;
+const testDir = join(baseDir, 'tmp-skill-discovery-tests');
+const projectPath = join(testDir, 'valid/decision-records');
+const skillsFolder = join(projectPath, '.cards/local/skills');
+const calcFolder = join(projectPath, '.cards/local/calculations');
+
+async function seedSkill(
+  id: string,
+  {
+    query = '',
+    content = `# ${id}\n`,
+    category,
+    relatedTools = [],
+  }: {
+    query?: string;
+    content?: string;
+    category?: string;
+    relatedTools?: string[];
+  } = {},
+) {
+  await mkdir(join(skillsFolder, id), { recursive: true });
+  await writeFile(
+    join(skillsFolder, '.schema'),
+    JSON.stringify([{ version: 1, id: 'skillSchema' }]),
+    'utf-8',
+  );
+  await writeFile(
+    join(skillsFolder, `${id}.json`),
+    JSON.stringify({
+      name: `decision/skills/${id}`,
+      displayName: id,
+      relatedTools,
+      ...(category ? { category } : {}),
+    }),
+    'utf-8',
+  );
+  await writeFile(join(skillsFolder, id, 'skill.md'), content, 'utf-8');
+  await writeFile(join(skillsFolder, id, 'query.lp'), query, 'utf-8');
+}
+
+async function seedEnableCalc(lp: string) {
+  await mkdir(join(calcFolder, 'enable'), { recursive: true });
+  await writeFile(
+    join(calcFolder, 'enable.json'),
+    JSON.stringify({
+      name: 'decision/calculations/enable',
+      displayName: 'enable',
+      calculation: '',
+    }),
+    'utf-8',
+  );
+  await writeFile(join(calcFolder, 'enable', 'calculation.lp'), lp, 'utf-8');
+}
+
+describe('skill discovery', () => {
+  let commands: CommandManager;
+
+  beforeAll(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir('test/test-data/', testDir);
+    await seedSkill('globalSkill', {
+      category: 'general',
+      relatedTools: ['query_cards', 'update_card'],
+      content: '# Global skill\nUse this any time.\n',
+    });
+    await seedSkill('complianceSkill', {
+      category: 'compliance',
+      content: '# Compliance skill\n',
+    });
+    await seedSkill('cardSkill', {
+      query: 'result({{cardKey}}).\n',
+      content: '# Card skill\nApplies to {{cardKey}}.\n',
+    });
+    await seedEnableCalc(
+      'enableSkill("decision/skills/globalSkill").\n' +
+        'enableSkill("decision/skills/complianceSkill").\n' +
+        'enableSkill("decision/skills/cardSkill", decision_5).\n',
+    );
+    commands = await CommandManager.getInstance(projectPath);
+  });
+
+  afterAll(() => {
+    commands.project.dispose();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  describe('enabledSkills query round-trip', () => {
+    it('returns string skill-name keys (global + all per-card) without a cardKey', async () => {
+      const keys = (
+        await commands.project.calculationEngine.runQuery('enabledSkills')
+      ).map((r) => r.key);
+      expect(keys).toContain('decision/skills/globalSkill');
+      expect(keys).toContain('decision/skills/cardSkill');
+    });
+
+    it('with a non-matching cardKey excludes per-card skills', async () => {
+      const keys = (
+        await commands.project.calculationEngine.runQuery(
+          'enabledSkills',
+          'localApp',
+          { cardKey: 'decision_1' },
+        )
+      ).map((r) => r.key);
+      expect(keys).toContain('decision/skills/globalSkill');
+      expect(keys).not.toContain('decision/skills/cardSkill');
+    });
+  });
+
+  describe('listSkills', () => {
+    it('without a cardKey lists all enabled skills (global + per-card)', async () => {
+      const names = (await commands.showCmd.listSkills()).map((s) => s.name);
+      expect(names).toEqual([
+        'decision/skills/cardSkill',
+        'decision/skills/complianceSkill',
+        'decision/skills/globalSkill',
+      ]);
+    });
+
+    it('with a cardKey lists global skills plus that card’s skills', async () => {
+      const names = (
+        await commands.showCmd.listSkills({ cardKey: 'decision_1' })
+      ).map((s) => s.name);
+      expect(names).toContain('decision/skills/globalSkill');
+      expect(names).toContain('decision/skills/complianceSkill');
+      expect(names).not.toContain('decision/skills/cardSkill');
+    });
+
+    it('filters by category', async () => {
+      const skills = await commands.showCmd.listSkills({
+        category: 'compliance',
+      });
+      expect(skills.map((s) => s.name)).toEqual([
+        'decision/skills/complianceSkill',
+      ]);
+    });
+
+    it('returns the lightweight summary fields', async () => {
+      const global = (await commands.showCmd.listSkills()).find(
+        (s) => s.name === 'decision/skills/globalSkill',
+      );
+      expect(global).toMatchObject({
+        displayName: 'globalSkill',
+        category: 'general',
+        relatedTools: ['query_cards', 'update_card'],
+        scope: 'global',
+      });
+      // listing is lightweight — no rendered instructions
+      expect(global).not.toHaveProperty('instructions');
+    });
+
+    it('marks each skill global or card scope', async () => {
+      const byName = new Map(
+        (await commands.showCmd.listSkills()).map((s) => [s.name, s.scope]),
+      );
+      expect(byName.get('decision/skills/globalSkill')).toBe('global');
+      expect(byName.get('decision/skills/cardSkill')).toBe('card');
+    });
+  });
+
+  describe('getSkill', () => {
+    it('renders a globally-enabled skill', async () => {
+      const result = await commands.showCmd.getSkill(
+        'decision/skills/globalSkill',
+      );
+      expect(result.status).toBe('ok');
+      if (result.status !== 'ok') return;
+      expect(result.skill.instructions).toContain('Use this any time.');
+      expect(result.skill.relatedTools).toEqual(['query_cards', 'update_card']);
+    });
+
+    it('renders a per-card skill with the cardKey interpolated', async () => {
+      const result = await commands.showCmd.getSkill(
+        'decision/skills/cardSkill',
+        { cardKey: 'decision_5' },
+      );
+      expect(result.status).toBe('ok');
+      if (result.status !== 'ok') return;
+      expect(result.skill.instructions).toContain('Applies to decision_5.');
+    });
+
+    it('asks for a cardKey when a per-card skill is requested without one', async () => {
+      const result = await commands.showCmd.getSkill(
+        'decision/skills/cardSkill',
+      );
+      expect(result.status).toBe('needs-card');
+    });
+
+    it('reports not-enabled for a per-card skill requested with the wrong card', async () => {
+      const result = await commands.showCmd.getSkill(
+        'decision/skills/cardSkill',
+        { cardKey: 'decision_1' },
+      );
+      expect(result.status).toBe('not-enabled');
+    });
+
+    it('reports not-enabled for an unknown skill', async () => {
+      const result = await commands.showCmd.getSkill(
+        'decision/skills/doesNotExist',
+      );
+      expect(result.status).toBe('not-enabled');
+    });
+  });
+});

--- a/tools/mcp/src/tools/index.ts
+++ b/tools/mcp/src/tools/index.ts
@@ -425,6 +425,75 @@ export function registerTools(
     },
   );
 
+  server.registerTool(
+    'list_skills',
+    {
+      description:
+        "List the skills currently enabled for this project. Skills are enabled dynamically by the project logic, so re-check before acting - availability can change. Returns lightweight summaries; call get_skill for full instructions. Each skill has a `scope`: 'global' (usable anywhere) or 'card' (enabled for specific cards - pass a cardKey to get_skill).",
+      inputSchema: {
+        projectPrefix: projectPrefixParam,
+        category: z
+          .string()
+          .optional()
+          .describe('Only return skills in this category.'),
+        cardKey: z
+          .string()
+          .optional()
+          .describe(
+            'Only return skills enabled for this card (in addition to globally-enabled skills).',
+          ),
+      },
+    },
+    async ({ projectPrefix, category, cardKey }) => {
+      try {
+        const commands = resolveCommands(provider, projectPrefix);
+        const skills = await commands.showCmd.listSkills({ category, cardKey });
+        return toolResult({ skills });
+      } catch (error) {
+        return toolError('listing skills', error);
+      }
+    },
+  );
+
+  server.registerTool(
+    'get_skill',
+    {
+      description:
+        'Get the full rendered instructions for a single enabled skill by name. Pass cardKey for a skill that applies to a specific card.',
+      inputSchema: {
+        projectPrefix: projectPrefixParam,
+        name: z
+          .string()
+          .describe('The skill name, e.g. "mod/skills/manageRiskRegister".'),
+        cardKey: z
+          .string()
+          .optional()
+          .describe('Card context for rendering a card-specific skill.'),
+      },
+    },
+    async ({ projectPrefix, name, cardKey }) => {
+      try {
+        const commands = resolveCommands(provider, projectPrefix);
+        const result = await commands.showCmd.getSkill(name, { cardKey });
+        if (result.status === 'not-enabled') {
+          return toolResult({
+            enabled: false,
+            message: `Skill '${name}' is not currently enabled. Call list_skills to see the enabled skills.`,
+          });
+        }
+        if (result.status === 'needs-card') {
+          return toolResult({
+            enabled: true,
+            message: `Skill '${name}' is enabled for specific cards. Call get_skill again with a 'cardKey' to render it.`,
+          });
+        }
+        return toolResult({ skill: result.skill });
+      } catch (error) {
+        return toolError('getting skill', error);
+      }
+    },
+  );
+
   // --- Phase 1: Quick Wins ---
 
   server.registerTool(

--- a/tools/mcp/test/skills.test.ts
+++ b/tools/mcp/test/skills.test.ts
@@ -1,0 +1,187 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { beforeAll, afterAll, describe, expect, test } from 'vitest';
+import { cp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { CommandManager } from '@cyberismo/data-handler';
+import { createMcpServer, singleProjectProvider } from '../src/server.js';
+import { testDataPath } from './test-utils.js';
+
+const baseDir = import.meta.dirname;
+const projectPath = join(baseDir, 'tmp-skills-mcp');
+const skillsFolder = join(projectPath, '.cards/local/skills');
+const calcFolder = join(projectPath, '.cards/local/calculations');
+
+let commands: CommandManager;
+let client: Client;
+
+type TextContent = { type: string; text: string };
+const parse = (result: Record<string, unknown>) =>
+  JSON.parse((result.content as TextContent[])[0].text);
+
+async function seedSkill(
+  id: string,
+  { query = '', content = `# ${id}\n`, relatedTools = [] as string[] } = {},
+) {
+  await mkdir(join(skillsFolder, id), { recursive: true });
+  await writeFile(
+    join(skillsFolder, '.schema'),
+    JSON.stringify([{ version: 1, id: 'skillSchema' }]),
+    'utf-8',
+  );
+  await writeFile(
+    join(skillsFolder, `${id}.json`),
+    JSON.stringify({
+      name: `decision/skills/${id}`,
+      displayName: id,
+      relatedTools,
+    }),
+    'utf-8',
+  );
+  await writeFile(join(skillsFolder, id, 'skill.md'), content, 'utf-8');
+  await writeFile(join(skillsFolder, id, 'query.lp'), query, 'utf-8');
+}
+
+beforeAll(async () => {
+  process.argv = [];
+  await rm(projectPath, { recursive: true, force: true });
+  await cp(testDataPath, projectPath, { recursive: true });
+
+  await seedSkill('globalSkill', {
+    relatedTools: ['query_cards'],
+    content: '# Global skill\nUse this any time.\n',
+  });
+  await seedSkill('cardSkill', {
+    query: 'result({{cardKey}}).\n',
+    content: '# Card skill\nApplies to {{cardKey}}.\n',
+  });
+  await mkdir(join(calcFolder, 'enable'), { recursive: true });
+  await writeFile(
+    join(calcFolder, 'enable.json'),
+    JSON.stringify({
+      name: 'decision/calculations/enable',
+      displayName: 'enable',
+      calculation: '',
+    }),
+    'utf-8',
+  );
+  await writeFile(
+    join(calcFolder, 'enable', 'calculation.lp'),
+    'enableSkill("decision/skills/globalSkill").\n' +
+      'enableSkill("decision/skills/cardSkill", decision_5).\n',
+    'utf-8',
+  );
+
+  commands = await CommandManager.getInstance(projectPath);
+  const server = createMcpServer(singleProjectProvider(commands));
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  client = new Client({ name: 'test-client', version: '1.0.0' });
+  await client.connect(clientTransport);
+});
+
+afterAll(async () => {
+  await client.close();
+  commands.project.dispose();
+  await rm(projectPath, { recursive: true, force: true });
+});
+
+describe('skill discovery MCP tools', () => {
+  test('list_skills returns enabled skills', async () => {
+    const result = await client.callTool({
+      name: 'list_skills',
+      arguments: { projectPrefix: 'decision' },
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = parse(result);
+    const names = parsed.skills.map((s: { name: string }) => s.name);
+    expect(names).toContain('decision/skills/globalSkill');
+    expect(names).toContain('decision/skills/cardSkill');
+    const global = parsed.skills.find(
+      (s: { name: string }) => s.name === 'decision/skills/globalSkill',
+    );
+    expect(global.relatedTools).toEqual(['query_cards']);
+    expect(global.scope).toBe('global');
+    const card = parsed.skills.find(
+      (s: { name: string }) => s.name === 'decision/skills/cardSkill',
+    );
+    expect(card.scope).toBe('card');
+  });
+
+  test('list_skills with cardKey excludes other cards’ skills', async () => {
+    const result = await client.callTool({
+      name: 'list_skills',
+      arguments: { projectPrefix: 'decision', cardKey: 'decision_1' },
+    });
+    const names = parse(result).skills.map((s: { name: string }) => s.name);
+    expect(names).toContain('decision/skills/globalSkill');
+    expect(names).not.toContain('decision/skills/cardSkill');
+  });
+
+  test('get_skill renders a globally-enabled skill', async () => {
+    const result = await client.callTool({
+      name: 'get_skill',
+      arguments: {
+        projectPrefix: 'decision',
+        name: 'decision/skills/globalSkill',
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = parse(result);
+    expect(parsed.skill.instructions).toContain('Use this any time.');
+  });
+
+  test('get_skill renders a per-card skill with the cardKey', async () => {
+    const result = await client.callTool({
+      name: 'get_skill',
+      arguments: {
+        projectPrefix: 'decision',
+        name: 'decision/skills/cardSkill',
+        cardKey: 'decision_5',
+      },
+    });
+    const parsed = parse(result);
+    expect(parsed.skill.instructions).toContain('Applies to decision_5.');
+  });
+
+  test('get_skill asks for a cardKey for a per-card skill', async () => {
+    const result = await client.callTool({
+      name: 'get_skill',
+      arguments: {
+        projectPrefix: 'decision',
+        name: 'decision/skills/cardSkill',
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = parse(result);
+    expect(parsed.enabled).toBe(true);
+    expect(parsed.message).toMatch(/cardKey/);
+  });
+
+  test('get_skill reports a not-enabled skill without erroring', async () => {
+    const result = await client.callTool({
+      name: 'get_skill',
+      arguments: { projectPrefix: 'decision', name: 'decision/skills/nope' },
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = parse(result);
+    expect(parsed.enabled).toBe(false);
+    expect(parsed.message).toMatch(/not currently enabled/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds dynamic skill discovery via two MCP tools (INTDEV-1334). Skills are enabled at runtime by the project's logic programs — `enableSkill(S)` (global) or `enableSkill(S, Card)` (per-card) — and agents discover the currently-enabled ones and fetch their server-rendered content on demand.

## Changes

- **MCP tools** (`tools/mcp/src/tools/index.ts`):
  - `list_skills(category?, cardKey?)` — lightweight summaries of the enabled skills.
  - `get_skill(name, cardKey?)` — full rendered `instructions` for one skill. Not-enabled / needs-cardKey cases return a friendly message rather than an error.
- **Enablement queries** (`tools/assets/src/calculations/queries/`): `enabledSkills.lp` (encodes the global-XOR-per-card rule + `cardKey` filtering) and `globalSkills.lp`, registered in `lpFiles.queries` + `QueryName`.
- **Discovery in the data-handler** (`commands/show.ts`): `Show.listSkills` / `Show.getSkill` resolve enablement, look up metadata, and render `skill.md` server-side via the existing `generateReportContent`. Kept in the command layer so a future backend/UI reuses it; MCP is a thin wrapper.
- **`scope` field**: each listing entry reports `scope: 'global' | 'card'` so an agent knows which skills need a `cardKey`.
- A skill is enabled either globally or per-card (not both); if both, global wins.
