### PR TITLE
INTDEV-1377 Save inline edits on focus loss instead of cancelling

### DIFF
--- a/tools/app/__tests__/CardTitle.test.tsx
+++ b/tools/app/__tests__/CardTitle.test.tsx
@@ -125,8 +125,7 @@ describe('CardTitle', () => {
     const cancelButton = container.querySelector(
       '[data-cy="cardTitleCancelButton"]',
     )!;
-    // A real click on the button fires `mousedown` (which our fix must
-    // preventDefault on) before the `click` that runs handleCancel.
+    // A real click fires mousedown before the click that runs handleCancel.
     const notCancelled = fireEvent.mouseDown(cancelButton);
     expect(notCancelled).toBe(false); // preventDefault() was called
     fireEvent.click(cancelButton);

--- a/tools/app/__tests__/CardTitle.test.tsx
+++ b/tools/app/__tests__/CardTitle.test.tsx
@@ -1,0 +1,137 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2026
+
+    This program is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Affero General Public License version 3 as published by
+    the Free Software Foundation. This program is distributed in the hope that it
+    will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    See the GNU Affero General Public License for more details.
+    You should have received a copy of the GNU Affero General Public
+    License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+const dispatch = vi.fn();
+// Keep the real module (CardTitle also imports `formKeyHandler` from
+// '@/lib/hooks' and calls it during render — a factory-only mock that
+// returns just useAppDispatch would crash with "formKeyHandler is not a
+// function") and override only the redux hook.
+vi.mock('@/lib/hooks', async (importOriginal) => {
+  const actual = await importOriginal<typeof HooksModule>();
+  return {
+    ...actual,
+    useAppDispatch: () => dispatch,
+  };
+});
+import type * as HooksModule from '@/lib/hooks';
+vi.mock('@/lib/auth', () => ({
+  UserRole: { Reader: 0, Editor: 1, Admin: 2 },
+  useHasMinRole: () => true,
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (s: string) => s }),
+}));
+
+import { CardTitle } from '@/components/card/CardTitle';
+
+describe('CardTitle', () => {
+  beforeEach(() => {
+    dispatch.mockClear();
+  });
+
+  it('saves the edited title when focus leaves the editor', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const { container } = render(
+      <CardTitle title="Original" onSave={onSave} />,
+    );
+
+    fireEvent.click(screen.getByText('Original'));
+    const input = container.querySelector(
+      '[data-cy="cardTitleInput"]',
+    ) as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: 'Edited title' } });
+
+    fireEvent.blur(input);
+
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith({
+        metadata: { title: 'Edited title' },
+      }),
+    );
+  });
+
+  it('does not save on blur when nothing changed', () => {
+    const onSave = vi.fn();
+    const { container } = render(
+      <CardTitle title="Original" onSave={onSave} />,
+    );
+
+    fireEvent.click(screen.getByText('Original'));
+    fireEvent.blur(container.querySelector('[data-cy="cardTitleInput"]')!);
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByText('Original')).toBeInTheDocument();
+  });
+
+  it('keeps the editor open and reports an error instead of silently discarding an emptied title', () => {
+    const onSave = vi.fn();
+    const { container } = render(
+      <CardTitle title="Original" onSave={onSave} />,
+    );
+
+    fireEvent.click(screen.getByText('Original'));
+    const input = container.querySelector('[data-cy="cardTitleInput"]')!;
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.blur(input);
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(
+      container.querySelector('[data-cy="cardTitleInput"]'),
+    ).toBeInTheDocument();
+  });
+
+  it('keeps the editor open when the save rejects', async () => {
+    const onSave = vi.fn().mockRejectedValue(new Error('network error'));
+    const { container } = render(
+      <CardTitle title="Original" onSave={onSave} />,
+    );
+
+    fireEvent.click(screen.getByText('Original'));
+    const input = container.querySelector('[data-cy="cardTitleInput"]')!;
+    fireEvent.change(input, { target: { value: 'Edited title' } });
+    fireEvent.blur(input);
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(
+      container.querySelector('[data-cy="cardTitleInput"]'),
+    ).toBeInTheDocument();
+  });
+
+  it('the Cancel button still discards the edit, even though clicking it blurs the input first', () => {
+    const onSave = vi.fn();
+    const { container } = render(
+      <CardTitle title="Original" onSave={onSave} />,
+    );
+
+    fireEvent.click(screen.getByText('Original'));
+    const input = container.querySelector('[data-cy="cardTitleInput"]')!;
+    fireEvent.change(input, { target: { value: 'Edited title' } });
+
+    const cancelButton = container.querySelector(
+      '[data-cy="cardTitleCancelButton"]',
+    )!;
+    // A real click on the button fires `mousedown` (which our fix must
+    // preventDefault on) before the `click` that runs handleCancel.
+    const notCancelled = fireEvent.mouseDown(cancelButton);
+    expect(notCancelled).toBe(false); // preventDefault() was called
+    fireEvent.click(cancelButton);
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByText('Original')).toBeInTheDocument();
+  });
+});

--- a/tools/app/__tests__/FieldRow.test.tsx
+++ b/tools/app/__tests__/FieldRow.test.tsx
@@ -154,9 +154,6 @@ describe('FieldRow', () => {
         fireEvent.click(clearButton);
       }
 
-      // Before the fix, the row's onKeyDown treats plain Enter as "save the
-      // dirty form value", so onSave gets called with the typed override
-      // instead of null — this assertion catches that regression.
       expect(onSave).toHaveBeenCalledTimes(1);
       expect(onSave).toHaveBeenCalledWith(null);
     });

--- a/tools/app/__tests__/FieldRow.test.tsx
+++ b/tools/app/__tests__/FieldRow.test.tsx
@@ -184,4 +184,213 @@ describe('FieldRow', () => {
       expect(onSave).toHaveBeenCalledWith('person2@example.com');
     });
   });
+
+  describe('save-on-blur (INTDEV-1377)', () => {
+    it('calls onSave on blur when the field is dirty', () => {
+      const onSave = vi.fn();
+      render(
+        <FieldRow
+          value="original"
+          label="Short text"
+          dataType="shortText"
+          isEditing
+          expanded
+          onSave={onSave}
+          onCancel={vi.fn()}
+        />,
+      );
+
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'changed' } });
+      fireEvent.blur(input);
+
+      expect(onSave).toHaveBeenCalledWith('changed');
+    });
+
+    it('still saves when focus moves to a button outside this row', () => {
+      const onSave = vi.fn();
+      render(
+        <>
+          <button type="button">Unrelated toolbar button</button>
+          <FieldRow
+            value="original"
+            label="Short text"
+            dataType="shortText"
+            isEditing
+            expanded
+            onSave={onSave}
+            onCancel={vi.fn()}
+          />
+        </>,
+      );
+
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'changed' } });
+      fireEvent.blur(input, {
+        relatedTarget: screen.getByRole('button', {
+          name: 'Unrelated toolbar button',
+        }),
+      });
+
+      expect(onSave).toHaveBeenCalledWith('changed');
+    });
+
+    it('does not save when focus moves to this row’s own Cancel button', () => {
+      const onSave = vi.fn();
+      const { container } = render(
+        <FieldRow
+          value="original"
+          label="Short text"
+          dataType="shortText"
+          isEditing
+          expanded
+          onSave={onSave}
+          onCancel={vi.fn()}
+        />,
+      );
+
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'changed' } });
+      fireEvent.blur(input, {
+        relatedTarget: container.querySelector(
+          '[data-cy="fieldCancelButton"]',
+        ) as HTMLElement,
+      });
+
+      expect(onSave).not.toHaveBeenCalled();
+    });
+
+    it('does not save while focus is inside a Select’s listbox popup', () => {
+      const onSave = vi.fn();
+      render(
+        <FieldRow
+          value="original"
+          label="Short text"
+          dataType="shortText"
+          isEditing
+          expanded
+          onSave={onSave}
+          onCancel={vi.fn()}
+        />,
+      );
+
+      // A Joy Select renders its listbox in a portal outside the row, and
+      // focuses an option while open — the field is still being edited.
+      const listbox = document.createElement('ul');
+      listbox.setAttribute('role', 'listbox');
+      const option = document.createElement('li');
+      listbox.appendChild(option);
+      document.body.appendChild(listbox);
+
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'changed' } });
+      fireEvent.blur(input, { relatedTarget: option });
+
+      expect(onSave).not.toHaveBeenCalled();
+      document.body.removeChild(listbox);
+    });
+
+    it('does not call onSave on blur when the field is unchanged', () => {
+      const onSave = vi.fn();
+      render(
+        <FieldRow
+          value="original"
+          label="Short text"
+          dataType="shortText"
+          isEditing
+          expanded
+          onSave={onSave}
+          onCancel={vi.fn()}
+        />,
+      );
+
+      fireEvent.blur(screen.getByRole('textbox'));
+      expect(onSave).not.toHaveBeenCalled();
+    });
+
+    it('Save and Cancel prevent the default mousedown action, so clicking them cannot be pre-empted by a blur-save', () => {
+      const onSave = vi.fn();
+      const { container } = render(
+        <FieldRow
+          value="original"
+          label="Short text"
+          dataType="shortText"
+          isEditing
+          expanded
+          onSave={onSave}
+          onCancel={vi.fn()}
+        />,
+      );
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: { value: 'changed' },
+      });
+
+      const saveButton = container.querySelector(
+        '[data-cy="fieldSaveButton"]',
+      )!;
+      const cancelButton = container.querySelector(
+        '[data-cy="fieldCancelButton"]',
+      )!;
+      expect(fireEvent.mouseDown(saveButton)).toBe(false);
+      expect(fireEvent.mouseDown(cancelButton)).toBe(false);
+    });
+
+    it('seeds the editor fresh each time a field is (re)opened for editing', () => {
+      const { rerender } = render(
+        <FieldRow
+          value="v1"
+          label="Short text"
+          dataType="shortText"
+          isEditing={false}
+          expanded={false}
+          onSave={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+      );
+      rerender(
+        <FieldRow
+          value="v1"
+          label="Short text"
+          dataType="shortText"
+          isEditing
+          expanded
+          onSave={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+      );
+      expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe(
+        'v1',
+      );
+
+      // Closed (e.g. editingFieldKey moved to a different field), then the
+      // saved value moves on before this field is reopened — reopening must
+      // show the latest value.
+      rerender(
+        <FieldRow
+          value="v2"
+          label="Short text"
+          dataType="shortText"
+          isEditing={false}
+          expanded={false}
+          onSave={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+      );
+      rerender(
+        <FieldRow
+          value="v2"
+          label="Short text"
+          dataType="shortText"
+          isEditing
+          expanded
+          onSave={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+      );
+      expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe(
+        'v2',
+      );
+    });
+  });
 });

--- a/tools/app/src/components/FieldEditor.tsx
+++ b/tools/app/src/components/FieldEditor.tsx
@@ -19,17 +19,14 @@ import type {
 import { useTranslation } from 'react-i18next';
 import Person from '@mui/icons-material/Person';
 import LabelEditor from './LabelEditor';
-import type { FocusEvent } from 'react';
 
 export interface FieldEditorProps {
   value: MetadataValue;
   dataType?: DataType | 'label';
   onChange?: (value: string | string[] | null) => void;
-  onBlur?: (e: FocusEvent) => void;
   /**
-   * Called when a dropdown editor finishes interaction (its listbox closes).
-   * A `Select` moves focus into a portalled listbox while it is open, so its
-   * `onBlur` cannot be used to decide when editing is over.
+   * Fires when a Select's listbox closes. Selects move focus into a
+   * portalled listbox, so blur can't tell when dropdown editing ends.
    */
   onCommit?: () => void;
   enumValues?: Array<EnumDefinition>;
@@ -40,7 +37,6 @@ export interface FieldEditorProps {
 export default function FieldEditor({
   value,
   onChange,
-  onBlur,
   onCommit,
   dataType,
   enumValues,
@@ -57,7 +53,6 @@ export default function FieldEditor({
       return (
         <Input
           onChange={(e) => onChange?.(e.target.value)}
-          onBlur={onBlur}
           disabled={disabled}
           value={(value as number | null) ?? ''}
           type="number"
@@ -79,7 +74,6 @@ export default function FieldEditor({
           value={value?.toString() ?? ''}
           disabled={disabled}
           onChange={(_, value) => onChange?.(value)}
-          onBlur={onBlur}
           onListboxOpenChange={handleListboxOpenChange}
           color="primary"
           sx={{
@@ -100,7 +94,6 @@ export default function FieldEditor({
           value={(value as string | null) ?? ''}
           disabled={disabled}
           onChange={(_, value) => onChange?.(value)}
-          onBlur={onBlur}
           onListboxOpenChange={handleListboxOpenChange}
           color="primary"
           sx={{
@@ -126,7 +119,6 @@ export default function FieldEditor({
           value={(value as string[] | null) ?? []}
           multiple
           onChange={(_, value) => onChange?.(value)}
-          onBlur={onBlur}
           onListboxOpenChange={handleListboxOpenChange}
           color="primary"
           sx={{
@@ -148,7 +140,6 @@ export default function FieldEditor({
       return (
         <Input
           onChange={(e) => onChange?.(e.target.value)}
-          onBlur={onBlur}
           disabled={disabled}
           value={(value as string | null) ?? ''}
           type="date"
@@ -162,7 +153,6 @@ export default function FieldEditor({
       return (
         <Input
           onChange={(e) => onChange?.(e.target.value)}
-          onBlur={onBlur}
           disabled={disabled}
           value={(value as string | null) ?? ''}
           type="datetime-local"
@@ -176,7 +166,6 @@ export default function FieldEditor({
       return (
         <Input
           onChange={(e) => onChange?.(e.target.value)}
-          onBlur={onBlur}
           disabled={disabled}
           value={(value as string | null) ?? ''}
           color="primary"
@@ -191,7 +180,6 @@ export default function FieldEditor({
       return (
         <Textarea
           onChange={(e) => onChange?.(e.target.value)}
-          onBlur={onBlur}
           disabled={disabled}
           value={(value as string | null) ?? ''}
           color="primary"
@@ -218,7 +206,6 @@ export default function FieldEditor({
       return (
         <Input
           onChange={(e) => onChange?.(e.target.value)}
-          onBlur={onBlur}
           disabled={disabled}
           value={(value as string | null) ?? ''}
           color="primary"

--- a/tools/app/src/components/FieldEditor.tsx
+++ b/tools/app/src/components/FieldEditor.tsx
@@ -19,11 +19,19 @@ import type {
 import { useTranslation } from 'react-i18next';
 import Person from '@mui/icons-material/Person';
 import LabelEditor from './LabelEditor';
+import type { FocusEvent } from 'react';
 
 export interface FieldEditorProps {
   value: MetadataValue;
   dataType?: DataType | 'label';
   onChange?: (value: string | string[] | null) => void;
+  onBlur?: (e: FocusEvent) => void;
+  /**
+   * Called when a dropdown editor finishes interaction (its listbox closes).
+   * A `Select` moves focus into a portalled listbox while it is open, so its
+   * `onBlur` cannot be used to decide when editing is over.
+   */
+  onCommit?: () => void;
   enumValues?: Array<EnumDefinition>;
   disabled?: boolean;
   focus?: boolean;
@@ -32,18 +40,24 @@ export interface FieldEditorProps {
 export default function FieldEditor({
   value,
   onChange,
+  onBlur,
+  onCommit,
   dataType,
   enumValues,
   disabled,
   focus,
 }: FieldEditorProps) {
   const { t } = useTranslation();
+  const handleListboxOpenChange = (open: boolean) => {
+    if (!open) onCommit?.();
+  };
   switch (dataType) {
     case 'integer':
     case 'number':
       return (
         <Input
           onChange={(e) => onChange?.(e.target.value)}
+          onBlur={onBlur}
           disabled={disabled}
           value={(value as number | null) ?? ''}
           type="number"
@@ -65,6 +79,8 @@ export default function FieldEditor({
           value={value?.toString() ?? ''}
           disabled={disabled}
           onChange={(_, value) => onChange?.(value)}
+          onBlur={onBlur}
+          onListboxOpenChange={handleListboxOpenChange}
           color="primary"
           sx={{
             width: '100%',
@@ -84,6 +100,8 @@ export default function FieldEditor({
           value={(value as string | null) ?? ''}
           disabled={disabled}
           onChange={(_, value) => onChange?.(value)}
+          onBlur={onBlur}
+          onListboxOpenChange={handleListboxOpenChange}
           color="primary"
           sx={{
             width: '100%',
@@ -108,6 +126,8 @@ export default function FieldEditor({
           value={(value as string[] | null) ?? []}
           multiple
           onChange={(_, value) => onChange?.(value)}
+          onBlur={onBlur}
+          onListboxOpenChange={handleListboxOpenChange}
           color="primary"
           sx={{
             width: '100%',
@@ -128,6 +148,7 @@ export default function FieldEditor({
       return (
         <Input
           onChange={(e) => onChange?.(e.target.value)}
+          onBlur={onBlur}
           disabled={disabled}
           value={(value as string | null) ?? ''}
           type="date"
@@ -141,6 +162,7 @@ export default function FieldEditor({
       return (
         <Input
           onChange={(e) => onChange?.(e.target.value)}
+          onBlur={onBlur}
           disabled={disabled}
           value={(value as string | null) ?? ''}
           type="datetime-local"
@@ -154,6 +176,7 @@ export default function FieldEditor({
       return (
         <Input
           onChange={(e) => onChange?.(e.target.value)}
+          onBlur={onBlur}
           disabled={disabled}
           value={(value as string | null) ?? ''}
           color="primary"
@@ -168,6 +191,7 @@ export default function FieldEditor({
       return (
         <Textarea
           onChange={(e) => onChange?.(e.target.value)}
+          onBlur={onBlur}
           disabled={disabled}
           value={(value as string | null) ?? ''}
           color="primary"
@@ -194,6 +218,7 @@ export default function FieldEditor({
       return (
         <Input
           onChange={(e) => onChange?.(e.target.value)}
+          onBlur={onBlur}
           disabled={disabled}
           value={(value as string | null) ?? ''}
           color="primary"

--- a/tools/app/src/components/card/CardTitle.tsx
+++ b/tools/app/src/components/card/CardTitle.tsx
@@ -44,8 +44,9 @@ export const CardTitle: React.FC<CardTitleProps> = ({
 
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState(title);
-  const editBoxRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  /** The editing frame, used to tell "focus left the editor" from "focus moved to Save/Cancel". */
+  const editBoxRef = useRef<HTMLDivElement>(null);
 
   const canEdit = !preview && !!onSave && !disabled && canEditRole;
 
@@ -104,22 +105,22 @@ export const CardTitle: React.FC<CardTitleProps> = ({
     dispatch(isEdited(false));
   };
 
-  useEffect(() => {
-    if (!editing) return;
-    const handleClickAway = (e: MouseEvent) => {
-      if (
-        editBoxRef.current &&
-        !editBoxRef.current.contains(e.target as Node)
-      ) {
-        handleCancel();
-      }
-    };
-    document.addEventListener('mousedown', handleClickAway);
-    return () => {
-      document.removeEventListener('mousedown', handleClickAway);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editing, value, title, onSave]);
+  const dirty = value.trim() !== title;
+
+  const handleBlur = (event: React.FocusEvent<HTMLTextAreaElement>) => {
+    const next = event.relatedTarget as HTMLElement | null;
+    if (next && editBoxRef.current?.contains(next)) {
+      // Focus moved to this editor's own Save/Cancel buttons; let the button
+      // decide. Mouse clicks are already covered by their onMouseDown
+      // preventDefault, this covers keyboard Tab.
+      return;
+    }
+    if (dirty) {
+      void handleSave();
+    } else {
+      handleCancel();
+    }
+  };
 
   useEffect(() => {
     if (!editing) return;
@@ -158,6 +159,7 @@ export const CardTitle: React.FC<CardTitleProps> = ({
               setValue(e.target.value);
               dispatch(isEdited(true));
             }}
+            onBlur={handleBlur}
             sx={{
               fontWeight: 'bold',
               fontSize: '1.8rem',
@@ -173,6 +175,7 @@ export const CardTitle: React.FC<CardTitleProps> = ({
               color="neutral"
               data-cy="cardTitleCancelButton"
               onClick={handleCancel}
+              onMouseDown={(e) => e.preventDefault()}
             >
               {t('cancel')}
             </Button>
@@ -183,6 +186,7 @@ export const CardTitle: React.FC<CardTitleProps> = ({
               data-cy="cardTitleSaveButton"
               startDecorator={<EditIcon />}
               onClick={handleSave}
+              onMouseDown={(e) => e.preventDefault()}
               disabled={value.trim() === ''}
             >
               {t('save')}

--- a/tools/app/src/components/card/CardTitle.tsx
+++ b/tools/app/src/components/card/CardTitle.tsx
@@ -17,7 +17,7 @@ import { Box, Button, IconButton, Stack, Textarea, Typography } from '@mui/joy';
 import EditIcon from '@mui/icons-material/Edit';
 import { useTranslation } from 'react-i18next';
 
-import { useAppDispatch, formKeyHandler } from '@/lib/hooks';
+import { useAppDispatch, focusLeftEditor, formKeyHandler } from '@/lib/hooks';
 import { addNotification } from '@/lib/slices/notifications';
 import { isEdited } from '@/lib/slices/pageState';
 import { UserRole, useHasMinRole } from '@/lib/auth';
@@ -45,7 +45,6 @@ export const CardTitle: React.FC<CardTitleProps> = ({
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState(title);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  /** The editing frame, used to tell "focus left the editor" from "focus moved to Save/Cancel". */
   const editBoxRef = useRef<HTMLDivElement>(null);
 
   const canEdit = !preview && !!onSave && !disabled && canEditRole;
@@ -107,12 +106,8 @@ export const CardTitle: React.FC<CardTitleProps> = ({
 
   const dirty = value.trim() !== title;
 
-  const handleBlur = (event: React.FocusEvent<HTMLTextAreaElement>) => {
-    const next = event.relatedTarget as HTMLElement | null;
-    if (next && editBoxRef.current?.contains(next)) {
-      // Focus moved to this editor's own Save/Cancel buttons; let the button
-      // decide. Mouse clicks are already covered by their onMouseDown
-      // preventDefault, this covers keyboard Tab.
+  const handleBlur = (event: React.FocusEvent) => {
+    if (!focusLeftEditor(event, editBoxRef.current)) {
       return;
     }
     if (dirty) {
@@ -140,6 +135,7 @@ export const CardTitle: React.FC<CardTitleProps> = ({
         borderColor="primary.outlinedBorder"
         borderRadius={6}
         padding={{ xs: 1, sm: 1.5 }}
+        onBlur={handleBlur}
         onKeyDown={formKeyHandler({
           canSubmit: true,
           onSubmit: handleSave,
@@ -159,7 +155,6 @@ export const CardTitle: React.FC<CardTitleProps> = ({
               setValue(e.target.value);
               dispatch(isEdited(true));
             }}
-            onBlur={handleBlur}
             sx={{
               fontWeight: 'bold',
               fontSize: '1.8rem',

--- a/tools/app/src/components/card/metadata-section/FieldRow.tsx
+++ b/tools/app/src/components/card/metadata-section/FieldRow.tsx
@@ -25,7 +25,7 @@ import EditableField, { FieldLabel } from '@/components/EditableField';
 import FieldEditor from '@/components/FieldEditor';
 import { OverrideEditorFrame, OverriddenMarker } from './OverrideEditorFrame';
 import { coerceMetadataValue, metadataValueToString } from '@/lib/utils';
-import { formKeyHandler } from '@/lib/hooks';
+import { focusLeftEditor, formKeyHandler } from '@/lib/hooks';
 
 export interface FieldRowProps {
   id?: string;
@@ -82,14 +82,9 @@ export function FieldRow({
     formState: { isDirty },
   } = useForm({ defaultValues: { value: initialValue } });
 
-  // Reseed the form only when a field is freshly opened for editing (the
-  // rising edge of `isEditing`) — not on every change, and specifically not
-  // when it is closed by the parent switching `editingFieldKey` to a
-  // different field. Resetting unconditionally there would silently wipe an
-  // in-flight, not-yet-saved draft out from under the onBlur-triggered save
-  // below.
+  // Reseed only when editing opens (rising edge). Resetting when the parent
+  // closes the row would wipe a draft before the blur-triggered save reads it.
   const serializedInitial = JSON.stringify(initialValue);
-  /** The editing row, used to tell "focus left the editor" from "focus moved to this row's own buttons". */
   const rowRef = useRef<HTMLDivElement>(null);
   const wasEditingRef = useRef(isEditing);
   useEffect(() => {
@@ -121,25 +116,13 @@ export function FieldRow({
     if (!isDirty) {
       return;
     }
-    const next = event.relatedTarget as HTMLElement | null;
-    if (next && rowRef.current?.contains(next)) {
-      // Focus moved to this row's own controls (Save, Cancel, Clear). That
-      // button decides the outcome, so do not pre-empt it with a save. Scoped
-      // to this row deliberately: focus landing on any *other* button in the
-      // app is a genuine "leaving the editor" and must still save.
-      return;
+    if (focusLeftEditor(event, rowRef.current)) {
+      handleSave();
     }
-    if (next?.closest('[role="listbox"]')) {
-      // A Select moves focus into its portalled listbox while open, so the
-      // field is still being edited. `handleCommit` saves once it closes.
-      return;
-    }
-    handleSave();
   };
 
-  // A Select's listbox has closed: interaction with the dropdown is over.
-  // Reads the live form value rather than `isDirty`, because the closing
-  // option click updates the value in the same tick as this callback.
+  // Reads the live value rather than `isDirty`: the option click that closes
+  // the listbox updates the value in the same tick as this callback.
   const handleCommit = () => {
     if (isValueDirty()) {
       handleSave();
@@ -161,7 +144,6 @@ export function FieldRow({
         <FieldEditor
           value={formValue}
           onChange={(e: string | string[] | null) => handleChange(e, onChange)}
-          onBlur={handleBlur}
           onCommit={handleCommit}
           dataType={dataType}
           enumValues={enumValues}
@@ -224,6 +206,7 @@ export function FieldRow({
             ref={rowRef}
             direction={{ xs: 'column', md: 'row' }}
             spacing={{ xs: 0.5, md: 4 }}
+            onBlur={handleBlur}
             onKeyDown={formKeyHandler({
               canSubmit: !!onSave && isDirty,
               onSubmit: handleSave,

--- a/tools/app/src/components/card/metadata-section/FieldRow.tsx
+++ b/tools/app/src/components/card/metadata-section/FieldRow.tsx
@@ -12,7 +12,8 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
+import type { FocusEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Accordion, AccordionDetails, Box, IconButton, Stack } from '@mui/joy';
 import CheckIcon from '@mui/icons-material/Check';
@@ -81,11 +82,24 @@ export function FieldRow({
     formState: { isDirty },
   } = useForm({ defaultValues: { value: initialValue } });
 
+  // Reseed the form only when a field is freshly opened for editing (the
+  // rising edge of `isEditing`) — not on every change, and specifically not
+  // when it is closed by the parent switching `editingFieldKey` to a
+  // different field. Resetting unconditionally there would silently wipe an
+  // in-flight, not-yet-saved draft out from under the onBlur-triggered save
+  // below.
   const serializedInitial = JSON.stringify(initialValue);
+  /** The editing row, used to tell "focus left the editor" from "focus moved to this row's own buttons". */
+  const rowRef = useRef<HTMLDivElement>(null);
+  const wasEditingRef = useRef(isEditing);
   useEffect(() => {
-    reset({ value: initialValue });
+    const enteringEdit = isEditing && !wasEditingRef.current;
+    wasEditingRef.current = isEditing;
+    if (enteringEdit) {
+      reset({ value: initialValue });
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [serializedInitial, reset, isEditing]);
+  }, [isEditing, serializedInitial, reset]);
 
   const handleChange = (
     rawValue: string | string[] | null,
@@ -98,6 +112,38 @@ export function FieldRow({
 
   const handleSave = () => {
     onSave?.(getValues('value'));
+  };
+
+  const isValueDirty = () =>
+    JSON.stringify(getValues('value')) !== serializedInitial;
+
+  const handleBlur = (event: FocusEvent) => {
+    if (!isDirty) {
+      return;
+    }
+    const next = event.relatedTarget as HTMLElement | null;
+    if (next && rowRef.current?.contains(next)) {
+      // Focus moved to this row's own controls (Save, Cancel, Clear). That
+      // button decides the outcome, so do not pre-empt it with a save. Scoped
+      // to this row deliberately: focus landing on any *other* button in the
+      // app is a genuine "leaving the editor" and must still save.
+      return;
+    }
+    if (next?.closest('[role="listbox"]')) {
+      // A Select moves focus into its portalled listbox while open, so the
+      // field is still being edited. `handleCommit` saves once it closes.
+      return;
+    }
+    handleSave();
+  };
+
+  // A Select's listbox has closed: interaction with the dropdown is over.
+  // Reads the live form value rather than `isDirty`, because the closing
+  // option click updates the value in the same tick as this callback.
+  const handleCommit = () => {
+    if (isValueDirty()) {
+      handleSave();
+    }
   };
 
   const handleCancel = () => {
@@ -115,6 +161,8 @@ export function FieldRow({
         <FieldEditor
           value={formValue}
           onChange={(e: string | string[] | null) => handleChange(e, onChange)}
+          onBlur={handleBlur}
+          onCommit={handleCommit}
           dataType={dataType}
           enumValues={enumValues}
           disabled={disabled}
@@ -134,6 +182,7 @@ export function FieldRow({
           color="primary"
           disabled={!isDirty}
           onClick={handleSave}
+          onMouseDown={(e) => e.preventDefault()}
         >
           <CheckIcon />
         </IconButton>
@@ -144,6 +193,7 @@ export function FieldRow({
         variant="soft"
         color="neutral"
         onClick={handleCancel}
+        onMouseDown={(e) => e.preventDefault()}
       >
         <CloseIcon />
       </IconButton>
@@ -171,6 +221,7 @@ export function FieldRow({
       <AccordionDetails>
         {isEditing ? (
           <Stack
+            ref={rowRef}
             direction={{ xs: 'column', md: 'row' }}
             spacing={{ xs: 0.5, md: 4 }}
             onKeyDown={formKeyHandler({

--- a/tools/app/src/components/card/metadata-section/MetadataSection.tsx
+++ b/tools/app/src/components/card/metadata-section/MetadataSection.tsx
@@ -101,7 +101,11 @@ export default function MetadataSection({
     if (!onUpdate) return;
     try {
       await onUpdate({ metadata: { [metadataKey]: value } });
-      setEditingFieldKey(null);
+      // A blur-triggered save resolves after the click that opened the next
+      // field, so only close the editor if this field is still the open one.
+      setEditingFieldKey((current) =>
+        current === metadataKey ? null : current,
+      );
     } catch (error) {
       notifyError(error);
     }

--- a/tools/app/src/components/card/metadata-section/OverrideEditorFrame.tsx
+++ b/tools/app/src/components/card/metadata-section/OverrideEditorFrame.tsx
@@ -33,6 +33,7 @@ export function ClearOverrideButton({
       color="neutral"
       disabled={disabled}
       onClick={onClick}
+      onMouseDown={(e) => e.preventDefault()}
     >
       {t('clearOverride')}
     </Button>

--- a/tools/app/src/lib/hooks/utils.ts
+++ b/tools/app/src/lib/hooks/utils.ts
@@ -247,6 +247,27 @@ export function formKeyHandler({
 }
 
 /**
+ * Whether a focusout event means focus truly left the inline editor rooted
+ * at `container`. Attach on the container — React's onBlur bubbles.
+ * Not counted as leaving: the editor's own buttons (they decide the outcome;
+ * their mousedown must preventDefault since Safari leaves relatedTarget null
+ * for clicked buttons) and a Select's portalled listbox (commit-on-close
+ * owns that save).
+ */
+export function focusLeftEditor(
+  event: React.FocusEvent,
+  container: HTMLElement | null,
+): boolean {
+  const next = event.relatedTarget as HTMLElement | null;
+  if (next && container?.contains(next)) return false;
+  if (next?.closest('[role="listbox"]')) return false;
+  if ((event.target as HTMLElement | null)?.closest('[role="listbox"]')) {
+    return false;
+  }
+  return true;
+}
+
+/**
  * This function is used to get the value of a ResizeObserverEntry.
  * @param entry - the ResizeObserverEntry
  * @param value - the value to get


### PR DESCRIPTION
Now inline edits in card view save after losing focus. A bit complex to get right, but the change seems to work suprisingly well.