### PR TITLE
INTDEV-1336 Static bootstrap skill & install-skills command

### DIFF
--- a/tools/assets/src/static/agentSkills/dynamic-skill-discovery/SKILL.md
+++ b/tools/assets/src/static/agentSkills/dynamic-skill-discovery/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: dynamic-skill-discovery
+description: Discover and apply Cyberismo project skills via the MCP server. Use before acting on any task in a Cyberismo project.
+---
+
+# Dynamic Skill Discovery
+
+This project uses a dynamic skill system managed by the Cyberismo platform.
+Available skills change based on the current state of project resources, workflow
+steps, and application context.
+
+## Discovering available skills
+
+Before acting on a task, check what skills are available:
+
+1. Call the `list_skills` tool on the Cyberismo MCP server to see all currently
+   enabled skills. You can filter by `category` or `cardKey` if you know the context.
+2. Review the returned skill names and descriptions to identify which skills are
+   relevant to the task at hand. Each skill has a `scope`: `global` (usable
+   anywhere) or `card` (enabled for specific cards — pass a `cardKey` to `get_skill`).
+3. Call the `get_skill` tool with the skill's `name` to retrieve full instructions
+   for any skill you need to apply.
+
+## Applying a discovered skill
+
+Each skill returned by `get_skill` contains: metadata (name, description, category),
+a `relatedTools` array listing the MCP tools used by the skill, and full instructions
+in the `instructions` field. Follow the instructions as you would any project skill.
+The `relatedTools` field tells you which tools you will need.
+
+## Important
+
+- Do not cache or assume skill availability across tasks. Always re-discover before
+  acting, as available skills may have changed.
+- Skills are enabled by the project's logic rules. If a skill you expect is not
+  listed, its preconditions are not currently met.
+- Prefer `list_skills` first, then `get_skill` for specific skills, rather than
+  fetching all skill contents at once.

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -1588,6 +1588,40 @@ validateCmd.action(async (options: CommandOptions<'validate'>) => {
   handleResponse(result);
 });
 
+// Install the dynamic skill discovery bootstrap skill + MCP config for an AI agent.
+const installSkillsCmd = new Command('install-skills')
+  .description(
+    'Install the dynamic skill discovery bootstrap skill and MCP server configuration for an AI agent platform. Installs into the current directory by default — run it from (or pass) the directory your AI agent operates in, usually the repository root.',
+  )
+  .argument(
+    '[path]',
+    'Directory to install into. Defaults to the current directory; set it to where your AI agent runs (e.g. the repository root) if that differs from where you run this command.',
+  )
+  .addOption(
+    new Option('-t, --target <platform>', 'Target AI agent platform')
+      .choices(['claude'])
+      .default('claude'),
+  )
+  .option(
+    '--url <url>',
+    'MCP server URL to register',
+    'http://localhost:3000/mcp',
+  );
+program.addCommand(installSkillsCmd);
+installSkillsCmd.action(
+  async (
+    path: string | undefined,
+    options: CommandOptions<'installSkills'>,
+  ) => {
+    const result = await commandHandler.command(
+      Cmd.installSkills,
+      [resolve(path ?? process.cwd())],
+      Object.assign({}, options, program.opts()),
+    );
+    handleResponse(result);
+  },
+);
+
 // Start app command.
 // If there are validation errors, user is prompted to continue or not.
 // There is 10 sec timeout on the prompt. If user does not reply, then

--- a/tools/cli/test/cli.test.ts
+++ b/tools/cli/test/cli.test.ts
@@ -2,7 +2,7 @@ import { expect, it, describe, beforeAll, afterAll } from 'vitest';
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
 import { join } from 'node:path';
-import { mkdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
 
 const execAsync = promisify(exec);
 
@@ -288,5 +288,18 @@ describe('Cli BAT test', function () {
     );
     expect(stdout).toContain('Done');
     expect(stdout).toContain('Project structure validated');
+  });
+  it('Install skill discovery bootstrap (claude target)', async () => {
+    const { stdout } = await execAsync(
+      `cd ${cliPath} && ${cli} install-skills`,
+    );
+    expect(stdout).toContain('Installed skill discovery');
+    expect(stdout).toContain('.claude/skills/dynamic-skill-discovery/SKILL.md');
+    expect(existsSync(join(cliPath, '.mcp.json'))).toBe(true);
+    expect(
+      existsSync(
+        join(cliPath, '.claude/skills/dynamic-skill-discovery/SKILL.md'),
+      ),
+    ).toBe(true);
   });
 }, 100000);

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -39,6 +39,7 @@ import type {
   AllCommandOptions,
   CalcCommandOptions,
   ExportCommandOptions,
+  InstallSkillsCommandOptions,
   MigrateCommandOptions,
   ReportCommandOptions,
   ShowCommandOptions,
@@ -49,6 +50,7 @@ import type {
 import type { requestStatus } from './interfaces/request-status-interfaces.js';
 
 import { Create } from './commands/create.js';
+import { InstallSkills } from './commands/install-skills.js';
 import { Validate } from './commands/validate.js';
 import { CommandManager } from './command-manager.js';
 import type {
@@ -77,6 +79,7 @@ export const Cmd = {
   export: 'export',
   fetch: 'fetch',
   import: 'import',
+  installSkills: 'install-skills',
   migrate: 'migrate',
   move: 'move',
   publish: 'publish',
@@ -139,13 +142,17 @@ export class Commands {
   ): Promise<requestStatus> {
     // Set project path and validate it.
     const creatingNewProject = command === Cmd.create && args[0] === 'project';
-    if (!creatingNewProject) {
+    // install-skills writes into a target directory (often a repo root, not a
+    // Cyberismo project), so it does not load/validate a project.
+    const projectNotRequired =
+      creatingNewProject || command === Cmd.installSkills;
+    if (!projectNotRequired) {
       try {
         await this.doSetProject(options);
       } catch (error) {
         return { statusCode: 400, message: errorFunction(error) };
       }
-    } else {
+    } else if (creatingNewProject) {
       this.projectPath = options.projectPath || '';
     }
     return await this.doHandleCommand(command, args, options, credentials);
@@ -307,6 +314,18 @@ export class Commands {
         } else {
           throw new Error(`Unknown type to create: '${target}'`);
         }
+      } else if (command === Cmd.installSkills) {
+        const [targetPath] = args;
+        const written = await InstallSkills.install(
+          targetPath,
+          options as InstallSkillsCommandOptions,
+        );
+        return {
+          statusCode: 200,
+          message: `Installed skill discovery into '${targetPath}':\n${written
+            .map((path) => `  ${path}`)
+            .join('\n')}`,
+        };
       } else if (command === Cmd.edit) {
         const [cardKey] = args;
         await this.commands?.editCmd.editCard(cardKey);

--- a/tools/data-handler/src/commands/install-skills.ts
+++ b/tools/data-handler/src/commands/install-skills.ts
@@ -1,0 +1,130 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { mkdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { getStaticDirectoryPath } from '@cyberismo/assets';
+
+import {
+  copyDir,
+  pathExists,
+  resolveTilde,
+  writeFileSafe,
+} from '../utils/file-utils.js';
+import { readJsonFile, writeJsonFile } from '../utils/json.js';
+
+import type { InstallSkillsCommandOptions } from '../interfaces/command-options.js';
+
+const SUPPORTED_TARGETS = ['claude'] as const;
+type InstallTarget = (typeof SUPPORTED_TARGETS)[number];
+
+const DEFAULT_MCP_URL = 'http://localhost:3000/mcp';
+
+// Markers delimiting the Cyberismo-managed block in CLAUDE.md, so the block can
+// be replaced idempotently without touching the user's own content.
+const CLAUDE_MD_BEGIN = '<!-- cyberismo:begin -->';
+const CLAUDE_MD_END = '<!-- cyberismo:end -->';
+const CLAUDE_MD_POINTER = [
+  'This project uses Cyberismo dynamic skills. Before acting, call `list_skills`',
+  'on the cyberismo MCP server and `get_skill` for any relevant skill it returns.',
+  'See `.claude/skills/dynamic-skill-discovery`.',
+].join('\n');
+
+/**
+ * Installs the static bootstrap skill and platform configuration that lets an AI
+ * agent discover Cyberismo's dynamic skills via the MCP server. Writes into a
+ * target directory (typically the repository root) — not a loaded project — and
+ * is idempotent: safe to run repeatedly.
+ */
+export class InstallSkills {
+  /**
+   * @param targetPath Directory to install into.
+   * @param options.target Target platform.
+   * @param options.url MCP server URL to register (defaults to localhost:3000).
+   * @returns paths (relative to targetPath) that were written.
+   * @throws if the target platform is not supported.
+   */
+  public static async install(
+    targetPath: string,
+    options: InstallSkillsCommandOptions = {},
+  ): Promise<string[]> {
+    const target = (options.target ?? 'claude') as InstallTarget;
+    if (!SUPPORTED_TARGETS.includes(target)) {
+      throw new Error(
+        `Unsupported target '${target}'. Supported targets: ${SUPPORTED_TARGETS.join(', ')}`,
+      );
+    }
+
+    const root = resolveTilde(targetPath);
+    await mkdir(root, { recursive: true });
+    const url = options.url ?? DEFAULT_MCP_URL;
+    const written: string[] = [];
+
+    const skillSource = join(
+      await getStaticDirectoryPath(),
+      'agentSkills',
+      'dynamic-skill-discovery',
+    );
+    const skillDest = join(
+      root,
+      '.claude',
+      'skills',
+      'dynamic-skill-discovery',
+    );
+    await copyDir(skillSource, skillDest);
+    written.push('.claude/skills/dynamic-skill-discovery/SKILL.md');
+
+    const mcpPath = join(root, '.mcp.json');
+    const config = pathExists(mcpPath)
+      ? ((await readJsonFile(mcpPath)) as McpConfig)
+      : {};
+    config.mcpServers = {
+      ...config.mcpServers,
+      cyberismo: { type: 'http', url },
+    };
+    await writeJsonFile(mcpPath, config);
+    written.push('.mcp.json');
+
+    const claudeMdPath = join(root, 'CLAUDE.md');
+    const existing = pathExists(claudeMdPath)
+      ? await readFile(claudeMdPath, 'utf-8')
+      : '';
+    await writeFileSafe(claudeMdPath, upsertMarkerBlock(existing));
+    written.push('CLAUDE.md');
+
+    return written;
+  }
+}
+
+interface McpConfig {
+  mcpServers?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+// Inserts or replaces the Cyberismo-managed block in CLAUDE.md content.
+function upsertMarkerBlock(existing: string): string {
+  const block = `${CLAUDE_MD_BEGIN}\n${CLAUDE_MD_POINTER}\n${CLAUDE_MD_END}`;
+  const begin = existing.indexOf(CLAUDE_MD_BEGIN);
+  const end = existing.indexOf(CLAUDE_MD_END);
+  if (begin !== -1 && end !== -1 && end > begin) {
+    const before = existing.slice(0, begin);
+    const after = existing.slice(end + CLAUDE_MD_END.length);
+    return `${(before + block + after).trimEnd()}\n`;
+  }
+  if (existing.trim() === '') {
+    return `${block}\n`;
+  }
+  return `${existing.trimEnd()}\n\n${block}\n`;
+}

--- a/tools/data-handler/src/commands/install-skills.ts
+++ b/tools/data-handler/src/commands/install-skills.ts
@@ -23,7 +23,7 @@ import {
   resolveTilde,
   writeFileSafe,
 } from '../utils/file-utils.js';
-import { readJsonFile, writeJsonFile } from '../utils/json.js';
+import { formatJson, readJsonFile } from '../utils/json.js';
 
 import type { InstallSkillsCommandOptions } from '../interfaces/command-options.js';
 
@@ -94,7 +94,7 @@ export class InstallSkills {
       ...config.mcpServers,
       cyberismo: { type: 'http', url },
     };
-    await writeJsonFile(mcpPath, config);
+    await writeFileSafe(mcpPath, formatJson(config));
     written.push('.mcp.json');
 
     const claudeMdPath = join(root, 'CLAUDE.md');

--- a/tools/data-handler/src/interfaces/command-options.ts
+++ b/tools/data-handler/src/interfaces/command-options.ts
@@ -120,6 +120,12 @@ export type UpdateModulesCommandOptions = BaseCommandOptions;
 // Options for 'validate' command
 export type ValidateCommandOptions = BaseCommandOptions;
 
+// Options for 'installSkills' command
+export interface InstallSkillsCommandOptions extends BaseCommandOptions {
+  target?: string;
+  url?: string;
+}
+
 // All possible command options
 export type AllCommandOptions =
   | AddCommandOptions
@@ -130,6 +136,7 @@ export type AllCommandOptions =
   | ExportCommandOptions
   | FetchCommandOptions
   | ImportCommandOptions
+  | InstallSkillsCommandOptions
   | MigrateCommandOptions
   | MoveCommandOptions
   | PublishCommandOptions
@@ -155,6 +162,7 @@ export type CommandOptions<T extends CmdKey> = {
   export: ExportCommandOptions;
   fetch: FetchCommandOptions;
   import: ImportCommandOptions;
+  installSkills: InstallSkillsCommandOptions;
   migrate: MigrateCommandOptions;
   move: MoveCommandOptions;
   publish: PublishCommandOptions;

--- a/tools/data-handler/test/command-install-skills.test.ts
+++ b/tools/data-handler/test/command-install-skills.test.ts
@@ -1,0 +1,118 @@
+import { expect, it, describe, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync } from 'node:fs';
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { Cmd, Commands } from '../src/command-handler.js';
+
+const baseDir = import.meta.dirname;
+const testDir = join(baseDir, 'tmp-install-skills-tests');
+
+const commandHandler = new Commands();
+
+const skillPath = join(
+  testDir,
+  '.claude/skills/dynamic-skill-discovery/SKILL.md',
+);
+const mcpPath = join(testDir, '.mcp.json');
+const claudeMdPath = join(testDir, 'CLAUDE.md');
+
+async function readMcp(): Promise<{
+  mcpServers?: Record<string, { type?: string; url?: string }>;
+  [k: string]: unknown;
+}> {
+  return JSON.parse(await readFile(mcpPath, 'utf-8'));
+}
+
+describe('install-skills command', () => {
+  beforeEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+    mkdirSync(testDir, { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('installs the bootstrap skill, MCP config and CLAUDE.md pointer', async () => {
+    const result = await commandHandler.command(
+      Cmd.installSkills,
+      [testDir],
+      {},
+    );
+    expect(result.statusCode).toBe(200);
+
+    const skill = await readFile(skillPath, 'utf-8');
+    expect(skill).toContain('name: dynamic-skill-discovery');
+    expect(skill).toContain('# Dynamic Skill Discovery');
+
+    const mcp = await readMcp();
+    expect(mcp.mcpServers?.cyberismo).toEqual({
+      type: 'http',
+      url: 'http://localhost:3000/mcp',
+    });
+
+    const claudeMd = await readFile(claudeMdPath, 'utf-8');
+    expect(claudeMd).toContain('<!-- cyberismo:begin -->');
+    expect(claudeMd).toContain('list_skills');
+  });
+
+  it('honors a custom --url', async () => {
+    await commandHandler.command(Cmd.installSkills, [testDir], {
+      url: 'http://localhost:9999/mcp',
+    });
+    const mcp = await readMcp();
+    expect(mcp.mcpServers?.cyberismo?.url).toBe('http://localhost:9999/mcp');
+  });
+
+  it('is idempotent — running twice does not duplicate', async () => {
+    await commandHandler.command(Cmd.installSkills, [testDir], {});
+    await commandHandler.command(Cmd.installSkills, [testDir], {});
+
+    const mcp = await readMcp();
+    // exactly one cyberismo server, still valid JSON
+    expect(Object.keys(mcp.mcpServers ?? {})).toEqual(['cyberismo']);
+
+    const claudeMd = await readFile(claudeMdPath, 'utf-8');
+    const blocks = claudeMd.match(/<!-- cyberismo:begin -->/g) ?? [];
+    expect(blocks).toHaveLength(1);
+  });
+
+  it('preserves existing .mcp.json servers and CLAUDE.md content', async () => {
+    await writeFile(
+      mcpPath,
+      JSON.stringify({ mcpServers: { other: { type: 'http', url: 'x' } } }),
+      'utf-8',
+    );
+    await writeFile(claudeMdPath, '# My project\n\nMy own notes.\n', 'utf-8');
+
+    await commandHandler.command(Cmd.installSkills, [testDir], {});
+
+    const mcp = await readMcp();
+    expect(mcp.mcpServers?.other).toEqual({ type: 'http', url: 'x' });
+    expect(mcp.mcpServers?.cyberismo).toBeDefined();
+
+    const claudeMd = await readFile(claudeMdPath, 'utf-8');
+    expect(claudeMd).toContain('My own notes.');
+    expect(claudeMd).toContain('<!-- cyberismo:begin -->');
+  });
+
+  it('rejects an unsupported target', async () => {
+    const result = await commandHandler.command(Cmd.installSkills, [testDir], {
+      target: 'github',
+    });
+    expect(result.statusCode).toBe(400);
+    expect(result.message).toMatch(/Unsupported target/);
+  });
+
+  it('creates the target directory if it does not exist', async () => {
+    const nested = join(testDir, 'repo-root');
+    const result = await commandHandler.command(
+      Cmd.installSkills,
+      [nested],
+      {},
+    );
+    expect(result.statusCode).toBe(200);
+    const mcp = JSON.parse(await readFile(join(nested, '.mcp.json'), 'utf-8'));
+    expect(mcp.mcpServers.cyberismo).toBeDefined();
+  });
+});

--- a/tools/data-handler/test/command-install-skills.test.ts
+++ b/tools/data-handler/test/command-install-skills.test.ts
@@ -115,4 +115,16 @@ describe('install-skills command', () => {
     const mcp = JSON.parse(await readFile(join(nested, '.mcp.json'), 'utf-8'));
     expect(mcp.mcpServers.cyberismo).toBeDefined();
   });
+
+  it('reports failure when .mcp.json cannot be written', async () => {
+    // Make .mcp.json a directory so writeFile fails deterministically (EISDIR),
+    // and verify the failure is surfaced instead of reported as success.
+    mkdirSync(mcpPath, { recursive: true });
+    const result = await commandHandler.command(
+      Cmd.installSkills,
+      [testDir],
+      {},
+    );
+    expect(result.statusCode).not.toBe(200);
+  });
 });


### PR DESCRIPTION
## Summary

Adds a `cyberismo install-skills [path] [--target claude] [--url <url>]` command that installs the dynamic skill discovery bootstrap skill and MCP server configuration for an AI agent, idempotently. This lets a user point an agent (e.g. Claude Code) at a Cyberismo project and have it discover and apply the project's skills via the MCP server.

## Changes

- **Bootstrap skill** (`tools/assets/src/static/agentSkills/dynamic-skill-discovery/SKILL.md`): a static skill (Claude agent-skill format) instructing agents to call `list_skills` / `get_skill` before acting, shipped via `@cyberismo/assets`.
- **`install-skills` command** (`tools/data-handler/src/commands/install-skills.ts`): for the `claude` target, writes — idempotently — into the install directory:
  - `.claude/skills/dynamic-skill-discovery/SKILL.md` (the bootstrap skill),
  - `.mcp.json` with the `cyberismo` MCP server (merge that preserves any other servers),
  - a marker-delimited pointer block in `CLAUDE.md` (always-loaded, so the agent knows to discover skills).
- Wired via `Cmd.installSkills` (project-not-required, like `create project`) + command-handler dispatch; `InstallSkillsCommandOptions` for `--target` / `--url`.
- **CLI** (`tools/cli/src/index.ts`): the `install-skills` command. Defaults the install dir to the current directory (the directory the AI agent runs from — usually the repo root) and prints the resolved absolute path; `--target` is validated (only `claude` initially).
- Idempotent: re-running yields one `cyberismo` server entry and one `CLAUDE.md` block; existing `.mcp.json` / `CLAUDE.md` content is preserved.
