### PR TITLE
INTDEV-1414 Upgrade to pnpm 11 and fix the installation instructions

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -24,13 +24,13 @@ git config --global --add safe.directory "${containerWorkspaceFolder:-/workspace
 echo "=== Running pnpm setup ==="
 SHELL="${SHELL:-/bin/bash}" pnpm setup
 export PNPM_HOME="${PNPM_HOME:-$HOME/.local/share/pnpm}"
-export PATH="$PNPM_HOME:$PATH"
+export PATH="$PNPM_HOME/bin:$PATH"
 
 echo "=== Building project ==="
 pnpm build
 
 echo "=== Linking packages globally ==="
-pnpm link -g
+pnpm add -g .
 
 echo "=== Installing Playwright browsers ==="
 pnpm --filter=app exec playwright install --with-deps

--- a/.dockerignore
+++ b/.dockerignore
@@ -20,6 +20,9 @@ vendor/
 # production
 **/build
 **/dist
+# tsc's incremental state must not outlive the dist/ it describes, or the
+# build inside the image emits nothing and dependent packages fail to compile
+**/*.tsbuildinfo
 
 # misc
 .DS_Store

--- a/.dockerignore
+++ b/.dockerignore
@@ -67,7 +67,6 @@ README.adoc
 SECURITY.md
 TRADEMARK.adoc
 CONTRIBUTING
-environment.yml
 
 # Ignore top-level dot files
 .*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -166,7 +166,7 @@ jobs:
           # Three layers pinning the registry to whichever target the mode
           # selects: env var, CLI flag, and (dry-run) no NPM_TOKEN in env.
           NPM_REGISTRY: ${{ env.DRYRUN == 'true' && 'http://localhost:4873/' || 'https://registry.npmjs.org/' }}
-          npm_config_registry: ${{ env.DRYRUN == 'true' && 'http://localhost:4873/' || 'https://registry.npmjs.org/' }}
+          pnpm_config_registry: ${{ env.DRYRUN == 'true' && 'http://localhost:4873/' || 'https://registry.npmjs.org/' }}
         run: pnpm --filter '!app' --filter '!@cyberismo/node-clingo' publish --access public --no-git-checks --registry "$NPM_REGISTRY"
 
       - name: Smoke test installed cli (dry-run only)

--- a/.github/workflows/release-node-clingo.yml
+++ b/.github/workflows/release-node-clingo.yml
@@ -117,7 +117,6 @@ jobs:
               set -eu
               apk add --no-cache g++ python3 make cmake git
               corepack enable
-              corepack prepare pnpm@10.8.0 --activate
               pnpm install --frozen-lockfile --ignore-scripts
               if [ "$CACHE_HIT" != "true" ]; then
                 pnpm --filter @cyberismo/node-clingo run build:clingo

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-# .npmrc
-engine-strict=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN cmake -P tools/node-clingo/scripts/build-clingo.cmake
 
 FROM node:22-alpine AS builder
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# pnpm version comes from the packageManager field in package.json
+RUN corepack enable
 RUN apk add --no-cache g++ python3 make
 
 WORKDIR /app
@@ -31,7 +32,7 @@ FROM node:22-alpine AS runtime
 
 # required environment variables for pnpm
 ENV SHELL=/bin/bash
-ENV PATH=/usr/local/share/pnpm:$PATH
+ENV PATH=/usr/local/share/pnpm/bin:$PATH
 ENV PNPM_HOME=/usr/local/share/pnpm
 
 # bind the backend to all interfaces so published ports are reachable
@@ -42,8 +43,9 @@ WORKDIR /app
 # make sure logs directory exists and is writable
 RUN mkdir /app/logs && chmod 777 /app/logs
 
-# enable corepack to use pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# enable corepack to use pnpm; the version comes from the packageManager
+# field in package.json
+RUN corepack enable
 
 # Copy monorepo root manifest files
 COPY --from=builder /app/package.json ./package.json
@@ -110,6 +112,6 @@ COPY --from=builder /app/tools/node-clingo/build ./tools/node-clingo/build
 
 # setup bin
 RUN pnpm setup
-RUN pnpm link -g
+RUN pnpm add -g .
 
 WORKDIR /project

--- a/README.adoc
+++ b/README.adoc
@@ -45,7 +45,7 @@ It installs all system dependencies automatically.
 4. Wait for the container to build and the post-create script to finish
 5. Run `pnpm dev` to start the development servers
 
-The dev container automatically installs all system dependencies (Clingo, Ruby, C++ build tools), Node.js 22, pnpm, and project dependencies.
+The dev container automatically installs all system dependencies (Ruby, C++ build tools, CMake), Node.js 22, pnpm, and project dependencies.
 
 === Manual Setup
 
@@ -57,45 +57,58 @@ If you prefer not to use a Dev Container, install the following system dependenc
 [source, shell]
 ----
 sudo apt-get update
-sudo apt-get install -y ruby-full build-essential g++-14 python3 make
+sudo apt-get install -y build-essential cmake python3 ruby-full
 sudo gem install --no-document asciidoctor-pdf rouge
 ----
 
 **Linux (Fedora)**
 [source, shell]
 ----
-sudo dnf install ruby rubygems gcc-c++ python3 make
+sudo dnf install gcc-c++ make cmake python3 ruby rubygems
 sudo gem install --no-document asciidoctor-pdf rouge
 ----
 
 **macOS**
 [source, shell]
 ----
-brew install clingo ruby
+xcode-select --install
+brew install cmake python ruby
 gem install --no-document asciidoctor-pdf rouge
 ----
-Xcode Command Line Tools are also required (`xcode-select --install`).
 
 **Windows**
 
-Install https://nodejs.org[Node.js] with the "Tools for Native Modules" option.
-Install Clingo via conda using the `environment.yml` at the repo root:
-[source, shell]
-----
-conda env create -f environment.yml
-conda activate cyberismo
-----
+Install https://nodejs.org[Node.js] with the "Tools for Native Modules" option, which brings the MSVC toolchain and Python, and install https://cmake.org[CMake].
+
+The C++ toolchain, CMake, Make and Python are used to build the bundled Clingo answer set programming runtime from source during `pnpm install`.
+Ruby and the asciidoctor-pdf gem are only needed for PDF export.
 
 ==== Node.js and pnpm
 
-Install https://nodejs.org[Node.js] 22 LTS, then enable pnpm via corepack:
+Install https://nodejs.org[Node.js] 22 LTS, then enable pnpm via corepack, which picks up the pnpm version pinned in *package.json*:
 [source, shell]
 ----
 corepack enable
 ----
 
+Corepack installs the `pnpm` command next to the Node.js binary, so prefix the command with `sudo` if Node.js is installed system-wide.
+
 ==== Install Dependencies and Build
 
+Clone the repository with its submodules. `@cyberismo/node-clingo` builds its native addon from the *clingo* and *BS_thread_pool* submodules, so they have to be in place before `pnpm install`:
+[source, shell]
+----
+git clone --recurse-submodules https://github.com/CyberismoCom/cyberismo.git
+cd cyberismo
+----
+
+In an existing clone, initialize them with:
+[source, shell]
+----
+git submodule update --init --recursive
+----
+
+Then install and build:
 [source, shell]
 ----
 pnpm install
@@ -108,7 +121,16 @@ Copy *env.example* files to respective *.env* files:
 cp tools/backend/env.example tools/backend/.env
 ----
 
-CLI related dependencies: link:tools/cli/README.md[README.md]
+==== Run Tests
+
+The app tests include Playwright end-to-end tests, so install the browsers once:
+[source, shell]
+----
+pnpm --filter=app exec playwright install --with-deps
+pnpm test
+----
+
+Optional extras, such as the Mermaid CLI for rendering diagrams in PDF exports, are described in link:tools/cli/README.md[the CLI package readme].
 
 === Run Project
 [source, shell]

--- a/docs/cardRoot/docs_13/c/docs_17/c/docs_9d8e92fm/index.adoc
+++ b/docs/cardRoot/docs_13/c/docs_17/c/docs_9d8e92fm/index.adoc
@@ -7,7 +7,7 @@ See {{#xref}}"cardKey":"docs_17"{{/xref}} for information about common prerequis
 Install the following:
 
 * Node.js v22 LTS or later, downloadable from https://nodejs.org/.
-* A C++20 toolchain (GCC 14+ or recent Clang), CMake 3.x, GNU Make, and Python 3. These are used to build the bundled Clingo answer set programming runtime from source.
+* A C++20 toolchain (GCC 13 or newer, or a recent Clang), CMake 3.x or newer, GNU Make, and Python 3. These are used to build the bundled Clingo answer set programming runtime from source.
 
 Install the build tools using your distribution's package manager:
 
@@ -23,6 +23,7 @@ Take the following steps:
 . Clone the source repository, including the Clingo submodule:
 
   $ git clone --recurse-submodules https://github.com/CyberismoCom/cyberismo.git
+  $ cd cyberismo
 
 +
 If you previously cloned the repository, change to the source directory and pull the latest changes:
@@ -31,17 +32,33 @@ If you previously cloned the repository, change to the source directory and pull
   $ git pull origin main
   $ git submodule update --init --recursive
 
-. Install pnpm with the npm command:
+. Enable pnpm. Cyberismo pins the pnpm version it is built with, and corepack, which ships with Node.js, picks that version automatically:
 
-  $ npm install -g pnpm
+  $ corepack enable
 
-. Execute the following commands:
++
+Corepack installs the `pnpm` command next to the Node.js binary. If Node.js is installed system-wide, the command fails with a permission error, and you need to run it as root:
+
+  $ sudo corepack enable
+
++
+If your Node.js installation does not include corepack, run `npm install -g pnpm` instead, with the same privileges.
+
+. Set up the directory that pnpm installs global commands into:
 
   $ pnpm setup
+
++
+This adds the directory to `PATH` in your shell startup file, which only affects shells started afterwards, so open a new terminal before continuing.
+
+. In the new terminal, build Cyberismo and install the `cyberismo` command:
+
+  $ cd cyberismo
   $ pnpm install
   $ pnpm build
-  $ pnpm link -g
+  $ pnpm add -g .
 
++
 `pnpm install` builds the bundled Clingo runtime as part of installing the `@cyberismo/node-clingo` workspace package.
 
 === Running

--- a/docs/cardRoot/docs_13/c/docs_17/c/docs_f90j31tm/index.adoc
+++ b/docs/cardRoot/docs_13/c/docs_17/c/docs_f90j31tm/index.adoc
@@ -11,7 +11,7 @@ Install the following:
 
   $ xcode-select --install
 
-* CMake 3.x and Python 3. With https://brew.sh[Homebrew]:
+* CMake 3.x or newer and Python 3. With https://brew.sh[Homebrew]:
 
   $ brew install cmake python
 
@@ -24,6 +24,7 @@ Take the following steps:
 . Clone the source repository, including the Clingo submodule:
 
   $ git clone --recurse-submodules https://github.com/CyberismoCom/cyberismo.git
+  $ cd cyberismo
 
 +
 If you previously cloned the repository, change to the source directory and pull the latest changes:
@@ -32,17 +33,33 @@ If you previously cloned the repository, change to the source directory and pull
   $ git pull origin main
   $ git submodule update --init --recursive
 
-. Install pnpm with the npm command:
+. Enable pnpm. Cyberismo pins the pnpm version it is built with, and corepack, which ships with Node.js, picks that version automatically:
 
-  $ npm install -g pnpm
+  $ corepack enable
 
-. Execute the following commands:
++
+Corepack installs the `pnpm` command next to the Node.js binary. If Node.js is installed system-wide rather than through Homebrew or a version manager, the command fails with a permission error, and you need to run it as root:
+
+  $ sudo corepack enable
+
++
+If your Node.js installation does not include corepack, run `npm install -g pnpm` instead, with the same privileges.
+
+. Set up the directory that pnpm installs global commands into:
 
   $ pnpm setup
+
++
+This adds the directory to `PATH` in your shell startup file, which only affects shells started afterwards, so open a new terminal before continuing.
+
+. In the new terminal, build Cyberismo and install the `cyberismo` command:
+
+  $ cd cyberismo
   $ pnpm install
   $ pnpm build
-  $ pnpm link -g
+  $ pnpm add -g .
 
++
 `pnpm install` builds the bundled Clingo runtime as part of installing the `@cyberismo/node-clingo` workspace package.
 
 === Running

--- a/docs/cardRoot/docs_13/c/docs_17/c/docs_il74geqj/index.adoc
+++ b/docs/cardRoot/docs_13/c/docs_17/c/docs_il74geqj/index.adoc
@@ -51,8 +51,6 @@ In PowerShell, run the image directly:
 
   > podman run --init --rm -it -e HOME=/tmp -v ${PWD}:/project -p 127.0.0.1:3000:3000 docker.io/cyberismo/cyberismo:latest cyberismo --help
 
-The `--userns=keep-id` flag of the Linux and macOS alias is not used here: it applies to rootless Podman on a Linux host, whereas on Windows the containers run inside the Podman virtual machine.
-
 For the same convenience that the alias gives on Linux and macOS, add a function to your PowerShell profile (`$PROFILE`):
 
   > function cyberismo { podman run --init --rm -it -e HOME=/tmp -v ${PWD}:/project -p 127.0.0.1:3000:3000 docker.io/cyberismo/cyberismo:latest cyberismo @args }

--- a/docs/cardRoot/docs_13/c/docs_17/c/docs_il74geqj/index.adoc
+++ b/docs/cardRoot/docs_13/c/docs_17/c/docs_il74geqj/index.adoc
@@ -47,6 +47,16 @@ Afterward, you can run the application using the following command:
 
 *Windows*
 
-The Windows environment does not support aliases like Linux and macOS do, so the command to use Podman is:
+In PowerShell, run the image directly:
 
-  $ podman run --rm -it --userns=keep-id -v .:/project -p 127.0.0.1:3000:3000 docker.io/cyberismo/cyberismo cyberismo --help
+  > podman run --init --rm -it -e HOME=/tmp -v ${PWD}:/project -p 127.0.0.1:3000:3000 docker.io/cyberismo/cyberismo:latest cyberismo --help
+
+The `--userns=keep-id` flag of the Linux and macOS alias is not used here: it applies to rootless Podman on a Linux host, whereas on Windows the containers run inside the Podman virtual machine.
+
+For the same convenience that the alias gives on Linux and macOS, add a function to your PowerShell profile (`$PROFILE`):
+
+  > function cyberismo { podman run --init --rm -it -e HOME=/tmp -v ${PWD}:/project -p 127.0.0.1:3000:3000 docker.io/cyberismo/cyberismo:latest cyberismo @args }
+
+Afterward, you can run the application from any directory:
+
+  > cyberismo --help

--- a/docs/cardRoot/docs_13/c/docs_17/c/docs_pw3rj3a9/index.adoc
+++ b/docs/cardRoot/docs_13/c/docs_17/c/docs_pw3rj3a9/index.adoc
@@ -8,7 +8,7 @@ Install the following:
 
 * Node.js v22 LTS or later, downloadable from https://nodejs.org/.
 * Visual Studio Build Tools 2022 with the "Desktop development with C++" workload (provides MSVC and Windows SDK).
-* CMake 3.x, downloadable from https://cmake.org/.
+* CMake 3.x or newer, downloadable from https://cmake.org/.
 * Python 3, downloadable from https://www.python.org/.
 
 These tools are used to build the bundled Clingo answer set programming runtime from source as part of `pnpm install`.
@@ -20,6 +20,7 @@ Take the following steps:
 . Clone the source repository, including the Clingo submodule:
 
   $ git clone --recurse-submodules https://github.com/CyberismoCom/cyberismo.git
+  $ cd cyberismo
 
 +
 If you previously cloned the repository, change to the source directory and pull the latest changes:
@@ -28,17 +29,31 @@ If you previously cloned the repository, change to the source directory and pull
   $ git pull origin main
   $ git submodule update --init --recursive
 
-. Install pnpm with the npm command:
+. Enable pnpm. Cyberismo pins the pnpm version it is built with, and corepack, which ships with Node.js, picks that version automatically:
 
-  $ npm install -g pnpm
+  $ corepack enable
 
-. Execute the following commands:
++
+Corepack installs the `pnpm` command next to the Node.js binary. If Node.js was installed for all users, run the command from a terminal started as administrator.
+
++
+If your Node.js installation does not include corepack, run `npm install -g pnpm` instead, with the same privileges.
+
+. Set up the directory that pnpm installs global commands into:
 
   $ pnpm setup
+
++
+This adds the directory to the `PATH` of your user account, which only affects terminals started afterwards, so open a new terminal before continuing.
+
+. In the new terminal, build Cyberismo and install the `cyberismo` command:
+
+  $ cd cyberismo
   $ pnpm install
   $ pnpm build
-  $ pnpm link -g
+  $ pnpm add -g .
 
++
 `pnpm install` builds the bundled Clingo runtime as part of installing the `@cyberismo/node-clingo` workspace package.
 
 === Running

--- a/docs/cardRoot/docs_13/c/docs_17/c/docs_w0puey08/index.adoc
+++ b/docs/cardRoot/docs_13/c/docs_17/c/docs_w0puey08/index.adoc
@@ -43,6 +43,16 @@ Afterward, you can run the application using the following command:
 
 *Windows*
 
-The Windows environment does not support aliases like Linux and macOS do, so the command to use Docker is:
+In PowerShell, run the image directly:
 
-  $ docker run --rm -it --user $(id -u):$(id -g) -v .:/project -p 127.0.0.1:3000:3000 cyberismo/cyberismo cyberismo --help
+  > docker run --init --rm -it -e HOME=/tmp -v ${PWD}:/project -p 127.0.0.1:3000:3000 cyberismo/cyberismo:latest cyberismo --help
+
+The `--user` flag of the Linux and macOS alias is not used here: on Windows, file ownership in the mounted directory is handled by the Docker Desktop virtual machine.
+
+For the same convenience that the alias gives on Linux and macOS, add a function to your PowerShell profile (`$PROFILE`):
+
+  > function cyberismo { docker run --init --rm -it -e HOME=/tmp -v ${PWD}:/project -p 127.0.0.1:3000:3000 cyberismo/cyberismo:latest cyberismo @args }
+
+Afterward, you can run the application from any directory:
+
+  > cyberismo --help

--- a/docs/cardRoot/docs_13/c/docs_19/index.adoc
+++ b/docs/cardRoot/docs_13/c/docs_19/index.adoc
@@ -15,7 +15,7 @@ Or with Podman:
   $ podman pull docker.io/cyberismo/cyberismo:latest
 
 == Local installation
-If you installed Cyberismo by building it locally from source, you can update it to the latest version by running the following commands. This pulls the latest changes from the upstream repository, updates the Clingo submodule to the revision that the new sources expect, and rebuilds the software:
+If you installed Cyberismo by building it locally from source, you can update it to the latest version by running the following commands. This pulls the latest changes from the upstream repository, updates the Clingo submodule, and rebuilds the software:
 
   $ cd cyberismo
   $ git pull

--- a/docs/cardRoot/docs_13/c/docs_19/index.adoc
+++ b/docs/cardRoot/docs_13/c/docs_19/index.adoc
@@ -15,10 +15,11 @@ Or with Podman:
   $ podman pull docker.io/cyberismo/cyberismo:latest
 
 == Local installation
-If you installed Cyberismo by building it locally from source, you can update it to the latest version by running the following commands. This pulls the latest changes from the upstream repository and rebuilds the software:
+If you installed Cyberismo by building it locally from source, you can update it to the latest version by running the following commands. This pulls the latest changes from the upstream repository, updates the Clingo submodule to the revision that the new sources expect, and rebuilds the software:
 
   $ cd cyberismo
   $ git pull
+  $ git submodule update --init --recursive
   $ pnpm install
   $ pnpm build
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,0 @@
-name: cyberismo
-channels:
-  - conda-forge
-  - potassco
-  - defaults
-dependencies:
-  - python=3.12
-  - clingo

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.8.0",
+  "packageManager": "pnpm@11.22.0",
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "build": "pnpm -r run build",
@@ -55,16 +55,5 @@
     "ci:publish": "pnpm --filter !app --filter !@cyberismo/node-clingo publish --access public --no-git-checks",
     "release": "node scripts/release.mjs",
     "check-licenses": "node scripts/check-licenses.mjs"
-  },
-  "pnpm": {
-    "ignoredOptionalDependencies": [
-      "@cyberismo/node-clingo-darwin-arm64",
-      "@cyberismo/node-clingo-darwin-x64",
-      "@cyberismo/node-clingo-linux-arm64-gnu",
-      "@cyberismo/node-clingo-linux-arm64-musl",
-      "@cyberismo/node-clingo-linux-x64-gnu",
-      "@cyberismo/node-clingo-linux-x64-musl",
-      "@cyberismo/node-clingo-win32-x64"
-    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@11.22.0",
+  "packageManager": "pnpm@11.22.0+sha512.1ff870c4c6133dfd88fb2afc46dd13d47f09c9794b438c6fdb47ca98caf3bc16381ee0be93a091b8e3824cf01f889f46d7d9e20910fb0be1ab0fb5baa80dd621",
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "build": "pnpm -r run build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,21 @@
 packages:
   - 'tools/*'
+
+engineStrict: true
+
+# node-clingo is built from source in this workspace, so the prebuilt
+# platform packages that the published package depends on must not be
+# installed here.
+ignoredOptionalDependencies:
+  - '@cyberismo/node-clingo-darwin-arm64'
+  - '@cyberismo/node-clingo-darwin-x64'
+  - '@cyberismo/node-clingo-linux-arm64-gnu'
+  - '@cyberismo/node-clingo-linux-arm64-musl'
+  - '@cyberismo/node-clingo-linux-x64-gnu'
+  - '@cyberismo/node-clingo-linux-x64-musl'
+  - '@cyberismo/node-clingo-win32-x64'
+
+# esbuild's postinstall only re-validates a binary that its platform
+# optional dependency already provides, so it stays denied.
+allowBuilds:
+  esbuild: false

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -4,10 +4,11 @@ The Cyberismo CLI is an open-source command-line tool that enables Security-as-C
 
 ### Prerequisites
 
-- **Clingo (required)**
-  - **macOS (Homebrew)**: `brew install clingo`
-  - **Ubuntu/Debian**: `sudo apt-get update && sudo apt-get install -y gringo`
-  - **Windows**: Included
+- **Node.js (required)**: v22 LTS or later.
+
+  The Clingo answer set solver is bundled as a prebuilt native binary for
+  Linux and macOS on x64 and arm64 and for Windows on x64, so no compiler,
+  toolchain or separate Clingo installation is needed.
 
 - **Asciidoctor PDF (optional, for PDF export)**
   - **macOS**: `brew install ruby && gem install --no-document asciidoctor-pdf rouge`


### PR DESCRIPTION
Updates pnpm to v11 and updated the installation instructions. Also added a powershell snippet for windows.

Personally tested on my linux machine, both with and without devcontainer.

Claude tested a first time install through a distrobox on Linux and created a temporary CI script to test macOS / windows for the source install and another job for testing the powershell snippets on windows.