### PR TITLE
INTDEV-1305 Add cyberismo clean command and CLI recommendations

### DIFF
--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -1557,6 +1557,9 @@ checkUpdatesCmd.action(
       message: `Apply ${autoUpdatable.length} available update(s)?`,
     });
     if (shouldUpdate) {
+      // Every successful update reports the same project-wide state, so the
+      // last note is printed once after the loop instead of per module.
+      let note: string | undefined;
       for (const mod of autoUpdatable) {
         const target = mod.latestSatisfyingConstraint ?? mod.latestVersion!;
         const updateResult = await commandHandler.command(
@@ -1567,11 +1570,17 @@ checkUpdatesCmd.action(
         );
         if (updateResult.statusCode === 200) {
           console.log(`  Updated ${mod.name} to ${target}`);
+          note = updateResult.message ?? note;
         } else {
           console.error(
             `  Failed to update ${mod.name}: ${updateResult.message}`,
           );
         }
+      }
+      if (note) {
+        // The note carries a leading 'Done' for the single-module update path,
+        // which already has its own success lines here.
+        console.log(`\n${note.replace(/^Done\n/, '')}`);
       }
     }
   },

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -107,6 +107,9 @@ function handleResponse(response: requestStatus) {
     } else {
       console.log('Done');
     }
+    if (response.note) {
+      console.log(`\n${response.note}`);
+    }
   } else {
     if (response.message) {
       program.error(response.message);
@@ -1570,7 +1573,7 @@ checkUpdatesCmd.action(
         );
         if (updateResult.statusCode === 200) {
           console.log(`  Updated ${mod.name} to ${target}`);
-          note = updateResult.message ?? note;
+          note = updateResult.note ?? note;
         } else {
           console.error(
             `  Failed to update ${mod.name}: ${updateResult.message}`,
@@ -1578,9 +1581,7 @@ checkUpdatesCmd.action(
         }
       }
       if (note) {
-        // The note carries a leading 'Done' for the single-module update path,
-        // which already has its own success lines here.
-        console.log(`\n${note.replace(/^Done\n/, '')}`);
+        console.log(`\n${note}`);
       }
     }
   },

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -1735,4 +1735,18 @@ publishCmd.action(async (options: CommandOptions<'publish'>) => {
   handleResponse(result);
 });
 
+// Clean command - removes field values that are not used by card types
+const cleanCmd = new CommandWithPath('clean')
+  .description(
+    'Remove field values that card types no longer use (null placeholders, removed fields, values on calculated fields)',
+  )
+  .option('--dry-run', 'Show what would be cleaned without cleaning');
+program.addCommand(cleanCmd);
+cleanCmd.action(async (options: CommandOptions<'clean'>) => {
+  const mergedOptions = Object.assign({}, options, program.opts());
+  const args = [options.dryRun ? 'true' : 'false'];
+  const result = await commandHandler.command(Cmd.clean, args, mergedOptions);
+  handleResponse(result);
+});
+
 export default program;

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -1745,10 +1745,10 @@ publishCmd.action(async (options: CommandOptions<'publish'>) => {
   handleResponse(result);
 });
 
-// Clean command - removes field values that are not used by card types
+// Clean command - removes dormant field values
 const cleanCmd = new CommandWithPath('clean')
   .description(
-    'Remove field values that card types no longer use (null placeholders, removed fields, values on calculated fields)',
+    'Remove dormant field values: values a card stores but that are not shown and not visible to logic programs (empty placeholders, fields the card type no longer declares, values on calculated fields)',
   )
   .option('--dry-run', 'Show what would be cleaned without cleaning');
 program.addCommand(cleanCmd);

--- a/tools/cli/test/cli.test.ts
+++ b/tools/cli/test/cli.test.ts
@@ -2,7 +2,7 @@ import { expect, it, describe, beforeAll, afterAll } from 'vitest';
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
 import { join } from 'node:path';
-import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
 
 const execAsync = promisify(exec);
 
@@ -302,6 +302,21 @@ describe('Cli BAT test', function () {
     expect(stdout).toContain(
       "Would publish v1.0.0 (create tag and push to remote 'origin')",
     );
+  });
+  it('Clean dry-run', async () => {
+    // Runs against a copy: a regressed --dry-run would write, and the tracked
+    // module-test fixture must not be the thing it writes to.
+    const dormantCard =
+      '.cards/local/templates/allDataTypes/c/test_y4i5enly/index.json';
+    const before = readFileSync(join(moduleTestPath, dormantCard), 'utf-8');
+    const { stdout } = await execAsync(
+      `cd ${cliPath} && cp -r ${moduleTestPath} clean-fixture && cd clean-fixture && ${cli} clean --dry-run`,
+    );
+    expect(stdout).toContain('(null-value)');
+    expect(stdout).toContain('Would remove');
+    expect(
+      readFileSync(join(cliPath, 'clean-fixture', dormantCard), 'utf-8'),
+    ).toBe(before);
   });
   it('Add default hub and check hub version', async () => {
     const { stdout } = await execAsync(

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -62,7 +62,8 @@ import { Project } from './containers/project.js';
 import { pathExists, resolveTilde } from './utils/file-utils.js';
 import { errorFunction } from './utils/error-utils.js';
 import { readJsonFile } from './utils/json.js';
-import { resourceName } from './utils/resource-utils.js';
+import { getChildLogger } from './utils/log-utils.js';
+import { resourceName, resourceNameToString } from './utils/resource-utils.js';
 
 import { type Level } from 'pino';
 import { type Context } from './interfaces/project-interfaces.js';
@@ -367,6 +368,10 @@ export class Commands {
             credentials,
             version,
           );
+          const note = await this.cleanRecommendation();
+          if (note) {
+            return note;
+          }
         }
         if (target === 'csv') {
           const [csvFile, cardKey] = args;
@@ -482,9 +487,10 @@ export class Commands {
           }
         }
 
+        const target = resourceName(resource);
         await this.commands?.updateCmd.apply({
           kind: 'edit',
-          target: resourceName(resource),
+          target,
           updateKey: parseUpdateKey(key),
           operation: buildOperation(
             operation as UpdateOperations,
@@ -493,6 +499,21 @@ export class Commands {
             mappingTable,
           ),
         });
+
+        // Dropping or replacing a custom field leaves the cards' values in
+        // place; only those two operations can create something to clean.
+        if (
+          target.type === 'cardTypes' &&
+          key === 'customFields' &&
+          (operation === 'remove' || operation === 'change')
+        ) {
+          const note = await this.cleanRecommendation(
+            resourceNameToString(target),
+          );
+          if (note) {
+            return note;
+          }
+        }
       } else if (command === Cmd.updateModules) {
         const [module, targetVersion] = args;
         if (module) {
@@ -508,6 +529,10 @@ export class Commands {
             );
           }
           await this.commands?.importCmd.updateAllModules(credentials);
+        }
+        const note = await this.cleanRecommendation();
+        if (note) {
+          return note;
         }
       } else if (command === Cmd.checkUpdates) {
         const [moduleName] = args;
@@ -664,6 +689,38 @@ export class Commands {
       statusCode: 200,
       message: `Bumped to v${result.newVersion}${previousInfo}`,
     };
+  }
+
+  // A recommendation when the project holds dormant field values, or undefined
+  // when there is nothing to clean. Never fails the parent operation.
+  private async cleanRecommendation(
+    cardType?: string,
+  ): Promise<requestStatus | undefined> {
+    if (!this.commands) {
+      return undefined;
+    }
+    try {
+      const result = await this.commands.cleanCmd.clean(true, cardType);
+      if (result.findings.length === 0) {
+        return undefined;
+      }
+      // The CLI prints 'Done' only when a command returns no message, so a note
+      // has to carry the success line itself.
+      return {
+        statusCode: 200,
+        message:
+          `Done\n${result.findings.length} unused field value(s) from ${result.cardCount} card(s) — ` +
+          `run 'cyberismo clean --dry-run' to list them, 'cyberismo clean' to remove them`,
+      };
+    } catch (error) {
+      // The logger is initialized while the project loads, so the child logger
+      // is taken here rather than at module scope.
+      getChildLogger({ module: 'command-handler' }).warn(
+        error,
+        'Could not scan for unused field values',
+      );
+      return undefined;
+    }
   }
 
   // Removes field values that are not used by card types.

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -368,10 +368,10 @@ export class Commands {
             credentials,
             version,
           );
-          const note = await this.cleanRecommendation();
-          if (note) {
-            return note;
-          }
+          return {
+            statusCode: 200,
+            note: await this.cleanRecommendation(),
+          };
         }
         if (target === 'csv') {
           const [csvFile, cardKey] = args;
@@ -507,12 +507,10 @@ export class Commands {
           key === 'customFields' &&
           (operation === 'remove' || operation === 'change')
         ) {
-          const note = await this.cleanRecommendation(
-            resourceNameToString(target),
-          );
-          if (note) {
-            return note;
-          }
+          return {
+            statusCode: 200,
+            note: await this.cleanRecommendation(resourceNameToString(target)),
+          };
         }
       } else if (command === Cmd.updateModules) {
         const [module, targetVersion] = args;
@@ -530,10 +528,10 @@ export class Commands {
           }
           await this.commands?.importCmd.updateAllModules(credentials);
         }
-        const note = await this.cleanRecommendation();
-        if (note) {
-          return note;
-        }
+        return {
+          statusCode: 200,
+          note: await this.cleanRecommendation(),
+        };
       } else if (command === Cmd.checkUpdates) {
         const [moduleName] = args;
         const results = await this.commands?.checkUpdatesCmd.checkUpdates(
@@ -693,9 +691,14 @@ export class Commands {
 
   // A recommendation when the project holds dormant field values, or undefined
   // when there is nothing to clean. Never fails the parent operation.
+  //
+  // The scan reports the project (or card type), not the caller's change: it
+  // counts values that were already dormant, and an operation that stranded
+  // nothing still reports whatever was dormant before it. The note therefore
+  // states what the project holds and never claims the operation caused it.
   private async cleanRecommendation(
     cardType?: string,
-  ): Promise<requestStatus | undefined> {
+  ): Promise<string | undefined> {
     if (!this.commands) {
       return undefined;
     }
@@ -704,14 +707,10 @@ export class Commands {
       if (result.findings.length === 0) {
         return undefined;
       }
-      // The CLI prints 'Done' only when a command returns no message, so a note
-      // has to carry the success line itself.
-      return {
-        statusCode: 200,
-        message:
-          `Done\n${result.findings.length} unused field value(s) from ${result.cardCount} card(s) — ` +
-          `run 'cyberismo clean --dry-run' to list them, 'cyberismo clean' to remove them`,
-      };
+      return (
+        `This project has ${result.findings.length} unused field value(s) on ${result.cardCount} card(s) — ` +
+        `run 'cyberismo clean --dry-run' to list them, 'cyberismo clean' to remove them`
+      );
     } catch (error) {
       // The logger is initialized while the project loads, so the child logger
       // is taken here rather than at module scope.

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -74,6 +74,7 @@ export const Cmd = {
   add: 'add',
   calc: 'calc',
   checkUpdates: 'check-updates',
+  clean: 'clean',
   create: 'create',
   edit: 'edit',
   export: 'export',
@@ -515,6 +516,8 @@ export class Commands {
           credentials,
         );
         return { statusCode: 200, payload: results };
+      } else if (command === Cmd.clean) {
+        return this.clean(args);
       } else if (command === Cmd.validate) {
         return this.validate();
       } else {
@@ -660,6 +663,46 @@ export class Commands {
     return {
       statusCode: 200,
       message: `Bumped to v${result.newVersion}${previousInfo}`,
+    };
+  }
+
+  // Removes field values that are not used by card types.
+  private async clean(args: string[]): Promise<requestStatus> {
+    if (!this.commands) {
+      return { statusCode: 500, message: 'Commands not initialized' };
+    }
+
+    const [dryRunFlag] = args;
+    const dryRun = dryRunFlag === 'true';
+
+    const result = await this.commands.cleanCmd.clean(dryRun);
+
+    const skipped = result.skippedCards.length
+      ? `\nSkipped ${result.skippedCards.length} card(s) with unresolvable card types: ${result.skippedCards.join(', ')}`
+      : '';
+    if (result.findings.length === 0) {
+      return { statusCode: 200, message: `Nothing to clean${skipped}` };
+    }
+
+    const failed = result.failedCards.length
+      ? `\nCould not update ${result.failedCards.length} card(s); their values were not removed: ${result.failedCards.join(', ')}`
+      : '';
+    const lines = result.findings.map(
+      (finding) => `  ${finding.cardKey}: ${finding.field} (${finding.reason})`,
+    );
+
+    // The headline counts what actually changed, so a partial failure cannot
+    // report a card as cleaned.
+    const failedCards = new Set(result.failedCards);
+    const removed = result.findings.filter(
+      (finding) => !failedCards.has(finding.cardKey),
+    );
+    const removedCards = new Set(removed.map((finding) => finding.cardKey))
+      .size;
+    const verb = dryRun ? 'Would remove' : 'Removed';
+    return {
+      statusCode: 200,
+      message: `${lines.join('\n')}\n${verb} ${removed.length} field value(s) from ${removedCards} card(s)${skipped}${failed}`,
     };
   }
 

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -708,7 +708,7 @@ export class Commands {
         return undefined;
       }
       return (
-        `This project has ${result.findings.length} unused field value(s) on ${result.cardCount} card(s) — ` +
+        `This project has ${result.findings.length} dormant field value(s) on ${result.cardCount} card(s) — ` +
         `run 'cyberismo clean --dry-run' to list them, 'cyberismo clean' to remove them`
       );
     } catch (error) {
@@ -716,7 +716,7 @@ export class Commands {
       // is taken here rather than at module scope.
       getChildLogger({ module: 'command-handler' }).warn(
         error,
-        'Could not scan for unused field values',
+        'Could not scan for dormant field values',
       );
       return undefined;
     }

--- a/tools/data-handler/src/command-manager.ts
+++ b/tools/data-handler/src/command-manager.ts
@@ -12,6 +12,7 @@
 
 import { Calculate } from './commands/calculate.js';
 import { CheckUpdates } from './commands/check-updates.js';
+import { Clean } from './commands/clean.js';
 import { Create } from './commands/create.js';
 import { Edit } from './commands/edit.js';
 import { Export } from './commands/export.js';
@@ -48,6 +49,7 @@ export class CommandManager {
   public project: Project;
   public calculateCmd: Calculate;
   public checkUpdatesCmd: CheckUpdates;
+  public cleanCmd: Clean;
   public createCmd: Create;
   public editCmd: Edit;
   public exportCmd: Export;
@@ -74,6 +76,7 @@ export class CommandManager {
 
     this.calculateCmd = new Calculate(this.project);
     this.checkUpdatesCmd = new CheckUpdates(this.project);
+    this.cleanCmd = new Clean(this.project);
     this.fetchCmd = new Fetch(this.project);
     this.showCmd = new Show(this.project);
     this.createCmd = new Create(this.project);

--- a/tools/data-handler/src/commands/clean.ts
+++ b/tools/data-handler/src/commands/clean.ts
@@ -83,7 +83,7 @@ export class Clean {
     return this.scan(true, cardType);
   }
 
-  @write(() => 'Clean unused field values')
+  @write(() => 'Remove dormant field values')
   private async removeUnused(cardType?: string): Promise<CleanResult> {
     return this.scan(false, cardType);
   }

--- a/tools/data-handler/src/commands/clean.ts
+++ b/tools/data-handler/src/commands/clean.ts
@@ -1,0 +1,170 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+  details. You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import type { Project } from '../containers/project.js';
+import { ResourcesFrom } from '../containers/project/resources-from.js';
+import { isPredefinedField } from '../utils/constants.js';
+import { getChildLogger } from '../utils/log-utils.js';
+import { write } from '../utils/rw-lock.js';
+
+import type {
+  Card,
+  CardMetadata,
+  MetadataContent,
+} from '../interfaces/project-interfaces.js';
+import type { CustomField } from '../interfaces/resource-interfaces.js';
+
+const logger = getChildLogger({ module: 'clean' });
+
+export type CleanReason = 'null-value' | 'undeclared' | 'calculated-locked';
+
+export interface CleanFinding {
+  cardKey: string;
+  field: string;
+  reason: CleanReason;
+}
+
+export interface CleanResult {
+  findings: CleanFinding[];
+  cardCount: number;
+  // Cards whose card type could not be resolved; they were not inspected.
+  skippedCards: string[];
+  // Cards that were reported in 'findings' but could not be written.
+  failedCards: string[];
+  dryRun: boolean;
+}
+
+/**
+ * Removes stored field values that the card's card type does not require:
+ * null placeholders, keys not declared by the card type, and values on
+ * calculated fields that do not enable override. Such data is preserved
+ * ("dormant") until this command runs; dry-run reports without writing.
+ */
+export class Clean {
+  constructor(private project: Project) {}
+
+  /**
+   * Removes unused custom field values from project cards and local template
+   * cards. Module cards are read-only and never visited.
+   *
+   * A card whose update fails does not stop the run: it is listed in
+   * 'failedCards' and the remaining cards are still cleaned. Removing an
+   * already-removed value is a no-op, so re-running after a partial clean is
+   * safe. Since per-card errors are handled here rather than raised, an
+   * '--autocommit' run commits a partial clean instead of rolling it back.
+   *
+   * A dry run takes the write lock as well, so that the report cannot be taken
+   * while another command is halfway through changing the cards.
+   * @param dryRun If true, reports the findings without changing any card.
+   * @param cardType Optional. Limits the scan to cards of this card type. Must
+   *   be a full resource name, e.g. 'decision/cardTypes/decision'.
+   * @returns What was removed, or would be removed in a dry run.
+   */
+  @write(() => 'Clean unused field values')
+  public async clean(dryRun: boolean, cardType?: string): Promise<CleanResult> {
+    const findings: CleanFinding[] = [];
+    const skippedCards: string[] = [];
+    const failedCards: string[] = [];
+
+    for (const card of this.cleanableCards()) {
+      if (!card.metadata) continue;
+      if (cardType && card.metadata.cardType !== cardType) continue;
+
+      const declared = this.declaredFields(card);
+      if (!declared) {
+        skippedCards.push(card.key);
+        continue;
+      }
+
+      const removals = this.unusedFields(card.metadata, declared).map(
+        (field) => ({ cardKey: card.key, ...field }),
+      );
+      if (removals.length === 0) continue;
+
+      findings.push(...removals);
+      if (!dryRun) {
+        const metadata: Record<string, MetadataContent> = card.metadata;
+        for (const removal of removals) {
+          delete metadata[removal.field];
+        }
+        try {
+          await this.project.updateCardMetadata(card, card.metadata);
+        } catch (error) {
+          logger.warn(error, `Could not clean card '${card.key}'`);
+          failedCards.push(card.key);
+        }
+      }
+    }
+
+    return {
+      findings,
+      cardCount: new Set(findings.map((finding) => finding.cardKey)).size,
+      skippedCards,
+      failedCards,
+      dryRun,
+    };
+  }
+
+  // All cards this command may write to: project cards and local template cards.
+  private cleanableCards(): Card[] {
+    return [
+      ...this.project.cards(),
+      ...this.project.resources
+        .templates(ResourcesFrom.localOnly)
+        .flatMap((template) => template.templateObject().cards()),
+    ];
+  }
+
+  // Custom fields the card's card type declares, or undefined if the card type
+  // cannot be resolved.
+  private declaredFields(card: Card): Map<string, CustomField> | undefined {
+    const cardTypeName = card.metadata?.cardType;
+    if (!cardTypeName) {
+      return undefined;
+    }
+    let customFields: CustomField[];
+    try {
+      customFields =
+        this.project.resources.byType(cardTypeName, 'cardTypes').show()
+          .customFields ?? [];
+    } catch (error) {
+      logger.warn(
+        error,
+        `Could not resolve card type '${cardTypeName}' of card '${card.key}'; skipping the card`,
+      );
+      return undefined;
+    }
+    return new Map(customFields.map((field) => [field.name, field]));
+  }
+
+  // Metadata keys whose stored value the card type does not use.
+  private unusedFields(
+    metadata: CardMetadata,
+    declared: Map<string, CustomField>,
+  ): Omit<CleanFinding, 'cardKey'>[] {
+    const unused: Omit<CleanFinding, 'cardKey'>[] = [];
+    for (const [field, value] of Object.entries(metadata)) {
+      if (isPredefinedField(field)) continue;
+
+      const declaration = declared.get(field);
+      if (value === null) {
+        unused.push({ field, reason: 'null-value' });
+      } else if (!declaration) {
+        unused.push({ field, reason: 'undeclared' });
+      } else if (declaration.isCalculated && !declaration.enableOverride) {
+        unused.push({ field, reason: 'calculated-locked' });
+      }
+    }
+    return unused;
+  }
+}

--- a/tools/data-handler/src/commands/clean.ts
+++ b/tools/data-handler/src/commands/clean.ts
@@ -15,7 +15,7 @@ import type { Project } from '../containers/project.js';
 import { ResourcesFrom } from '../containers/project/resources-from.js';
 import { isPredefinedField } from '../utils/constants.js';
 import { getChildLogger } from '../utils/log-utils.js';
-import { write } from '../utils/rw-lock.js';
+import { read, write } from '../utils/rw-lock.js';
 
 import type {
   Card,
@@ -65,15 +65,32 @@ export class Clean {
    * safe. Since per-card errors are handled here rather than raised, an
    * '--autocommit' run commits a partial clean instead of rolling it back.
    *
-   * A dry run takes the write lock as well, so that the report cannot be taken
-   * while another command is halfway through changing the cards.
+   * A dry run takes the read lock, which already excludes writers, so the
+   * report still cannot be taken mid-write. Taking the write lock instead
+   * would give a dry run a writer's side effects: an autocommit run would
+   * commit and, on a failed scan, roll the working tree back.
    * @param dryRun If true, reports the findings without changing any card.
    * @param cardType Optional. Limits the scan to cards of this card type. Must
    *   be a full resource name, e.g. 'decision/cardTypes/decision'.
    * @returns What was removed, or would be removed in a dry run.
    */
-  @write(() => 'Clean unused field values')
   public async clean(dryRun: boolean, cardType?: string): Promise<CleanResult> {
+    return dryRun ? this.report(cardType) : this.removeUnused(cardType);
+  }
+
+  @read
+  private async report(cardType?: string): Promise<CleanResult> {
+    return this.scan(true, cardType);
+  }
+
+  @write(() => 'Clean unused field values')
+  private async removeUnused(cardType?: string): Promise<CleanResult> {
+    return this.scan(false, cardType);
+  }
+
+  // Walks the cleanable cards, collecting the unused values and, unless this
+  // is a dry run, removing them.
+  private async scan(dryRun: boolean, cardType?: string): Promise<CleanResult> {
     const findings: CleanFinding[] = [];
     const skippedCards: string[] = [];
     const failedCards: string[] = [];

--- a/tools/data-handler/src/commands/clean.ts
+++ b/tools/data-handler/src/commands/clean.ts
@@ -24,7 +24,9 @@ import type {
 } from '../interfaces/project-interfaces.js';
 import type { CustomField } from '../interfaces/resource-interfaces.js';
 
-const logger = getChildLogger({ module: 'clean' });
+// The logger is initialized while the project loads, so the child logger is
+// taken at call time; binding it at module scope would keep the silent default.
+const logger = () => getChildLogger({ module: 'clean' });
 
 export type CleanReason = 'null-value' | 'undeclared' | 'calculated-locked';
 
@@ -100,7 +102,7 @@ export class Clean {
         try {
           await this.project.updateCardMetadata(card, card.metadata);
         } catch (error) {
-          logger.warn(error, `Could not clean card '${card.key}'`);
+          logger().warn(error, `Could not clean card '${card.key}'`);
           failedCards.push(card.key);
         }
       }
@@ -138,7 +140,7 @@ export class Clean {
         this.project.resources.byType(cardTypeName, 'cardTypes').show()
           .customFields ?? [];
     } catch (error) {
-      logger.warn(
+      logger().warn(
         error,
         `Could not resolve card type '${cardTypeName}' of card '${card.key}'; skipping the card`,
       );

--- a/tools/data-handler/src/commands/index.ts
+++ b/tools/data-handler/src/commands/index.ts
@@ -13,6 +13,7 @@
 
 import { Calculate } from './calculate.js';
 import { CheckUpdates } from './check-updates.js';
+import { Clean } from './clean.js';
 import { Create } from './create.js';
 import { Edit } from './edit.js';
 import { Export } from './export.js';
@@ -31,6 +32,7 @@ import { Version } from './version.js';
 export {
   Calculate,
   CheckUpdates,
+  Clean,
   Create,
   Edit,
   Export,

--- a/tools/data-handler/src/interfaces/command-options.ts
+++ b/tools/data-handler/src/interfaces/command-options.ts
@@ -114,6 +114,11 @@ export interface UpdateCommandOptions extends BaseCommandOptions {
 // Options for 'checkUpdates' command
 export type CheckUpdatesCommandOptions = BaseCommandOptions;
 
+// Options for 'clean' command
+export interface CleanCommandOptions extends BaseCommandOptions {
+  dryRun?: boolean;
+}
+
 // Options for 'updateModules' command
 export type UpdateModulesCommandOptions = BaseCommandOptions;
 
@@ -131,6 +136,7 @@ export type AllCommandOptions =
   | AddCommandOptions
   | CalcCommandOptions
   | CheckUpdatesCommandOptions
+  | CleanCommandOptions
   | CreateCommandOptions
   | EditCommandOptions
   | ExportCommandOptions
@@ -157,6 +163,7 @@ export type CommandOptions<T extends CmdKey> = {
   add: AddCommandOptions;
   calc: CalcCommandOptions;
   checkUpdates: CheckUpdatesCommandOptions;
+  clean: CleanCommandOptions;
   create: CreateCommandOptions;
   edit: EditCommandOptions;
   export: ExportCommandOptions;

--- a/tools/data-handler/src/interfaces/request-status-interfaces.ts
+++ b/tools/data-handler/src/interfaces/request-status-interfaces.ts
@@ -21,6 +21,9 @@ export interface requestStatus {
   message?: string;
   affectsCards?: string[];
   payload?: object | attachmentPayload;
+  // Advice printed after the outcome, when the command left something the user
+  // may want to act on. Separate from 'message' so it never replaces it.
+  note?: string;
 }
 
 // todo: this should be someplace else

--- a/tools/data-handler/test/command-clean.test.ts
+++ b/tools/data-handler/test/command-clean.test.ts
@@ -323,7 +323,8 @@ describe('clean recommendation', () => {
   const baseDir = import.meta.dirname;
   const DECISION = 'decision/cardTypes/decision';
   const RECOMMENDATION = "'cyberismo clean' to remove them";
-  const COUNTS = /\d+ unused field value\(s\) from \d+ card\(s\)/;
+  const COUNTS =
+    /this project has \d+ unused field value\(s\) on \d+ card\(s\)/i;
 
   // Each test gets its own project folder: the CommandManager instance the
   // handler uses is keyed by project path, so a reused path would be served
@@ -357,10 +358,11 @@ describe('clean recommendation', () => {
       );
 
       expect(result.statusCode).toBe(200);
-      // The note carries the success line, which the CLI would otherwise print.
-      expect(result.message).toContain('Done');
-      expect(result.message).toMatch(COUNTS);
-      expect(result.message).toContain(RECOMMENDATION);
+      // The note travels beside 'message' so the CLI keeps printing its own
+      // success line.
+      expect(result.message).toBeUndefined();
+      expect(result.note).toMatch(COUNTS);
+      expect(result.note).toContain(RECOMMENDATION);
     } finally {
       rmSync(testDir, { recursive: true, force: true });
     }
@@ -389,8 +391,9 @@ describe('clean recommendation', () => {
       );
 
       expect(result.statusCode).toBe(200);
-      expect(result.message).toMatch(COUNTS);
-      expect(result.message).toContain(RECOMMENDATION);
+      expect(result.message).toBeUndefined();
+      expect(result.note).toMatch(COUNTS);
+      expect(result.note).toContain(RECOMMENDATION);
     } finally {
       rmSync(testDir, { recursive: true, force: true });
     }
@@ -423,7 +426,7 @@ describe('clean recommendation', () => {
       );
 
       expect(result.statusCode).toBe(200);
-      expect(result.message).toBeUndefined();
+      expect(result.note).toBeUndefined();
     } finally {
       rmSync(testDir, { recursive: true, force: true });
     }
@@ -470,7 +473,7 @@ describe('clean recommendation', () => {
       );
 
       expect(result.statusCode).toBe(200);
-      expect(result.message).toBeUndefined();
+      expect(result.note).toBeUndefined();
     } finally {
       rmSync(testDir, { recursive: true, force: true });
     }
@@ -489,11 +492,11 @@ describe('clean recommendation', () => {
         options,
       );
       expect(imported.statusCode).toBe(200);
-      expect(imported.message).toContain(RECOMMENDATION);
+      expect(imported.note).toContain(RECOMMENDATION);
 
       const updated = await handler.command(Cmd.updateModules, [], options);
       expect(updated.statusCode).toBe(200);
-      expect(updated.message).toContain(RECOMMENDATION);
+      expect(updated.note).toContain(RECOMMENDATION);
     } finally {
       rmSync(testDir, { recursive: true, force: true });
     }
@@ -522,7 +525,7 @@ describe('clean recommendation', () => {
 
       expect(failingScan).toHaveBeenCalled();
       expect(result.statusCode).toBe(200);
-      expect(result.message).toBeUndefined();
+      expect(result.note).toBeUndefined();
     } finally {
       vi.restoreAllMocks();
       rmSync(testDir, { recursive: true, force: true });

--- a/tools/data-handler/test/command-clean.test.ts
+++ b/tools/data-handler/test/command-clean.test.ts
@@ -5,7 +5,8 @@ import { mkdirSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 
 import { copyDir } from '../src/utils/file-utils.js';
 import { CommandManager } from '../src/command-manager.js';
-import type { Clean } from '../src/commands/clean.js';
+import { Cmd, Commands } from '../src/command-handler.js';
+import { Clean } from '../src/commands/clean.js';
 
 const GHOST = 'decision/fieldTypes/ghost';
 const OBSOLETED_BY = 'decision/fieldTypes/obsoletedBy';
@@ -314,6 +315,217 @@ describe('clean command', () => {
     for (const finding of result.findings) {
       const card = commands.project.findCard(finding.cardKey);
       expect(card.metadata!.cardType).toBe('decision/cardTypes/simplepage');
+    }
+  });
+});
+
+describe('clean recommendation', () => {
+  const baseDir = import.meta.dirname;
+  const DECISION = 'decision/cardTypes/decision';
+  const RECOMMENDATION = "'cyberismo clean' to remove them";
+  const COUNTS = /\d+ unused field value\(s\) from \d+ card\(s\)/;
+
+  // Each test gets its own project folder: the CommandManager instance the
+  // handler uses is keyed by project path, so a reused path would be served
+  // from a stale in-memory project.
+  async function handlerProject(testDirName: string) {
+    const testDir = join(baseDir, testDirName);
+    mkdirSync(testDir, { recursive: true });
+    await copyDir('test/test-data/', testDir);
+    return {
+      testDir,
+      handler: new Commands(),
+      options: { projectPath: join(testDir, 'valid/decision-records') },
+    };
+  }
+
+  it('recommends clean after removing a custom field from a card type', async () => {
+    const { testDir, handler, options } = await handlerProject(
+      'tmp-clean-recommend-remove',
+    );
+    try {
+      const result = await handler.command(
+        Cmd.update,
+        [
+          DECISION,
+          'remove',
+          'customFields',
+          JSON.stringify({ name: 'decision/fieldTypes/responsible' }),
+          '',
+        ],
+        options,
+      );
+
+      expect(result.statusCode).toBe(200);
+      // The note carries the success line, which the CLI would otherwise print.
+      expect(result.message).toContain('Done');
+      expect(result.message).toMatch(COUNTS);
+      expect(result.message).toContain(RECOMMENDATION);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('recommends clean after making a custom field calculated', async () => {
+    const { testDir, handler, options } = await handlerProject(
+      'tmp-clean-recommend-change',
+    );
+    try {
+      // decision_6 stores a value for this field; once the field is calculated
+      // without an override, that stored value is dormant.
+      const result = await handler.command(
+        Cmd.update,
+        [
+          DECISION,
+          'change',
+          'customFields',
+          JSON.stringify({ name: 'decision/fieldTypes/numberOfCommits' }),
+          JSON.stringify({
+            name: 'decision/fieldTypes/numberOfCommits',
+            isCalculated: true,
+          }),
+        ],
+        options,
+      );
+
+      expect(result.statusCode).toBe(200);
+      expect(result.message).toMatch(COUNTS);
+      expect(result.message).toContain(RECOMMENDATION);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not recommend clean after adding a custom field', async () => {
+    const { testDir, handler, options } = await handlerProject(
+      'tmp-clean-recommend-add',
+    );
+    try {
+      const created = await handler.command(
+        Cmd.create,
+        ['fieldType', 'extra', 'shortText'],
+        options,
+      );
+      expect(created.statusCode).toBe(200);
+
+      // The card type's cards do hold dormant values, so a scan would report
+      // findings — an 'add' must not run one.
+      const result = await handler.command(
+        Cmd.update,
+        [
+          DECISION,
+          'add',
+          'customFields',
+          JSON.stringify({ name: 'decision/fieldTypes/extra' }),
+          '',
+        ],
+        options,
+      );
+
+      expect(result.statusCode).toBe(200);
+      expect(result.message).toBeUndefined();
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not recommend clean when no card of the card type has dormant data', async () => {
+    const { testDir, handler, options } = await handlerProject(
+      'tmp-clean-recommend-unused-card-type',
+    );
+    try {
+      await handler.command(
+        Cmd.create,
+        ['fieldType', 'extra', 'shortText'],
+        options,
+      );
+      await handler.command(
+        Cmd.create,
+        ['cardType', 'unused', 'decision/workflows/decision'],
+        options,
+      );
+      const added = await handler.command(
+        Cmd.update,
+        [
+          'decision/cardTypes/unused',
+          'add',
+          'customFields',
+          JSON.stringify({ name: 'decision/fieldTypes/extra' }),
+          '',
+        ],
+        options,
+      );
+      expect(added.statusCode).toBe(200);
+
+      const result = await handler.command(
+        Cmd.update,
+        [
+          'decision/cardTypes/unused',
+          'remove',
+          'customFields',
+          JSON.stringify({ name: 'decision/fieldTypes/extra' }),
+          '',
+        ],
+        options,
+      );
+
+      expect(result.statusCode).toBe(200);
+      expect(result.message).toBeUndefined();
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('recommends clean after a module import and after a module update', async () => {
+    const { testDir, handler, options } = await handlerProject(
+      'tmp-clean-recommend-modules',
+    );
+    try {
+      // The project's own cards already hold dormant values, so both module
+      // operations have something to report.
+      const imported = await handler.command(
+        Cmd.import,
+        ['module', join(testDir, 'valid/minimal')],
+        options,
+      );
+      expect(imported.statusCode).toBe(200);
+      expect(imported.message).toContain(RECOMMENDATION);
+
+      const updated = await handler.command(Cmd.updateModules, [], options);
+      expect(updated.statusCode).toBe(200);
+      expect(updated.message).toContain(RECOMMENDATION);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('a failing scan does not fail the operation', async () => {
+    const { testDir, handler, options } = await handlerProject(
+      'tmp-clean-recommend-scan-failure',
+    );
+    try {
+      const failingScan = vi
+        .spyOn(Clean.prototype, 'clean')
+        .mockRejectedValue(new Error('scan failed'));
+
+      const result = await handler.command(
+        Cmd.update,
+        [
+          DECISION,
+          'remove',
+          'customFields',
+          JSON.stringify({ name: 'decision/fieldTypes/responsible' }),
+          '',
+        ],
+        options,
+      );
+
+      expect(failingScan).toHaveBeenCalled();
+      expect(result.statusCode).toBe(200);
+      expect(result.message).toBeUndefined();
+    } finally {
+      vi.restoreAllMocks();
+      rmSync(testDir, { recursive: true, force: true });
     }
   });
 });

--- a/tools/data-handler/test/command-clean.test.ts
+++ b/tools/data-handler/test/command-clean.test.ts
@@ -1,0 +1,319 @@
+// testing
+import { expect, it, describe, beforeAll, afterAll, vi } from 'vitest';
+import { join } from 'node:path';
+import { mkdirSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
+
+import { copyDir } from '../src/utils/file-utils.js';
+import { CommandManager } from '../src/command-manager.js';
+import type { Clean } from '../src/commands/clean.js';
+
+const GHOST = 'decision/fieldTypes/ghost';
+const OBSOLETED_BY = 'decision/fieldTypes/obsoletedBy';
+
+describe('clean command', () => {
+  const baseDir = import.meta.dirname;
+  const testDir = join(baseDir, 'tmp-clean-tests');
+  const decisionRecordsPath = join(testDir, 'valid/decision-records');
+  let commands: CommandManager;
+  let cleanCmd: Clean;
+
+  beforeAll(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir('test/test-data/', testDir);
+    commands = new CommandManager(decisionRecordsPath, {
+      autoSaveConfiguration: false,
+    });
+    await commands.initialize();
+    cleanCmd = commands.cleanCmd;
+  });
+
+  afterAll(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  // Cleaning is destructive, so tests that need the fixture's own dormant data
+  // (its null placeholders) run against their own project copy.
+  async function freshProject(
+    testDirName: string,
+    prepare?: (projectPath: string) => void,
+  ) {
+    const freshTestDir = join(baseDir, testDirName);
+    mkdirSync(freshTestDir, { recursive: true });
+    await copyDir('test/test-data/', freshTestDir);
+    const projectPath = join(freshTestDir, 'valid/decision-records');
+    prepare?.(projectPath);
+
+    const freshCommands = new CommandManager(projectPath, {
+      autoSaveConfiguration: false,
+    });
+    await freshCommands.initialize();
+    return { freshTestDir, freshCommands };
+  }
+
+  async function storeValue(
+    manager: CommandManager,
+    cardKey: string,
+    field: string,
+    value: string,
+  ) {
+    const card = manager.project.findCard(cardKey);
+    card.metadata![field] = value;
+    await manager.project.updateCardMetadata(card, card.metadata!);
+  }
+
+  it('dry-run reports null-valued custom fields without writing', async () => {
+    const { freshTestDir, freshCommands } =
+      await freshProject('tmp-clean-dry-run');
+    try {
+      const card = freshCommands.project.findCard('decision_6');
+      const file = join(card.path, 'index.json');
+      const before = readFileSync(file, 'utf-8');
+
+      const result = await freshCommands.cleanCmd.clean(true);
+
+      expect(result.dryRun).toBe(true);
+      expect(result.findings.some((f) => f.reason === 'null-value')).toBe(true);
+      expect(readFileSync(file, 'utf-8')).toBe(before);
+    } finally {
+      rmSync(freshTestDir, { recursive: true, force: true });
+    }
+  });
+
+  it('removes null-valued custom fields', async () => {
+    const { freshTestDir, freshCommands } =
+      await freshProject('tmp-clean-nulls');
+    try {
+      const result = await freshCommands.cleanCmd.clean(false);
+
+      expect(result.findings.length).toBeGreaterThan(0);
+      for (const card of freshCommands.project.cards()) {
+        const nulls = Object.entries(card.metadata!).filter(
+          ([key, value]) => value === null && key.includes('/'),
+        );
+        expect(nulls).toEqual([]);
+      }
+    } finally {
+      rmSync(freshTestDir, { recursive: true, force: true });
+    }
+  });
+
+  it('removes keys the card type does not declare', async () => {
+    await storeValue(commands, 'decision_6', GHOST, 'stale');
+
+    const result = await cleanCmd.clean(false);
+
+    expect(result.findings).toContainEqual({
+      cardKey: 'decision_6',
+      field: GHOST,
+      reason: 'undeclared',
+    });
+    expect(
+      commands.project.findCard('decision_6').metadata!,
+    ).not.toHaveProperty([GHOST]);
+  });
+
+  it('removes stored values on calculated fields without override', async () => {
+    await storeValue(commands, 'decision_6', OBSOLETED_BY, 'stale');
+
+    const result = await cleanCmd.clean(false);
+
+    expect(result.findings).toContainEqual({
+      cardKey: 'decision_6',
+      field: OBSOLETED_BY,
+      reason: 'calculated-locked',
+    });
+    expect(
+      commands.project.findCard('decision_6').metadata!,
+    ).not.toHaveProperty([OBSOLETED_BY]);
+  });
+
+  it('keeps a calculated field value when the card type enables override', async () => {
+    const { freshTestDir, freshCommands } = await freshProject(
+      'tmp-clean-override',
+      (projectPath) => {
+        const cardTypePath = join(
+          projectPath,
+          '.cards/local/cardTypes/decision.json',
+        );
+        const cardType = JSON.parse(readFileSync(cardTypePath, 'utf-8'));
+        const field = cardType.customFields.find(
+          (f: { name: string }) => f.name === OBSOLETED_BY,
+        );
+        expect(field).toBeDefined();
+        field.enableOverride = true;
+        writeFileSync(cardTypePath, JSON.stringify(cardType));
+      },
+    );
+    try {
+      await storeValue(freshCommands, 'decision_6', OBSOLETED_BY, 'decision_5');
+      // A sibling removal proves the card really was visited and written.
+      await storeValue(freshCommands, 'decision_6', GHOST, 'stale');
+
+      const result = await freshCommands.cleanCmd.clean(false);
+
+      expect(result.skippedCards).not.toContain('decision_6');
+      expect(result.findings).toContainEqual({
+        cardKey: 'decision_6',
+        field: GHOST,
+        reason: 'undeclared',
+      });
+      expect(result.findings.every((f) => f.field !== OBSOLETED_BY)).toBe(true);
+
+      const cleaned = freshCommands.project.findCard('decision_6');
+      expect(cleaned.metadata!).not.toHaveProperty([GHOST]);
+      expect(cleaned.metadata![OBSOLETED_BY]).toBe('decision_5');
+    } finally {
+      rmSync(freshTestDir, { recursive: true, force: true });
+    }
+  });
+
+  it('skips cards whose card type cannot be resolved', async () => {
+    const { freshTestDir, freshCommands } = await freshProject(
+      'tmp-clean-skipped',
+      (projectPath) => {
+        const cardFile = join(
+          projectPath,
+          'cardRoot/decision_5/c/decision_6/index.json',
+        );
+        const metadata = JSON.parse(readFileSync(cardFile, 'utf-8'));
+        metadata.cardType = 'decision/cardTypes/gone';
+        writeFileSync(cardFile, JSON.stringify(metadata, null, 4));
+      },
+    );
+    try {
+      const cardFile = join(
+        freshCommands.project.findCard('decision_6').path,
+        'index.json',
+      );
+      const before = readFileSync(cardFile, 'utf-8');
+
+      const result = await freshCommands.cleanCmd.clean(false);
+
+      expect(result.skippedCards).toContain('decision_6');
+      expect(result.findings.every((f) => f.cardKey !== 'decision_6')).toBe(
+        true,
+      );
+      expect(readFileSync(cardFile, 'utf-8')).toBe(before);
+    } finally {
+      rmSync(freshTestDir, { recursive: true, force: true });
+    }
+  });
+
+  it('a card that cannot be written does not stop the run', async () => {
+    const { freshTestDir, freshCommands } = await freshProject(
+      'tmp-clean-write-failure',
+    );
+    try {
+      const failingFile = join(
+        freshCommands.project.findCard('decision_6').path,
+        'index.json',
+      );
+      const before = readFileSync(failingFile, 'utf-8');
+      const templateCard = freshCommands.project
+        .templateCards('decision/templates/decision')
+        .at(0)!;
+      const templateFile = join(templateCard.path, 'index.json');
+
+      // Project cards are visited first, and decision_6 is the only one with
+      // removals, so the single rejection lands on it.
+      const failingWrite = vi
+        .spyOn(freshCommands.project, 'updateCardMetadata')
+        .mockRejectedValueOnce(new Error('write failed'));
+      const result = await freshCommands.cleanCmd.clean(false);
+      failingWrite.mockRestore();
+
+      expect(result.failedCards).toEqual(['decision_6']);
+      expect(readFileSync(failingFile, 'utf-8')).toBe(before);
+
+      // The run continued: the template card after it was still cleaned.
+      expect(result.findings.some((f) => f.cardKey === templateCard.key)).toBe(
+        true,
+      );
+      expect(readFileSync(templateFile, 'utf-8')).not.toContain('null');
+    } finally {
+      rmSync(freshTestDir, { recursive: true, force: true });
+    }
+  });
+
+  it('never touches module cards', async () => {
+    const moduleTestDir = join(baseDir, 'tmp-clean-module');
+    mkdirSync(moduleTestDir, { recursive: true });
+    await copyDir('test/test-data/', moduleTestDir);
+    const importing = new CommandManager(join(moduleTestDir, 'valid/minimal'), {
+      autoSaveConfiguration: false,
+    });
+    await importing.initialize();
+    try {
+      // The imported project's template card carries null placeholders.
+      await importing.importCmd.importModule(
+        join(moduleTestDir, 'valid/decision-records'),
+      );
+      const moduleCards = importing.project
+        .allTemplateCards()
+        .filter((card) => card.path.includes(join('.cards', 'modules')));
+      expect(moduleCards.length).toBeGreaterThan(0);
+      const moduleFiles = moduleCards.map((card) =>
+        join(card.path, 'index.json'),
+      );
+      const before = moduleFiles.map((file) => readFileSync(file, 'utf-8'));
+      expect(before.some((content) => content.includes('null'))).toBe(true);
+
+      const result = await importing.cleanCmd.clean(false);
+
+      const moduleKeys = moduleCards.map((card) => card.key);
+      expect(
+        result.findings.every((f) => !moduleKeys.includes(f.cardKey)),
+      ).toBe(true);
+      expect(moduleFiles.map((file) => readFileSync(file, 'utf-8'))).toEqual(
+        before,
+      );
+    } finally {
+      rmSync(moduleTestDir, { recursive: true, force: true });
+    }
+  });
+
+  it('cleans local template cards too', async () => {
+    const templateCard = commands.project
+      .templateCards('decision/templates/decision')
+      .at(0)!;
+    await storeValue(commands, templateCard.key, GHOST, 'stale');
+
+    const result = await cleanCmd.clean(false);
+
+    expect(result.findings).toContainEqual({
+      cardKey: templateCard.key,
+      field: GHOST,
+      reason: 'undeclared',
+    });
+    expect(
+      commands.project.findCard(templateCard.key).metadata!,
+    ).not.toHaveProperty([GHOST]);
+  });
+
+  it('never touches predefined fields', async () => {
+    await cleanCmd.clean(false);
+
+    const card = commands.project.findCard('decision_6');
+    expect(card.metadata!.title).toBeDefined();
+    expect(card.metadata!.cardType).toBe('decision/cardTypes/decision');
+    expect(card.metadata!.workflowState).toBeDefined();
+  });
+
+  it('cardType filter scopes the scan', async () => {
+    await storeValue(commands, 'decision_5', GHOST, 'stale');
+    await storeValue(commands, 'decision_6', GHOST, 'stale');
+
+    const result = await cleanCmd.clean(true, 'decision/cardTypes/simplepage');
+
+    expect(result.findings).toContainEqual({
+      cardKey: 'decision_5',
+      field: GHOST,
+      reason: 'undeclared',
+    });
+    expect(result.findings.every((f) => f.cardKey !== 'decision_6')).toBe(true);
+    for (const finding of result.findings) {
+      const card = commands.project.findCard(finding.cardKey);
+      expect(card.metadata!.cardType).toBe('decision/cardTypes/simplepage');
+    }
+  });
+});

--- a/tools/data-handler/test/command-clean.test.ts
+++ b/tools/data-handler/test/command-clean.test.ts
@@ -350,7 +350,7 @@ describe('clean recommendation', () => {
   const DECISION = 'decision/cardTypes/decision';
   const RECOMMENDATION = "'cyberismo clean' to remove them";
   const COUNTS =
-    /this project has \d+ unused field value\(s\) on \d+ card\(s\)/i;
+    /this project has \d+ dormant field value\(s\) on \d+ card\(s\)/i;
 
   // Each test gets its own project folder: the CommandManager instance the
   // handler uses is keyed by project path, so a reused path would be served

--- a/tools/data-handler/test/command-clean.test.ts
+++ b/tools/data-handler/test/command-clean.test.ts
@@ -168,6 +168,32 @@ describe('clean command', () => {
     }
   });
 
+  it('a dry run takes the read lock, not the write lock', async () => {
+    const { freshTestDir, freshCommands } =
+      await freshProject('tmp-clean-lock');
+    try {
+      // The write lock's after-write hooks commit and recalculate; a dry run
+      // changes nothing and must not trigger either.
+      const afterWrite = vi.fn().mockResolvedValue(undefined);
+      freshCommands.project.lock.onAfterWrite(afterWrite);
+
+      await freshCommands.cleanCmd.clean(true);
+      expect(afterWrite).not.toHaveBeenCalled();
+
+      // A read lock is reentrant from a read context; a write lock throws.
+      const nested = await freshCommands.project.lock.read(() =>
+        freshCommands.cleanCmd.clean(true),
+      );
+      expect(nested.findings.length).toBeGreaterThan(0);
+      expect(afterWrite).not.toHaveBeenCalled();
+
+      await freshCommands.cleanCmd.clean(false);
+      expect(afterWrite).toHaveBeenCalled();
+    } finally {
+      rmSync(freshTestDir, { recursive: true, force: true });
+    }
+  });
+
   it('skips cards whose card type cannot be resolved', async () => {
     const { freshTestDir, freshCommands } = await freshProject(
       'tmp-clean-skipped',


### PR DESCRIPTION
The relaxed state is allowed, but `cyberismo clean` then does the following:
* Removes all field values(in cards and templates), where the field type is not configured for the given card type
* Removes all null values and replaces them with undefined values

Additionally, `cyberismo clean --dry-run` allows seeing what the command would do before acting on it