### PR TITLE
INTDEV-1359 Fix wrong create button in template card editor

### DIFF
--- a/tools/app/__tests__/hooks.utils.test.tsx
+++ b/tools/app/__tests__/hooks.utils.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, test, vi, beforeEach } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { render, screen } from '@testing-library/react';
 
-import { useConfigTemplateCreationContext } from '@/lib/hooks';
+import { useConfigTemplateCreationContext, useIsInCards } from '@/lib/hooks';
 import { formKeyHandler } from '@/lib/hooks/utils';
 import type { AnyNode } from '@/lib/api/types';
 
@@ -178,15 +178,53 @@ function HookProbe() {
   );
 }
 
-function renderAt(pathname: string) {
+function renderAt(
+  pathname: string,
+  element: React.ReactElement = <HookProbe />,
+) {
   return render(
     <MemoryRouter initialEntries={[pathname]}>
       <Routes>
-        <Route path="*" element={<HookProbe />} />
+        <Route path="*" element={element} />
       </Routes>
     </MemoryRouter>,
   );
 }
+
+function InCardsProbe() {
+  return <div data-testid="inCards">{String(useIsInCards())}</div>;
+}
+
+function renderInCardsAt(pathname: string) {
+  renderAt(pathname, <InCardsProbe />);
+  return screen.getByTestId('inCards').textContent;
+}
+
+describe('useIsInCards', () => {
+  test('is true in the card tree view', () => {
+    expect(renderInCardsAt('/projects/test/cards')).toBe('true');
+  });
+
+  test('is true in a card view', () => {
+    expect(renderInCardsAt('/projects/test/cards/test_1')).toBe('true');
+  });
+
+  test('is false in the configuration view', () => {
+    expect(renderInCardsAt('/projects/test/configuration')).toBe('false');
+  });
+
+  test('is false in a template card editor', () => {
+    expect(
+      renderInCardsAt('/projects/test/configuration/test/cards/test_1'),
+    ).toBe('false');
+  });
+
+  test('is false in a template editor', () => {
+    expect(
+      renderInCardsAt('/projects/test/configuration/test/templates/mytemplate'),
+    ).toBe('false');
+  });
+});
 
 describe('useConfigTemplateCreationContext', () => {
   beforeEach(() => {

--- a/tools/app/e2e/tests/app.spec.ts
+++ b/tools/app/e2e/tests/app.spec.ts
@@ -689,6 +689,35 @@ test.describe('Navigation', () => {
     await expect(page.getByTestId('contentSaveButton')).toBeDisabled();
   });
 
+  test('template card editor shows the resource create button', async ({
+    page,
+  }) => {
+    const keys = JSON.parse(
+      readFileSync(
+        join(import.meta.dirname, '..', 'assets', 'e2e-keys.json'),
+        'utf8',
+      ),
+    ) as { localTemplateCardKey: string };
+    const url = page.url();
+    const projectPrefix = url.split('/projects/')[1].split('/')[0];
+    await page.goto(
+      `/configuration/${projectPrefix}/cards/${keys.localTemplateCardKey}`,
+    );
+    await expect(page.getByTestId('metadataView')).toBeVisible();
+
+    await expect(page.getByTestId('createNewButton')).toHaveCount(0);
+
+    // Template card creation is available, because a template card is being
+    // viewed.
+    await page.getByRole('button', { name: t.toolbar.newResource }).click();
+    await page.getByRole('menuitem', { name: t.templateCard }).click();
+    await expect(
+      page.getByRole('dialog').getByRole('heading', { name: t.templateCard }),
+    ).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+  });
+
   test('test notifications and policy checks', async ({ page }) => {
     await page.getByTestId('createNewButton').click();
     await page

--- a/tools/app/src/lib/hooks/utils.ts
+++ b/tools/app/src/lib/hooks/utils.ts
@@ -13,7 +13,7 @@
 import { useMemo, useEffect, useState, useCallback, useRef } from 'react';
 import { findParentCard } from '../utils';
 import { useTree } from '../api';
-import { useLocation, useParams } from 'react-router';
+import { useLocation, useMatch, useParams } from 'react-router';
 import { useResourceTree } from '../api/resources';
 import type { AnyNode } from '../api/types';
 
@@ -340,11 +340,14 @@ export function useDocumentTitle(title: string) {
 
 /**
  * This hook is used to check if the current location is in the cards page.
+ * Matches the cards routes explicitly, since configuration routes of template
+ * cards also contain a `cards` segment (e.g. /configuration/module/cards/key).
  * @returns true if the current location is in the cards page, false otherwise
  */
 export function useIsInCards() {
-  const location = useLocation();
-  return location.pathname.includes('/cards');
+  return (
+    useMatch({ path: '/projects/:projectPrefix/cards', end: false }) !== null
+  );
 }
 
 /**


### PR DESCRIPTION
Match the cards routes explicitly with `useMatch({ path: '/projects/:projectPrefix/cards', end: false })`. Configuration routes now get the resource dropdown, where the existing logic already enables "Template card" only for templates and template cards.