### PR TITLE
INTDEV-1342 Add functionality to read metatada of modules at different versions

### DIFF
--- a/tools/data-handler/src/modules/source-composite.ts
+++ b/tools/data-handler/src/modules/source-composite.ts
@@ -13,7 +13,14 @@
 */
 
 import type { FetchTarget, SourceLayer } from './source.js';
-import type { RemoteQueryOutcome, Source, VersionRange } from './types.js';
+import type {
+  RemoteQueryOutcome,
+  Source,
+  Version,
+  VersionRange,
+} from './types.js';
+import type { SealFile } from '../mutations/replay/seal-files.js';
+import type { ProjectSettings } from '../interfaces/project-interfaces.js';
 
 /** One dispatch route: a predicate plus the layer to delegate to. */
 export interface SourceRoute {
@@ -68,5 +75,19 @@ export class CompositeSourceLayer implements SourceLayer {
     options?: { remoteUrl?: string; range?: VersionRange | string },
   ): Promise<RemoteQueryOutcome> {
     return this.pick(source.location).queryRemote(source, options);
+  }
+
+  async readMetadata(
+    source: Source,
+    version: Version | null,
+    remoteUrl?: string,
+  ): Promise<{ config: ProjectSettings; seals: SealFile[] }> {
+    return this.pick(source.location).readMetadata(source, version, remoteUrl);
+  }
+
+  async dispose(): Promise<void> {
+    for (const { layer } of this.routes) {
+      await layer.dispose?.();
+    }
   }
 }

--- a/tools/data-handler/src/modules/source-file.ts
+++ b/tools/data-handler/src/modules/source-file.ts
@@ -18,10 +18,16 @@ import { join, resolve as pathResolve } from 'node:path';
 import { Validate } from '../commands/validate.js';
 import { ProjectPaths } from '../containers/project/project-paths.js';
 import { copyDir, deleteDir, pathExists } from '../utils/file-utils.js';
+import {
+  listSealFiles,
+  type SealFile,
+} from '../mutations/replay/seal-files.js';
+import { readModuleConfig } from './resolver.js';
 
 import { isFileLocation, stripFileProtocol } from './location.js';
 import type { FetchTarget, SourceLayer } from './source.js';
-import type { RemoteQueryOutcome } from './types.js';
+import type { RemoteQueryOutcome, Source } from './types.js';
+import type { ProjectSettings } from '../interfaces/project-interfaces.js';
 
 /**
  * Source layer for `file:` URLs and bare filesystem paths.
@@ -94,5 +100,16 @@ export class FileSourceLayer implements SourceLayer {
       latest: undefined,
       latestSatisfying: undefined,
     };
+  }
+
+  async readMetadata(
+    source: Source,
+  ): Promise<{ config: ProjectSettings; seals: SealFile[] }> {
+    const base = stripFileProtocol(source.location);
+    const config = await readModuleConfig(base);
+    const seals = await listSealFiles(
+      new ProjectPaths(base).migrationLogFolder,
+    );
+    return { config, seals };
   }
 }

--- a/tools/data-handler/src/modules/source-git.ts
+++ b/tools/data-handler/src/modules/source-git.ts
@@ -12,8 +12,9 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { mkdir, rm } from 'node:fs/promises';
-import { join } from 'node:path';
+import { mkdtemp, mkdir, rm } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 import { simpleGit, type SimpleGit } from 'simple-git';
 
@@ -24,9 +25,19 @@ import {
   resolveGitServiceClonePath,
 } from '../utils/git-service-client.js';
 import { GitManager } from '../utils/git-manager.js';
-import { pickVersion } from './version.js';
+import {
+  parseSealFileName,
+  type SealFile,
+} from '../mutations/replay/seal-files.js';
+import { pickVersion, versionToTag } from './version.js';
 import type { FetchTarget, SourceLayer } from './source.js';
-import type { RemoteQueryOutcome, Source, VersionRange } from './types.js';
+import type {
+  RemoteQueryOutcome,
+  Source,
+  Version,
+  VersionRange,
+} from './types.js';
+import type { ProjectSettings } from '../interfaces/project-interfaces.js';
 
 function cloneOptions(ref?: string): string[] {
   const options = ['--depth', '1'];
@@ -130,5 +141,81 @@ export class GitSourceLayer implements SourceLayer {
       latest,
       latestSatisfying,
     };
+  }
+
+  // Per-repo blobless clones reused across readMetadata calls.
+  private repos = new Map<string, Promise<string>>();
+
+  private ensureRepo(url: string): Promise<string> {
+    let p = this.repos.get(url);
+    if (!p) {
+      p = (async () => {
+        const dir = await mkdtemp(join(tmpdir(), 'cyb-meta-'));
+        try {
+          const git = simpleGit({ timeout: { block: gitTimeout() } }).env({
+            ...NON_INTERACTIVE_GIT_ENV,
+          });
+          // All refs, no checkout, blobs lazy. Fall back to a full clone if the
+          // server rejects partial clone.
+          try {
+            await git.clone(url, dir, ['--no-checkout', '--filter=blob:none']);
+          } catch {
+            await git.clone(url, dir, ['--no-checkout']);
+          }
+          return dir;
+        } catch (e) {
+          this.repos.delete(url); // don't cache the failure
+          await rm(dir, { recursive: true, force: true }).catch(() => {});
+          throw e;
+        }
+      })();
+      this.repos.set(url, p);
+    }
+    return p;
+  }
+
+  async readMetadata(
+    source: Source,
+    version: Version | null,
+    remoteUrl?: string,
+  ): Promise<{ config: ProjectSettings; seals: SealFile[] }> {
+    const ref = version === null ? 'HEAD' : versionToTag(version);
+    const g = simpleGit(
+      await this.ensureRepo(remoteUrl ?? source.location),
+    ).env({ ...NON_INTERACTIVE_GIT_ENV });
+    const config = JSON.parse(
+      await g.raw(['cat-file', '-p', `${ref}:.cards/local/cardsConfig.json`]),
+    ) as ProjectSettings;
+    let seals: SealFile[];
+    try {
+      const listing = await g.raw([
+        'ls-tree',
+        '--name-only',
+        ref,
+        '.cards/local/migrations/',
+      ]);
+      seals = listing
+        .split('\n')
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .map((s) => parseSealFileName(basename(s)))
+        .filter((s): s is SealFile => s !== undefined);
+    } catch {
+      seals = [];
+    }
+    return { config, seals };
+  }
+
+  /** Remove cached clones; called once a solve finishes. */
+  async dispose(): Promise<void> {
+    const paths = [...this.repos.values()];
+    this.repos.clear();
+    for (const p of paths) {
+      try {
+        await rm(await p, { recursive: true, force: true });
+      } catch {
+        /* best effort */
+      }
+    }
   }
 }

--- a/tools/data-handler/src/modules/source.ts
+++ b/tools/data-handler/src/modules/source.ts
@@ -19,8 +19,11 @@ import { GitSourceLayer } from './source-git.js';
 import {
   type RemoteQueryOutcome,
   type Source,
+  type Version,
   type VersionRange,
 } from './types.js';
+import type { ProjectSettings } from '../interfaces/project-interfaces.js';
+import type { SealFile } from '../mutations/replay/seal-files.js';
 
 /** A concrete fetch target. `remoteUrl` is pre-built with any credentials injected. */
 export interface FetchTarget {
@@ -61,6 +64,22 @@ export interface SourceLayer {
     source: Source,
     options?: { remoteUrl?: string; range?: VersionRange | string },
   ): Promise<RemoteQueryOutcome>;
+
+  /**
+   * Read a version's manifest + seal filenames WITHOUT a full checkout.
+   * Git: read the tag from a per-repo blobless clone reused across candidates.
+   * File: read the source dir.
+   * Pass `null` for `version` to read the default branch / install-as-is state
+   * (for unversioned modules: file sources, or git remotes with no tags).
+   */
+  readMetadata(
+    source: Source,
+    version: Version | null,
+    remoteUrl?: string,
+  ): Promise<{ config: ProjectSettings; seals: SealFile[] }>;
+
+  /** Optional: release any cached working clones (git layer). No-op otherwise. */
+  dispose?(): Promise<void>;
 }
 
 /**

--- a/tools/data-handler/test/helpers/module-fixtures.ts
+++ b/tools/data-handler/test/helpers/module-fixtures.ts
@@ -156,6 +156,9 @@ export function inMemorySource(opts: InMemorySourceOptions): SourceLayer {
       return availableByLocation.get(location) ?? [];
     },
     queryRemote,
+    async readMetadata() {
+      throw new Error('readMetadata not implemented in inMemorySource stub');
+    },
   };
 }
 

--- a/tools/data-handler/test/modules/source-composite.test.ts
+++ b/tools/data-handler/test/modules/source-composite.test.ts
@@ -106,6 +106,9 @@ describe('modules/source-composite', () => {
           supportsVersioning: () => true,
           listRemoteVersions: async () => sentinel,
           queryRemote: async () => ({ reachable: true }),
+          readMetadata: async () => {
+            throw new Error('readMetadata not used in this test');
+          },
         },
       },
       {

--- a/tools/data-handler/test/modules/source-metadata.test.ts
+++ b/tools/data-handler/test/modules/source-metadata.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { simpleGit } from 'simple-git';
+import { GitSourceLayer } from '../../src/modules/source-git.js';
+import { FileSourceLayer } from '../../src/modules/source-file.js';
+
+/** Create a simpleGit instance with a test identity so tests work without global git config. */
+function testGit(dir: string) {
+  return simpleGit(dir, {
+    config: ['user.name=Test', 'user.email=test@test.com'],
+  });
+}
+
+async function layoutModule(
+  root: string,
+  cfg: object,
+  seals: Array<[string, string]>,
+) {
+  const local = join(root, '.cards', 'local');
+  await mkdir(join(local, 'migrations'), { recursive: true });
+  await writeFile(join(local, 'cardsConfig.json'), JSON.stringify(cfg));
+  for (const [f, t] of seals)
+    await writeFile(
+      join(local, 'migrations', `migrationLog_${f}_${t}.jsonl`),
+      '',
+    );
+}
+
+describe('SourceLayer.readMetadata', () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'meta-'));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('git: returns config + seals from a tag without a full checkout', async () => {
+    const repo = join(dir, 'repo');
+    await layoutModule(
+      repo,
+      {
+        cardKeyPrefix: 'A',
+        version: '1.0.0',
+        modules: [{ name: 'B', location: 'x/B', version: '^1.0.0' }],
+      },
+      [['0.9.0', '1.0.0']],
+    );
+    const git = testGit(repo);
+    await git.init().add('.').commit('init');
+    await git.addTag('v1.0.0');
+
+    const layer = new GitSourceLayer();
+    const out = await layer.readMetadata(
+      { location: repo },
+      '1.0.0' as never,
+      repo,
+    );
+    expect(out.config.modules?.[0].name).toBe('B');
+    expect(out.seals.map((s) => s.fileName)).toContain(
+      'migrationLog_0.9.0_1.0.0.jsonl',
+    );
+    await layer.dispose();
+  });
+
+  it('file: reads config + seals from the source dir', async () => {
+    const src = join(dir, 'src');
+    await layoutModule(src, { cardKeyPrefix: 'A', name: 'A', modules: [] }, [
+      ['1.0.0', '1.1.0'],
+    ]);
+    const out = await new FileSourceLayer().readMetadata({
+      location: `file:${src}`,
+    });
+    expect(out.seals).toHaveLength(1);
+  });
+
+  it('git: null version reads config + seals from HEAD', async () => {
+    const repo = join(dir, 'repo-null');
+    await layoutModule(repo, { cardKeyPrefix: 'Z', modules: [] }, [
+      ['1.0.0', '2.0.0'],
+    ]);
+    const git = testGit(repo);
+    await git.init().add('.').commit('init');
+
+    const layer = new GitSourceLayer();
+    const out = await layer.readMetadata({ location: repo }, null, repo);
+    expect(out.config.cardKeyPrefix).toBe('Z');
+    expect(out.seals.map((s) => s.fileName)).toContain(
+      'migrationLog_1.0.0_2.0.0.jsonl',
+    );
+    await layer.dispose();
+  });
+
+  it('file: null version reads config + seals from the source dir', async () => {
+    const src = join(dir, 'src-null');
+    await layoutModule(src, { cardKeyPrefix: 'B', name: 'B', modules: [] }, [
+      ['2.0.0', '2.1.0'],
+    ]);
+    const out = await new FileSourceLayer().readMetadata({
+      location: `file:${src}`,
+    });
+    expect(out.config.cardKeyPrefix).toBe('B');
+    expect(out.seals).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
A better version resolution requires metadata of the modules(their cards config). Separated the PR so it is a bit nicer to review.

The calls added in this PR are expensive on their and they are done repeatedly so that's why there's the requirement to do the calls and then call `dispose()`. Solver calls this during the resolve loop, so it'd be hard to do a single call that returns all required metadata without searching for too much information.

It's a bit slow, can be optimized with a local cache later.

Requires changes to the git service outside this repo.