### PR TITLE
INTDEV-1293 Add urlPath calculated field for cards

### DIFF
--- a/docs/cardRoot/docs_6/c/docs_9/c/docs_29/c/docs_6b6ix9ro/index.adoc
+++ b/docs/cardRoot/docs_6/c/docs_9/c/docs_29/c/docs_6b6ix9ro/index.adoc
@@ -1,0 +1,20 @@
+== Parameters
+
+* `CardKey`: The card key of a project card
+* `Path`: The path of the card in the Cyberismo app
+
+== Description
+
+Cyberismo defines a built-in calculated field `urlPath` for every project card. Its value is an application-relative path that navigates to the card, for example `/projects/example/cards/example_2`. The path works both in the Cyberismo app and in an exported static site.
+
+Use this field instead of constructing the path yourself, so that your logic programs keep working when the paths of the application change. For example, the nodes of a graph can be made clickable as follows:
+
+----
+attr(node, Card, "href", Path) :-
+    node(Card, _),
+    field(Card, "urlPath", Path).
+----
+
+See {{#xref}}"cardKey":"docs_hbskjelr"{{/xref}} for more information about implementing graphs.
+
+Template cards do not have a `urlPath` field, because template cards are viewed in the configuration section of the app.

--- a/docs/cardRoot/docs_6/c/docs_9/c/docs_29/c/docs_6b6ix9ro/index.json
+++ b/docs/cardRoot/docs_6/c/docs_9/c/docs_29/c/docs_6b6ix9ro/index.json
@@ -1,0 +1,13 @@
+{
+    "title": "field(CardKey, \"urlPath\", Path)",
+    "cardType": "base/cardTypes/predicate",
+    "workflowState": "Ready",
+    "rank": "0|m",
+    "lastUpdated": "2026-08-07T13:13:08.272Z",
+    "base/fieldTypes/briefDescription": "The path for navigating to a card in the app",
+    "base/fieldTypes/category": "Cards",
+    "links": [],
+    "templateCardKey": "base_weu9g7lz",
+    "createdAt": "2026-08-07T13:11:56.459Z",
+    "lastTransitioned": "2026-08-07T13:13:08.272Z"
+}

--- a/docs/cardRoot/docs_6/c/docs_9/c/docs_hbskjelr/index.adoc
+++ b/docs/cardRoot/docs_6/c/docs_9/c/docs_hbskjelr/index.adoc
@@ -159,6 +159,20 @@ Cyberismo keeps track of the ordering of cards in the navigation tree with the b
 
 If you generate your graph so that nodes and subgraphs are cards, then these elements will automatically have a `rank` field. Otherwise, if you want to influence the ordering of the DOT file, you can define terms of the format `field(Element, "rank", Rank)` to set a rank. The exact format of the rank does not matter, as long as the elements can be ordered by their rank.
 
+== Linking nodes to cards
+
+If the nodes of your graph are cards, you can make the nodes clickable by setting the Graphviz `href` attribute from the built-in xref:docs_6b6ix9ro.adoc[`urlPath`] field of the card:
+
+----
+attr(node, Card, "href", Path) :-
+    node(Card, _),
+    field(Card, "urlPath", Path).
+----
+
+Do not construct the path yourself, as the paths of the application may change.
+
+Only project cards have a `urlPath` field. If your graph also contains nodes that are not cards, or nodes that are template cards, the rule above leaves those nodes without a link.
+
 == Comparison with Clingraph
 
 Cyberismo's graph support is based on https://github.com/potassco/clingraph[Clingraph], the graph visualiser from the Potassco collection. However, Cyberismo does not use the Python implementation of Clingraph but includes its own implementation, which is internally a Cyberismo report that produces Graphviz DOT format. If you are familiar with Clingraph, it is useful to understand the following differences:

--- a/tools/assets/src/calculations/common/base.lp
+++ b/tools/assets/src/calculations/common/base.lp
@@ -36,10 +36,8 @@ field(Card, "workflowStateCategory", Category) :-
     field(CardType, "workflow", Workflow),
     workflowState(Workflow, State, Category).
 
-% urlPath: the app-relative path used to navigate to a card, e.g. as the
-% href attribute in graph model views (INTDEV-1293). Project cards only —
-% template cards live under /configuration/..., not /cards/:key, so they
-% are deliberately excluded.
+% app-relative path for navigating to a card, e.g. as an href in a graph view.
+% Only project cards have one; template cards are viewed under /configuration.
 field(Card, "urlPath", @concatenate("/projects/", ProjectPrefix, "/cards/", Card)) :-
     projectCard(Card),
     project(ProjectPrefix).

--- a/tools/assets/src/calculations/common/base.lp
+++ b/tools/assets/src/calculations/common/base.lp
@@ -36,6 +36,14 @@ field(Card, "workflowStateCategory", Category) :-
     field(CardType, "workflow", Workflow),
     workflowState(Workflow, State, Category).
 
+% urlPath: the app-relative path used to navigate to a card, e.g. as the
+% href attribute in graph model views (INTDEV-1293). Project cards only —
+% template cards live under /configuration/..., not /cards/:key, so they
+% are deliberately excluded.
+field(Card, "urlPath", @concatenate("/projects/", ProjectPrefix, "/cards/", Card)) :-
+    projectCard(Card),
+    project(ProjectPrefix).
+
 
 % data types of fields
 dataType(Key, Field, DataType) :-

--- a/tools/data-handler/test/calculation-engine.test.ts
+++ b/tools/data-handler/test/calculation-engine.test.ts
@@ -216,6 +216,33 @@ describe('calculate', () => {
   });
 });
 
+describe('urlPath calculated field', () => {
+  const baseDir = import.meta.dirname;
+  const testDir = join(baseDir, 'tmp-urlpath-tests');
+  const decisionRecordsPath = join(testDir, 'valid/decision-records');
+  let project: Project;
+
+  beforeAll(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir('test/test-data/', testDir);
+    project = getTestProject(decisionRecordsPath);
+    await project.populateCaches();
+    await project.calculationEngine.generate();
+  });
+
+  afterAll(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('computes an app-routable path for a project card', async () => {
+    const res = await project.calculationEngine.runLogicProgram(
+      'result(Path) :- field(decision_6, "urlPath", Path).',
+    );
+    expect(res.results).toHaveLength(1);
+    expect(res.results[0].key).toBe('/projects/decision/cards/decision_6');
+  });
+});
+
 describe('calculation validation on generate', () => {
   // The fixture contains broken calculations on disk, simulating invalid .lp
   // files arriving via git pull or hand-editing.


### PR DESCRIPTION
Adds a built-in calculated field urlPath. It's a calculated field in the sense that it does not use `fieldCalculated`, but there is no benefit to it being an "official" calculated field.