### PR TITLE
INTDEV-1339 Fix absolute app URLs

### DIFF
--- a/tools/app/__tests__/SvgWrapper.test.tsx
+++ b/tools/app/__tests__/SvgWrapper.test.tsx
@@ -12,17 +12,20 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom';
 import { withRouter } from './helpers/router';
 import type * as libHooksModule from '@/lib/hooks';
+
+// A stable safePush across renders so navigation targets can be asserted
+const { safePush } = vi.hoisted(() => ({ safePush: vi.fn() }));
 
 vi.mock('@/lib/hooks', async (importOriginal) => {
   const actual = await importOriginal<typeof libHooksModule>();
   const { mockAppRouter } = await import('./helpers/router');
   return {
     ...actual,
-    useAppRouter: vi.fn(mockAppRouter),
+    useAppRouter: vi.fn(() => ({ ...mockAppRouter(), safePush })),
   };
 });
 
@@ -116,5 +119,53 @@ describe('SvgWrapper', () => {
 
     // The inline diagram plus its serialized copy inside the viewer modal
     expect(document.querySelectorAll('svg#diagram')).toHaveLength(2);
+  });
+
+  describe('links inside the diagram', () => {
+    // Graph macro SVGs use xlink:href, which the content parser does not turn
+    // into router links — SvgWrapper intercepts the clicks instead.
+    const diagram = (href: string) => (
+      <SvgWrapper>
+        <svg
+          viewBox="0 0 10 10"
+          dangerouslySetInnerHTML={{
+            __html: `<a xlink:href="${href}"><text>target card</text></a>`,
+          }}
+        />
+      </SvgWrapper>
+    );
+
+    beforeEach(() => {
+      safePush.mockClear();
+    });
+
+    it('routes a root-relative link through the router', () => {
+      render(withRouter(diagram('/cards/csecdev_6wccziw3')));
+
+      fireEvent.click(screen.getByText('target card'));
+
+      expect(safePush).toHaveBeenCalledWith('/cards/csecdev_6wccziw3');
+    });
+
+    // Regression: the absolute URL was pushed to the router as-is, which
+    // resolved it relative to the current location.
+    it('routes an absolute same-origin link as an origin-relative path', () => {
+      const href = `${window.location.origin}/projects/csecdev/cards/csecdev_6wccziw3`;
+      render(withRouter(diagram(href)));
+
+      fireEvent.click(screen.getByText('target card'));
+
+      expect(safePush).toHaveBeenCalledWith(
+        '/projects/csecdev/cards/csecdev_6wccziw3',
+      );
+    });
+
+    it('leaves external links to the browser', () => {
+      render(withRouter(diagram('https://example.com/cards/x')));
+
+      fireEvent.click(screen.getByText('target card'));
+
+      expect(safePush).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tools/app/__tests__/renderCardContent.test.tsx
+++ b/tools/app/__tests__/renderCardContent.test.tsx
@@ -11,18 +11,21 @@
   You should have received a copy of the GNU Affero General Public
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
-import { render, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom';
 import { BrowserRouter } from 'react-router';
 import type * as libHooksModule from '@/lib/hooks';
+
+// A stable safePush across renders so navigation targets can be asserted
+const { safePush } = vi.hoisted(() => ({ safePush: vi.fn() }));
 
 vi.mock('@/lib/hooks', async (importOriginal) => {
   const actual = await importOriginal<typeof libHooksModule>();
   const { mockAppRouter } = await import('./helpers/router');
   return {
     ...actual,
-    useAppRouter: vi.fn(mockAppRouter),
+    useAppRouter: vi.fn(() => ({ ...mockAppRouter(), safePush })),
   };
 });
 
@@ -115,5 +118,55 @@ describe('renderCardHtml', () => {
     expect(container.querySelectorAll('[data-cy="svg-controls"]')).toHaveLength(
       1,
     );
+  });
+
+  describe('links', () => {
+    const link = (href: string) =>
+      `<div class="paragraph"><p><a href="${href}">target card</a></p></div>`;
+
+    beforeEach(() => {
+      safePush.mockClear();
+    });
+
+    it('routes a root-relative link through the router', () => {
+      render(<Content html={link('/cards/csecdev_6wccziw3')} />);
+
+      fireEvent.click(screen.getByText('target card'));
+
+      expect(safePush).toHaveBeenCalledWith('/cards/csecdev_6wccziw3');
+    });
+
+    // Regression: pasting a full app URL into card content navigated to
+    // <current path>/http:/localhost:3000/... because the absolute URL was
+    // passed to the router, which resolves non-slash-prefixed targets
+    // relative to the current location.
+    it('routes an absolute same-origin link as an origin-relative path', () => {
+      const href = `${window.location.origin}/projects/csecdev/cards/csecdev_6wccziw3`;
+      render(<Content html={link(href)} />);
+
+      fireEvent.click(screen.getByText('target card'));
+
+      expect(safePush).toHaveBeenCalledWith(
+        '/projects/csecdev/cards/csecdev_6wccziw3',
+      );
+    });
+
+    it('leaves external links to the browser', () => {
+      render(<Content html={link('https://example.com/cards/x')} />);
+
+      const anchor = screen.getByText('target card');
+      fireEvent.click(anchor);
+
+      expect(safePush).not.toHaveBeenCalled();
+      expect(anchor).toHaveAttribute('href', 'https://example.com/cards/x');
+    });
+
+    it('leaves anchor fragments to the browser', () => {
+      render(<Content html={link('#_section_title')} />);
+
+      fireEvent.click(screen.getByText('target card'));
+
+      expect(safePush).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tools/app/__tests__/utils.test.ts
+++ b/tools/app/__tests__/utils.test.ts
@@ -9,6 +9,7 @@ import type { ExpandedLinkType } from '@/lib/definitions';
 import { expect, test, describe } from 'vitest';
 
 import {
+  appRoutePath,
   countChildren,
   deepCopy,
   isSafeRedirectPath,
@@ -835,5 +836,53 @@ describe('getInitials', () => {
 
   test('handles whitespace-only input', () => {
     expect(getInitials('   ')).toBe('');
+  });
+});
+
+describe('appRoutePath', () => {
+  const origin = window.location.origin;
+
+  test('returns the path unchanged for a root-relative path', () => {
+    expect(appRoutePath('/cards/csecdev_6wccziw3')).toBe(
+      '/cards/csecdev_6wccziw3',
+    );
+  });
+
+  // Regression: an absolute same-origin URL used to be handed to the router
+  // as-is, which resolved it relative to the current location and produced
+  // e.g. /cards/x/http:/localhost:3000/cards/x
+  test('strips the origin from an absolute same-origin URL', () => {
+    expect(
+      appRoutePath(`${origin}/projects/csecdev/cards/csecdev_6wccziw3`),
+    ).toBe('/projects/csecdev/cards/csecdev_6wccziw3');
+  });
+
+  test('keeps search and hash when stripping the origin', () => {
+    expect(appRoutePath(`${origin}/cards/x?tab=links#section`)).toBe(
+      '/cards/x?tab=links#section',
+    );
+  });
+
+  test('normalizes relative segments in a same-origin URL', () => {
+    expect(appRoutePath(`${origin}/cards/../cards/x`)).toBe('/cards/x');
+  });
+
+  test.each([
+    'https://example.com/cards/x',
+    'http://localhost:4000/cards/x',
+    'mailto:someone@example.com',
+    'tel:+358401234567',
+    'javascript:alert(1)',
+    '#_section_title',
+    '/api',
+    '/api/cards/csecdev_6wccziw3',
+    `${window.location.origin}/api/cards/csecdev_6wccziw3`,
+    '',
+  ])('returns null for %s so the browser handles it', (href) => {
+    expect(appRoutePath(href)).toBeNull();
+  });
+
+  test('returns null for a missing href', () => {
+    expect(appRoutePath(undefined)).toBeNull();
   });
 });

--- a/tools/app/src/components/SvgWrapper.tsx
+++ b/tools/app/src/components/SvgWrapper.tsx
@@ -19,7 +19,7 @@ import OpenInFullIcon from '@mui/icons-material/OpenInFull';
 
 import SvgViewerModal from '@/components/modals/svgViewerModal';
 import { useAppRouter } from '@/lib/hooks';
-import { isAppUrl } from '@/lib/utils';
+import { appRoutePath } from '@/lib/utils';
 
 export interface SvgWrapperProps {
   /** The SVG content (already sanitized). */
@@ -92,9 +92,10 @@ function SvgWrapper({ children, downloadName }: SvgWrapperProps) {
     if (!anchor) return;
     const href =
       anchor.getAttribute('href') ?? anchor.getAttribute('xlink:href');
-    if (!href || !isAppUrl(href)) return;
+    const routePath = href ? appRoutePath(href) : null;
+    if (!routePath) return;
     e.preventDefault();
-    router.safePush(href);
+    router.safePush(routePath);
   };
 
   return (

--- a/tools/app/src/components/card/renderCardContent.tsx
+++ b/tools/app/src/components/card/renderCardContent.tsx
@@ -28,7 +28,7 @@ import { macros as UImacros } from '@/components/macros';
 import Mermaid from '@/components/macros/Mermaid';
 import { SafeRouterLink } from '@/components/SafeRouterLink';
 import SvgWrapper from '@/components/SvgWrapper';
-import { isAppUrl, parseDataAttributes } from '@/lib/utils';
+import { appRoutePath, parseDataAttributes } from '@/lib/utils';
 
 // Derive allowed macro tags from the frontend macro definitions so they survive sanitization
 const MACRO_TAGS = Object.values(macroMetadata)
@@ -98,9 +98,10 @@ export function renderCardHtml(html: string, options: RenderCardHtmlOptions) {
     }
     if (node.name === 'a') {
       const href = node.attribs?.href;
-      if (href && isAppUrl(href)) {
+      const routePath = href ? appRoutePath(href) : null;
+      if (routePath) {
         return (
-          <SafeRouterLink to={href}>
+          <SafeRouterLink to={routePath}>
             {domToReact(node.children as DOMNode[])}
           </SafeRouterLink>
         );

--- a/tools/app/src/lib/utils.ts
+++ b/tools/app/src/lib/utils.ts
@@ -510,25 +510,31 @@ export function isAlreadyLinked(
 }
 
 /**
- * Returns true if `href` should be handled by React Router (SPA navigation)
- * rather than the browser's default link behavior.
+ * Returns the origin-relative path to navigate to if `href` should be handled
+ * by React Router (SPA navigation), or null if the browser's default link
+ * behavior should apply.
  *
  * App URLs are same-origin http(s) paths that aren't backend API endpoints.
  * External URLs, `mailto:`/`tel:`/`javascript:` schemes, anchor fragments, and
- * `/api/*` paths fall through to the browser.
+ * `/api/*` paths return null and fall through to the browser.
+ *
+ * The origin is always stripped from the returned path: React Router resolves a
+ * `to`/`navigate()` string that does not start with `/` relative to the current
+ * location, so passing an absolute URL through would append it to the current
+ * path instead of navigating to it.
  */
-export function isAppUrl(href: string): boolean {
-  if (href.startsWith('#')) return false;
+export function appRoutePath(href: string | undefined): string | null {
+  if (!href || href.startsWith('#')) return null;
 
   try {
     const url = new URL(href, window.location.origin);
-    if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
-    if (url.origin !== window.location.origin) return false;
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+    if (url.origin !== window.location.origin) return null;
     if (url.pathname === '/api' || url.pathname.startsWith('/api/'))
-      return false;
-    return true;
+      return null;
+    return `${url.pathname}${url.search}${url.hash}`;
   } catch {
-    return false;
+    return null;
   }
 }
 


### PR DESCRIPTION
Previously internal app urls turned into format:
https://cyberismo-intra.cyberismo.net/projects/cisms/cards/cisms_2y5nhz4e/https:/cyberismo-intra.cyberismo.net/projects/csecdev/cards/csecdev_siramo01

