### PR TITLE
INTDEV-1369 Fix dev mode startup race and watch output

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "prettier-check": "prettier --check .",
     "prettier-fix": "prettier --write .",
     "cyberismo": "node tools/cli/bin/run",
-    "dev": "pnpm -r --parallel dev",
+    "dev": "pnpm --filter backend^... --filter=!app build && pnpm -r --parallel dev",
     "prepare-export": "pnpm --filter backend export && shx cp -r tools/backend/static/api tools/app/public",
     "dev-export": "pnpm prepare-export && cross-env VITE_CYBERISMO_EXPORT=true pnpm --filter app dev",
     "build-docker": "docker build -t cyberismo .",

--- a/tools/assets/package.json
+++ b/tools/assets/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "shx rm -rf dist && shx mkdir -p dist && pnpm script:schemas && node scripts/build.js && tsc && shx cp -r src/static dist/",
+    "build": "shx mkdir -p dist && pnpm script:schemas && node scripts/build.js && tsc && shx cp -r src/static dist/",
     "dev": "pnpm build && chokidar 'src/**/*' -i 'src/schemas.ts' -c 'pnpm build'",
     "script:schemas": "node scripts/generateSchemaImports && prettier --write src/schemas.ts"
   },

--- a/tools/assets/tsconfig.json
+++ b/tools/assets/tsconfig.json
@@ -2,6 +2,8 @@
   "compilerOptions": {
     "target": "ES2023",
     "module": "NodeNext",
+    "incremental": true,
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "declaration": true,

--- a/tools/backend/tsconfig.build.json
+++ b/tools/backend/tsconfig.build.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "incremental": true,
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo",
     "outDir": "./dist",
     "rootDir": "src",
     "skipLibCheck": true,

--- a/tools/data-handler/package.json
+++ b/tools/data-handler/package.json
@@ -20,7 +20,7 @@
     "pretest": "pnpm build",
     "test": "vitest",
     "test-coverage": "c8 pnpm test",
-    "dev": "tsc --watch -p tsconfig.build.json",
+    "dev": "tsc --watch --preserveWatchOutput -p tsconfig.build.json",
     "watch": "pnpm dev"
   },
   "exports": {

--- a/tools/data-handler/tsconfig.build.json
+++ b/tools/data-handler/tsconfig.build.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "incremental": true,
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo",
     "outDir": "./dist",
     "rootDir": "src",
     "types": ["node"],

--- a/tools/mcp/tsconfig.build.json
+++ b/tools/mcp/tsconfig.build.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "incremental": true,
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo",
     "outDir": "./dist",
     "rootDir": "src",
     "skipLibCheck": true,

--- a/tools/migrations/tsconfig.json
+++ b/tools/migrations/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
     "strict": true,
+    "incremental": true,
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "allowJs": true,
     "alwaysStrict": true,
     "sourceMap": true,

--- a/tools/node-clingo/package.json
+++ b/tools/node-clingo/package.json
@@ -12,7 +12,7 @@
     "prepack": "node scripts/manage-publish-manifest.js strip",
     "postpack": "node scripts/manage-publish-manifest.js restore",
     "clean": "rm -rf build dist dist-packages external/clingo/build",
-    "dev": "tsc -p tsconfig.build.json --watch",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint .",

--- a/tools/node-clingo/tsconfig.build.json
+++ b/tools/node-clingo/tsconfig.build.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "incremental": true,
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo",
     "outDir": "./dist",
     "rootDir": "lib"
   },


### PR DESCRIPTION
Was running into race during `pnpm dev`, this fixes that. At the same time enabled incremental build for almost all packages so dev is now a bit faster to start.