### PR TITLE
INTDEV-1305 Remove null placeholders from the custom-field write path

### DIFF
--- a/tools/data-handler/src/containers/card-container.ts
+++ b/tools/data-handler/src/containers/card-container.ts
@@ -235,7 +235,7 @@ export class CardContainer {
   /**
    * Removes non-metadata fields that should not be persisted.
    *
-   * @param metadata The metadata object to sanitize
+   * @param card The card whose metadata is sanitized
    * @returns Clean metadata object with only valid metadata fields
    */
   private static sanitizeMetadata(card: Card): CardMetadata {
@@ -243,6 +243,11 @@ export class CardContainer {
 
     if (card.metadata) {
       for (const [key, value] of Object.entries(card.metadata)) {
+        // JSON.stringify drops undefined, so drop it here too: the cache must
+        // not retain keys the file lacks.
+        if (value === undefined) {
+          continue;
+        }
         // Keys are not filtered out if they are: predefined, or field types
         if (isPredefinedField(key) || key.includes('/')) {
           sanitized[key] = value;

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -65,7 +65,7 @@ import { getCommitContext } from '../utils/commit-context.js';
 import type { MigrationResult } from '@cyberismo/migrations';
 import type { Template } from './template.js';
 
-import { ROOT } from '../utils/constants.js';
+import { isPredefinedField, ROOT } from '../utils/constants.js';
 
 /**
  * Options for Project initialization.
@@ -220,27 +220,6 @@ export class Project extends CardContainer {
       if (newAttachments) {
         this.cardCache.updateCardAttachments(cardKey, newAttachments);
       }
-    }
-  }
-
-  // Checks if a metadata key is a calculated custom field in the card's card type.
-  private isCalculatedField(card: Card, fieldName: string): boolean {
-    if (!card.metadata?.cardType) {
-      return false;
-    }
-    try {
-      const cardType = this.resources
-        .byType(card.metadata.cardType, 'cardTypes')
-        .show();
-      return (cardType.customFields ?? []).some(
-        (field) => field.name === fieldName && field.isCalculated,
-      );
-    } catch (error) {
-      this.logger.warn(
-        error,
-        `Could not resolve card type '${card.metadata.cardType}' of card '${card.key}'; treating field '${fieldName}' as not calculated`,
-      );
-      return false;
     }
   }
 
@@ -1191,10 +1170,9 @@ export class Project extends CardContainer {
       return;
     }
 
-    // Clearing a calculated field removes the stored override entirely, so
-    // that no null residue remains and the calculated value applies again.
-    const removeKey =
-      newValue == null && this.isCalculatedField(card, changedKey);
+    // Clearing a custom field removes the key entirely: absent and null both
+    // mean "no value". Predefined fields keep their stored representation.
+    const removeKey = newValue == null && !isPredefinedField(changedKey);
     if (removeKey) {
       if (!(changedKey in card.metadata)) {
         return;
@@ -1211,7 +1189,9 @@ export class Project extends CardContainer {
     if (removeKey) {
       delete cardAsRecord[changedKey];
     } else {
-      cardAsRecord[changedKey] = newValue;
+      // A predefined field is never removed, so undefined must land as null:
+      // an undefined value would be dropped from both the file and the cache.
+      cardAsRecord[changedKey] = newValue ?? null;
     }
 
     const invalidCard = isTemplateCard(card)

--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -38,7 +38,7 @@ import { isModulePath } from '../utils/card-utils.js';
 import { Project } from './project.js';
 import { isInitialTransition, resourceName } from '../utils/resource-utils.js';
 
-import { ROOT } from '../utils/constants.js';
+import { isPredefinedField, ROOT } from '../utils/constants.js';
 
 // @todo: Fix the constructor to not use Resource.
 import type { Resource } from './project/resource-cache.js';
@@ -223,13 +223,6 @@ export class Template extends CardContainer {
     }
 
     const cardWithRank = parentCards.find((c) => c.key === card.key);
-    const customFields = cardType.customFields.reduce((acc, curr) => {
-      if (curr.isCalculated) return acc;
-      return {
-        ...acc,
-        [curr.name]: card.metadata?.[curr.name] || null,
-      };
-    }, {});
 
     let templateCardKey;
     for (const [key, value] of templateIDMap) {
@@ -240,13 +233,19 @@ export class Template extends CardContainer {
     }
     const newMetadata = {
       ...card.metadata,
-      ...customFields,
       templateCardKey,
       workflowState: initialWorkflowState.toState,
       cardType: cardType.name,
       createdAt: new Date().toISOString(),
       rank: cardWithRank?.metadata?.rank || card.metadata.rank || EMPTY_RANK,
     };
+
+    // Null custom-field values on the template card are a 'no value' marker, not content.
+    for (const [key, value] of Object.entries(newMetadata)) {
+      if (value === null && !isPredefinedField(key)) {
+        delete (newMetadata as Record<string, unknown>)[key];
+      }
+    }
 
     return { ...card, metadata: newMetadata };
   }

--- a/tools/data-handler/src/resources/create-defaults.ts
+++ b/tools/data-handler/src/resources/create-defaults.ts
@@ -12,7 +12,7 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import type { Card } from '../interfaces/project-interfaces.js';
+import type { Card, CardMetadata } from '../interfaces/project-interfaces.js';
 import type {
   CalculationMetadata,
   CardType,
@@ -55,22 +55,18 @@ function latestRank(cards: Card[]): string {
 export abstract class DefaultContent {
   /**
    * Returns card with default content. Card is automatically ranked last, if siblings are provided.
-   * @param cardType Card type; custom values from card type are set to null.
+   * @param cardType Card type of the new card.
    * @param siblings Optional. If given, content will have been ranked last.
    * @returns card with default content.
    */
-  static card(cardType: CardType, siblings?: Card[]) {
-    return Object.assign(
-      {
-        title: 'Untitled',
-        cardType: cardType.name,
-        workflowState: '',
-        rank: siblings ? latestRank(siblings) : '',
-      },
-      ...cardType.customFields
-        .filter((field) => !field.isCalculated)
-        .map((field) => ({ [field.name]: null })),
-    );
+  static card(cardType: CardType, siblings?: Card[]): CardMetadata {
+    return {
+      title: 'Untitled',
+      cardType: cardType.name,
+      workflowState: '',
+      links: [],
+      rank: siblings ? latestRank(siblings) : '',
+    };
   }
 
   /**

--- a/tools/data-handler/test/command-create.test.ts
+++ b/tools/data-handler/test/command-create.test.ts
@@ -213,7 +213,6 @@ describe('create command', () => {
     );
     expect(result.statusCode).toBe(200);
 
-    // Check that created card contains custom fields, but not calculated fields
     const createdCard = result.affectsCards?.at(0) || '';
     const cardDetails = (
       await commandHandler.command(Cmd.show, ['card', createdCard], options)
@@ -222,7 +221,7 @@ describe('create command', () => {
       expect((cardDetails as Card).metadata).to.not.include.keys(
         'decision/fieldTypes/obsoletedBy',
       );
-      expect((cardDetails as Card).metadata).to.include.keys(
+      expect((cardDetails as Card).metadata).to.not.include.keys(
         'decision/fieldTypes/admins',
       );
     }
@@ -1213,6 +1212,77 @@ describe('create command', () => {
     expect(defaultCard.rank).toBe('0|b');
     expect(defaultCard.title).toBe('Untitled');
     expect(defaultCard.workflowState).toBe('');
+  });
+});
+
+describe('created cards and custom field values', () => {
+  const testRoot = join(import.meta.dirname, 'tmp-create-no-nulls-tests');
+  const projectPath = join(testRoot, 'valid/decision-records');
+  const templateName = 'decision/templates/decision';
+  let commands: CommandManager;
+
+  beforeAll(async () => {
+    mkdirSync(testRoot, { recursive: true });
+    await copyDir('test/test-data/', testRoot);
+    commands = new CommandManager(projectPath, {
+      autoSaveConfiguration: false,
+    });
+    await commands.initialize();
+  });
+
+  afterAll(() => {
+    rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  it('new cards do not contain null custom-field placeholders', async () => {
+    const created = await commands.createCmd.createCard(
+      templateName,
+      undefined,
+    );
+    const card = commands.project.findCard(created[0].key);
+    const nullCustomFieldKeys = (metadata: object) =>
+      Object.entries(metadata)
+        .filter(([key, value]) => value === null && key.includes('/'))
+        .map(([key]) => key);
+
+    expect(nullCustomFieldKeys(card.metadata!)).toEqual([]);
+
+    const persisted = JSON.parse(
+      readFileSync(join(card.path, 'index.json'), 'utf-8'),
+    );
+    expect(nullCustomFieldKeys(persisted)).toEqual([]);
+  });
+
+  it('cards added to a template get no null placeholders', async () => {
+    // 'decision/cardTypes/decision' declares eight non-calculated custom fields;
+    // the empty template keeps this out of the way of the tests below.
+    const added = await commands.createCmd.addCards(
+      'decision/cardTypes/decision',
+      'decision/templates/empty',
+    );
+    const card = commands.project.findCard(added[0]);
+    const customFieldKeys = Object.keys(card.metadata!).filter((key) =>
+      key.includes('/'),
+    );
+    expect(customFieldKeys).toEqual([]);
+  });
+
+  it('falsy template values survive instantiation', async () => {
+    // Mutates the shared template card, so this test must stay last.
+    const templateCards = commands.project.templateCards(templateName);
+    const templateCard = templateCards.at(0)!;
+    await commands.editCmd.editCardMetadata(
+      templateCard.key,
+      'decision/fieldTypes/finished',
+      false,
+    );
+
+    const created = await commands.createCmd.createCard(
+      templateName,
+      undefined,
+    );
+    const card = commands.project.findCard(created[0].key);
+    expect(card.metadata!['decision/fieldTypes/finished']).toBe(false);
   });
 });
 

--- a/tools/data-handler/test/command-edit.test.ts
+++ b/tools/data-handler/test/command-edit.test.ts
@@ -364,4 +364,113 @@ describe('edit card', () => {
       rmSync(freshTestDir, { recursive: true, force: true });
     }
   });
+
+  // Own project copy: these tests clear stored metadata, which must not leak
+  // into the suite-wide project. Each test establishes its own precondition, so
+  // they do not depend on each other's order either.
+  describe('clearing a field', () => {
+    const RESPONSIBLE = 'decision/fieldTypes/responsible';
+    const clearTestDir = join(baseDir, 'tmp-edit-clear-tests');
+    let clearCommands: CommandManager;
+
+    beforeAll(async () => {
+      mkdirSync(clearTestDir, { recursive: true });
+      await copyDir('test/test-data/', clearTestDir);
+      clearCommands = new CommandManager(
+        join(clearTestDir, 'valid/decision-records'),
+        { autoSaveConfiguration: false },
+      );
+      await clearCommands.initialize();
+    });
+
+    afterAll(() => {
+      rmSync(clearTestDir, { recursive: true, force: true });
+    });
+
+    // Gives RESPONSIBLE a real value, so that clearing it removes an actual
+    // value rather than null residue.
+    async function cardWithResponsibleSet(): Promise<Card> {
+      await clearCommands.editCmd.editCardMetadata(
+        'decision_6',
+        RESPONSIBLE,
+        'someone@example.com',
+      );
+      const card = clearCommands.project.findCard('decision_6');
+      expect(card.metadata![RESPONSIBLE]).toBeTruthy();
+      return card;
+    }
+
+    it('clearing a regular custom field removes the key from index.json', async () => {
+      const card = await cardWithResponsibleSet();
+      const keysBefore = Object.keys(card.metadata!).sort();
+
+      await clearCommands.editCmd.editCardMetadata(card.key, RESPONSIBLE, null);
+
+      const changed = clearCommands.project.findCard(card.key);
+      expect(changed.metadata!).not.toHaveProperty([RESPONSIBLE]);
+      const onDisk = readFileSync(join(changed.path, 'index.json'), 'utf-8');
+      expect(onDisk).not.toContain(RESPONSIBLE);
+
+      // Only the cleared key is gone; its siblings survive.
+      expect(Object.keys(changed.metadata!).sort()).toEqual(
+        keysBefore.filter((key) => key !== RESPONSIBLE),
+      );
+    });
+
+    it('clearing a regular custom field with undefined removes the key too', async () => {
+      const card = await cardWithResponsibleSet();
+
+      await clearCommands.editCmd.editCardMetadata(
+        card.key,
+        RESPONSIBLE,
+        undefined,
+      );
+
+      const changed = clearCommands.project.findCard(card.key);
+      expect(changed.metadata!).not.toHaveProperty([RESPONSIBLE]);
+      const onDisk = readFileSync(join(changed.path, 'index.json'), 'utf-8');
+      expect(onDisk).not.toContain(RESPONSIBLE);
+    });
+
+    it('clearing a predefined field does not delete the key', async () => {
+      await clearCommands.editCmd.editCardMetadata(
+        'decision_6',
+        'title',
+        'a real title',
+      );
+
+      // Key deletion covers custom fields; predefined fields are out of scope.
+      await clearCommands.editCmd.editCardMetadata('decision_6', 'title', null);
+
+      const changed = clearCommands.project.findCard('decision_6');
+      expect('title' in changed.metadata!).toBe(true);
+      expect(changed.metadata!.title).toBeNull();
+      const onDisk = JSON.parse(
+        readFileSync(join(changed.path, 'index.json'), 'utf-8'),
+      );
+      expect(onDisk).toHaveProperty('title', null);
+    });
+
+    it('writing undefined to a predefined field stores null', async () => {
+      await clearCommands.editCmd.editCardMetadata(
+        'decision_6',
+        'title',
+        'a real title',
+      );
+
+      await clearCommands.editCmd.editCardMetadata(
+        'decision_6',
+        'title',
+        undefined,
+      );
+
+      const changed = clearCommands.project.findCard('decision_6');
+      expect('title' in changed.metadata!).toBe(true);
+      expect(changed.metadata!.title).toBeNull();
+      const onDisk = JSON.parse(
+        readFileSync(join(changed.path, 'index.json'), 'utf-8'),
+      );
+      expect(onDisk).toHaveProperty('title', null);
+    });
+  });
 });


### PR DESCRIPTION
Instead of null, when either writing a metadata field or creating a card, just do not write that field. For predefined values like labels or a cardType, null is used.