### PR TITLE
INTDEV-1368 Follow configuration changes saved elsewhere

### DIFF
--- a/tools/app/__tests__/ConfigCardEditor.test.tsx
+++ b/tools/app/__tests__/ConfigCardEditor.test.tsx
@@ -35,10 +35,16 @@ vi.mock('@/components/card/AttachmentPanel', () => ({
 // Preview renders through the shared CardLayout (read-only). Mock it and
 // capture the previewCard it receives.
 let previewTitle: unknown;
-let previewCardArg: { fields?: { key: string; value: unknown }[] } | undefined;
+let previewCardArg:
+  | { rawContent?: string; fields?: { key: string; value: unknown }[] }
+  | undefined;
 vi.mock('@/components/card/CardLayout', () => ({
   CardLayout: (props: {
-    card: { title: unknown; fields?: { key: string; value: unknown }[] };
+    card: {
+      title: unknown;
+      rawContent?: string;
+      fields?: { key: string; value: unknown }[];
+    };
   }) => {
     previewTitle = props.card.title;
     previewCardArg = props.card;
@@ -54,11 +60,13 @@ vi.mock('@/lib/api', () => ({
   useCardMutations: () => ({ updateCard }),
 }));
 
+const { dispatchSpy } = vi.hoisted(() => ({ dispatchSpy: vi.fn() }));
+
 vi.mock('@/lib/hooks', async () => {
   const utils = await vi.importActual<typeof HooksUtils>('@/lib/hooks/utils');
   return {
     useAppRouter: () => ({ push: vi.fn() }),
-    useAppDispatch: () => vi.fn(),
+    useAppDispatch: () => dispatchSpy,
     useIsDarkMode: () => false,
     formKeyHandler: utils.formKeyHandler,
   };
@@ -84,6 +92,7 @@ vi.mock('react-i18next', () => ({
 }));
 
 import { ConfigCardEditor } from '@/components/config-editors/ConfigCardEditor';
+import { isEdited } from '@/lib/slices/pageState';
 
 const baseCard = {
   key: 'c1',
@@ -153,6 +162,7 @@ const rowButton = (container: HTMLElement, key: string, dataCy: string) =>
 describe('ConfigCardEditor (template card editor)', () => {
   beforeEach(() => {
     updateCard.mockClear();
+    dispatchSpy.mockClear();
     previewTitle = undefined;
     previewCardArg = undefined;
   });
@@ -286,6 +296,96 @@ describe('ConfigCardEditor (template card editor)', () => {
   it('is read-only for a read-only node (no save controls)', () => {
     const { container } = renderEditor(undefined, { readOnly: true });
     expect(container.querySelector('[data-cy="fieldSaveButton"]')).toBeNull();
+  });
+
+  // Regression coverage for INTDEV-1368: a change saved elsewhere (another tab,
+  // another user, the CLI) reaches this editor as fresh SWR data. Nothing was
+  // typed here, so the editor must follow the new saved values instead of
+  // holding a stale draft that the navigation guard then offers to "save".
+  describe('a change saved elsewhere', () => {
+    const refreshTo = (
+      utils: ReturnType<typeof renderEditor>,
+      next: Partial<CardFixture>,
+    ) => {
+      useRawCard.mockReturnValue({
+        card: { ...baseCard, ...next },
+        isLoading: false,
+        error: null,
+      });
+      dispatchSpy.mockClear();
+      utils.rerender(
+        <ConfigCardEditor node={{ id: 'c1', readOnly: false } as never} />,
+      );
+    };
+
+    const titleInput = (container: HTMLElement) =>
+      container.querySelector(
+        '[data-cy="cardTitleInput"]',
+      ) as HTMLTextAreaElement;
+
+    it('shows the new title and does not report unsaved changes', () => {
+      const utils = renderEditor();
+      const { container } = utils;
+
+      refreshTo(utils, { title: 'Edited in another tab' });
+
+      expect(titleInput(container).value).toBe('Edited in another tab');
+      expect(
+        container.querySelector('[data-cy="titleSaveButton"]'),
+      ).toBeDisabled();
+      expect(dispatchSpy).not.toHaveBeenCalledWith(isEdited(true));
+    });
+
+    it('shows the new content and does not report unsaved changes', () => {
+      const utils = renderEditor();
+      const { container } = utils;
+
+      refreshTo(utils, { rawContent: '== Edited elsewhere' });
+
+      expect(
+        container.querySelector('[data-cy="contentSaveButton"]'),
+      ).toBeDisabled();
+      expect(dispatchSpy).not.toHaveBeenCalledWith(isEdited(true));
+
+      // The draft feeding both the editor and Preview holds the new content.
+      fireEvent.click(screen.getByRole('button', { name: 'preview' }));
+      expect(previewCardArg?.rawContent).toBe('== Edited elsewhere');
+    });
+
+    it('shows the new value of a metadata field', () => {
+      const utils = renderEditor();
+      const { container } = utils;
+
+      refreshTo(utils, {
+        fields: [
+          { ...baseCard.fields[0], value: 'set elsewhere' },
+          baseCard.fields[1],
+        ],
+      });
+
+      expect((fieldInput(container, 'f1') as HTMLInputElement).value).toBe(
+        'set elsewhere',
+      );
+      expect(rowButton(container, 'f1', 'fieldSaveButton')).toBeDisabled();
+    });
+
+    it('keeps an edit typed here, which stays dirty against the new value', () => {
+      const utils = renderEditor();
+      const { container } = utils;
+
+      fireEvent.change(titleInput(container), {
+        target: { value: 'Typed in this tab' },
+      });
+
+      refreshTo(utils, { title: 'Edited in another tab' });
+
+      // The unsaved edit is not silently discarded, and it is still offered
+      // for saving so the user resolves the conflict deliberately.
+      expect(titleInput(container).value).toBe('Typed in this tab');
+      expect(
+        container.querySelector('[data-cy="titleSaveButton"]'),
+      ).not.toBeDisabled();
+    });
   });
 
   // An overridable field is presented as an override rather than as a plain

--- a/tools/app/__tests__/TextEditor.test.tsx
+++ b/tools/app/__tests__/TextEditor.test.tsx
@@ -1,0 +1,106 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+import type { FileNode } from '@/lib/api/types';
+
+// Regression coverage for INTDEV-1368: a file resource saved elsewhere
+// (another tab, another user, the CLI) arrives as a refetched resource tree
+// while this editor is open on it.
+
+// CodeMirror is replaced by a plain textarea so the content it is handed, and
+// the content it hands back, are both observable.
+vi.mock('@uiw/react-codemirror', () => ({
+  default: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (v: string) => void;
+  }) => (
+    <textarea
+      data-cy="codemirror"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+vi.mock('@/components/toolbar/ConfigToolbar', () => ({
+  default: ({ disabled }: { disabled?: boolean }) => (
+    <button data-cy="configSave" disabled={disabled} />
+  ),
+}));
+vi.mock('@/lib/api', () => ({
+  useResource: () => ({
+    update: vi.fn().mockResolvedValue(undefined),
+    isUpdating: () => false,
+  }),
+}));
+vi.mock('@/lib/hooks', () => ({
+  useAppDispatch: () => vi.fn(),
+  useIsDarkMode: () => false,
+}));
+vi.mock('@/lib/auth', () => ({
+  UserRole: { Reader: 0, Editor: 1, Admin: 2 },
+  useHasMinRole: () => true,
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (s: string) => s }),
+}));
+
+import { TextEditor } from '@/components/config-editors/TextEditor';
+
+const nodeWith = (content: string) =>
+  ({
+    name: 'base/templates/page/index.adoc',
+    type: 'file',
+    fileName: 'index.adoc',
+    resourceName: 'base/templates/page',
+    readOnly: false,
+    data: { content },
+  }) as unknown as FileNode;
+
+const editor = (container: HTMLElement) =>
+  container.querySelector('[data-cy="codemirror"]') as HTMLTextAreaElement;
+const saveButton = (container: HTMLElement) =>
+  container.querySelector('[data-cy="configSave"]') as HTMLButtonElement;
+
+describe('TextEditor on a save made elsewhere', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('shows the new content and does not report unsaved changes', () => {
+    const { container, rerender } = render(
+      <TextEditor node={nodeWith('= Original')} />,
+    );
+
+    rerender(<TextEditor node={nodeWith('= Edited elsewhere')} />);
+
+    expect(editor(container).value).toBe('= Edited elsewhere');
+    expect(saveButton(container)).toBeDisabled();
+  });
+
+  it('keeps unsaved typing, still dirty against the new content', () => {
+    const { container, rerender } = render(
+      <TextEditor node={nodeWith('= Original')} />,
+    );
+
+    fireEvent.change(editor(container), { target: { value: '= Typed here' } });
+
+    rerender(<TextEditor node={nodeWith('= Edited elsewhere')} />);
+
+    expect(editor(container).value).toBe('= Typed here');
+    expect(saveButton(container)).not.toBeDisabled();
+  });
+});

--- a/tools/app/__tests__/useResourceEditorHelpers.test.tsx
+++ b/tools/app/__tests__/useResourceEditorHelpers.test.tsx
@@ -1,0 +1,158 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { describe, it, expect, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+// Regression coverage for INTDEV-1368: a resource saved elsewhere (another tab,
+// another user, the CLI) arrives as a refetched resource tree while the
+// configuration editor is open on it.
+
+vi.mock('@/lib/api', () => ({
+  useResourceTree: () => ({ resourceTree: [] }),
+  useResource: () => ({ update: vi.fn().mockResolvedValue(undefined) }),
+}));
+vi.mock('@/lib/hooks/redux', () => ({
+  useAppRouter: () => ({ push: vi.fn() }),
+}));
+vi.mock('@/lib/hooks', () => ({ useAppDispatch: () => vi.fn() }));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (s: string) => s }),
+}));
+
+import {
+  useEditableField,
+  useResourceEditorHelpers,
+} from '@/lib/hooks/configurationEditor';
+import type { ResourceNode } from '@/lib/api/types';
+
+const nodeWith = (data: Record<string, unknown>) =>
+  ({
+    name: 'base/cardTypes/page',
+    type: 'cardTypes',
+    data: { name: 'base/cardTypes/page', ...data },
+  }) as unknown as ResourceNode;
+
+const renderWith = (data: Record<string, unknown>) =>
+  renderHook(
+    ({ node }: { node: ResourceNode }) => useResourceEditorHelpers(node),
+    { initialProps: { node: nodeWith(data) } },
+  );
+
+describe('useResourceEditorHelpers on a save made elsewhere', () => {
+  it('adopts the new saved value for an untouched field', () => {
+    const { result, rerender } = renderWith({ displayName: 'Page' });
+
+    rerender({ node: nodeWith({ displayName: 'Renamed elsewhere' }) });
+
+    expect(result.current.form.displayName).toBe('Renamed elsewhere');
+    expect(result.current.isDirty('displayName')).toBe(false);
+  });
+
+  it('adopts the new saved value for an untouched multi-value field', () => {
+    const { result, rerender } = renderWith({ alwaysVisibleFields: ['a'] });
+
+    rerender({ node: nodeWith({ alwaysVisibleFields: ['a', 'b'] }) });
+
+    expect(result.current.form.alwaysVisibleFields).toEqual(['a', 'b']);
+    expect(result.current.isDirty('alwaysVisibleFields')).toBe(false);
+  });
+
+  // Resource data is nested (workflow states, card type fields), and a refetch
+  // hands back value-equal objects at fresh references. Comparing those by
+  // reference would leave the form permanently dirty.
+  it('does not go dirty when a nested value returns value-equal', () => {
+    const states = [{ name: 'Draft', category: 'initial' }];
+    const { result, rerender } = renderWith({ states });
+
+    rerender({ node: nodeWith({ states: structuredClone(states) }) });
+
+    expect(result.current.isDirty('states')).toBe(false);
+  });
+
+  it('counts a multi-value field with a repeated entry as dirty', () => {
+    const { result, rerender } = renderWith({
+      alwaysVisibleFields: ['a', 'b'],
+    });
+
+    act(() => result.current.onChange('alwaysVisibleFields', ['a', 'a']));
+    rerender({ node: nodeWith({ alwaysVisibleFields: ['a', 'b'] }) });
+
+    expect(result.current.form.alwaysVisibleFields).toEqual(['a', 'a']);
+    expect(result.current.isDirty('alwaysVisibleFields')).toBe(true);
+  });
+
+  it('ignores the order of a multi-value field', () => {
+    const { result } = renderWith({ alwaysVisibleFields: ['a', 'b'] });
+
+    act(() => result.current.onChange('alwaysVisibleFields', ['b', 'a']));
+
+    expect(result.current.isDirty('alwaysVisibleFields')).toBe(false);
+  });
+
+  it('keeps an unsaved edit typed here, still dirty against the new value', () => {
+    const { result, rerender } = renderWith({ displayName: 'Page' });
+
+    act(() => result.current.onChange('displayName', 'Typed here'));
+    rerender({ node: nodeWith({ displayName: 'Renamed elsewhere' }) });
+
+    expect(result.current.form.displayName).toBe('Typed here');
+    expect(result.current.isDirty('displayName')).toBe(true);
+  });
+
+  it('cancel then reverts to the new saved value, not the old one', () => {
+    const { result, rerender } = renderWith({ displayName: 'Page' });
+
+    act(() => result.current.onChange('displayName', 'Typed here'));
+    rerender({ node: nodeWith({ displayName: 'Renamed elsewhere' }) });
+    act(() => result.current.cancelField('displayName'));
+
+    expect(result.current.form.displayName).toBe('Renamed elsewhere');
+    expect(result.current.isDirty('displayName')).toBe(false);
+  });
+});
+
+describe('useEditableField on a save made elsewhere', () => {
+  const renderField = (initialValue: string) =>
+    renderHook(
+      ({ value }: { value: string }) =>
+        useEditableField({
+          initialValue: value,
+          actionKey: 'update',
+          readOnly: false,
+          saveValue: vi.fn().mockResolvedValue(undefined),
+          isUpdating: () => false,
+        }),
+      { initialProps: { value: initialValue } },
+    );
+
+  it('adopts the new saved value when nothing was typed here', () => {
+    const { result, rerender } = renderField('Page');
+
+    rerender({ value: 'Renamed elsewhere' });
+
+    expect(result.current.value).toBe('Renamed elsewhere');
+    expect(result.current.dirty).toBe(false);
+  });
+
+  it('keeps unsaved typing, still dirty against the new saved value', () => {
+    const { result, rerender } = renderField('Page');
+
+    act(() => result.current.setValue('Typed here'));
+    rerender({ value: 'Renamed elsewhere' });
+
+    expect(result.current.value).toBe('Typed here');
+    expect(result.current.dirty).toBe(true);
+  });
+});

--- a/tools/app/src/components/config-editors/TextEditor.tsx
+++ b/tools/app/src/components/config-editors/TextEditor.tsx
@@ -19,6 +19,7 @@ import BaseEditor from './BaseEditor';
 import { addNotification } from '@/lib/slices/notifications';
 import { isEdited } from '@/lib/slices/pageState';
 import { useAppDispatch } from '@/lib/hooks';
+import { useSavedDraft } from '@/lib/hooks/savedDraft';
 import { useTranslation } from 'react-i18next';
 import { CODE_MIRROR_CONFIG_PROPS, CODE_MIRROR_THEMES } from '@/lib/constants';
 import { useResource } from '@/lib/api';
@@ -33,13 +34,9 @@ export function TextEditor({ node }: { node: FileNode }) {
   const { t } = useTranslation();
   const isDarkMode = useIsDarkMode();
   const isAdmin = useHasMinRole(UserRole.Admin);
-  const [content, setContent] = useState(node.data.content);
+  // Follows a save made elsewhere, unless there is unsaved typing here.
+  const [content, setContent] = useSavedDraft(node.data.content);
   const [isPreview, setIsPreview] = useState(false);
-  const [prevNode, setPrevNode] = useState(node);
-  if (node !== prevNode) {
-    setPrevNode(node);
-    setContent(node.data.content);
-  }
 
   // The preview posts to an Admin-only route, so a lesser role would only ever
   // get a 403 out of the toggle.
@@ -63,7 +60,7 @@ export function TextEditor({ node }: { node: FileNode }) {
   const handleCancel = useCallback(() => {
     setContent(node.data.content);
     dispatch(isEdited(false));
-  }, [node.data.content, dispatch]);
+  }, [node.data.content, dispatch, setContent]);
 
   return (
     <BaseEditor

--- a/tools/app/src/components/config-editors/template-card/TemplateCardEditor.tsx
+++ b/tools/app/src/components/config-editors/template-card/TemplateCardEditor.tsx
@@ -27,6 +27,7 @@ import type { MetadataValue } from '@/lib/definitions';
 import { findCardParentInResourceTree, metadataValuesEqual } from '@/lib/utils';
 import { UserRole, useHasMinRole } from '@/lib/auth';
 import { useAppDispatch, useAppRouter } from '@/lib/hooks';
+import { useSavedDraft, useSavedRecordDraft } from '@/lib/hooks/savedDraft';
 import { addNotification } from '@/lib/slices/notifications';
 import { isEdited } from '@/lib/slices/pageState';
 import { parseContent } from '@/lib/api/actions/card';
@@ -65,14 +66,20 @@ export function TemplateCardEditor({
   const editable = !node?.readOnly && isAdmin;
   const [isPreview, setIsPreview] = useState(false);
 
-  const [draft, setDraft] = useState<Record<string, MetadataValue>>(() =>
-    buildDraft(card),
+  const savedDraft = useMemo(() => buildDraft(card), [card]);
+  const savedContent = card.rawContent ?? '';
+
+  // Both follow a save made elsewhere (another tab, another user, the CLI): the
+  // refetched card is the new saved state, so untouched parts of the draft
+  // adopt it instead of showing stale values the navigation guard would then
+  // offer to "save" back over it.
+  const [draft, setDraft] = useSavedRecordDraft(
+    savedDraft,
+    metadataValuesEqual,
   );
-  const [content, setContent] = useState(card.rawContent ?? '');
+  const [content, setContent] = useSavedDraft(savedContent);
   const [previewHtml, setPreviewHtml] = useState<string | null>(null);
   const contentRef = useRef<ContentEditorHandle>(null);
-
-  const savedDraft = useMemo(() => buildDraft(card), [card]);
   const titleDenied = (card.deniedOperations.editField ?? [])
     .map((f) => f.fieldName)
     .includes('title');
@@ -81,7 +88,7 @@ export function TemplateCardEditor({
     draft[TITLE_KEY],
     savedDraft[TITLE_KEY],
   );
-  const contentDirty = content !== (card.rawContent ?? '');
+  const contentDirty = content !== savedContent;
   const anyDirty =
     contentDirty ||
     Object.keys(savedDraft).some(
@@ -236,7 +243,7 @@ export function TemplateCardEditor({
                   attachments={card.attachments ?? []}
                   onChange={setContent}
                   onSave={saveContent}
-                  onCancel={() => setContent(card.rawContent ?? '')}
+                  onCancel={() => setContent(savedContent)}
                 />
               </Stack>
             </Box>

--- a/tools/app/src/lib/hooks/configurationEditor.ts
+++ b/tools/app/src/lib/hooks/configurationEditor.ts
@@ -11,7 +11,7 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { useState } from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useResourceTree } from '@/lib/api';
 import type { ResourceNode } from '@/lib/api/types';
@@ -24,6 +24,11 @@ import { useAppRouter } from '@/lib/hooks/redux';
 import { useAppDispatch } from '@/lib/hooks';
 import { addNotification } from '@/lib/slices/notifications';
 import { useResource } from '@/lib/api';
+import {
+  deepEqual,
+  useSavedDraft,
+  useSavedRecordDraft,
+} from '@/lib/hooks/savedDraft';
 type EditableFieldOptions = {
   initialValue: string;
   actionKey: string;
@@ -41,12 +46,7 @@ export function useEditableField({
   saveValue,
   isUpdating,
 }: EditableFieldOptions) {
-  const [value, setValue] = useState(initialValue);
-  const [prevInitialValue, setPrevInitialValue] = useState(initialValue);
-  if (initialValue !== prevInitialValue) {
-    setPrevInitialValue(initialValue);
-    setValue(initialValue);
-  }
+  const [value, setValue] = useSavedDraft(initialValue);
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
 
@@ -73,36 +73,40 @@ export function useEditableField({
   return { value, setValue, dirty, save, cancel, saving, disabled };
 }
 
+/**
+ * Multi-value fields are compared as multisets, since their order carries no
+ * meaning; everything else deeply, so nested resource data (workflow states,
+ * card type fields) is not left comparing by reference.
+ */
+const valuesEqual = (a?: unknown, b?: unknown): boolean => {
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  if (!Array.isArray(a) || !Array.isArray(b)) return deepEqual(a, b);
+  if (a.length !== b.length) return false;
+  const unmatched = [...b];
+  return a.every((v) => {
+    const i = unmatched.findIndex((w) => valuesEqual(v, w));
+    if (i !== -1) unmatched.splice(i, 1);
+    return i !== -1;
+  });
+};
+
 export function useResourceEditorHelpers(node: ResourceNode) {
-  const originalData = ('data' in node ? node.data : {}) as Record<
-    string,
-    unknown
-  >;
+  const originalData = useMemo(
+    () => ('data' in node ? node.data : {}) as Record<string, unknown>,
+    [node],
+  );
   const { resourceTree } = useResourceTree();
   const { update } = useResource(node.data.name);
   const { push } = useAppRouter();
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
 
-  const [form, setForm] = useState<Record<string, unknown>>(() => ({
-    ...originalData,
-  }));
+  const [form, setForm] = useSavedRecordDraft(originalData, valuesEqual);
   const onChange = (key: string, value: unknown) =>
     setForm((prev) => ({ ...prev, [key]: value }));
 
-  const isArrayEqual = (a?: unknown, b?: unknown) => {
-    if (!Array.isArray(a) || !Array.isArray(b)) return false;
-    if (a.length !== b.length) return false;
-    return a.every((v) => b.includes(v));
-  };
-
-  const isDirty = (key: string): boolean => {
-    const oldVal = originalData?.[key];
-    const newVal = form[key];
-    if (Array.isArray(oldVal) || Array.isArray(newVal))
-      return !isArrayEqual(oldVal, newVal);
-    return oldVal !== newVal;
-  };
+  const isDirty = (key: string): boolean =>
+    !valuesEqual(originalData?.[key], form[key]);
 
   function changeOp<T>(oldValue: T, newValue: T): ChangeOperation<T> | null {
     if (oldValue === newValue) return null;

--- a/tools/app/src/lib/hooks/index.ts
+++ b/tools/app/src/lib/hooks/index.ts
@@ -16,5 +16,6 @@ export * from './utils';
 export * from './configurationEditor';
 export * from './theme';
 export * from './themeCycle';
+export * from './savedDraft';
 export * from './useListItemEditing';
 export * from './useTreeNodeVisualState';

--- a/tools/app/src/lib/hooks/savedDraft.ts
+++ b/tools/app/src/lib/hooks/savedDraft.ts
@@ -1,0 +1,83 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+
+// An editor holds a working draft while the fetched resource behind it stays
+// canonical, so a save made elsewhere (another tab, another user, the CLI)
+// moves the base the draft was seeded from. These hooks merge the new base in:
+// what the user has not typed into follows it, and what holds unsaved edits
+// keeps them and stays dirty, so the conflict is resolved deliberately rather
+// than by silently discarding one side.
+
+/** Deep equality over JSON-shaped values (the shape all resource data has). */
+export const deepEqual = (a: unknown, b: unknown) =>
+  JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+
+/**
+ * Draft state seeded from `saved`, which follows `saved` when it changes unless
+ * the draft holds an unsaved edit.
+ */
+export function useSavedDraft<T>(
+  saved: T,
+  equals: (a: T, b: T) => boolean = Object.is,
+): [T, Dispatch<SetStateAction<T>>] {
+  const [draft, setDraft] = useState(saved);
+  const [prevSaved, setPrevSaved] = useState(saved);
+  if (!Object.is(prevSaved, saved)) {
+    setPrevSaved(saved);
+    if (equals(draft, prevSaved)) setDraft(saved);
+  }
+  return [draft, setDraft];
+}
+
+/**
+ * As {@link useSavedDraft}, but merged key by key: every key follows its new
+ * saved value except the ones holding unsaved edits. Keys absent from `saved`
+ * are left alone, so a field that disappears mid-edit does not lose its draft.
+ */
+export function useSavedRecordDraft<T>(
+  saved: Record<string, T>,
+  equals: (a: T, b: T) => boolean,
+): [Record<string, T>, Dispatch<SetStateAction<Record<string, T>>>] {
+  const [draft, setDraft] = useState(saved);
+  const [prevSaved, setPrevSaved] = useState(saved);
+  if (!Object.is(prevSaved, saved)) {
+    setPrevSaved(saved);
+    setDraft((d) => mergeSaved(d, prevSaved, saved, equals));
+  }
+  return [draft, setDraft];
+}
+
+/**
+ * Per-key merge of a new saved record into a draft. Returns the same draft
+ * when nothing moves, so React can skip the re-render.
+ */
+function mergeSaved<T>(
+  draft: Record<string, T>,
+  prevSaved: Record<string, T>,
+  nextSaved: Record<string, T>,
+  equals: (a: T, b: T) => boolean,
+): Record<string, T> {
+  const next = { ...draft };
+  let changed = false;
+  for (const [key, savedValue] of Object.entries(nextSaved)) {
+    if (equals(savedValue, draft[key])) continue;
+    if (!equals(draft[key], prevSaved[key])) continue;
+    next[key] = savedValue;
+    changed = true;
+  }
+  return changed ? next : draft;
+}


### PR DESCRIPTION
Now changes will follow unless the user has made changes. Similar pattern does happen on the card side, but it is less of a problem, because editing must be opened manually unlike in config editor, which is in a permanent edit mode.