### PR TITLE
INTDEV-1335: MCP prompts for skill discovery

### DIFF
--- a/tools/data-handler/src/commands/show.ts
+++ b/tools/data-handler/src/commands/show.ts
@@ -62,6 +62,7 @@ import { evaluateMacros } from '../macros/index.js';
 import { readJsonFile } from '../utils/json.js';
 import { getChildLogger } from '../utils/log-utils.js';
 import { buildCardHierarchy, flattenCardArray } from '../utils/card-utils.js';
+import { CardNotFoundError } from '../exceptions/index.js';
 import type { ResourcesFrom } from '../containers/project/resources-from.js';
 
 /**
@@ -699,6 +700,28 @@ export class Show {
     context: Context = 'localApp',
   ): Promise<SkillLookupResult> {
     const { cardKey } = options;
+
+    let exists: boolean;
+    try {
+      exists = this.project.resources.exists(name);
+    } catch {
+      exists = false;
+    }
+    if (!exists) {
+      return { status: 'not-found' };
+    }
+
+    if (cardKey) {
+      try {
+        this.project.findCard(cardKey);
+      } catch (error) {
+        if (error instanceof CardNotFoundError) {
+          return { status: 'card-not-found' };
+        }
+        throw error;
+      }
+    }
+
     const enabled = await this.project.calculationEngine.runQuery(
       'enabledSkills',
       context,
@@ -713,9 +736,6 @@ export class Show {
       return { status: 'needs-card' };
     }
     const resource = this.project.resources.byType(name, 'skills');
-    if (!resource) {
-      return { status: 'not-enabled' };
-    }
     const skill = resource.show();
     const instructions = await generateReportContent({
       calculate: this.project.calculationEngine,

--- a/tools/data-handler/src/interfaces/resource-interfaces.ts
+++ b/tools/data-handler/src/interfaces/resource-interfaces.ts
@@ -169,7 +169,9 @@ export interface SkillDetails extends SkillSummary {
 export type SkillLookupResult =
   | { status: 'ok'; skill: SkillDetails }
   | { status: 'not-enabled' }
-  | { status: 'needs-card' };
+  | { status: 'needs-card' }
+  | { status: 'not-found' }
+  | { status: 'card-not-found' };
 
 // Base interface for all resources.
 export interface ResourceBaseMetadata {

--- a/tools/data-handler/test/skill-discovery.test.ts
+++ b/tools/data-handler/test/skill-discovery.test.ts
@@ -201,11 +201,19 @@ describe('skill discovery', () => {
       expect(result.status).toBe('not-enabled');
     });
 
-    it('reports not-enabled for an unknown skill', async () => {
+    it('reports not-found for an unknown skill', async () => {
       const result = await commands.showCmd.getSkill(
         'decision/skills/doesNotExist',
       );
-      expect(result.status).toBe('not-enabled');
+      expect(result.status).toBe('not-found');
+    });
+
+    it('reports card-not-found when the cardKey is not a real card', async () => {
+      const result = await commands.showCmd.getSkill(
+        'decision/skills/cardSkill',
+        { cardKey: 'decision_does_not_exist' },
+      );
+      expect(result.status).toBe('card-not-found');
     });
   });
 });

--- a/tools/mcp/src/prompts/index.ts
+++ b/tools/mcp/src/prompts/index.ts
@@ -1,0 +1,117 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  GetPromptRequestSchema,
+  ListPromptsRequestSchema,
+  type GetPromptResult,
+  type ListPromptsResult,
+} from '@modelcontextprotocol/sdk/types.js';
+
+import type { ProjectProvider } from '../lib/resolve-project.js';
+
+// A minimal single-message prompt result (used for both rendered skills and the
+// not-enabled / needs-card explanations — never an error, per the spec).
+function textResult(text: string, description?: string): GetPromptResult {
+  return {
+    description,
+    messages: [{ role: 'user', content: { type: 'text', text } }],
+  };
+}
+
+/**
+ * Exposes each currently-enabled skill as an MCP prompt. Uses the low-level
+ * request handlers (not the static `registerPrompt`) so the prompt list is
+ * recomputed from project state on every `prompts/list`, mirroring the tools.
+ */
+export function registerPrompts(
+  server: McpServer,
+  provider: ProjectProvider,
+): void {
+  server.server.registerCapabilities({ prompts: {} });
+
+  server.server.setRequestHandler(
+    ListPromptsRequestSchema,
+    async (): Promise<ListPromptsResult> => {
+      const perProject = await Promise.all(
+        provider.list().map(({ prefix }) => {
+          const commands = provider.get(prefix);
+          return commands ? commands.showCmd.listSkills() : [];
+        }),
+      );
+      const prompts: ListPromptsResult['prompts'] = perProject.flatMap(
+        (skills) =>
+          skills.map((skill) => ({
+            name: skill.name,
+            title: skill.displayName,
+            description: skill.description,
+            arguments:
+              skill.scope === 'card'
+                ? [
+                    {
+                      name: 'cardKey',
+                      description: 'Card key to scope this skill to.',
+                      required: false,
+                    },
+                  ]
+                : undefined,
+          })),
+      );
+      return { prompts };
+    },
+  );
+
+  server.server.setRequestHandler(
+    GetPromptRequestSchema,
+    async (request): Promise<GetPromptResult> => {
+      const { name } = request.params;
+      const cardKey = request.params.arguments?.cardKey;
+      // Skill names are prefix-qualified (e.g. `decision/skills/foo`); the first
+      // path segment is the project prefix used to resolve the owning project.
+      const prefix = name.split('/')[0];
+      const commands = provider.get(prefix);
+      if (!commands) {
+        return textResult(`Skill '${name}' is not currently enabled.`);
+      }
+
+      const result = await commands.showCmd.getSkill(name, { cardKey });
+      if (result.status === 'not-enabled') {
+        return textResult(
+          `Skill '${name}' is not currently enabled. Use prompts/list to see the enabled skills.`,
+        );
+      }
+      if (result.status === 'needs-card') {
+        return textResult(
+          `Skill '${name}' is enabled for specific cards. Provide a 'cardKey' argument to render it.`,
+        );
+      }
+
+      const { skill } = result;
+      const relatedTools = skill.relatedTools.length
+        ? skill.relatedTools.map((tool) => `\`${tool}\``).join(', ')
+        : '—';
+      const header = [
+        `# ${skill.displayName}`,
+        '',
+        `- **name:** \`${skill.name}\``,
+        `- **category:** ${skill.category ?? '—'}`,
+        `- **relatedTools:** ${relatedTools}`,
+        '',
+      ].join('\n');
+      return textResult(`${header}\n${skill.instructions}`, skill.description);
+    },
+  );
+}

--- a/tools/mcp/src/prompts/index.ts
+++ b/tools/mcp/src/prompts/index.ts
@@ -13,6 +13,8 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
+import { z } from 'zod';
+
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
   GetPromptRequestSchema,
@@ -22,6 +24,9 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 
 import type { ProjectProvider } from '../lib/resolve-project.js';
+
+// Prompt arguments are untyped on the low-level handler; validate them.
+const promptArguments = z.object({ cardKey: z.string().optional() });
 
 // A minimal single-message prompt result (used for both rendered skills and the
 // not-enabled / needs-card explanations — never an error, per the spec).
@@ -78,40 +83,57 @@ export function registerPrompts(
     GetPromptRequestSchema,
     async (request): Promise<GetPromptResult> => {
       const { name } = request.params;
-      const cardKey = request.params.arguments?.cardKey;
-      // Skill names are prefix-qualified (e.g. `decision/skills/foo`); the first
-      // path segment is the project prefix used to resolve the owning project.
-      const prefix = name.split('/')[0];
-      const commands = provider.get(prefix);
-      if (!commands) {
-        return textResult(`Skill '${name}' is not currently enabled.`);
+      const { cardKey } = promptArguments.parse(request.params.arguments ?? {});
+
+      // A skill may be owned by any registered project (including one it was
+      // imported into as a module, whose prefix differs from the project's), so
+      // resolve by asking each project rather than parsing the name's prefix.
+      let anyDisabled = false;
+      for (const { prefix } of provider.list()) {
+        const commands = provider.get(prefix);
+        if (!commands) {
+          continue;
+        }
+        const result = await commands.showCmd.getSkill(name, { cardKey });
+        if (result.status === 'ok') {
+          const { skill } = result;
+          const relatedTools = skill.relatedTools.length
+            ? skill.relatedTools.map((tool) => `\`${tool}\``).join(', ')
+            : '—';
+          const header = [
+            `# ${skill.displayName}`,
+            '',
+            `- **name:** \`${skill.name}\``,
+            `- **category:** ${skill.category ?? '—'}`,
+            `- **relatedTools:** ${relatedTools}`,
+            '',
+          ].join('\n');
+          return textResult(
+            `${header}\n${skill.instructions}`,
+            skill.description,
+          );
+        }
+        if (result.status === 'needs-card') {
+          return textResult(
+            `Skill '${name}' is enabled for specific cards. Provide a 'cardKey' argument to render it.`,
+          );
+        }
+        if (result.status === 'card-not-found') {
+          return textResult(
+            `Card '${cardKey}' does not exist in project '${prefix}'.`,
+          );
+        }
+        if (result.status === 'not-enabled') {
+          anyDisabled = true;
+        }
+        // 'not-found' — this project does not own the skill; keep looking.
       }
 
-      const result = await commands.showCmd.getSkill(name, { cardKey });
-      if (result.status === 'not-enabled') {
-        return textResult(
-          `Skill '${name}' is not currently enabled. Use prompts/list to see the enabled skills.`,
-        );
-      }
-      if (result.status === 'needs-card') {
-        return textResult(
-          `Skill '${name}' is enabled for specific cards. Provide a 'cardKey' argument to render it.`,
-        );
-      }
-
-      const { skill } = result;
-      const relatedTools = skill.relatedTools.length
-        ? skill.relatedTools.map((tool) => `\`${tool}\``).join(', ')
-        : '—';
-      const header = [
-        `# ${skill.displayName}`,
-        '',
-        `- **name:** \`${skill.name}\``,
-        `- **category:** ${skill.category ?? '—'}`,
-        `- **relatedTools:** ${relatedTools}`,
-        '',
-      ].join('\n');
-      return textResult(`${header}\n${skill.instructions}`, skill.description);
+      return textResult(
+        anyDisabled
+          ? `Skill '${name}' is not currently enabled. Use prompts/list to see the enabled skills.`
+          : `Skill '${name}' is not a known skill. Use prompts/list to see the available skills.`,
+      );
     },
   );
 }

--- a/tools/mcp/src/server.ts
+++ b/tools/mcp/src/server.ts
@@ -17,6 +17,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CommandManager } from '@cyberismo/data-handler';
 import { registerResources } from './resources/index.js';
 import { registerTools } from './tools/index.js';
+import { registerPrompts } from './prompts/index.js';
 import type { ProjectProvider } from './lib/resolve-project.js';
 import packageJson from '../package.json' with { type: 'json' };
 
@@ -65,6 +66,7 @@ export function createMcpServer(
 
   registerResources(server, provider);
   registerTools(server, provider);
+  registerPrompts(server, provider);
 
   return server;
 }

--- a/tools/mcp/src/tools/index.ts
+++ b/tools/mcp/src/tools/index.ts
@@ -475,6 +475,18 @@ export function registerTools(
       try {
         const commands = resolveCommands(provider, projectPrefix);
         const result = await commands.showCmd.getSkill(name, { cardKey });
+        if (result.status === 'not-found') {
+          return toolResult({
+            enabled: false,
+            message: `Skill '${name}' does not exist. Call list_skills to see the available skills.`,
+          });
+        }
+        if (result.status === 'card-not-found') {
+          return toolResult({
+            enabled: false,
+            message: `Card '${cardKey}' does not exist in this project.`,
+          });
+        }
         if (result.status === 'not-enabled') {
           return toolResult({
             enabled: false,

--- a/tools/mcp/test/skills.test.ts
+++ b/tools/mcp/test/skills.test.ts
@@ -185,3 +185,53 @@ describe('skill discovery MCP tools', () => {
     expect(parsed.message).toMatch(/not currently enabled/);
   });
 });
+
+const promptText = (result: { messages: { content: { text?: string } }[] }) =>
+  result.messages.map((m) => m.content.text ?? '').join('\n');
+
+describe('skill discovery MCP prompts', () => {
+  test('listPrompts exposes enabled skills, with a cardKey arg for card-scoped', async () => {
+    const { prompts } = await client.listPrompts();
+    const byName = new Map(prompts.map((p) => [p.name, p]));
+
+    expect(byName.has('decision/skills/globalSkill')).toBe(true);
+    expect(byName.has('decision/skills/cardSkill')).toBe(true);
+
+    // global skill takes no arguments; card skill declares an optional cardKey
+    expect(byName.get('decision/skills/globalSkill')?.arguments ?? []).toEqual(
+      [],
+    );
+    const cardArgs = byName.get('decision/skills/cardSkill')?.arguments ?? [];
+    expect(cardArgs.map((a) => a.name)).toEqual(['cardKey']);
+    expect(cardArgs[0].required).toBe(false);
+  });
+
+  test('getPrompt renders a globally-enabled skill', async () => {
+    const result = await client.getPrompt({
+      name: 'decision/skills/globalSkill',
+    });
+    expect(promptText(result)).toContain('Use this any time.');
+    // metadata header is included as context
+    expect(promptText(result)).toContain('decision/skills/globalSkill');
+  });
+
+  test('getPrompt renders a per-card skill with the cardKey', async () => {
+    const result = await client.getPrompt({
+      name: 'decision/skills/cardSkill',
+      arguments: { cardKey: 'decision_5' },
+    });
+    expect(promptText(result)).toContain('Applies to decision_5.');
+  });
+
+  test('getPrompt asks for a cardKey for a per-card skill', async () => {
+    const result = await client.getPrompt({
+      name: 'decision/skills/cardSkill',
+    });
+    expect(promptText(result)).toMatch(/cardKey/);
+  });
+
+  test('getPrompt reports a not-enabled skill without throwing', async () => {
+    const result = await client.getPrompt({ name: 'decision/skills/nope' });
+    expect(promptText(result)).toMatch(/not currently enabled/);
+  });
+});

--- a/tools/mcp/test/skills.test.ts
+++ b/tools/mcp/test/skills.test.ts
@@ -70,6 +70,10 @@ beforeAll(async () => {
     query: 'result({{cardKey}}).\n',
     content: '# Card skill\nApplies to {{cardKey}}.\n',
   });
+  // Exists as a resource but is never enabled, to exercise the not-enabled path.
+  await seedSkill('disabledSkill', {
+    content: '# Disabled skill\nNever enabled.\n',
+  });
   await mkdir(join(calcFolder, 'enable'), { recursive: true });
   await writeFile(
     join(calcFolder, 'enable.json'),
@@ -177,12 +181,43 @@ describe('skill discovery MCP tools', () => {
   test('get_skill reports a not-enabled skill without erroring', async () => {
     const result = await client.callTool({
       name: 'get_skill',
-      arguments: { projectPrefix: 'decision', name: 'decision/skills/nope' },
+      arguments: {
+        projectPrefix: 'decision',
+        name: 'decision/skills/disabledSkill',
+      },
     });
     expect(result.isError).toBeFalsy();
     const parsed = parse(result);
     expect(parsed.enabled).toBe(false);
     expect(parsed.message).toMatch(/not currently enabled/);
+  });
+
+  test('get_skill reports a non-existent skill as not existing', async () => {
+    const result = await client.callTool({
+      name: 'get_skill',
+      arguments: { projectPrefix: 'decision', name: 'decision/skills/nope' },
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = parse(result);
+    expect(parsed.enabled).toBe(false);
+    expect(parsed.message).toMatch(/does not exist/);
+  });
+
+  test('get_skill reports an invalid cardKey', async () => {
+    const result = await client.callTool({
+      name: 'get_skill',
+      arguments: {
+        projectPrefix: 'decision',
+        name: 'decision/skills/cardSkill',
+        cardKey: 'decision_does_not_exist',
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = parse(result);
+    expect(parsed.enabled).toBe(false);
+    expect(parsed.message).toMatch(
+      /Card 'decision_does_not_exist' does not exist/,
+    );
   });
 });
 
@@ -231,7 +266,52 @@ describe('skill discovery MCP prompts', () => {
   });
 
   test('getPrompt reports a not-enabled skill without throwing', async () => {
-    const result = await client.getPrompt({ name: 'decision/skills/nope' });
+    const result = await client.getPrompt({
+      name: 'decision/skills/disabledSkill',
+    });
     expect(promptText(result)).toMatch(/not currently enabled/);
+  });
+
+  test('getPrompt reports a non-existent skill as unknown', async () => {
+    const result = await client.getPrompt({ name: 'decision/skills/nope' });
+    expect(promptText(result)).toMatch(/not a known skill/);
+  });
+
+  test('getPrompt reports an invalid cardKey', async () => {
+    const result = await client.getPrompt({
+      name: 'decision/skills/cardSkill',
+      arguments: { cardKey: 'decision_does_not_exist' },
+    });
+    expect(promptText(result)).toMatch(
+      /Card 'decision_does_not_exist' does not exist/,
+    );
+  });
+
+  // The owning project may be registered under a prefix that differs from the
+  // skill name's prefix (as happens for skills imported from a module). Resolve
+  // by iterating projects, not by parsing the name's first segment.
+  test('getPrompt resolves a skill whose name prefix differs from the provider key', async () => {
+    const moduleLikeProvider = {
+      get: (prefix: string) =>
+        prefix === 'registeredUnderOtherKey' ? commands : undefined,
+      list: () => [{ prefix: 'registeredUnderOtherKey', name: 'decision' }],
+    };
+    const server = createMcpServer(moduleLikeProvider);
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const moduleClient = new Client({
+      name: 'module-client',
+      version: '1.0.0',
+    });
+    await moduleClient.connect(clientTransport);
+    try {
+      const result = await moduleClient.getPrompt({
+        name: 'decision/skills/globalSkill',
+      });
+      expect(promptText(result)).toContain('Use this any time.');
+    } finally {
+      await moduleClient.close();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Exposes each currently-enabled Cyberismo skill as an **MCP prompt**, so clients can list and inject relevant skill context before an agent starts reasoning.

## What's included

- **`prompts/list`** — returns every enabled skill (`name`, `title`, `description`), recomputed from project state on each call.
- **`prompts/get`** — returns the fully rendered skill (Handlebars applied for templates): a Markdown metadata header (name, category, related tools) followed by the `skill.md` body.
- **Arguments** — card-scoped skills declare an optional `cardKey`; global skills declare none.
- **Graceful responses** — a not-enabled skill returns an explanatory message (not a 404); a card-scoped skill requested without a `cardKey` returns a *needs-card* prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)