### PR TITLE
Potential fix for code scanning alert no. 996: Superfluous trailing arguments

### DIFF
--- a/tools/data-handler/test/project.test.ts
+++ b/tools/data-handler/test/project.test.ts
@@ -658,7 +658,7 @@ describe('project', () => {
       'local',
       Project.projectConfigFileName,
     );
-    const projectSettings = new ProjectConfiguration(configFile, false);
+    const projectSettings = new ProjectConfiguration(configFile);
     expect(projectSettings).not.toBeUndefined();
     expect(projectSettings.modules.length).toBe(0);
 


### PR DESCRIPTION
Potential fix for [https://github.com/CyberismoCom/cyberismo/security/code-scanning/996](https://github.com/CyberismoCom/cyberismo/security/code-scanning/996)

Remove the extra trailing argument from the `ProjectConfiguration` constructor call in `tools/data-handler/test/project.test.ts` at the test case `"add module to project"`.

- **General fix**: when a function/constructor is called with more arguments than declared and extras are unused, remove the extras.
- **Best fix here**: change
  `new ProjectConfiguration(configFile, false)`  
  to  
  `new ProjectConfiguration(configFile)`.
- **Scope**: only line 661 region in `tools/data-handler/test/project.test.ts`.
- **No additional imports, methods, or dependency changes** are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
