### PR TITLE
Schema version enforcement

### DIFF
--- a/tools/assets/src/schema/cardsConfigSchema.json
+++ b/tools/assets/src/schema/cardsConfigSchema.json
@@ -78,7 +78,7 @@
       }
     }
   },
-  "required": ["cardKeyPrefix"],
+  "required": ["cardKeyPrefix", "schemaVersion"],
   "title": "CardsConfig",
   "type": "object"
 }

--- a/tools/data-handler/src/command-handler.ts
+++ b/tools/data-handler/src/command-handler.ts
@@ -150,7 +150,7 @@ export class Commands {
       creatingNewProject || command === Cmd.installSkills;
     if (!projectNotRequired) {
       try {
-        await this.doSetProject(options);
+        await this.doSetProject(options, command === Cmd.migrate);
       } catch (error) {
         return { statusCode: 400, message: errorFunction(error) };
       }
@@ -176,7 +176,10 @@ export class Commands {
   }
 
   // Handles initializing the project so that it can be used in the class.
-  private async doSetProject(options: AllCommandOptions) {
+  private async doSetProject(
+    options: AllCommandOptions,
+    skipSchemaVersionCheck = false,
+  ) {
     const path = options.projectPath || '';
     this.projectPath = resolveTilde(await this.setProjectPath(path));
     if (!Validate.validateFolder(this.projectPath)) {
@@ -196,15 +199,10 @@ export class Commands {
       watchResourceChanges: (options as StartCommandOptions)
         .watchResourceChanges,
       autocommit: options.autocommit,
+      skipSchemaVersionCheck,
     });
     if (!this.commands) {
       throw new Error('Cannot get instance of CommandManager');
-    }
-
-    // Check schema version and log warning if there's a mismatch
-    const versionCheck = this.commands.checkSchemaVersion();
-    if (!versionCheck.isCompatible) {
-      console.error(versionCheck.message);
     }
   }
 

--- a/tools/data-handler/src/command-manager.ts
+++ b/tools/data-handler/src/command-manager.ts
@@ -37,7 +37,6 @@ import { DEFAULT_HUB } from '@cyberismo/assets';
 
 export interface CommandManagerOptions {
   watchResourceChanges?: boolean;
-  autoSaveConfiguration?: boolean;
   logLevel?: Level;
   autocommit?: boolean;
 }
@@ -68,7 +67,6 @@ export class CommandManager {
 
   constructor(path: string, options?: CommandManagerOptions) {
     this.project = new Project(path, {
-      autoSave: options?.autoSaveConfiguration,
       watchResourceChanges: options?.watchResourceChanges,
       autocommit: options?.autocommit,
     });

--- a/tools/data-handler/src/command-manager.ts
+++ b/tools/data-handler/src/command-manager.ts
@@ -39,6 +39,8 @@ export interface CommandManagerOptions {
   watchResourceChanges?: boolean;
   logLevel?: Level;
   autocommit?: boolean;
+  /** Bypass the schema-version gate. Only the migrate path may set this. */
+  skipSchemaVersionCheck?: boolean;
 }
 
 // Handles commands and ensures that no extra instances are created.
@@ -70,6 +72,13 @@ export class CommandManager {
       watchResourceChanges: options?.watchResourceChanges,
       autocommit: options?.autocommit,
     });
+    if (!options?.skipSchemaVersionCheck) {
+      const compat = this.project.configuration.checkSchemaVersion();
+      if (!compat.isCompatible) {
+        this.project.dispose();
+        throw new Error(compat.message);
+      }
+    }
     this.validateCmd = Validate.getInstance();
 
     this.calculateCmd = new Calculate(this.project);
@@ -170,6 +179,16 @@ export class CommandManager {
     if (!CommandManager.instance) {
       CommandManager.instance = new CommandManager(path, options);
       await CommandManager.instance.initialize();
+    }
+
+    // A cached instance may have been created with the migrate bypass;
+    // re-check so reuse does not silently extend the bypass to other
+    // commands.
+    if (!options?.skipSchemaVersionCheck) {
+      const compat = CommandManager.instance.checkSchemaVersion();
+      if (!compat.isCompatible) {
+        throw new Error(compat.message);
+      }
     }
 
     return CommandManager.instance;

--- a/tools/data-handler/src/commands/import.ts
+++ b/tools/data-handler/src/commands/import.ts
@@ -23,6 +23,7 @@ import {
   buildRemoteUrl,
   conflictReason,
   declaredModules,
+  ensureStagedSchemas,
   installedModules,
   installedModulesWithSources,
   resolveForApply,
@@ -127,6 +128,10 @@ export class Import {
     resolved: ResolvedModule[],
     backfill: ModuleSetting[] = [],
   ): Promise<void> {
+    // Staged trees older than the tool are migrated in place (still in
+    // staging); a newer or unversioned tree aborts before any disk change.
+    await ensureStagedSchemas(resolved);
+
     const installedBefore = await installedModulesWithSources(this.project);
     const steps = await planModuleReplays(resolved, installedBefore);
 

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -69,11 +69,9 @@ import { isPredefinedField, ROOT } from '../utils/constants.js';
 
 /**
  * Options for Project initialization.
- * autoSave - If project configuration changes are saved automatically. Default true.
  * watchResourceChanges - If project refresh automatically to filesystem changes. Default false.
  */
 export interface ProjectOptions {
-  autoSave?: boolean;
   watchResourceChanges?: boolean;
   autocommit?: boolean;
 }
@@ -96,13 +94,11 @@ export class Project extends CardContainer {
   constructor(
     path: string,
     private options: ProjectOptions = {
-      autoSave: true,
       watchResourceChanges: false,
     },
   ) {
     const settings = new ProjectConfiguration(
       join(path, '.cards', 'local', Project.projectConfigFileName),
-      options.autoSave ?? true,
     );
     super(path, settings.cardKeyPrefix);
     this.settings = settings;

--- a/tools/data-handler/src/migrations/run-chain.ts
+++ b/tools/data-handler/src/migrations/run-chain.ts
@@ -31,6 +31,8 @@ const logger = getChildLogger({ module: 'run-migration-chain' });
  * timeouts, backups or validation — and `schemaVersion` is stamped into
  * cardsConfig.json after each successful step. Callers own validation
  * policy. The tree may lack `cardRoot`; migrations tolerate its absence.
+ * A migration that declares `before`, `backup` or `after` is refused
+ * rather than partially executed.
  */
 export async function runMigrationChain(
   root: string,
@@ -62,6 +64,16 @@ export async function runMigrationChain(
     const step = migration(v);
     if (!step) {
       throw new Error(`Migration ${v} is not registered`);
+    }
+    // The harness steps are never run here; refuse rather than silently
+    // change a migration's semantics for this code path.
+    const skipped = (['before', 'backup', 'after'] as const).filter(
+      (name) => step[name] !== undefined,
+    );
+    if (skipped.length > 0) {
+      throw new Error(
+        `Migration ${v} defines ${skipped.join(', ')} step(s), which the in-process chain runner does not execute`,
+      );
     }
     logger.info(
       { root, fromVersion: current, toVersion: v },

--- a/tools/data-handler/src/migrations/run-chain.ts
+++ b/tools/data-handler/src/migrations/run-chain.ts
@@ -1,0 +1,91 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { writeJsonFile as atomicWriteJson } from 'write-json-file';
+
+import { SCHEMA_VERSION } from '@cyberismo/assets';
+import { availableMigrations, migration } from '@cyberismo/migrations';
+
+import { ProjectPaths } from '../containers/project/project-paths.js';
+import { getChildLogger } from '../utils/log-utils.js';
+import { readJsonFile } from '../utils/json.js';
+
+const logger = getChildLogger({ module: 'run-migration-chain' });
+
+/**
+ * Run the contiguous migration chain from `fromVersion` up to
+ * SCHEMA_VERSION against a bare `.cards` tree, in-process.
+ *
+ * Mechanism only: each migration's `migrate` runs directly — no workers,
+ * timeouts, backups or validation — and `schemaVersion` is stamped into
+ * cardsConfig.json after each successful step. Callers own validation
+ * policy. The tree may lack `cardRoot`; migrations tolerate its absence.
+ */
+export async function runMigrationChain(
+  root: string,
+  fromVersion: number,
+): Promise<void> {
+  const paths = new ProjectPaths(root);
+  const versions = availableMigrations().filter(
+    (v) => v > fromVersion && v <= SCHEMA_VERSION,
+  );
+
+  // The chain must be contiguous from fromVersion+1 up to SCHEMA_VERSION.
+  let expected = fromVersion + 1;
+  for (const v of versions) {
+    if (v !== expected) {
+      throw new Error(
+        `No migration path from schema ${fromVersion} to ${SCHEMA_VERSION}: migration ${expected} is missing`,
+      );
+    }
+    expected = v + 1;
+  }
+  if (expected !== SCHEMA_VERSION + 1) {
+    throw new Error(
+      `No migration path from schema ${fromVersion} to ${SCHEMA_VERSION}: migration ${expected} is missing`,
+    );
+  }
+
+  let current = fromVersion;
+  for (const v of versions) {
+    const step = migration(v);
+    if (!step) {
+      throw new Error(`Migration ${v} is not registered`);
+    }
+    logger.info(
+      { root, fromVersion: current, toVersion: v },
+      'running migration step',
+    );
+    const result = await step.migrate({
+      cardRootPath: paths.cardRootFolder,
+      cardsConfigPath: paths.internalRootFolder,
+      fromVersion: current,
+      toVersion: v,
+    });
+    if (!result.success) {
+      throw new Error(
+        `Migration to schema ${v} failed: ${result.message ?? 'unknown error'}`,
+      );
+    }
+    // Raw file I/O: the migration may have rewritten cardsConfig.json on
+    // disk, so no in-memory settings object can be trusted to re-save it.
+    const raw = await readJsonFile(paths.configurationFile);
+    if (!raw) {
+      throw new Error(`Cannot read ${paths.configurationFile}`);
+    }
+    raw.schemaVersion = v;
+    await atomicWriteJson(paths.configurationFile, raw, { indent: 4 });
+    current = v;
+  }
+}

--- a/tools/data-handler/src/modules/index.ts
+++ b/tools/data-handler/src/modules/index.ts
@@ -70,5 +70,6 @@ export {
 export { createSourceLayer } from './source.js';
 export { resolve, resolveForApply } from './resolve/solver.js';
 export { conflictReason } from './resolve/format.js';
+export { ensureStagedSchemas } from './staged-migration.js';
 export { applyModules } from './applier.js';
 export { cleanOrphans } from './orphans.js';

--- a/tools/data-handler/src/modules/staged-migration.ts
+++ b/tools/data-handler/src/modules/staged-migration.ts
@@ -1,0 +1,127 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { writeJsonFile as atomicWriteJson } from 'write-json-file';
+
+import { SCHEMA_VERSION } from '@cyberismo/assets';
+import { availableMigrations, migration } from '@cyberismo/migrations';
+
+import { ProjectPaths } from '../containers/project/project-paths.js';
+import { readModuleConfig } from '../containers/project/cards-config.js';
+import { getChildLogger } from '../utils/log-utils.js';
+import { readJsonFile } from '../utils/json.js';
+
+import type { ResolvedModule } from './resolve/types.js';
+
+const logger = getChildLogger({ module: 'staged-migration' });
+
+/**
+ * Enforce the schema-level invariant on staged module trees before any
+ * of them is copied into the project: a tree older than the tool is
+ * migrated in place (still in staging), a newer or unversioned tree
+ * aborts the whole operation.
+ */
+export async function ensureStagedSchemas(
+  resolved: ResolvedModule[],
+): Promise<void> {
+  for (const entry of resolved) {
+    const name = entry.declaration.name;
+    const config = await readModuleConfig(entry.stagedPath);
+    const staged = config.schemaVersion;
+
+    if (staged === undefined) {
+      throw new Error(
+        `Module '${name}' has no 'schemaVersion' in its cardsConfig.json and cannot be installed.`,
+      );
+    }
+    if (staged > SCHEMA_VERSION) {
+      throw new Error(
+        `Module '${name}' requires schema version ${staged}; this tool supports up to ${SCHEMA_VERSION}. Upgrade cyberismo, or choose an older module version.`,
+      );
+    }
+    if (staged < SCHEMA_VERSION) {
+      await migrateStagedTree(entry.stagedPath, staged);
+      console.log(
+        `Migrated staged module '${name}' from schema ${staged} to ${SCHEMA_VERSION}`,
+      );
+    }
+  }
+}
+
+/**
+ * Run schema migrations against a staged module checkout, in-process.
+ *
+ * The staged tree never touches the project, so the interactive
+ * executor's workers, backups, disk-space checks and per-step validation
+ * are deliberately skipped — the import flow validates the project after
+ * apply. Staged file-source trees may lack `cardRoot`; migrations
+ * tolerate its absence.
+ */
+export async function migrateStagedTree(
+  stagedRoot: string,
+  fromVersion: number,
+): Promise<void> {
+  const paths = new ProjectPaths(stagedRoot);
+  const versions = availableMigrations().filter(
+    (v) => v > fromVersion && v <= SCHEMA_VERSION,
+  );
+
+  // The chain must be contiguous from fromVersion+1 up to SCHEMA_VERSION.
+  let expected = fromVersion + 1;
+  for (const v of versions) {
+    if (v !== expected) {
+      throw new Error(
+        `No migration path from schema ${fromVersion} to ${SCHEMA_VERSION}: migration ${expected} is missing`,
+      );
+    }
+    expected = v + 1;
+  }
+  if (expected !== SCHEMA_VERSION + 1) {
+    throw new Error(
+      `No migration path from schema ${fromVersion} to ${SCHEMA_VERSION}: migration ${expected} is missing`,
+    );
+  }
+
+  let current = fromVersion;
+  for (const v of versions) {
+    const step = migration(v);
+    if (!step) {
+      throw new Error(`Migration ${v} is not registered`);
+    }
+    logger.info(
+      { stagedRoot, fromVersion: current, toVersion: v },
+      'migrating staged tree',
+    );
+    const result = await step.migrate({
+      cardRootPath: paths.cardRootFolder,
+      cardsConfigPath: paths.internalRootFolder,
+      fromVersion: current,
+      toVersion: v,
+    });
+    if (!result.success) {
+      throw new Error(
+        `Migration to schema ${v} failed for staged tree: ${result.message ?? 'unknown error'}`,
+      );
+    }
+    // Raw file I/O: the migration may have rewritten cardsConfig.json on
+    // disk, so no in-memory settings object can be trusted to re-save it.
+    const raw = await readJsonFile(paths.configurationFile);
+    if (!raw) {
+      throw new Error(`Cannot read ${paths.configurationFile}`);
+    }
+    raw.schemaVersion = v;
+    await atomicWriteJson(paths.configurationFile, raw, { indent: 4 });
+    current = v;
+  }
+}

--- a/tools/data-handler/src/modules/staged-migration.ts
+++ b/tools/data-handler/src/modules/staged-migration.ts
@@ -12,25 +12,24 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { writeJsonFile as atomicWriteJson } from 'write-json-file';
-
 import { SCHEMA_VERSION } from '@cyberismo/assets';
-import { availableMigrations, migration } from '@cyberismo/migrations';
 
-import { ProjectPaths } from '../containers/project/project-paths.js';
 import { readModuleConfig } from '../containers/project/cards-config.js';
-import { getChildLogger } from '../utils/log-utils.js';
-import { readJsonFile } from '../utils/json.js';
+import { runMigrationChain } from '../migrations/run-chain.js';
 
 import type { ResolvedModule } from './resolve/types.js';
-
-const logger = getChildLogger({ module: 'staged-migration' });
 
 /**
  * Enforce the schema-level invariant on staged module trees before any
  * of them is copied into the project: a tree older than the tool is
  * migrated in place (still in staging), a newer or unversioned tree
  * aborts the whole operation.
+ *
+ * Migrations run in-process via the chain runner. The staged tree never
+ * touches the project, so the interactive executor's workers, backups,
+ * disk-space checks and per-step validation are deliberately skipped —
+ * the import flow validates the project after apply. Staged file-source
+ * trees may lack `cardRoot`; migrations tolerate its absence.
  */
 export async function ensureStagedSchemas(
   resolved: ResolvedModule[],
@@ -51,77 +50,10 @@ export async function ensureStagedSchemas(
       );
     }
     if (staged < SCHEMA_VERSION) {
-      await migrateStagedTree(entry.stagedPath, staged);
+      await runMigrationChain(entry.stagedPath, staged);
       console.log(
         `Migrated staged module '${name}' from schema ${staged} to ${SCHEMA_VERSION}`,
       );
     }
-  }
-}
-
-/**
- * Run schema migrations against a staged module checkout, in-process.
- *
- * The staged tree never touches the project, so the interactive
- * executor's workers, backups, disk-space checks and per-step validation
- * are deliberately skipped — the import flow validates the project after
- * apply. Staged file-source trees may lack `cardRoot`; migrations
- * tolerate its absence.
- */
-export async function migrateStagedTree(
-  stagedRoot: string,
-  fromVersion: number,
-): Promise<void> {
-  const paths = new ProjectPaths(stagedRoot);
-  const versions = availableMigrations().filter(
-    (v) => v > fromVersion && v <= SCHEMA_VERSION,
-  );
-
-  // The chain must be contiguous from fromVersion+1 up to SCHEMA_VERSION.
-  let expected = fromVersion + 1;
-  for (const v of versions) {
-    if (v !== expected) {
-      throw new Error(
-        `No migration path from schema ${fromVersion} to ${SCHEMA_VERSION}: migration ${expected} is missing`,
-      );
-    }
-    expected = v + 1;
-  }
-  if (expected !== SCHEMA_VERSION + 1) {
-    throw new Error(
-      `No migration path from schema ${fromVersion} to ${SCHEMA_VERSION}: migration ${expected} is missing`,
-    );
-  }
-
-  let current = fromVersion;
-  for (const v of versions) {
-    const step = migration(v);
-    if (!step) {
-      throw new Error(`Migration ${v} is not registered`);
-    }
-    logger.info(
-      { stagedRoot, fromVersion: current, toVersion: v },
-      'migrating staged tree',
-    );
-    const result = await step.migrate({
-      cardRootPath: paths.cardRootFolder,
-      cardsConfigPath: paths.internalRootFolder,
-      fromVersion: current,
-      toVersion: v,
-    });
-    if (!result.success) {
-      throw new Error(
-        `Migration to schema ${v} failed for staged tree: ${result.message ?? 'unknown error'}`,
-      );
-    }
-    // Raw file I/O: the migration may have rewritten cardsConfig.json on
-    // disk, so no in-memory settings object can be trusted to re-save it.
-    const raw = await readJsonFile(paths.configurationFile);
-    if (!raw) {
-      throw new Error(`Cannot read ${paths.configurationFile}`);
-    }
-    raw.schemaVersion = v;
-    await atomicWriteJson(paths.configurationFile, raw, { indent: 4 });
-    current = v;
   }
 }

--- a/tools/data-handler/src/project-settings.ts
+++ b/tools/data-handler/src/project-settings.ts
@@ -12,7 +12,6 @@
 */
 
 import { writeJsonFile as atomicWrite } from 'write-json-file';
-import { writeFileSync } from 'node:fs';
 
 import { resolve } from 'node:path';
 import { URL } from 'node:url';
@@ -23,7 +22,6 @@ import type {
   ProjectSettings,
 } from './interfaces/project-interfaces.js';
 import { canonicalHubLocation } from './utils/hub-utils.js';
-import { formatJson } from './utils/json.js';
 import { getChildLogger } from './utils/log-utils.js';
 import { readCardsConfigSync } from './containers/project/cards-config.js';
 import { Validate } from './commands/validate.js';
@@ -43,30 +41,15 @@ export class ProjectConfiguration implements ProjectSettings {
   hubs: HubSetting[];
   private logger = getChildLogger({ module: 'Project' });
   private settingPath: string;
-  private autoSave: boolean = false;
 
-  constructor(path: string, autoSave: boolean = true) {
+  constructor(path: string) {
     this.name = '';
     this.settingPath = path;
     this.cardKeyPrefix = '';
     this.description = '';
     this.modules = [];
     this.hubs = [];
-    this.autoSave = autoSave;
     this.readSettings();
-    this.ensureSchemaVersionAndSave();
-  }
-
-  // Ensures that schemaVersion is set in the project configuration.
-  // If missing, sets it to the current SCHEMA_VERSION and marks for auto-save.
-  private ensureSchemaVersionAndSave() {
-    if (this.schemaVersion === undefined) {
-      this.schemaVersion = SCHEMA_VERSION;
-      // Auto-saves the configuration, if schema version was updated.
-      if (this.autoSave) {
-        this.saveSync();
-      }
-    }
   }
 
   // Sets configuration values from file.
@@ -81,20 +64,6 @@ export class ProjectConfiguration implements ProjectSettings {
     this.version = settings.version;
     this.modules = settings.modules || [];
     this.hubs = settings.hubs || [];
-  }
-
-  // Synchronously persists configuration file to disk.
-  private saveSync() {
-    if (this.cardKeyPrefix === '') {
-      throw new Error('wrong configuration');
-    }
-    try {
-      writeFileSync(this.settingPath, formatJson(this.toJSON()), 'utf-8');
-    } catch (error) {
-      if (error instanceof Error) {
-        this.logger.error({ error }, 'Cannot write project configuration');
-      }
-    }
   }
 
   // Return the configuration as object
@@ -166,22 +135,23 @@ export class ProjectConfiguration implements ProjectSettings {
   public checkSchemaVersion(): { isCompatible: boolean; message: string } {
     if (this.schemaVersion === undefined) {
       return {
-        isCompatible: true,
-        message: '',
+        isCompatible: false,
+        message:
+          "Project's cardsConfig.json has no 'schemaVersion'. Set it manually to the schema version the project conforms to, then run 'cyberismo migrate'.",
       };
     }
 
     if (this.schemaVersion < SCHEMA_VERSION) {
       return {
         isCompatible: false,
-        message: `Schema version mismatch: Project schema version (${this.schemaVersion}) is older than the application schema version (${SCHEMA_VERSION}). A migration is needed. Run 'cyberismo migrate' to update the project schema.`,
+        message: `Schema version mismatch: project is at schema version ${this.schemaVersion}, this tool requires ${SCHEMA_VERSION}. Run 'cyberismo migrate' to update the project.`,
       };
     }
 
     if (this.schemaVersion > SCHEMA_VERSION) {
       return {
         isCompatible: false,
-        message: `Schema version mismatch: Project schema version (${this.schemaVersion}) is newer than the application schema version (${SCHEMA_VERSION}). Please update the application.`,
+        message: `Schema version mismatch: project is at schema version ${this.schemaVersion}, this tool supports up to ${SCHEMA_VERSION}. Upgrade cyberismo.`,
       };
     }
 

--- a/tools/data-handler/test/card-cache.test.ts
+++ b/tools/data-handler/test/card-cache.test.ts
@@ -618,8 +618,7 @@ describe('Card cache', () => {
       // Set path and create CommandManager after directory exists
       decisionProjectPath = join(tempDir, 'valid', 'decision-records');
 
-      commands = new CommandManager(decisionProjectPath, {
-      });
+      commands = new CommandManager(decisionProjectPath, {});
       await commands.initialize();
     });
 

--- a/tools/data-handler/test/card-cache.test.ts
+++ b/tools/data-handler/test/card-cache.test.ts
@@ -619,7 +619,6 @@ describe('Card cache', () => {
       decisionProjectPath = join(tempDir, 'valid', 'decision-records');
 
       commands = new CommandManager(decisionProjectPath, {
-        autoSaveConfiguration: false,
       });
       await commands.initialize();
     });

--- a/tools/data-handler/test/command-clean.test.ts
+++ b/tools/data-handler/test/command-clean.test.ts
@@ -22,7 +22,6 @@ describe('clean command', () => {
     mkdirSync(testDir, { recursive: true });
     await copyDir('test/test-data/', testDir);
     commands = new CommandManager(decisionRecordsPath, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
     cleanCmd = commands.cleanCmd;
@@ -45,7 +44,6 @@ describe('clean command', () => {
     prepare?.(projectPath);
 
     const freshCommands = new CommandManager(projectPath, {
-      autoSaveConfiguration: false,
     });
     await freshCommands.initialize();
     return { freshTestDir, freshCommands };
@@ -267,7 +265,6 @@ describe('clean command', () => {
     mkdirSync(moduleTestDir, { recursive: true });
     await copyDir('test/test-data/', moduleTestDir);
     const importing = new CommandManager(join(moduleTestDir, 'valid/minimal'), {
-      autoSaveConfiguration: false,
     });
     await importing.initialize();
     try {

--- a/tools/data-handler/test/command-clean.test.ts
+++ b/tools/data-handler/test/command-clean.test.ts
@@ -21,8 +21,7 @@ describe('clean command', () => {
   beforeAll(async () => {
     mkdirSync(testDir, { recursive: true });
     await copyDir('test/test-data/', testDir);
-    commands = new CommandManager(decisionRecordsPath, {
-    });
+    commands = new CommandManager(decisionRecordsPath, {});
     await commands.initialize();
     cleanCmd = commands.cleanCmd;
   });
@@ -43,8 +42,7 @@ describe('clean command', () => {
     const projectPath = join(freshTestDir, 'valid/decision-records');
     prepare?.(projectPath);
 
-    const freshCommands = new CommandManager(projectPath, {
-    });
+    const freshCommands = new CommandManager(projectPath, {});
     await freshCommands.initialize();
     return { freshTestDir, freshCommands };
   }
@@ -264,8 +262,10 @@ describe('clean command', () => {
     const moduleTestDir = join(baseDir, 'tmp-clean-module');
     mkdirSync(moduleTestDir, { recursive: true });
     await copyDir('test/test-data/', moduleTestDir);
-    const importing = new CommandManager(join(moduleTestDir, 'valid/minimal'), {
-    });
+    const importing = new CommandManager(
+      join(moduleTestDir, 'valid/minimal'),
+      {},
+    );
     await importing.initialize();
     try {
       // The imported project's template card carries null placeholders.

--- a/tools/data-handler/test/command-create.test.ts
+++ b/tools/data-handler/test/command-create.test.ts
@@ -229,8 +229,7 @@ describe('create command', () => {
   it('card with parent returns root cards sorted first by rank', async () => {
     const parentCard = 'decision_5';
     const templateName = 'decision/templates/simplepage';
-    const commands = new CommandManager(decisionRecordsPath, {
-    });
+    const commands = new CommandManager(decisionRecordsPath, {});
     await commands.initialize();
     const createdCards = await commands.createCmd.createCard(
       templateName,
@@ -1223,8 +1222,7 @@ describe('created cards and custom field values', () => {
   beforeAll(async () => {
     mkdirSync(testRoot, { recursive: true });
     await copyDir('test/test-data/', testRoot);
-    commands = new CommandManager(projectPath, {
-    });
+    commands = new CommandManager(projectPath, {});
     await commands.initialize();
   });
 

--- a/tools/data-handler/test/command-create.test.ts
+++ b/tools/data-handler/test/command-create.test.ts
@@ -230,7 +230,6 @@ describe('create command', () => {
     const parentCard = 'decision_5';
     const templateName = 'decision/templates/simplepage';
     const commands = new CommandManager(decisionRecordsPath, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
     const createdCards = await commands.createCmd.createCard(
@@ -1225,7 +1224,6 @@ describe('created cards and custom field values', () => {
     mkdirSync(testRoot, { recursive: true });
     await copyDir('test/test-data/', testRoot);
     commands = new CommandManager(projectPath, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
   });

--- a/tools/data-handler/test/command-edit.test.ts
+++ b/tools/data-handler/test/command-edit.test.ts
@@ -20,7 +20,6 @@ describe('edit card', () => {
     mkdirSync(testDir, { recursive: true });
     await copyDir('test/test-data/', testDir);
     commands = new CommandManager(decisionRecordsPath, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
     editCmd = commands.editCmd;
@@ -97,7 +96,6 @@ describe('edit card', () => {
       'valid/decision-records',
     );
     const freshCommands = new CommandManager(freshDecisionRecordsPath, {
-      autoSaveConfiguration: false,
     });
     await freshCommands.initialize();
     const freshEditCmd = freshCommands.editCmd;
@@ -121,7 +119,7 @@ describe('edit card', () => {
     await copyDir('test/test-data/', freshTestDir);
     const freshCommands = new CommandManager(
       join(freshTestDir, 'valid/decision-records'),
-      { autoSaveConfiguration: false },
+      {},
     );
     await freshCommands.initialize();
 
@@ -201,7 +199,6 @@ describe('edit card', () => {
     writeFileSync(cardTypePath, JSON.stringify(cardType));
 
     const freshCommands = new CommandManager(projectPath, {
-      autoSaveConfiguration: false,
     });
     await freshCommands.initialize();
     return { freshTestDir, freshCommands };
@@ -318,7 +315,6 @@ describe('edit card', () => {
     writeFileSync(metadataFile, JSON.stringify(metadata));
 
     const freshCommands = new CommandManager(projectPath, {
-      autoSaveConfiguration: false,
     });
     await freshCommands.initialize();
 
@@ -378,7 +374,7 @@ describe('edit card', () => {
       await copyDir('test/test-data/', clearTestDir);
       clearCommands = new CommandManager(
         join(clearTestDir, 'valid/decision-records'),
-        { autoSaveConfiguration: false },
+        {},
       );
       await clearCommands.initialize();
     });

--- a/tools/data-handler/test/command-edit.test.ts
+++ b/tools/data-handler/test/command-edit.test.ts
@@ -19,8 +19,7 @@ describe('edit card', () => {
   beforeAll(async () => {
     mkdirSync(testDir, { recursive: true });
     await copyDir('test/test-data/', testDir);
-    commands = new CommandManager(decisionRecordsPath, {
-    });
+    commands = new CommandManager(decisionRecordsPath, {});
     await commands.initialize();
     editCmd = commands.editCmd;
   });
@@ -95,8 +94,7 @@ describe('edit card', () => {
       freshTestDir,
       'valid/decision-records',
     );
-    const freshCommands = new CommandManager(freshDecisionRecordsPath, {
-    });
+    const freshCommands = new CommandManager(freshDecisionRecordsPath, {});
     await freshCommands.initialize();
     const freshEditCmd = freshCommands.editCmd;
 
@@ -198,8 +196,7 @@ describe('edit card', () => {
     field.enableOverride = true;
     writeFileSync(cardTypePath, JSON.stringify(cardType));
 
-    const freshCommands = new CommandManager(projectPath, {
-    });
+    const freshCommands = new CommandManager(projectPath, {});
     await freshCommands.initialize();
     return { freshTestDir, freshCommands };
   }
@@ -314,8 +311,7 @@ describe('edit card', () => {
     metadata['decision/fieldTypes/obsoletedBy'] = 'decision_999';
     writeFileSync(metadataFile, JSON.stringify(metadata));
 
-    const freshCommands = new CommandManager(projectPath, {
-    });
+    const freshCommands = new CommandManager(projectPath, {});
     await freshCommands.initialize();
 
     try {

--- a/tools/data-handler/test/command-export-pdf.test.ts
+++ b/tools/data-handler/test/command-export-pdf.test.ts
@@ -18,7 +18,6 @@ describe('PDF export — AsciiDoc source assembly', () => {
     mkdirSync(testDir, { recursive: true });
     await copyDir('test/test-data/', testDir);
     commands = new CommandManager(decisionRecordsPath, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
     exportCmd = commands.exportCmd;

--- a/tools/data-handler/test/command-export-pdf.test.ts
+++ b/tools/data-handler/test/command-export-pdf.test.ts
@@ -17,8 +17,7 @@ describe('PDF export — AsciiDoc source assembly', () => {
   beforeAll(async () => {
     mkdirSync(testDir, { recursive: true });
     await copyDir('test/test-data/', testDir);
-    commands = new CommandManager(decisionRecordsPath, {
-    });
+    commands = new CommandManager(decisionRecordsPath, {});
     await commands.initialize();
     exportCmd = commands.exportCmd;
 

--- a/tools/data-handler/test/command-import.test.ts
+++ b/tools/data-handler/test/command-import.test.ts
@@ -565,8 +565,7 @@ describe('module update — spec behaviours', () => {
     );
     expect(create.statusCode).toBe(200);
 
-    const commands = new CommandManager(projectDir, {
-    });
+    const commands = new CommandManager(projectDir, {});
     await commands.initialize();
 
     await commands.importCmd.importModule(hostRoot);
@@ -612,8 +611,7 @@ describe('module update — spec behaviours', () => {
     );
     expect(create.statusCode).toBe(200);
 
-    const commands = new CommandManager(projectDir, {
-    });
+    const commands = new CommandManager(projectDir, {});
     await commands.initialize();
 
     // First import: host is declared, dep is installed transitively on disk.
@@ -674,8 +672,7 @@ describe('module update — spec behaviours', () => {
     );
     expect(create.statusCode).toBe(200);
 
-    const commands = new CommandManager(projectDir, {
-    });
+    const commands = new CommandManager(projectDir, {});
     await commands.initialize();
 
     await commands.importCmd.importModule(hostRoot);
@@ -717,8 +714,7 @@ describe('module update — spec behaviours', () => {
     const depRoot = join(moduleTestDir, 'fake-override-mod');
     makeFakeModuleFixture(depRoot, { cardKeyPrefix: 'ovmod' });
 
-    const commands = new CommandManager(projectDir, {
-    });
+    const commands = new CommandManager(projectDir, {});
     await commands.initialize();
     await commands.importCmd.importModule(depRoot);
 
@@ -753,8 +749,7 @@ describe('module update — spec behaviours', () => {
     const depRoot = join(moduleTestDir, 'fake-override-mod-ok');
     makeFakeModuleFixture(depRoot, { cardKeyPrefix: 'ovkmod' });
 
-    const commands = new CommandManager(projectDir, {
-    });
+    const commands = new CommandManager(projectDir, {});
     await commands.initialize();
     await commands.importCmd.importModule(depRoot);
 
@@ -800,8 +795,7 @@ describe('module update — spec behaviours', () => {
     );
     expect(create.statusCode).toBe(200);
 
-    const commands = new CommandManager(projectDir, {
-    });
+    const commands = new CommandManager(projectDir, {});
     await commands.initialize();
 
     await commands.importCmd.importModule(hostRoot);
@@ -836,8 +830,7 @@ describe('module update — spec behaviours', () => {
     );
     expect(create.statusCode).toBe(200);
 
-    const commands = new CommandManager(projectDir, {
-    });
+    const commands = new CommandManager(projectDir, {});
     await commands.initialize();
     await commands.importCmd.importModule(modRoot);
 
@@ -970,8 +963,7 @@ describe('module update — spec behaviours', () => {
     );
     expect(create.statusCode).toBe(200);
 
-    const commands = new CommandManager(projectDir, {
-    });
+    const commands = new CommandManager(projectDir, {});
     await commands.initialize();
     await commands.importCmd.importModule(moduleSource);
 

--- a/tools/data-handler/test/command-import.test.ts
+++ b/tools/data-handler/test/command-import.test.ts
@@ -564,7 +564,6 @@ describe('module update — spec behaviours', () => {
     expect(create.statusCode).toBe(200);
 
     const commands = new CommandManager(projectDir, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
 
@@ -612,7 +611,6 @@ describe('module update — spec behaviours', () => {
     expect(create.statusCode).toBe(200);
 
     const commands = new CommandManager(projectDir, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
 
@@ -675,7 +673,6 @@ describe('module update — spec behaviours', () => {
     expect(create.statusCode).toBe(200);
 
     const commands = new CommandManager(projectDir, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
 
@@ -719,7 +716,6 @@ describe('module update — spec behaviours', () => {
     makeFakeModuleFixture(depRoot, { cardKeyPrefix: 'ovmod' });
 
     const commands = new CommandManager(projectDir, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
     await commands.importCmd.importModule(depRoot);
@@ -756,7 +752,6 @@ describe('module update — spec behaviours', () => {
     makeFakeModuleFixture(depRoot, { cardKeyPrefix: 'ovkmod' });
 
     const commands = new CommandManager(projectDir, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
     await commands.importCmd.importModule(depRoot);
@@ -804,7 +799,6 @@ describe('module update — spec behaviours', () => {
     expect(create.statusCode).toBe(200);
 
     const commands = new CommandManager(projectDir, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
 
@@ -841,7 +835,6 @@ describe('module update — spec behaviours', () => {
     expect(create.statusCode).toBe(200);
 
     const commands = new CommandManager(projectDir, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
     await commands.importCmd.importModule(modRoot);
@@ -976,7 +969,6 @@ describe('module update — spec behaviours', () => {
     expect(create.statusCode).toBe(200);
 
     const commands = new CommandManager(projectDir, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
     await commands.importCmd.importModule(moduleSource);

--- a/tools/data-handler/test/command-import.test.ts
+++ b/tools/data-handler/test/command-import.test.ts
@@ -31,6 +31,8 @@ import {
   getTestProject,
   mockEnsureModuleListUpToDate,
 } from './helpers/test-utils.js';
+import { readJsonFileSync } from '../src/utils/json.js';
+import { SCHEMA_VERSION } from '@cyberismo/assets';
 import { toVersionRange } from '../src/modules/types.js';
 import { ModuleValidationFailedError } from '../src/mutations/replay/replay.js';
 import { logLine, writeSeals } from './helpers/replay-fixtures.js';
@@ -1170,4 +1172,81 @@ describe('module update — spec behaviours', () => {
       ),
     ).toBe(false);
   }, 30000);
+});
+
+describe('module schema version enforcement on import', () => {
+  const schemaTestDir = join(baseDir, 'tmp-import-schema-tests');
+  const hostPath = join(schemaTestDir, 'valid/minimal');
+  const modulePath = join(schemaTestDir, 'valid/decision-records');
+  const moduleConfigPath = join(
+    modulePath,
+    '.cards',
+    'local',
+    'cardsConfig.json',
+  );
+  const installedConfigPath = join(
+    hostPath,
+    '.cards',
+    'modules',
+    'decision',
+    'cardsConfig.json',
+  );
+
+  function setModuleSchemaVersion(version: number | undefined) {
+    const config = readJsonFileSync(moduleConfigPath) as Record<
+      string,
+      unknown
+    >;
+    if (version === undefined) {
+      delete config.schemaVersion;
+    } else {
+      config.schemaVersion = version;
+    }
+    writeFileSync(moduleConfigPath, JSON.stringify(config, null, 4));
+  }
+
+  beforeEach(async () => {
+    rmSync(schemaTestDir, { recursive: true, force: true });
+    mkdirSync(schemaTestDir, { recursive: true });
+    await copyDir('test/test-data', schemaTestDir);
+    mockEnsureModuleListUpToDate();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(schemaTestDir, { recursive: true, force: true });
+  });
+
+  it('migrates an older module before installing it', async () => {
+    setModuleSchemaVersion(4);
+    const commands = new CommandManager(hostPath);
+    await commands.initialize();
+    await commands.importCmd.importModule(modulePath);
+    const installed = readJsonFileSync(installedConfigPath) as {
+      schemaVersion: number;
+    };
+    expect(installed.schemaVersion).toBe(SCHEMA_VERSION);
+    commands.project.dispose();
+  });
+
+  it('refuses a module newer than the tool, before any disk change', async () => {
+    setModuleSchemaVersion(SCHEMA_VERSION + 1);
+    const commands = new CommandManager(hostPath);
+    await commands.initialize();
+    await expect(commands.importCmd.importModule(modulePath)).rejects.toThrow(
+      'Upgrade cyberismo',
+    );
+    expect(existsSync(installedConfigPath)).toBe(false);
+    commands.project.dispose();
+  });
+
+  it('refuses a module without a schema version', async () => {
+    setModuleSchemaVersion(undefined);
+    const commands = new CommandManager(hostPath);
+    await commands.initialize();
+    await expect(commands.importCmd.importModule(modulePath)).rejects.toThrow(
+      "no 'schemaVersion'",
+    );
+    commands.project.dispose();
+  });
 });

--- a/tools/data-handler/test/command-manager.test.ts
+++ b/tools/data-handler/test/command-manager.test.ts
@@ -1,0 +1,90 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { SCHEMA_VERSION } from '@cyberismo/assets';
+import { CommandManager } from '../src/command-manager.js';
+import { copyDir } from '../src/utils/file-utils.js';
+import { readJsonFileSync } from '../src/utils/json.js';
+
+const testDir = join(import.meta.dirname, 'tmp-command-manager-tests');
+const projectPath = join(testDir, 'valid/decision-records');
+const configPath = join(projectPath, '.cards', 'local', 'cardsConfig.json');
+
+function setSchemaVersion(version: number | undefined) {
+  const config = readJsonFileSync(configPath) as Record<string, unknown>;
+  if (version === undefined) {
+    delete config.schemaVersion;
+  } else {
+    config.schemaVersion = version;
+  }
+  writeFileSync(configPath, JSON.stringify(config, null, 4));
+}
+
+describe('CommandManager schema version gate', () => {
+  beforeEach(async () => {
+    rmSync(testDir, { recursive: true, force: true });
+    mkdirSync(testDir, { recursive: true });
+    await copyDir('test/test-data', testDir);
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('constructs when schema versions match', () => {
+    const commands = new CommandManager(projectPath);
+    expect(commands.project).toBeDefined();
+    commands.project.dispose();
+  });
+
+  it('throws when the project schema is older', () => {
+    setSchemaVersion(SCHEMA_VERSION - 1);
+    expect(() => new CommandManager(projectPath)).toThrow(
+      "Run 'cyberismo migrate'",
+    );
+  });
+
+  it('throws when the project schema is newer', () => {
+    setSchemaVersion(SCHEMA_VERSION + 1);
+    expect(() => new CommandManager(projectPath)).toThrow('Upgrade cyberismo');
+  });
+
+  it('throws when schemaVersion is missing', () => {
+    setSchemaVersion(undefined);
+    expect(() => new CommandManager(projectPath)).toThrow("no 'schemaVersion'");
+  });
+
+  it('skipSchemaVersionCheck bypasses the gate', () => {
+    setSchemaVersion(SCHEMA_VERSION - 1);
+    const commands = new CommandManager(projectPath, {
+      skipSchemaVersionCheck: true,
+    });
+    expect(commands.checkSchemaVersion().isCompatible).toBe(false);
+    commands.project.dispose();
+  });
+
+  it('getInstance re-checks when reusing a cached instance', async () => {
+    setSchemaVersion(SCHEMA_VERSION - 1);
+    await CommandManager.getInstance(projectPath, {
+      skipSchemaVersionCheck: true,
+    });
+    await expect(CommandManager.getInstance(projectPath)).rejects.toThrow(
+      "Run 'cyberismo migrate'",
+    );
+  });
+});

--- a/tools/data-handler/test/command-migrate.test.ts
+++ b/tools/data-handler/test/command-migrate.test.ts
@@ -1,7 +1,13 @@
-import { expect, it, describe } from 'vitest';
+import { afterEach, beforeEach, expect, it, describe } from 'vitest';
+
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 import { Migrate } from '../src/commands/migrate.js';
 import { SCHEMA_VERSION } from '@cyberismo/assets';
+import { Cmd, Commands } from '../src/command-handler.js';
+import { copyDir } from '../src/utils/file-utils.js';
+import { readJsonFileSync } from '../src/utils/json.js';
 
 import type { MigrationResult } from '@cyberismo/migrations';
 import type { Project } from '../src/containers/project.js';
@@ -165,5 +171,43 @@ describe('Migrate command', () => {
     await migrateCmd.migrate(targetVersion, undefined, customTimeout);
     expect(capturedTimeout).toBe(customTimeout);
     expect(mockProject.configuration.schemaVersion).toBe(targetVersion);
+  });
+});
+
+describe('schema version gate via command handler', () => {
+  const testDir = join(import.meta.dirname, 'tmp-command-migrate-gate-tests');
+  const projectPath = join(testDir, 'valid/decision-records');
+  const configPath = join(projectPath, '.cards', 'local', 'cardsConfig.json');
+
+  beforeEach(async () => {
+    rmSync(testDir, { recursive: true, force: true });
+    mkdirSync(testDir, { recursive: true });
+    await copyDir('test/test-data', testDir);
+    const config = readJsonFileSync(configPath) as Record<string, unknown>;
+    config.schemaVersion = SCHEMA_VERSION - 1;
+    writeFileSync(configPath, JSON.stringify(config, null, 4));
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('refuses other commands on an older project but lets migrate through', async () => {
+    const commandHandler = new Commands();
+    const refused = await commandHandler.command(Cmd.validate, [], {
+      projectPath,
+    });
+    expect(refused.statusCode).toBe(400);
+    expect(refused.message).toContain("Run 'cyberismo migrate'");
+
+    const migrated = await commandHandler.command(Cmd.migrate, [], {
+      projectPath,
+    });
+    expect(migrated.statusCode).toBe(200);
+
+    const allowed = await commandHandler.command(Cmd.validate, [], {
+      projectPath,
+    });
+    expect(allowed.statusCode).toBe(200);
   });
 });

--- a/tools/data-handler/test/command-remove.test.ts
+++ b/tools/data-handler/test/command-remove.test.ts
@@ -630,7 +630,6 @@ describe('remove card', () => {
     mkdirSync(testDir, { recursive: true });
     await copyDir('test/test-data/', testDir);
     commands = new CommandManager(decisionRecordsPath, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
   });
@@ -784,7 +783,6 @@ describe('remove module — spec behaviours', () => {
     expect(create.statusCode).toBe(200);
 
     const commands = new CommandManager(projectDir, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
 
@@ -828,7 +826,6 @@ describe('remove module — spec behaviours', () => {
     expect(create.statusCode).toBe(200);
 
     const commands = new CommandManager(projectDir, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
 
@@ -863,7 +860,6 @@ describe('remove module — spec behaviours', () => {
     expect(create.statusCode).toBe(200);
 
     const commands = new CommandManager(projectDir, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
 
@@ -921,7 +917,6 @@ describe('remove module — spec behaviours', () => {
     expect(create.statusCode).toBe(200);
 
     const commands = new CommandManager(projectDir, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
 

--- a/tools/data-handler/test/command-remove.test.ts
+++ b/tools/data-handler/test/command-remove.test.ts
@@ -629,8 +629,7 @@ describe('remove card', () => {
   beforeEach(async () => {
     mkdirSync(testDir, { recursive: true });
     await copyDir('test/test-data/', testDir);
-    commands = new CommandManager(decisionRecordsPath, {
-    });
+    commands = new CommandManager(decisionRecordsPath, {});
     await commands.initialize();
   });
 
@@ -782,8 +781,7 @@ describe('remove module — spec behaviours', () => {
     );
     expect(create.statusCode).toBe(200);
 
-    const commands = new CommandManager(projectDir, {
-    });
+    const commands = new CommandManager(projectDir, {});
     await commands.initialize();
 
     await commands.importCmd.importModule(hostRoot);
@@ -825,8 +823,7 @@ describe('remove module — spec behaviours', () => {
     );
     expect(create.statusCode).toBe(200);
 
-    const commands = new CommandManager(projectDir, {
-    });
+    const commands = new CommandManager(projectDir, {});
     await commands.initialize();
 
     await expect(
@@ -859,8 +856,7 @@ describe('remove module — spec behaviours', () => {
     );
     expect(create.statusCode).toBe(200);
 
-    const commands = new CommandManager(projectDir, {
-    });
+    const commands = new CommandManager(projectDir, {});
     await commands.initialize();
 
     await commands.importCmd.importModule(aRoot);
@@ -916,8 +912,7 @@ describe('remove module — spec behaviours', () => {
     );
     expect(create.statusCode).toBe(200);
 
-    const commands = new CommandManager(projectDir, {
-    });
+    const commands = new CommandManager(projectDir, {});
     await commands.initialize();
 
     await commands.importCmd.importModule(aRoot);

--- a/tools/data-handler/test/command-show.test.ts
+++ b/tools/data-handler/test/command-show.test.ts
@@ -639,8 +639,7 @@ describe('show', () => {
   beforeEach(async () => {
     mkdirSync(testDir, { recursive: true });
     await copyDir('test/test-data/', testDir);
-    commands = new CommandManager(decisionRecordsPath, {
-    });
+    commands = new CommandManager(decisionRecordsPath, {});
     await commands.initialize();
     showCmd = commands.showCmd;
   });

--- a/tools/data-handler/test/command-show.test.ts
+++ b/tools/data-handler/test/command-show.test.ts
@@ -640,7 +640,6 @@ describe('show', () => {
     mkdirSync(testDir, { recursive: true });
     await copyDir('test/test-data/', testDir);
     commands = new CommandManager(decisionRecordsPath, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
     showCmd = commands.showCmd;

--- a/tools/data-handler/test/helpers/module-fixtures.ts
+++ b/tools/data-handler/test/helpers/module-fixtures.ts
@@ -17,6 +17,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { vi } from 'vitest';
 
+import { SCHEMA_VERSION } from '@cyberismo/assets';
 import { ProjectPaths } from '../../src/containers/project/project-paths.js';
 import type { Project } from '../../src/containers/project.js';
 import { isGitLocation } from '../../src/modules/location.js';
@@ -73,6 +74,7 @@ export function rewriteFakeModuleFixture(
 
 function buildConfigPayload(config: FakeModuleConfig) {
   return {
+    schemaVersion: SCHEMA_VERSION,
     cardKeyPrefix: config.cardKeyPrefix,
     name: config.name ?? config.cardKeyPrefix,
     description: '',

--- a/tools/data-handler/test/helpers/test-utils.ts
+++ b/tools/data-handler/test/helpers/test-utils.ts
@@ -25,10 +25,10 @@ export function getTestBaseDir(
 }
 
 /**
- * Creates a project for tests with auto-save disabled and schema version injected.
+ * Creates a project for tests with schema version injected when missing.
  */
 export function getTestProject(path: string): InstanceType<typeof Project> {
-  const project = new Project(path, { autoSave: false });
+  const project = new Project(path);
   if (project.configuration.schemaVersion === undefined) {
     project.configuration.schemaVersion = SCHEMA_VERSION;
   }

--- a/tools/data-handler/test/import-live-git.test.ts
+++ b/tools/data-handler/test/import-live-git.test.ts
@@ -21,8 +21,7 @@ describe('import command — live git', () => {
   beforeEach(async () => {
     mkdirSync(testDir, { recursive: true });
     await copyDir('test/test-data/', testDir);
-    commands = new CommandManager(decisionRecordsPath, {
-    });
+    commands = new CommandManager(decisionRecordsPath, {});
     await commands.initialize();
   });
 

--- a/tools/data-handler/test/import-live-git.test.ts
+++ b/tools/data-handler/test/import-live-git.test.ts
@@ -22,7 +22,6 @@ describe('import command — live git', () => {
     mkdirSync(testDir, { recursive: true });
     await copyDir('test/test-data/', testDir);
     commands = new CommandManager(decisionRecordsPath, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
   });

--- a/tools/data-handler/test/migration-v5.test.ts
+++ b/tools/data-handler/test/migration-v5.test.ts
@@ -31,6 +31,13 @@ const localDir = join(cardsConfigPath, 'local');
 const migrationsDir = join(localDir, 'migrations');
 const currentDir = join(migrationsDir, 'current');
 
+const moduleMigrationsDir = join(
+  cardsConfigPath,
+  'modules',
+  'base',
+  'migrations',
+);
+
 const oldSnapshot = 'migrationLog_1.0.0.jsonl';
 const lineageSeal = 'migrationLog_0.0.0_1.0.0.jsonl';
 const currentLog = 'migrationLog.jsonl';
@@ -42,6 +49,9 @@ describe('migration v5 (remove pre-replay migration log snapshots)', () => {
     writeFileSync(join(migrationsDir, oldSnapshot), '{}\n', 'utf-8');
     writeFileSync(join(migrationsDir, lineageSeal), '{}\n', 'utf-8');
     writeFileSync(join(currentDir, currentLog), '{}\n', 'utf-8');
+    mkdirSync(moduleMigrationsDir, { recursive: true });
+    writeFileSync(join(moduleMigrationsDir, oldSnapshot), '{}\n', 'utf-8');
+    writeFileSync(join(moduleMigrationsDir, lineageSeal), '{}\n', 'utf-8');
   });
 
   afterEach(() => {
@@ -68,6 +78,14 @@ describe('migration v5 (remove pre-replay migration log snapshots)', () => {
     expect(existsSync(join(migrationsDir, oldSnapshot))).toBe(false);
     expect(existsSync(join(migrationsDir, lineageSeal))).toBe(true);
     expect(existsSync(join(currentDir, currentLog))).toBe(true);
+  });
+
+  it('removes old snapshots from installed module trees too', async () => {
+    const result = await v5().migrate(ctx);
+    expect(result.success).toBe(true);
+
+    expect(existsSync(join(moduleMigrationsDir, oldSnapshot))).toBe(false);
+    expect(existsSync(join(moduleMigrationsDir, lineageSeal))).toBe(true);
   });
 
   it('reports removed files in stepsExecuted', async () => {

--- a/tools/data-handler/test/migrations/run-chain.test.ts
+++ b/tools/data-handler/test/migrations/run-chain.test.ts
@@ -1,0 +1,54 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { SCHEMA_VERSION } from '@cyberismo/assets';
+import { runMigrationChain } from '../../src/migrations/run-chain.js';
+
+import type { Migration } from '@cyberismo/migrations';
+
+const registry = vi.hoisted(() => ({
+  migrations: {} as Record<number, Migration>,
+}));
+
+vi.mock('@cyberismo/migrations', () => ({
+  availableMigrations: () =>
+    Object.keys(registry.migrations)
+      .map(Number)
+      .sort((a, b) => a - b),
+  migration: (version: number) => registry.migrations[version],
+}));
+
+const okStep = async () => ({ success: true });
+
+describe('runMigrationChain step guard', () => {
+  afterEach(() => {
+    registry.migrations = {};
+    vi.restoreAllMocks();
+  });
+
+  it('refuses a migration that defines steps this runner does not execute', async () => {
+    const migrate = vi.fn(okStep);
+    registry.migrations = {
+      [SCHEMA_VERSION]: { before: okStep, after: okStep, migrate },
+    };
+    await expect(
+      runMigrationChain('/nonexistent', SCHEMA_VERSION - 1),
+    ).rejects.toThrow(
+      `Migration ${SCHEMA_VERSION} defines before, after step(s)`,
+    );
+    expect(migrate).not.toHaveBeenCalled();
+  });
+});

--- a/tools/data-handler/test/project-settings.test.ts
+++ b/tools/data-handler/test/project-settings.test.ts
@@ -53,7 +53,7 @@ describe('project settings', () => {
 
   it('should load valid configuration file', () => {
     const configPath = createTestConfig('test-config-load.json');
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
 
     expect(projectSettings).not.toBeUndefined();
     expect(projectSettings.cardKeyPrefix).toBe('test');
@@ -70,7 +70,7 @@ describe('project settings', () => {
       category: 'Development',
       description: 'A test project with category and description',
     });
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
 
     expect(projectSettings.category).toBe('Development');
     expect(projectSettings.description).toBe(
@@ -86,28 +86,27 @@ describe('project settings', () => {
         description: '',
       },
     );
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
 
     expect(projectSettings.category).toBe('');
     expect(projectSettings.description).toBe('');
   });
 
-  // Test disabled for now to avoid getting the schemaVersion to test files.
-  it('should auto-add schema version when missing', () => {
+  it('should not modify file when schema version is missing', () => {
     const configPath = createTestConfig('test-config-no-schema.json', {
       schemaVersion: undefined as unknown as number,
     });
 
-    const config = new ProjectConfiguration(configPath, true);
-    expect(config.schemaVersion).toBe(SCHEMA_VERSION);
+    const config = new ProjectConfiguration(configPath);
+    expect(config.schemaVersion).toBe(undefined);
     const savedConfig = readJsonFileSync(configPath);
-    expect(savedConfig.schemaVersion).toBe(SCHEMA_VERSION);
+    expect(savedConfig.schemaVersion).toBe(undefined);
   });
 
   it('should not modify file when schema version already exists', () => {
     const configPath = createTestConfig('test-config-with-schema.json');
     const initialContent = readJsonFileSync(configPath);
-    new ProjectConfiguration(configPath, false);
+    new ProjectConfiguration(configPath);
     const finalContent = readJsonFileSync(configPath);
     expect(finalContent).to.deep.equal(initialContent);
   });
@@ -116,7 +115,7 @@ describe('project settings', () => {
     const configPath = createTestConfig('test-config-remove-module.json', {
       modules: [{ name: 'test-module', location: 'https://example.com' }],
     });
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
     expect(projectSettings.modules.length).toBe(1);
 
     await projectSettings.removeModule('test-module');
@@ -128,7 +127,7 @@ describe('project settings', () => {
 
   it('should reject removing non-existent module', async () => {
     const configPath = createTestConfig('test-config-remove-missing.json');
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
 
     await expect(projectSettings.removeModule('non-existent')).rejects.toThrow(
       "Module 'non-existent' is not imported",
@@ -137,7 +136,7 @@ describe('project settings', () => {
 
   it('should reject removing module with empty name', async () => {
     const configPath = createTestConfig('test-config-remove-empty.json');
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
 
     await expect(projectSettings.removeModule('')).rejects.toThrow(
       'Name must be provided to remove module',
@@ -185,7 +184,7 @@ describe('project settings', () => {
       const configPath = createTestConfig(
         `test-config-add-hub-${name.replace(/\W/g, '-')}.json`,
       );
-      const projectSettings = new ProjectConfiguration(configPath, false);
+      const projectSettings = new ProjectConfiguration(configPath);
       await projectSettings.addHub(input);
 
       expect(projectSettings.hubs.length).toBe(1);
@@ -203,7 +202,7 @@ describe('project settings', () => {
         hubs: [{ location: 'https://example.com/hub/' }],
       },
     );
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
 
     await expect(
       projectSettings.addHub('https://example.com/hub'),
@@ -215,7 +214,7 @@ describe('project settings', () => {
 
   it('should reject empty hub URL', async () => {
     const configPath = createTestConfig('test-config-hub-empty.json');
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
 
     await expect(projectSettings.addHub('')).rejects.toThrow(
       'Cannot add empty hub to the project',
@@ -229,7 +228,7 @@ describe('project settings', () => {
     const configPath = createTestConfig('test-config-hub-duplicate.json', {
       hubs: [{ location: 'https://example.com/hub' }],
     });
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
 
     await expect(
       projectSettings.addHub('https://example.com/hub'),
@@ -247,7 +246,7 @@ describe('project settings', () => {
     const configPath = createTestConfig(
       `test-config-hub-invalid-${name.replace(/\W/g, '-')}.json`,
     );
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
 
     await expect(projectSettings.addHub(input)).rejects.toThrow(
       `Invalid hub URL '${input}'`,
@@ -257,7 +256,7 @@ describe('project settings', () => {
 
   it('should reject non-HTTP/HTTPS protocols', async () => {
     const configPath = createTestConfig('test-config-hub-protocol.json');
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
 
     await expect(
       projectSettings.addHub('ftp://example.com/hub'),
@@ -268,7 +267,7 @@ describe('project settings', () => {
     const configPath = createTestConfig('test-config-remove-hub.json', {
       hubs: [{ location: 'https://example.com/hub' }],
     });
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
     expect(projectSettings.hubs.length).toBe(1);
 
     await projectSettings.removeHub('https://example.com/hub');
@@ -280,7 +279,7 @@ describe('project settings', () => {
 
   it('should reject removing non-existent hub', async () => {
     const configPath = createTestConfig('test-config-remove-missing-hub.json');
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
 
     await expect(
       projectSettings.removeHub('https://example.com/hub'),
@@ -291,7 +290,7 @@ describe('project settings', () => {
     const configPath = createTestConfig('test-config-set-prefix.json', {
       cardKeyPrefix: 'old',
     });
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
     await projectSettings.setCardPrefix('newprefix');
     expect(projectSettings.cardKeyPrefix).toBe('newprefix');
 
@@ -303,7 +302,7 @@ describe('project settings', () => {
     const configPath = createTestConfig('test-config-invalid-prefix.json', {
       cardKeyPrefix: 'valid',
     });
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
     await expect(projectSettings.setCardPrefix('UPPERCASE')).rejects.toThrow(
       'is not valid prefix',
     );
@@ -317,7 +316,7 @@ describe('project settings', () => {
 
   it('should set and persist category', async () => {
     const configPath = createTestConfig('test-config-set-category.json');
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
     await projectSettings.setCategory('Security');
     expect(projectSettings.category).toBe('Security');
 
@@ -327,7 +326,7 @@ describe('project settings', () => {
 
   it('should set and persist description', async () => {
     const configPath = createTestConfig('test-config-set-description.json');
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
     await projectSettings.setDescription('A detailed project description');
     expect(projectSettings.description).toBe('A detailed project description');
 
@@ -343,7 +342,7 @@ describe('project settings', () => {
         description: 'Some description',
       },
     );
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
     await projectSettings.setCategory('');
     await projectSettings.setDescription('');
     expect(projectSettings.category).toBe('');
@@ -356,48 +355,47 @@ describe('project settings', () => {
 
   it('should report compatible when schema versions match', () => {
     const configPath = createTestConfig('test-config-schema-match.json');
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
     const result = projectSettings.checkSchemaVersion();
     expect(result.isCompatible).toBe(true);
     expect(result.message).toBe('');
   });
 
-  it('should report compatible when schema version is undefined', () => {
+  it('should report incompatible when schema version is undefined', () => {
     const configPath = createTestConfig('test-config-schema-undefined.json', {
       schemaVersion: undefined as unknown as number,
     });
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
     const result = projectSettings.checkSchemaVersion();
-    expect(result.isCompatible).toBe(true);
+    expect(result.isCompatible).toBe(false);
+    expect(result.message).to.include("no 'schemaVersion'");
   });
 
   it('should report incompatible when project schema is older', () => {
     const configPath = createTestConfig('test-config-schema-old.json', {
       schemaVersion: SCHEMA_VERSION - 1,
     });
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
     const result = projectSettings.checkSchemaVersion();
     expect(result.isCompatible).toBe(false);
-    expect(result.message).to.include('older');
-    expect(result.message).to.include('migration');
+    expect(result.message).to.include("Run 'cyberismo migrate'");
   });
 
   it('should report incompatible when project schema is newer', () => {
     const configPath = createTestConfig('test-config-schema-new.json', {
       schemaVersion: SCHEMA_VERSION + 1,
     });
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
     const result = projectSettings.checkSchemaVersion();
     expect(result.isCompatible).toBe(false);
-    expect(result.message).to.include('newer');
-    expect(result.message).to.include('update the application');
+    expect(result.message).to.include('Upgrade cyberismo');
   });
 
   it('should reject saving with empty card prefix', async () => {
     const configPath = createTestConfig('test-config-empty-prefix.json', {
       cardKeyPrefix: 'valid',
     });
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
     projectSettings.cardKeyPrefix = '';
     await expect(projectSettings.save()).rejects.toThrow('wrong configuration');
   });
@@ -413,7 +411,7 @@ describe('project settings', () => {
         { name: 'other', location: 'https://example.com/other.git' },
       ],
     });
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
 
     await projectSettings.upsertModule({
       name: 'newname',
@@ -436,7 +434,7 @@ describe('project settings', () => {
 
   it('should persist all configuration changes', async () => {
     const configPath = createTestConfig('test-config-persist.json');
-    const projectSettings = new ProjectConfiguration(configPath, false);
+    const projectSettings = new ProjectConfiguration(configPath);
     await projectSettings.upsertModule({
       name: 'module1',
       location: 'https://example.com',

--- a/tools/data-handler/test/resource-cache.test.ts
+++ b/tools/data-handler/test/resource-cache.test.ts
@@ -381,8 +381,7 @@ describe('Resource cache', () => {
     beforeEach(async () => {
       mkdirSync(testDir, { recursive: true });
       await copyDir('test/test-data/', testDir);
-      commands = new CommandManager(testProjectPath, {
-      });
+      commands = new CommandManager(testProjectPath, {});
       await commands.initialize();
     });
 

--- a/tools/data-handler/test/resource-cache.test.ts
+++ b/tools/data-handler/test/resource-cache.test.ts
@@ -382,7 +382,6 @@ describe('Resource cache', () => {
       mkdirSync(testDir, { recursive: true });
       await copyDir('test/test-data/', testDir);
       commands = new CommandManager(testProjectPath, {
-        autoSaveConfiguration: false,
       });
       await commands.initialize();
     });

--- a/tools/data-handler/test/staged-migration.test.ts
+++ b/tools/data-handler/test/staged-migration.test.ts
@@ -1,0 +1,108 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { SCHEMA_VERSION } from '@cyberismo/assets';
+import { ensureStagedSchemas } from '../src/modules/staged-migration.js';
+import { copyDir } from '../src/utils/file-utils.js';
+import { readJsonFileSync } from '../src/utils/json.js';
+
+import type { ResolvedModule } from '../src/modules/resolve/types.js';
+
+const testDir = join(import.meta.dirname, 'tmp-staged-migration-tests');
+const stagedPath = join(testDir, 'staged');
+const configPath = join(stagedPath, '.cards', 'local', 'cardsConfig.json');
+const oldSnapshot = join(
+  stagedPath,
+  '.cards',
+  'local',
+  'migrations',
+  'migrationLog_1.0.0.jsonl',
+);
+
+function setSchemaVersion(version: number | undefined) {
+  const config = readJsonFileSync(configPath) as Record<string, unknown>;
+  if (version === undefined) {
+    delete config.schemaVersion;
+  } else {
+    config.schemaVersion = version;
+  }
+  writeFileSync(configPath, JSON.stringify(config, null, 4));
+}
+
+function entry(): ResolvedModule {
+  return {
+    declaration: {
+      project: 'mini',
+      name: 'decision',
+      source: { location: `file:${stagedPath}` },
+    },
+    remoteUrl: '',
+    stagedPath,
+  };
+}
+
+describe('ensureStagedSchemas', () => {
+  beforeEach(async () => {
+    rmSync(testDir, { recursive: true, force: true });
+    mkdirSync(testDir, { recursive: true });
+    await copyDir('test/test-data/valid/decision-records', stagedPath);
+    mkdirSync(join(stagedPath, '.cards', 'local', 'migrations'), {
+      recursive: true,
+    });
+    writeFileSync(oldSnapshot, '{}\n', 'utf-8');
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('migrates an older staged tree up to the current schema', async () => {
+    setSchemaVersion(4);
+    await ensureStagedSchemas([entry()]);
+    const config = readJsonFileSync(configPath) as { schemaVersion: number };
+    expect(config.schemaVersion).toBe(SCHEMA_VERSION);
+    // migration 5 removed the old-format snapshot, proving it ran
+    expect(existsSync(oldSnapshot)).toBe(false);
+  });
+
+  it('leaves a current staged tree untouched', async () => {
+    await ensureStagedSchemas([entry()]);
+    expect(existsSync(oldSnapshot)).toBe(true);
+  });
+
+  it('refuses a staged tree newer than the tool', async () => {
+    setSchemaVersion(SCHEMA_VERSION + 1);
+    await expect(ensureStagedSchemas([entry()])).rejects.toThrow(
+      'Upgrade cyberismo',
+    );
+  });
+
+  it('refuses a staged tree without a schema version', async () => {
+    setSchemaVersion(undefined);
+    await expect(ensureStagedSchemas([entry()])).rejects.toThrow(
+      "no 'schemaVersion'",
+    );
+  });
+
+  it('refuses when the migration chain cannot reach the current schema', async () => {
+    setSchemaVersion(0);
+    await expect(ensureStagedSchemas([entry()])).rejects.toThrow(
+      'No migration path',
+    );
+  });
+});

--- a/tools/data-handler/test/test-data/invalid/invalid-calculations/.cards/local/cardsConfig.json
+++ b/tools/data-handler/test/test-data/invalid/invalid-calculations/.cards/local/cardsConfig.json
@@ -1,5 +1,5 @@
 {
-    "schemaVersion": 4,
+    "schemaVersion": 5,
     "cardKeyPrefix": "mini",
     "name": "minimal",
     "description": "",

--- a/tools/data-handler/test/test-data/invalid/invalid-wrong-resource-names/.cards/local/cardsConfig.json
+++ b/tools/data-handler/test/test-data/invalid/invalid-wrong-resource-names/.cards/local/cardsConfig.json
@@ -1,4 +1,5 @@
 {
+    "schemaVersion": 5,
     "cardKeyPrefix": "decision",
     "name": "missing",
     "modules": [],

--- a/tools/data-handler/test/test-data/valid/card-with-dormant-field/.cards/local/cardsConfig.json
+++ b/tools/data-handler/test/test-data/valid/card-with-dormant-field/.cards/local/cardsConfig.json
@@ -1,4 +1,5 @@
 {
+    "schemaVersion": 5,
     "cardKeyPrefix": "decision",
     "name": "decision",
     "modules": [],

--- a/tools/data-handler/test/test-data/valid/minimal/.cards/local/cardsConfig.json
+++ b/tools/data-handler/test/test-data/valid/minimal/.cards/local/cardsConfig.json
@@ -1,4 +1,5 @@
 {
+    "schemaVersion": 5,
     "cardKeyPrefix": "mini",
     "name": "minimal",
     "modules": [],

--- a/tools/data-handler/test/utils/card-override-facts.test.ts
+++ b/tools/data-handler/test/utils/card-override-facts.test.ts
@@ -84,8 +84,7 @@ describe('fieldOverride fact generation', () => {
     // derivation (override wins over calculated) can be exercised too.
     appendFieldCalculatedRule(projectPath);
 
-    commands = new CommandManager(projectPath, {
-    });
+    commands = new CommandManager(projectPath, {});
     await commands.initialize();
   });
 
@@ -132,8 +131,7 @@ describe('fieldOverride fact generation', () => {
         `\nfield(Card, "${FIELD}", "conflicting") :- projectCard(Card).\n`,
     );
 
-    const fresh = new CommandManager(projectPath, {
-    });
+    const fresh = new CommandManager(projectPath, {});
     await fresh.initialize();
     const result = await fresh.project.calculationEngine.runQuery(
       'card',
@@ -191,8 +189,7 @@ describe('card query: calculated value without a stored override', () => {
 
     appendFieldCalculatedRule(projectPath);
 
-    commands = new CommandManager(projectPath, {
-    });
+    commands = new CommandManager(projectPath, {});
     await commands.initialize();
   });
 
@@ -292,8 +289,7 @@ describe('disabling override on a calculated field that holds values', () => {
     metadata[FIELD] = 'decision_999';
     writeFileSync(cardJsonPath, JSON.stringify(metadata, null, 4));
 
-    commands = new CommandManager(projectPath, {
-    });
+    commands = new CommandManager(projectPath, {});
     await commands.initialize();
   });
 
@@ -349,8 +345,7 @@ describe('stored value on a calculated non-overridable field is dormant', () => 
 
     appendFieldCalculatedRule(projectPath);
 
-    commands = new CommandManager(projectPath, {
-    });
+    commands = new CommandManager(projectPath, {});
     await commands.initialize();
   });
 
@@ -466,8 +461,7 @@ describe('fieldCalculated is ignored for a field the card type does not declare 
     metadata[FIELD] = 'decision_999';
     writeFileSync(cardJsonPath, JSON.stringify(metadata, null, 4));
 
-    commands = new CommandManager(projectPath, {
-    });
+    commands = new CommandManager(projectPath, {});
     await commands.initialize();
   });
 

--- a/tools/data-handler/test/utils/card-override-facts.test.ts
+++ b/tools/data-handler/test/utils/card-override-facts.test.ts
@@ -85,7 +85,6 @@ describe('fieldOverride fact generation', () => {
     appendFieldCalculatedRule(projectPath);
 
     commands = new CommandManager(projectPath, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
   });
@@ -134,7 +133,6 @@ describe('fieldOverride fact generation', () => {
     );
 
     const fresh = new CommandManager(projectPath, {
-      autoSaveConfiguration: false,
     });
     await fresh.initialize();
     const result = await fresh.project.calculationEngine.runQuery(
@@ -194,7 +192,6 @@ describe('card query: calculated value without a stored override', () => {
     appendFieldCalculatedRule(projectPath);
 
     commands = new CommandManager(projectPath, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
   });
@@ -296,7 +293,6 @@ describe('disabling override on a calculated field that holds values', () => {
     writeFileSync(cardJsonPath, JSON.stringify(metadata, null, 4));
 
     commands = new CommandManager(projectPath, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
   });
@@ -354,7 +350,6 @@ describe('stored value on a calculated non-overridable field is dormant', () => 
     appendFieldCalculatedRule(projectPath);
 
     commands = new CommandManager(projectPath, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
   });
@@ -472,7 +467,6 @@ describe('fieldCalculated is ignored for a field the card type does not declare 
     writeFileSync(cardJsonPath, JSON.stringify(metadata, null, 4));
 
     commands = new CommandManager(projectPath, {
-      autoSaveConfiguration: false,
     });
     await commands.initialize();
   });

--- a/tools/migrations/HOWTO_CREATE_MIGRATIONS.md
+++ b/tools/migrations/HOWTO_CREATE_MIGRATIONS.md
@@ -25,6 +25,28 @@ For example, migrating from version 1 to version 3 would:
 3. Execute migration in `3/index.ts` (v2 → v3)
 4. Update project schemaVersion to 3
 
+## Migration scope
+
+A migration owns the **entire** `.cards` tree it is given:
+
+- `.cards/local/` — the project's own resources.
+- `.cards/modules/<prefix>/` — every installed module. Installed module
+  content is always at the same schema level as the project, and
+  `cyberismo migrate` is the only thing that moves it forward, so a
+  structural change must be applied to installed module trees too.
+
+The same script also runs against *staged module checkouts* during
+`cyberismo import module` / `cyberismo update modules`: a module released
+at an older schema version is migrated in the staging directory before its
+resources are copied into the project. Only the `migrate` step runs there
+(no `before`/`backup`/`after`). Therefore:
+
+- Do not assume the tree is the host project.
+- Tolerate a missing `cardRoot` — staged file-source modules stage only
+  the resources folder.
+- Migrations must be structural and idempotent: they transform file
+  layout and format, never project-specific content.
+
 ## Creating a new migration
 
 ### 1. Generate migration scaffolding

--- a/tools/migrations/HOWTO_CREATE_MIGRATIONS.md
+++ b/tools/migrations/HOWTO_CREATE_MIGRATIONS.md
@@ -35,7 +35,7 @@ A migration owns the **entire** `.cards` tree it is given:
   `cyberismo migrate` is the only thing that moves it forward, so a
   structural change must be applied to installed module trees too.
 
-The same script also runs against *staged module checkouts* during
+The same script also runs against _staged module checkouts_ during
 `cyberismo import module` / `cyberismo update modules`: a module released
 at an older schema version is migrated in the staging directory before its
 resources are copied into the project. Only the `migrate` step runs there

--- a/tools/migrations/HOWTO_CREATE_MIGRATIONS.md
+++ b/tools/migrations/HOWTO_CREATE_MIGRATIONS.md
@@ -38,8 +38,9 @@ A migration owns the **entire** `.cards` tree it is given:
 The same script also runs against _staged module checkouts_ during
 `cyberismo import module` / `cyberismo update modules`: a module released
 at an older schema version is migrated in the staging directory before its
-resources are copied into the project. Only the `migrate` step runs there
-(no `before`/`backup`/`after`). Therefore:
+resources are copied into the project. Only the `migrate` step runs there —
+the in-process runner refuses a migration that defines
+`before`/`backup`/`after` rather than silently skipping them. Therefore:
 
 - Do not assume the tree is the host project.
 - Tolerate a missing `cardRoot` — staged file-source modules stage only

--- a/tools/migrations/src/5/index.ts
+++ b/tools/migrations/src/5/index.ts
@@ -53,9 +53,7 @@ const migration: Migration = {
       `Migrating from schema version ${context.fromVersion} to ${context.toVersion}`,
     );
 
-    const sweepTargets = [
-      join(context.cardsConfigPath, 'local', 'migrations'),
-    ];
+    const sweepTargets = [join(context.cardsConfigPath, 'local', 'migrations')];
     const modulesFolder = join(context.cardsConfigPath, 'modules');
     for (const name of await readdirOrEmpty(modulesFolder)) {
       sweepTargets.push(join(modulesFolder, name, 'migrations'));

--- a/tools/migrations/src/5/index.ts
+++ b/tools/migrations/src/5/index.ts
@@ -30,8 +30,9 @@ const OLD_SEAL_NAME = /^migrationLog_\d+\.\d+\.\d+\.jsonl$/;
  *
  * Changes:
  * - Removes pre-replay migration log snapshots
- *   (`.cards/local/migrations/migrationLog_<version>.jsonl`). The replay
- *   system reads only lineage-named seals
+ *   (`migrationLog_<version>.jsonl`) from `.cards/local/migrations/` and
+ *   from every installed module tree's `.cards/modules/<prefix>/migrations/`.
+ *   The replay system reads only lineage-named seals
  *   (`migrationLog_<from>_<to>.jsonl`) and ignores the old single-version
  *   files, so they are dead data.
  * - Introduces calculated custom field override support: card types may
@@ -52,29 +53,24 @@ const migration: Migration = {
       `Migrating from schema version ${context.fromVersion} to ${context.toVersion}`,
     );
 
-    const migrationsFolder = join(
-      context.cardsConfigPath,
-      'local',
-      'migrations',
-    );
-
-    let entries: string[] = [];
-    try {
-      entries = await readdir(migrationsFolder);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-        throw error;
-      }
+    const sweepTargets = [
+      join(context.cardsConfigPath, 'local', 'migrations'),
+    ];
+    const modulesFolder = join(context.cardsConfigPath, 'modules');
+    for (const name of await readdirOrEmpty(modulesFolder)) {
+      sweepTargets.push(join(modulesFolder, name, 'migrations'));
     }
 
     const stepsExecuted: string[] = [];
-    const oldSnapshots = entries.filter((name) => OLD_SEAL_NAME.test(name));
-    for (const name of oldSnapshots) {
-      await rm(join(migrationsFolder, name));
-      console.log(`Removed pre-replay migration log snapshot '${name}'.`);
-      stepsExecuted.push(`Removed pre-replay migration log snapshot ${name}`);
+    for (const folder of sweepTargets) {
+      const entries = await readdirOrEmpty(folder);
+      for (const name of entries.filter((n) => OLD_SEAL_NAME.test(n))) {
+        await rm(join(folder, name));
+        console.log(`Removed pre-replay migration log snapshot '${name}'.`);
+        stepsExecuted.push(`Removed pre-replay migration log snapshot ${name}`);
+      }
     }
-    if (oldSnapshots.length === 0) {
+    if (stepsExecuted.length === 0) {
       console.log('No pre-replay migration log snapshots found.');
     }
     stepsExecuted.push('Schema version incremented');
@@ -87,5 +83,16 @@ const migration: Migration = {
     };
   },
 };
+
+async function readdirOrEmpty(dir: string): Promise<string[]> {
+  try {
+    return await readdir(dir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+    return [];
+  }
+}
 
 export default migration;


### PR DESCRIPTION
To not break schemas during module updates:
* Introduce the check right before applying the modules to disk: This is a bit bad UX, since with an old tool, you will have some trouble updating to newer versions, since it is not a constraint during the search, but checked only after the update
* If same schema --> dont do anything
* If module schema is below --> migrate the staged tree
* If module schema is above --> error, complain that the tool must be updated

Up to debate: Also strictened the validation so that tool schema version must be same as project schema version, instead of being a "please do the migrations". This also has UX downsides, but since we don't guarantee backwards compability, this is deemed acceptable. Hopefully schema is not updated too often.