### PR TITLE
INTDEV-1376 assume version 1.x if a project imports modules without version

### DIFF
--- a/tools/assets/src/schema/cardsConfigSchema.json
+++ b/tools/assets/src/schema/cardsConfigSchema.json
@@ -70,7 +70,7 @@
             "type": "boolean"
           },
           "version": {
-            "description": "Semver version or range constraint (e.g., '1.0.0', '^1.0.0', '>=1.2.0 <2.0.0'). When omitted, the module is assumed to be bound to version 1.x.",
+            "description": "Semver version or range constraint (e.g., '1.0.0', '^1.0.0', '>=1.2.0 <2.0.0'). When omitted, the module is assumed to be bound to version 1.x, and the next module operation writes that assumption here.",
             "type": "string"
           }
         },

--- a/tools/assets/src/schema/cardsConfigSchema.json
+++ b/tools/assets/src/schema/cardsConfigSchema.json
@@ -70,7 +70,7 @@
             "type": "boolean"
           },
           "version": {
-            "description": "Semver version or range constraint (e.g., '1.0.0', '^1.0.0', '>=1.2.0 <2.0.0'). When omitted, any version is accepted.",
+            "description": "Semver version or range constraint (e.g., '1.0.0', '^1.0.0', '>=1.2.0 <2.0.0'). When omitted, the module is assumed to be bound to version 1.x.",
             "type": "string"
           }
         },

--- a/tools/data-handler/src/commands/import.ts
+++ b/tools/data-handler/src/commands/import.ts
@@ -48,6 +48,7 @@ import {
 import type { Create } from './create.js';
 import type {
   Credentials,
+  ModuleSetting,
   ModuleSettingOptions,
 } from '../interfaces/project-interfaces.js';
 import type { Fetch } from './fetch.js';
@@ -124,12 +125,14 @@ export class Import {
    */
   private async applyResolvedWithReplay(
     resolved: ResolvedModule[],
+    backfill: ModuleSetting[] = [],
   ): Promise<void> {
     const installedBefore = await installedModulesWithSources(this.project);
     const steps = await planModuleReplays(resolved, installedBefore);
 
     const appliedModules = await applyModules(this.project, resolved, {
       tempDir: this.tempModulesDir,
+      backfill,
     });
     await cleanOrphans(this.project);
 
@@ -330,7 +333,7 @@ export class Import {
       }
     }
 
-    const { plan, resolved } = await resolveForApply(
+    const { plan, resolved, backfill } = await resolveForApply(
       this.project,
       {
         kind: 'add',
@@ -341,7 +344,7 @@ export class Import {
       { credentials: options?.credentials, tempDir: this.tempModulesDir },
     );
     if (!plan.ok) throw resolutionConflictError(plan.conflicts);
-    await this.applyResolvedWithReplay(resolved);
+    await this.applyResolvedWithReplay(resolved, backfill);
 
     // Validate the project after module has been imported.
     const afterImportValidateErrors = await Validate.getInstance().validate(
@@ -421,12 +424,16 @@ export class Import {
     const req = version
       ? { kind: 'update' as const, module: moduleName, to: toVersion(version) }
       : { kind: 'update' as const, module: moduleName };
-    const { plan, resolved } = await resolveForApply(this.project, req, {
-      credentials,
-      tempDir: this.tempModulesDir,
-    });
+    const { plan, resolved, backfill } = await resolveForApply(
+      this.project,
+      req,
+      {
+        credentials,
+        tempDir: this.tempModulesDir,
+      },
+    );
     if (!plan.ok) throw resolutionConflictError(plan.conflicts);
-    await this.applyResolvedWithReplay(resolved);
+    await this.applyResolvedWithReplay(resolved, backfill);
   }
 
   /**
@@ -444,12 +451,12 @@ export class Import {
       throw new Error('No modules in the project!');
     }
 
-    const { plan, resolved } = await resolveForApply(
+    const { plan, resolved, backfill } = await resolveForApply(
       this.project,
       { kind: 'updateAll' },
       { credentials, tempDir: this.tempModulesDir },
     );
     if (!plan.ok) throw resolutionConflictError(plan.conflicts);
-    await this.applyResolvedWithReplay(resolved);
+    await this.applyResolvedWithReplay(resolved, backfill);
   }
 }

--- a/tools/data-handler/src/modules/applier.ts
+++ b/tools/data-handler/src/modules/applier.ts
@@ -32,6 +32,12 @@ const logger = getChildLogger({ module: 'applier' });
 export interface ApplyOptions {
   /** Directory holding each entry's `stagedPath` tree. */
   tempDir: string;
+  /**
+   * Declarations to rewrite for modules this apply does not install —
+   * roots that stayed at their installed version but never wrote down a
+   * version range. Persisted verbatim, no files touched.
+   */
+  backfill?: ModuleSetting[];
 }
 
 interface StagedModule {
@@ -124,6 +130,12 @@ export async function applyModules(
       continue;
     }
     await project.configuration.upsertModule(toPersistedSetting(entry));
+  }
+
+  // Declaration-only rewrites: these modules keep the files they already
+  // have, so they are persisted regardless of what landed above.
+  for (const setting of options.backfill ?? []) {
+    await project.configuration.upsertModule(setting);
   }
 
   await Promise.all(

--- a/tools/data-handler/src/modules/resolve/format.ts
+++ b/tools/data-handler/src/modules/resolve/format.ts
@@ -35,7 +35,9 @@ export function conflictReason(c: ResolveConflict): string {
   // project itself can lift.
   if (c.pinned)
     parts.push(
-      `declared as '${c.pinned.range}' in this project, but ${c.pinned.wouldNeed} is needed`,
+      c.pinned.assumed
+        ? `no version declared in this project (assumed '${c.pinned.range}'), but ${c.pinned.wouldNeed} is needed`
+        : `declared as '${c.pinned.range}' in this project, but ${c.pinned.wouldNeed} is needed`,
     );
   if (c.nonReplayable)
     parts.push(

--- a/tools/data-handler/src/modules/resolve/solver.ts
+++ b/tools/data-handler/src/modules/resolve/solver.ts
@@ -34,7 +34,10 @@ import {
 } from '../types.js';
 import { createSourceLayer, type SourceLayer } from '../source.js';
 import type { Project } from '../../containers/project.js';
-import type { Credentials } from '../../interfaces/project-interfaces.js';
+import type {
+  Credentials,
+  ModuleSetting,
+} from '../../interfaces/project-interfaces.js';
 import type {
   Change,
   ConflictDemand,
@@ -62,6 +65,28 @@ interface Decision {
   edges: Edge[];
 }
 type Assignment = Map<string, Decision>;
+
+/**
+ * Range to persist for a root that declared none. The assumption is only
+ * written down where it actually governs, so the config never states
+ * something untrue:
+ *
+ * - a source with no tags is left alone, matching the same choice `import`
+ *   makes for a fresh one — a range there would bind the module the moment
+ *   its source gains tags;
+ * - a root drifted above 1.x is exempt from the assumed pin as pre-existing
+ *   drift, so 1.x is not what holds it.
+ */
+function assumedRangeFor(
+  version: Version | null | undefined,
+  versionedSource: boolean,
+): VersionRange | undefined {
+  return versionedSource &&
+    version != null &&
+    semver.satisfies(version, DEFAULT_VERSION_RANGE)
+    ? DEFAULT_VERSION_RANGE
+    : undefined;
+}
 
 /** Versions a node may take, in preference order, and the range still to enforce. */
 interface Candidates {
@@ -526,7 +551,16 @@ export async function resolveForApply(
     tempDir?: string;
     credentials?: Credentials;
   },
-): Promise<{ plan: ResolveResult; resolved: ResolvedModule[] }> {
+): Promise<{
+  plan: ResolveResult;
+  resolved: ResolvedModule[];
+  /**
+   * Declarations to rewrite for roots that keep their installed version but
+   * never wrote down a range. Empty on a refused plan — nothing is persisted
+   * when nothing is applied.
+   */
+  backfill: ModuleSetting[];
+}> {
   const ownsSource = !opts?.sourceLayer;
   const source = opts?.sourceLayer ?? createSourceLayer();
   const tempDir = opts?.tempDir ?? join(project.paths.tempFolder, 'resolve');
@@ -537,7 +571,7 @@ export async function resolveForApply(
       source,
       opts?.credentials,
     );
-    if (!result.ok) return { plan: result, resolved: [] };
+    if (!result.ok) return { plan: result, resolved: [], backfill: [] };
 
     const resolved: ResolvedModule[] = [];
     for (const change of result.changes) {
@@ -563,7 +597,11 @@ export async function resolveForApply(
           name: change.module,
           source: node.source,
           versionRange: node.isRoot
-            ? (node.declaredRange ?? undefined)
+            ? (node.declaredRange ??
+              assumedRangeFor(
+                change.to,
+                source.supportsVersioning(node.source.location),
+              ))
             : undefined,
           parent: referrer
             ? { project: project.basePath, name: referrer }
@@ -575,7 +613,29 @@ export async function resolveForApply(
         stagedPath,
       });
     }
-    return { plan: result, resolved };
+    // Roots the plan leaves in place never reach `resolved`, so their
+    // assumed range would survive forever. Sweep them here — the solve
+    // already listed every root's versions, so this costs no extra fetch.
+    const moved = new Set(result.changes.map((c) => c.module));
+    const backfill: ModuleSetting[] = [];
+    for (const [name, decision] of assign) {
+      if (moved.has(name)) continue;
+      const node = nodes.get(name)!;
+      if (!node.isRoot || node.declaredRange !== null) continue;
+      const range = assumedRangeFor(
+        decision.version,
+        source.supportsVersioning(node.source.location),
+      );
+      if (!range) continue;
+      backfill.push({
+        name,
+        location: node.source.location,
+        private: node.source.private ?? false,
+        version: range,
+      });
+    }
+
+    return { plan: result, resolved, backfill };
   } finally {
     if (ownsSource) await source.dispose?.();
   }

--- a/tools/data-handler/src/modules/resolve/solver.ts
+++ b/tools/data-handler/src/modules/resolve/solver.ts
@@ -25,6 +25,7 @@ import { installedModulesWithSources, declaredModules } from '../inventory.js';
 import { buildRemoteUrl } from '../remote-url.js';
 import { versionToTag } from '../version.js';
 import {
+  DEFAULT_VERSION_RANGE,
   toVersion,
   toVersionRange,
   type Source,
@@ -69,6 +70,8 @@ interface Candidates {
   pin: VersionRange | null;
   /** Whether the installed version is exempt from `pin` (pre-existing drift). */
   keepInstalled: boolean;
+  /** Whether `pin` is the assumed default, not a range written in the config. */
+  pinAssumed?: boolean;
 }
 
 /** Solver internals shared between {@link resolve} and {@link resolveForApply}. */
@@ -104,9 +107,10 @@ function toEdges(config: {
     .map((d) => ({
       name: d.name,
       source: { location: d.location, private: d.private ?? false },
-      range: toVersionRange(
-        d.version && d.version.length > 0 ? d.version : '*',
-      ),
+      range:
+        d.version && d.version.length > 0
+          ? toVersionRange(d.version)
+          : DEFAULT_VERSION_RANGE,
     }));
 }
 
@@ -257,14 +261,20 @@ async function solve(
     if (avail.length === 0)
       return { versions: [null], pin: null, keepInstalled: false };
     const newestFirst = [...avail].sort(semver.rcompare) as Version[];
+    // A root that declares no range is still bound: a missing version means
+    // 1.x, so no operation silently crosses a major. Transitives are instead
+    // constrained by their parents' edges (defaulted the same way in toEdges).
+    const pin = n.declaredRange ?? (n.isRoot ? DEFAULT_VERSION_RANGE : null);
+    const pinAssumed = pin !== null && n.declaredRange === null;
     // A declared range is a hard constraint wherever it applies, so it is
     // handed to the search instead of pre-filtered here: the DFS can then
     // report the version a pin excluded rather than collapsing into a generic
     // "no version satisfies its constraints".
     const inRange = (): Candidates => ({
       versions: newestFirst,
-      pin: n.declaredRange,
+      pin,
       keepInstalled: false,
+      pinAssumed,
     });
     // A bystander is offered its installed version first, so an update
     // disturbs the rest of the tree as little as possible, and keeps it even
@@ -275,8 +285,9 @@ async function solve(
         versions: n.installed
           ? [n.installed, ...asc.filter((v) => v !== n.installed)]
           : asc,
-        pin: n.declaredRange,
+        pin,
         keepInstalled: true,
+        pinAssumed,
       };
     };
     switch (req.kind) {
@@ -339,9 +350,9 @@ async function solve(
     if (assign.has(n.name)) return dfs(rest, assign);
     const incoming = dependentRanges(n.name, assign);
     let downgrade: { from: Version; to: Version } | undefined;
-    let pinned: { range: VersionRange; wouldNeed: Version } | undefined;
+    let pinned: ResolveConflict['pinned'];
     let nonReplayable: { from: Version; to: Version } | undefined;
-    const { versions, pin, keepInstalled } = await candidatesFor(n);
+    const { versions, pin, keepInstalled, pinAssumed } = await candidatesFor(n);
     for (const v of versions) {
       if (v !== null && !incoming.every((d) => semver.satisfies(v, d.range)))
         continue;
@@ -361,7 +372,11 @@ async function solve(
           !(n.installed && semver.lt(v, n.installed)) &&
           (!pinned || semver.lt(v, pinned.wouldNeed))
         )
-          pinned = { range: pin, wouldNeed: v };
+          pinned = {
+            range: pin,
+            wouldNeed: v,
+            ...(pinAssumed ? { assumed: true } : {}),
+          };
         continue;
       }
       // An explicit older target is a downgrade: unreachable by replay.

--- a/tools/data-handler/src/modules/resolve/types.ts
+++ b/tools/data-handler/src/modules/resolve/types.ts
@@ -50,9 +50,10 @@ export interface ResolveConflict {
    * Set when a version satisfying every demand on this module existed, but
    * fell outside the module's own declared range. Unlike the other kinds this
    * one is fixable from the project config: widening `range` admits
-   * `wouldNeed` and unblocks the resolution.
+   * `wouldNeed` and unblocks the resolution. `assumed` marks a range the
+   * project never wrote — the default for a declaration without a version.
    */
-  pinned?: { range: VersionRange; wouldNeed: Version };
+  pinned?: { range: VersionRange; wouldNeed: Version; assumed?: boolean };
   /**
    * Set when a version satisfying every demand (and pin) existed, but the
    * migration seal chain cannot bridge the installed version to it, so the

--- a/tools/data-handler/src/modules/types.ts
+++ b/tools/data-handler/src/modules/types.ts
@@ -52,6 +52,13 @@ export function toVersionRange(range: string): VersionRange {
   return range as VersionRange;
 }
 
+/**
+ * Range assumed for a dependency declared without a version: bound to 1.x,
+ * never floated across majors. Compat guard for configs written before
+ * version support existed.
+ */
+export const DEFAULT_VERSION_RANGE = '1.x' as VersionRange;
+
 // ---------------------------------------------------------------------------
 // Entities
 // ---------------------------------------------------------------------------

--- a/tools/data-handler/src/modules/types.ts
+++ b/tools/data-handler/src/modules/types.ts
@@ -56,6 +56,12 @@ export function toVersionRange(range: string): VersionRange {
  * Range assumed for a dependency declared without a version: bound to 1.x,
  * never floated across majors. Compat guard for configs written before
  * version support existed.
+ *
+ * The assumption is meant to be temporary. Wherever it governs a project's
+ * own declaration, the next module operation writes it into
+ * `cardsConfig.json`, so a config only stays version-less until it is next
+ * touched. Dependency edges inside an installed module's own config are not
+ * rewritten — that file belongs to the module, not the project.
  */
 export const DEFAULT_VERSION_RANGE = '1.x' as VersionRange;
 

--- a/tools/data-handler/test/command-import.test.ts
+++ b/tools/data-handler/test/command-import.test.ts
@@ -871,6 +871,72 @@ describe('module update — spec behaviours', () => {
     expect(afterConfig.version).toBe('1.0.0');
   });
 
+  it('updateAllModules writes the assumed 1.x into a version-less declaration', async () => {
+    // The shim's exit: a legacy declaration (written before version support
+    // existed) is converted the next time any module operation runs, even
+    // though this module has nowhere to move.
+    const projectDir = join(moduleTestDir, 'proj-backfill');
+    const handler = new Commands();
+    const create = await handler.command(
+      Cmd.create,
+      ['project', 'backfill-proj', 'bkf'],
+      { projectPath: projectDir },
+    );
+    expect(create.statusCode).toBe(200);
+
+    const depRoot = join(moduleTestDir, 'fake-backfill-mod');
+    makeFakeModuleFixture(depRoot, { cardKeyPrefix: 'bkfmod' });
+
+    const commands = new CommandManager(projectDir, {
+      autoSaveConfiguration: false,
+    });
+    await commands.initialize();
+    await commands.importCmd.importModule(depRoot);
+
+    // Reshape the persisted declaration into the legacy form: a versioned
+    // (git) source with no declared range. Importing from a file source
+    // already leaves the range off, so only the location has to change.
+    const declaration = commands.project.configuration.modules.find(
+      (m) => m.name === 'bkfmod',
+    );
+    expect(declaration).toBeDefined();
+    expect(declaration!.version).toBeUndefined();
+    declaration!.location = 'https://example.com/bkfmod.git';
+
+    // Seed the installed version so the module resolves to 1.0.0.
+    const installedConfigPath = join(
+      projectDir,
+      '.cards',
+      'modules',
+      'bkfmod',
+      'cardsConfig.json',
+    );
+    rewriteJson(installedConfigPath, (config) => {
+      config.version = '1.0.0';
+    });
+
+    mockEnsureModuleListUpToDate();
+    // 1.0.0 is the only tag, so the module stays exactly where it is.
+    vi.spyOn(GitManager, 'listRemoteVersionTags').mockResolvedValue(['1.0.0']);
+
+    await commands.importCmd.updateAllModules();
+
+    const persisted = JSON.parse(
+      readFileSync(
+        join(projectDir, '.cards', 'local', 'cardsConfig.json'),
+        'utf-8',
+      ),
+    );
+    const entry = persisted.modules.find(
+      (m: { name: string }) => m.name === 'bkfmod',
+    );
+    expect(entry.version).toBe('1.x');
+    // Still installed at the version it had — this is a declaration-only
+    // rewrite, not an update.
+    const installed = JSON.parse(readFileSync(installedConfigPath, 'utf-8'));
+    expect(installed.version).toBe('1.0.0');
+  });
+
   // --- updateModule replay end to end -------------------------------------
   //
   // File sources expose no remote versions (`listRemoteVersions` → []), and

--- a/tools/data-handler/test/modules/applier.test.ts
+++ b/tools/data-handler/test/modules/applier.test.ts
@@ -110,6 +110,45 @@ describe('modules/applier', () => {
     expect(persisted.location).toBe('https://example.com/A.git');
   });
 
+  it('writes backfilled declarations for roots that did not move', async () => {
+    const stagedPath = await stage(tempDir, 'A', {
+      'cardsConfig.json': JSON.stringify({
+        cardKeyPrefix: 'A',
+        name: 'A',
+        version: '1.2.3',
+        modules: [],
+      }),
+    });
+    const { project, modules } = makeProjectStub({
+      basePath: projectDir,
+      modules: [{ name: 'H', location: 'https://example.com/H.git' }],
+    });
+
+    const resolved = [
+      buildResolved('A', 'https://example.com/A.git', stagedPath, {
+        version: '1.2.3',
+        range: '^1.0.0',
+      }),
+    ];
+
+    const applied = await applyModules(project, resolved, {
+      tempDir,
+      backfill: [
+        {
+          name: 'H',
+          location: 'https://example.com/H.git',
+          private: false,
+          version: '1.x',
+        },
+      ],
+    });
+
+    // H is not installed by this apply — only its declaration is written.
+    expect(applied).toEqual(['A']);
+    expect(existsSync(join(projectDir, '.cards', 'modules', 'H'))).toBe(false);
+    expect(modules.find((m) => m.name === 'H')?.version).toBe('1.x');
+  });
+
   it('does not persist a transitive declaration (parent defined)', async () => {
     const stagedA = await stage(tempDir, 'A', {
       'cardsConfig.json': JSON.stringify({

--- a/tools/data-handler/test/modules/resolve/solver.test.ts
+++ b/tools/data-handler/test/modules/resolve/solver.test.ts
@@ -1505,4 +1505,190 @@ describe('resolve solver', () => {
       );
     });
   });
+
+  describe('missing version defaults to 1.x', () => {
+    it('update: a root declared without a version stays within 1.x', async () => {
+      const project = buildProjectWithModules([
+        { name: 'A', location: 'https://x/A.git', private: false },
+      ]);
+      await installModule(project, { name: 'A', version: '1.2.0' });
+
+      const configs = new Map<string, FakeModuleConfig>([
+        [
+          'https://x/A.git@v1.6.0',
+          { cardKeyPrefix: 'A', name: 'A', version: '1.6.0', modules: [] },
+        ],
+        [
+          'https://x/A.git@v2.0.0',
+          { cardKeyPrefix: 'A', name: 'A', version: '2.0.0', modules: [] },
+        ],
+      ]);
+      const available = new Map([
+        ['https://x/A.git', ['2.0.0', '1.6.0', '1.2.0']],
+      ]);
+      // Both moves are sealed, so the assumed range is the only discriminator.
+      const seals = new Map<string, Array<[string, string]>>([
+        ['https://x/A.git@v1.6.0', [['1.2.0', '1.6.0']]],
+        ['https://x/A.git@v2.0.0', [['1.2.0', '2.0.0']]],
+      ]);
+      const source = new InMemorySource(configs, available, new Map(), seals);
+
+      const result = await resolve(
+        project,
+        { kind: 'update', module: 'A' },
+        { sourceLayer: source, tempDir: testDir },
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.changes).toHaveLength(1);
+      expect(result.changes[0]).toMatchObject({
+        module: 'A',
+        from: '1.2.0',
+        to: '1.6.0',
+      });
+    });
+
+    it('updateAll: a dependency edge without a version demands 1.x', async () => {
+      const project = buildProjectWithModules([
+        {
+          name: 'A',
+          location: 'https://x/A.git',
+          version: '^1.0.0',
+          private: false,
+        },
+      ]);
+      await installModule(project, {
+        name: 'A',
+        version: '1.0.0',
+        modules: [{ name: 'B', location: 'https://x/B.git' }],
+      });
+      await installModule(project, { name: 'B', version: '1.0.0' });
+
+      const configs = new Map<string, FakeModuleConfig>([
+        [
+          'https://x/B.git@v1.5.0',
+          { cardKeyPrefix: 'B', name: 'B', version: '1.5.0', modules: [] },
+        ],
+        [
+          'https://x/B.git@v2.0.0',
+          { cardKeyPrefix: 'B', name: 'B', version: '2.0.0', modules: [] },
+        ],
+      ]);
+      const available = new Map([
+        ['https://x/A.git', ['1.0.0']],
+        ['https://x/B.git', ['2.0.0', '1.5.0', '1.0.0']],
+      ]);
+      // Both moves are sealed, so the assumed range is the only discriminator.
+      const seals = new Map<string, Array<[string, string]>>([
+        ['https://x/B.git@v1.5.0', [['1.0.0', '1.5.0']]],
+        ['https://x/B.git@v2.0.0', [['1.0.0', '2.0.0']]],
+      ]);
+      const source = new InMemorySource(configs, available, new Map(), seals);
+
+      const result = await resolve(
+        project,
+        { kind: 'updateAll' },
+        { sourceLayer: source, tempDir: testDir },
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const b = result.changes.find((c) => c.module === 'B');
+      expect(b).toMatchObject({ from: '1.0.0', to: '1.5.0' });
+    });
+
+    it('availability: a pin conflict names the assumed 1.x range', async () => {
+      const project = buildProjectWithModules([
+        { name: 'E', location: 'https://x/E.git', private: false },
+      ]);
+      await installModule(project, { name: 'E', version: '1.0.0' });
+
+      const configs = new Map<string, FakeModuleConfig>([
+        [
+          'https://x/E.git@v2.0.0',
+          { cardKeyPrefix: 'E', name: 'E', version: '2.0.0', modules: [] },
+        ],
+      ]);
+      const available = new Map([['https://x/E.git', ['2.0.0']]]);
+      const seals = new Map<string, Array<[string, string]>>([
+        ['https://x/E.git@v2.0.0', [['1.0.0', '2.0.0']]],
+      ]);
+      const source = new InMemorySource(configs, available, new Map(), seals);
+
+      const result = await resolve(
+        project,
+        { kind: 'availability', module: 'E' },
+        { sourceLayer: source, tempDir: testDir },
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.conflicts).toHaveLength(1);
+      expect(result.conflicts[0].pinned).toEqual({
+        range: '1.x',
+        wouldNeed: '2.0.0',
+        assumed: true,
+      });
+      expect(conflictReason(result.conflicts[0])).toContain("assumed '1.x'");
+    });
+
+    it('verify: an installed root outside the assumed 1.x is not flagged', async () => {
+      const project = buildProjectWithModules([
+        { name: 'G', location: 'https://x/G.git', private: false },
+      ]);
+      await installModule(project, { name: 'G', version: '2.0.0' });
+
+      const source = new InMemorySource(
+        new Map(),
+        new Map([['https://x/G.git', ['2.0.0']]]),
+      );
+      const result = await resolve(
+        project,
+        { kind: 'verify' },
+        { sourceLayer: source, tempDir: testDir },
+      );
+
+      expect(result).toEqual({ ok: true, changes: [] });
+    });
+
+    it('update: a bystander outside the assumed 1.x keeps its installed version', async () => {
+      const project = buildProjectWithModules([
+        {
+          name: 'A',
+          location: 'https://x/A.git',
+          version: '^1.0.0',
+          private: false,
+        },
+        { name: 'H', location: 'https://x/H.git', private: false },
+      ]);
+      await installModule(project, { name: 'A', version: '1.0.0' });
+      await installModule(project, { name: 'H', version: '2.0.0' });
+
+      const configs = new Map<string, FakeModuleConfig>([
+        [
+          'https://x/A.git@v1.1.0',
+          { cardKeyPrefix: 'A', name: 'A', version: '1.1.0', modules: [] },
+        ],
+      ]);
+      const available = new Map([
+        ['https://x/A.git', ['1.1.0', '1.0.0']],
+        ['https://x/H.git', ['2.0.0', '1.0.0']],
+      ]);
+      const seals = new Map<string, Array<[string, string]>>([
+        ['https://x/A.git@v1.1.0', [['1.0.0', '1.1.0']]],
+      ]);
+      const source = new InMemorySource(configs, available, new Map(), seals);
+
+      const result = await resolve(
+        project,
+        { kind: 'update', module: 'A' },
+        { sourceLayer: source, tempDir: testDir },
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.changes.map((c) => c.module)).toEqual(['A']);
+    });
+  });
 });

--- a/tools/data-handler/test/modules/resolve/solver.test.ts
+++ b/tools/data-handler/test/modules/resolve/solver.test.ts
@@ -1691,4 +1691,188 @@ describe('resolve solver', () => {
       expect(result.changes.map((c) => c.module)).toEqual(['A']);
     });
   });
+
+  describe('the assumed 1.x is written back as a declaration', () => {
+    /**
+     * Root A pinned `^1.0.0` and installed 1.0.0, with 1.1.0 available and
+     * sealed — so `update A` always has one move to make. The second root is
+     * supplied by the caller and never moves, which is the point: it is the
+     * bystander whose declaration the sweep has to reach.
+     */
+    async function buildSweepFixture(bystander: {
+      setting: ModuleSetting;
+      installed: string;
+      available?: string[];
+    }) {
+      const project = buildProjectWithModules([
+        {
+          name: 'A',
+          location: 'https://x/A.git',
+          version: '^1.0.0',
+          private: false,
+        },
+        bystander.setting,
+      ]);
+      await installModule(project, { name: 'A', version: '1.0.0' });
+      await installModule(project, {
+        name: bystander.setting.name,
+        version: bystander.installed,
+      });
+
+      const configs = new Map<string, FakeModuleConfig>([
+        [
+          'https://x/A.git@v1.1.0',
+          { cardKeyPrefix: 'A', name: 'A', version: '1.1.0', modules: [] },
+        ],
+      ]);
+      const available = new Map([['https://x/A.git', ['1.1.0', '1.0.0']]]);
+      if (bystander.available) {
+        available.set(bystander.setting.location, bystander.available);
+      }
+      const seals = new Map<string, Array<[string, string]>>([
+        ['https://x/A.git@v1.1.0', [['1.0.0', '1.1.0']]],
+      ]);
+      return {
+        project,
+        source: new InMemorySource(configs, available, new Map(), seals),
+      };
+    }
+
+    it('update: a version-less root that moves carries 1.x into its declaration', async () => {
+      const project = buildProjectWithModules([
+        { name: 'A', location: 'https://x/A.git', private: false },
+      ]);
+      await installModule(project, { name: 'A', version: '1.2.0' });
+
+      const configs = new Map<string, FakeModuleConfig>([
+        [
+          'https://x/A.git@v1.6.0',
+          { cardKeyPrefix: 'A', name: 'A', version: '1.6.0', modules: [] },
+        ],
+      ]);
+      const available = new Map([['https://x/A.git', ['1.6.0', '1.2.0']]]);
+      const seals = new Map<string, Array<[string, string]>>([
+        ['https://x/A.git@v1.6.0', [['1.2.0', '1.6.0']]],
+      ]);
+      const source = new InMemorySource(configs, available, new Map(), seals);
+
+      const { plan, resolved } = await resolveForApply(
+        project,
+        { kind: 'update', module: 'A' },
+        { sourceLayer: source, tempDir: testDir },
+      );
+
+      expect(plan.ok).toBe(true);
+      expect(resolved).toHaveLength(1);
+      // The applier persists `declaration.versionRange` verbatim, so the
+      // assumption reaches cardsConfig.json through the moved entry itself.
+      expect(resolved[0].declaration.versionRange).toBe('1.x');
+    });
+
+    it('update: a version-less root that stays put is returned as a backfill', async () => {
+      const { project, source } = await buildSweepFixture({
+        setting: { name: 'H', location: 'https://x/H.git', private: false },
+        installed: '1.0.0',
+        available: ['1.0.0'],
+      });
+
+      const { plan, resolved, backfill } = await resolveForApply(
+        project,
+        { kind: 'update', module: 'A' },
+        { sourceLayer: source, tempDir: testDir },
+      );
+
+      expect(plan.ok).toBe(true);
+      // H never moves, so it is not re-fetched or re-installed...
+      expect(resolved.map((r) => r.declaration.name)).toEqual(['A']);
+      // ...but its assumed range is still written down.
+      expect(backfill).toEqual([
+        {
+          name: 'H',
+          location: 'https://x/H.git',
+          private: false,
+          version: '1.x',
+        },
+      ]);
+    });
+
+    it('a tagless root is left without a declared version', async () => {
+      const { project, source } = await buildSweepFixture({
+        setting: { name: 'H', location: 'file:/somewhere/H', private: false },
+        installed: '1.0.0',
+      });
+
+      const { backfill } = await resolveForApply(
+        project,
+        { kind: 'update', module: 'A' },
+        { sourceLayer: source, tempDir: testDir },
+      );
+
+      // A source with no tags is never asked for versions, so nothing binds
+      // it — and a written range would, the moment it grows tags. `import`
+      // declines to write one for the same reason.
+      expect(backfill).toEqual([]);
+    });
+
+    it('a root drifted above the assumed range is left alone', async () => {
+      const { project, source } = await buildSweepFixture({
+        setting: { name: 'H', location: 'https://x/H.git', private: false },
+        installed: '2.0.0',
+        available: ['2.0.0'],
+      });
+
+      const { backfill } = await resolveForApply(
+        project,
+        { kind: 'update', module: 'A' },
+        { sourceLayer: source, tempDir: testDir },
+      );
+
+      // 2.0.0 is exempt from the assumed pin as pre-existing drift, so 1.x is
+      // not what governs H — writing it down would be a false declaration.
+      expect(backfill).toEqual([]);
+    });
+
+    it('an explicitly declared range is never rewritten', async () => {
+      const { project, source } = await buildSweepFixture({
+        setting: {
+          name: 'H',
+          location: 'https://x/H.git',
+          version: '^1.0.0',
+          private: false,
+        },
+        installed: '1.0.0',
+        available: ['1.0.0'],
+      });
+
+      const { backfill } = await resolveForApply(
+        project,
+        { kind: 'update', module: 'A' },
+        { sourceLayer: source, tempDir: testDir },
+      );
+
+      expect(backfill).toEqual([]);
+    });
+
+    it('a refused resolution writes nothing back', async () => {
+      const { project, source } = await buildOutOfPinFixture();
+      // Give the drifted-in bystander a version-less declaration, so a
+      // successful resolve would have backfilled it.
+      project.configuration.modules.push({
+        name: 'D',
+        location: 'https://x/D.git',
+        private: false,
+      });
+      await installModule(project, { name: 'D', version: '1.0.0' });
+
+      const { plan, resolved, backfill } = await resolveForApply(
+        project,
+        { kind: 'update', module: 'A', to: '1.8.0' as Version },
+        { sourceLayer: source, tempDir: testDir },
+      );
+
+      expect(plan.ok).toBe(false);
+      expect(resolved).toEqual([]);
+      expect(backfill).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
Most projects truly depend on what we call "v1" so let's make it a assumption that an undeclared range is 1.x.