### PR TITLE
INTDEV-733: Maintain adjacency and location indexes in the card cache

### DIFF
--- a/tools/data-handler/src/commands/clean.ts
+++ b/tools/data-handler/src/commands/clean.ts
@@ -15,6 +15,7 @@ import type { Project } from '../containers/project.js';
 import { ResourcesFrom } from '../containers/project/resources-from.js';
 import { isPredefinedField } from '../utils/constants.js';
 import { getChildLogger } from '../utils/log-utils.js';
+import { sortCards } from '../utils/card-utils.js';
 import { read, write } from '../utils/rw-lock.js';
 
 import type {
@@ -72,7 +73,8 @@ export class Clean {
    * @param dryRun If true, reports the findings without changing any card.
    * @param cardType Optional. Limits the scan to cards of this card type. Must
    *   be a full resource name, e.g. 'decision/cardTypes/decision'.
-   * @returns What was removed, or would be removed in a dry run.
+   * @returns What was removed, or would be removed in a dry run. Findings and
+   *   card lists are sorted by card key.
    */
   public async clean(dryRun: boolean, cardType?: string): Promise<CleanResult> {
     return dryRun ? this.report(cardType) : this.removeUnused(cardType);
@@ -126,10 +128,10 @@ export class Clean {
     }
 
     return {
-      findings,
+      findings: findings.sort((a, b) => sortCards(a.cardKey, b.cardKey)),
       cardCount: new Set(findings.map((finding) => finding.cardKey)).size,
-      skippedCards,
-      failedCards,
+      skippedCards: skippedCards.sort(sortCards),
+      failedCards: failedCards.sort(sortCards),
       dryRun,
     };
   }

--- a/tools/data-handler/src/commands/create.ts
+++ b/tools/data-handler/src/commands/create.ts
@@ -23,7 +23,7 @@ import { pathExists } from '../utils/file-utils.js';
 import { Project } from '../containers/project.js';
 import { Validate } from './validate.js';
 
-import { EMPTY_RANK, sortItems } from '../utils/lexorank.js';
+import { compare, EMPTY_RANK, sortItems } from '../utils/lexorank.js';
 import { ROOT } from '../utils/constants.js';
 import { isModulePath, isExternalItemKey } from '../utils/card-utils.js';
 import type {
@@ -182,7 +182,7 @@ export class Create {
    * Creates card(s) to a project. All cards from template are instantiated to the project.
    * @param templateName name of a template to use
    * @param parentCardKey (Optional) card-key of a parent card. If missing, cards are added to the card root.
-   * @returns array of card keys that were created. Cards are sorted by their parent key and rank. Template root cards are first but the order between other card groups is not guaranteed. However, the order of cards within a group is guaranteed to be ordered by rank.
+   * @returns the cards that were created. Template root cards come first, in rank order; the rest follow, grouped by parent key and in rank order within a group.
    */
   @write((templateName) => `Create card from template ${templateName}`)
   public async createCard(
@@ -222,10 +222,15 @@ export class Create {
           childCards.push(card);
         }
       }
-      return sortItems(
-        rootCards,
-        (item) => item.metadata?.rank || EMPTY_RANK,
-      ).concat(childCards);
+      const rankOf = (card: Card) => card.metadata?.rank || EMPTY_RANK;
+      return sortItems(rootCards, rankOf).concat(
+        childCards.toSorted(
+          (a, b) =>
+            compare(a.parent ?? '', b.parent ?? '') ||
+            compare(rankOf(a), rankOf(b)) ||
+            compare(a.key, b.key),
+        ),
+      );
     }
     return [];
   }

--- a/tools/data-handler/src/commands/export.ts
+++ b/tools/data-handler/src/commands/export.ts
@@ -204,7 +204,10 @@ export class Export {
       if (card.children) {
         await this.toAdocFileAsContent(
           path,
-          this.project.cardKeysToCards(card.children),
+          sortItems(
+            this.project.cardKeysToCards(card.children),
+            (child) => child.metadata?.rank || '1|z',
+          ),
         );
       }
     }

--- a/tools/data-handler/src/commands/show.ts
+++ b/tools/data-handler/src/commands/show.ts
@@ -64,7 +64,11 @@ import { evaluateMacros } from '../macros/index.js';
 import { readJsonFile } from '../utils/json.js';
 import { sleep } from '../utils/common-utils.js';
 import { getChildLogger } from '../utils/log-utils.js';
-import { buildCardHierarchy, flattenCardArray } from '../utils/card-utils.js';
+import {
+  buildCardHierarchy,
+  compareAttachments,
+  flattenCardArray,
+} from '../utils/card-utils.js';
 import { CardNotFoundError } from '../exceptions/index.js';
 import type { ResourcesFrom } from '../containers/project/resources-from.js';
 
@@ -177,14 +181,14 @@ export class Show {
 
   /**
    * Shows all attachments (either template or project attachments) from a project.
-   * @returns array of card attachments
+   * @returns array of card attachments, sorted by card key and file name
    */
   @read
   public async showAttachments(): Promise<CardAttachment[]> {
     const attachments = this.project.attachments();
     const templateAttachments = await this.attachmentsFromTemplates();
     attachments.push(...templateAttachments);
-    return attachments;
+    return attachments.sort(compareAttachments);
   }
 
   /**
@@ -390,7 +394,7 @@ export class Show {
 
   /**
    * Returns all unique labels in a project
-   * @returns labels in a list
+   * @returns labels in a list, sorted alphabetically
    */
   @read
   public async showLabels(): Promise<string[]> {
@@ -401,7 +405,7 @@ export class Show {
     const templateCards = this.project.allTemplateCards();
 
     const labels = this.collectLabels([...cards, ...templateCards]);
-    return Array.from(new Set(labels));
+    return Array.from(new Set(labels)).sort();
   }
 
   /**

--- a/tools/data-handler/src/commands/validate.ts
+++ b/tools/data-handler/src/commands/validate.ts
@@ -37,7 +37,7 @@ import type {
   Workflow,
 } from '../interfaces/resource-interfaces.js';
 import { errorFunction } from '../utils/error-utils.js';
-import { isTemplateCard } from '../utils/card-utils.js';
+import { isTemplateCard, sortCards } from '../utils/card-utils.js';
 import { isPredefinedField } from '../utils/constants.js';
 import { pathExists } from '../utils/file-utils.js';
 import type { Project } from '../containers/project.js';
@@ -580,9 +580,11 @@ export class Validate {
           }
         }
 
-        // Finally, validate that each card is correct
-        const cards = project.cards();
-        cards.push(...project.allTemplateCards());
+        // Finally, validate that each card is correct. Sorted so the reported
+        // errors come out in the same order on every run.
+        const cards = [...project.cards(), ...project.allTemplateCards()].sort(
+          (a, b) => sortCards(a.key, b.key),
+        );
 
         const allPrefixes = project.allModulePrefixes();
 

--- a/tools/data-handler/src/containers/card-container.ts
+++ b/tools/data-handler/src/containers/card-container.ts
@@ -128,15 +128,10 @@ export class CardContainer {
     const attachments: CardAttachment[] = [];
 
     const targetLocation = this.determineContainer(path);
-    const cards = [...this.cardCache.getCards()];
-    const filteredCards = cards.filter((card) => {
-      if (card.attachments.length === 0) {
-        return false;
-      }
-      return card.location === targetLocation;
-    });
-
-    filteredCards.forEach((item) => attachments.push(...item.attachments));
+    this.cardCache
+      .cardsAtLocation(targetLocation)
+      .filter((card) => card.attachments.length > 0)
+      .forEach((item) => attachments.push(...item.attachments));
     return attachments;
   }
 
@@ -152,9 +147,7 @@ export class CardContainer {
     }
 
     const targetLocation = this.determineContainer(path);
-    const relevantCards = this.cardCache
-      .getCards()
-      .filter((cachedCard) => cachedCard.location === targetLocation);
+    const relevantCards = this.cardCache.cardsAtLocation(targetLocation);
     return this.filterCardsDetails(relevantCards, details);
   }
 
@@ -272,15 +265,13 @@ export class CardContainer {
   protected showCards(path: string): Card[] {
     const container = this.determineContainer(path);
     const rootCards: Card[] = [];
-    const relevantCards = Array.from(this.cardCache.getCards()).filter(
-      (cachedCard) => cachedCard.location === container,
-    );
+    const relevantCards = this.cardCache.cardsAtLocation(container);
 
     relevantCards.forEach((card) => {
       if (
         card.parent === ROOT ||
         !card.parent ||
-        !relevantCards.find((cachedCard) => cachedCard.key === card.parent)
+        this.cardCache.getCard(card.parent)?.location !== container
       ) {
         const cardWithChildren: Card = {
           ...card,

--- a/tools/data-handler/src/containers/card-container.ts
+++ b/tools/data-handler/src/containers/card-container.ts
@@ -18,7 +18,7 @@ import { writeFile } from 'node:fs/promises';
 
 import { CardCache } from './project/card-cache.js';
 import { CardNotFoundError } from '../exceptions/index.js';
-import { cardPathParts } from '../utils/card-utils.js';
+import { cardPathParts, compareAttachments } from '../utils/card-utils.js';
 import { deleteDir } from '../utils/file-utils.js';
 import { getChildLogger } from '../utils/log-utils.js';
 import { writeJsonFile } from '../utils/json.js';
@@ -122,7 +122,7 @@ export class CardContainer {
   /**
    * Lists all attachments from the container.
    * @param path Path where attachments should be collected.
-   * @returns attachments from the container.
+   * @returns attachments from the container, sorted by card key and file name.
    */
   protected attachments(path: string): CardAttachment[] {
     const attachments: CardAttachment[] = [];
@@ -132,7 +132,7 @@ export class CardContainer {
       .cardsAtLocation(targetLocation)
       .filter((card) => card.attachments.length > 0)
       .forEach((item) => attachments.push(...item.attachments));
-    return attachments;
+    return attachments.sort(compareAttachments);
   }
 
   /**

--- a/tools/data-handler/src/containers/card-container.ts
+++ b/tools/data-handler/src/containers/card-container.ts
@@ -181,7 +181,7 @@ export class CardContainer {
     const card = this.cardCache.getCard(cardKey);
     if (card) {
       // Children must removed first
-      const children = card.children;
+      const children = this.cardCache.childrenOf(cardKey);
       for (const child of children) {
         await this.removeCard(child);
       }

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -1039,13 +1039,10 @@ export class Project extends CardContainer {
    * @returns List of cards from template.
    */
   public templateCards(templateName: string): Card[] {
-    const templateCards = this.cardCache.getAllTemplateCards();
-    return templateCards.filter((cachedCard) => {
-      if (cachedCard.location === 'project') {
-        return false;
-      }
-      return cachedCard.location === templateName;
-    });
+    if (templateName === 'project') {
+      return [];
+    }
+    return this.cardCache.cardsAtLocation(templateName);
   }
 
   /**

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -62,7 +62,7 @@ import { getCommitContext } from '../utils/commit-context.js';
 
 import type { Template } from './template.js';
 
-import { isPredefinedField, ROOT } from '../utils/constants.js';
+import { isPredefinedField } from '../utils/constants.js';
 
 /**
  * Options for Project initialization. All default to off.
@@ -181,17 +181,6 @@ export class Project extends CardContainer {
     }
   }
 
-  // Changes a card's parent in the cache and updates all relationships.
-  private changeParent(updatedCard: Card, previousParent?: string) {
-    if (previousParent && previousParent !== ROOT) {
-      this.removeCachedChildren(previousParent, updatedCard.key);
-    }
-    if (updatedCard.parent && updatedCard.parent !== ROOT) {
-      this.updateCachedChildren(updatedCard.parent, updatedCard);
-    }
-    this.cardCache.updateCard(updatedCard.key, updatedCard);
-  }
-
   // Finds specific module.
   private async findModule(
     moduleName: string,
@@ -237,32 +226,6 @@ export class Project extends CardContainer {
   // todo: could be moved to card-utils
   private parentFromPath(cardPath: string): string {
     return cardPathParts(this.projectPrefix, cardPath).parents.at(-1) || 'root';
-  }
-
-  // Remove children from a card in the card cache
-  private removeCachedChildren(parentKey: string, childKey: string) {
-    const parentCard = this.cardCache.getCard(parentKey);
-    if (parentCard && parentCard.children) {
-      parentCard.children = parentCard.children.filter(
-        (child) => child !== childKey,
-      );
-      this.cardCache.updateCard(parentCard.key, parentCard);
-    }
-  }
-
-  // Updates children in the card cache
-  private updateCachedChildren(parentKey: string, newChild: Card) {
-    const parentCard = this.cardCache.getCard(parentKey);
-    if (parentCard) {
-      // Add or update the child in the parent's children array
-      const existingChildIndex = parentCard.children?.findIndex(
-        (child) => child === newChild.key,
-      );
-      if (existingChildIndex === -1) {
-        parentCard.children.push(newChild.key);
-      }
-      this.cardCache.updateCard(parentCard.key, parentCard);
-    }
   }
 
   // Refreshes the cached list of all module prefixes.
@@ -354,14 +317,10 @@ export class Project extends CardContainer {
 
         await this.cardCache.populateFromPath(
           templateObject.templateCardsFolder(),
-          false,
         );
       });
 
       await Promise.all(loadPromises);
-
-      // Once all templates have been fetched, build child-parent relationships.
-      this.cardCache.populateChildrenRelationships();
     } catch (error) {
       if (error instanceof DuplicateCardKeyError) {
         throw error;
@@ -740,9 +699,6 @@ export class Project extends CardContainer {
    */
   public async handleCardMoved(movedCard: Card) {
     this.cardCache.updateCard(movedCard.key, movedCard);
-
-    // Rebuild all parent-child relationships from the parent fields
-    this.cardCache.populateChildrenRelationships();
     await this.handleCardChanged(movedCard);
     await this.calculationEngine.handleCardMoved();
   }
@@ -760,11 +716,6 @@ export class Project extends CardContainer {
       };
 
       this.cardCache.updateCard(cardWithParent.key, cardWithParent);
-
-      // Update the parent's children list in the cache
-      if (cardWithParent.parent && cardWithParent.parent !== ROOT) {
-        this.updateCachedChildren(cardWithParent.parent, cardWithParent);
-      }
     });
     return this.calculationEngine.handleNewCards(cards);
   }
@@ -1144,7 +1095,6 @@ export class Project extends CardContainer {
 
     const isRankChange = changedKey === 'rank';
     const previousPath = isRankChange ? card.path : undefined;
-    const previousParent = isRankChange ? card.parent : undefined;
 
     const cardAsRecord: Record<string, MetadataContent> = card.metadata;
     if (removeKey) {
@@ -1169,7 +1119,7 @@ export class Project extends CardContainer {
     if (isRankChange) {
       const updatedCard = this.findCard(cardKey);
       if (updatedCard.path !== previousPath) {
-        this.changeParent(updatedCard, previousParent);
+        this.cardCache.updateCard(updatedCard.key, updatedCard);
       }
     }
   }
@@ -1219,10 +1169,6 @@ export class Project extends CardContainer {
   public async updateCard(card: Card) {
     const cachedCard = this.cardCache.getCard(card.key);
     const pathChange = cachedCard && cachedCard.path !== card.path;
-
-    if (pathChange) {
-      this.changeParent(card, cachedCard.parent);
-    }
 
     const metadataChanged =
       cachedCard &&

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -45,6 +45,7 @@ import {
   cardPathParts,
   isModulePath,
   isTemplateCard,
+  sortCards,
 } from '../utils/card-utils.js';
 import { ActionGuard } from '../permissions/action-guard.js';
 import { applySideEffects, type SideEffects } from '../side-effects.js';
@@ -733,7 +734,7 @@ export class Project extends CardContainer {
    * Returns an array of cards in the project, in the templates or both.
    * Cards don't have content and nor metadata.
    * @param cardsFrom Where to return cards from (project, templates, or both)
-   * @returns all cards in the project per container.
+   * @returns all cards in the project per container, each container's keys sorted.
    */
   public async listCards(
     cardsFrom: CardLocation = CardLocation.all,
@@ -745,7 +746,8 @@ export class Project extends CardContainer {
     ) {
       const projectCards = super
         .cards(this.paths.cardRootFolder)
-        .map((item) => item.key);
+        .map((item) => item.key)
+        .sort(sortCards);
       cardListContainer.push({
         name: this.projectName,
         type: 'project',
@@ -767,7 +769,7 @@ export class Project extends CardContainer {
             cardListContainer.push({
               name: template.data?.name || '',
               type: 'template',
-              cards: templateCards.map((item) => item.key),
+              cards: templateCards.map((item) => item.key).sort(sortCards),
             });
           }
         }

--- a/tools/data-handler/src/containers/project/card-cache.ts
+++ b/tools/data-handler/src/containers/project/card-cache.ts
@@ -45,17 +45,16 @@ const cardContentFile = 'index.adoc';
 const PROJECT_LOCATION = 'project';
 
 /**
+ * Caches a container's cards, indexed by parent and by location.
  *
+ * Reads return their elements in unspecified but stable order: the order does
+ * not change between reads of a location that was not mutated. A caller that
+ * needs a particular order sorts for it.
  */
 export class CardCache {
   private cardCache: Map<string, CachedCard> = new Map();
   private childrenIndex: Map<string, string[]> = new Map();
-  // Position assigned on first insert and kept while the card stays cached.
-  // Child lists are ordered by it, so a parent change cannot reorder siblings.
-  private insertionOrder: Map<string, number> = new Map();
-  private nextInsertion: number = 0;
   private locationIndex: Map<string, Set<string>> = new Map();
-  private locationHighWater: Map<string, number> = new Map();
   private cachePopulated: boolean = false;
   constructor(private prefix: string) {}
 
@@ -80,17 +79,7 @@ export class CardCache {
       this.setChildren(parentKey, [cardKey]);
       return;
     }
-    const position = this.positionOf(cardKey);
-    if (position > this.positionOf(siblings[siblings.length - 1])) {
-      siblings.push(cardKey);
-      return;
-    }
-    const at = siblings.findIndex(
-      (sibling) => this.positionOf(sibling) > position,
-    );
-    const updated = [...siblings];
-    updated.splice(at === -1 ? updated.length : at, 0, cardKey);
-    this.setChildren(parentKey, updated);
+    siblings.push(cardKey);
   }
 
   // The list is replaced, not mutated: callers walk a parent's child list while
@@ -109,31 +98,13 @@ export class CardCache {
     );
   }
 
-  private positionOf(cardKey: string): number {
-    return this.insertionOrder.get(cardKey) ?? Number.MAX_SAFE_INTEGER;
-  }
-
   private addToLocation(cardKey: string, location: string) {
-    const position = this.positionOf(cardKey);
     const keys = this.locationIndex.get(location);
     if (!keys) {
       this.locationIndex.set(location, new Set([cardKey]));
-      this.locationHighWater.set(location, position);
       return;
     }
-    if (position > (this.locationHighWater.get(location) ?? -1)) {
-      keys.add(cardKey);
-      this.locationHighWater.set(location, position);
-      return;
-    }
-    this.locationIndex.set(
-      location,
-      new Set(
-        [...keys, cardKey].sort(
-          (a, b) => this.positionOf(a) - this.positionOf(b),
-        ),
-      ),
-    );
+    keys.add(cardKey);
   }
 
   private removeFromLocation(cardKey: string, location?: string) {
@@ -145,14 +116,10 @@ export class CardCache {
       return;
     }
     this.locationIndex.delete(location);
-    this.locationHighWater.delete(location);
   }
 
   private store(cardKey: string, card: CachedCard) {
     const previous = this.cardCache.get(cardKey);
-    if (!previous) {
-      this.insertionOrder.set(cardKey, this.nextInsertion++);
-    }
     card.children = this.childrenIndex.get(cardKey) ?? [];
     this.cardCache.set(cardKey, card);
     if (previous?.parent !== card.parent) {
@@ -171,7 +138,6 @@ export class CardCache {
       return false;
     }
     this.cardCache.delete(cardKey);
-    this.insertionOrder.delete(cardKey);
     this.detachFromParent(cardKey, card.parent);
     this.removeFromLocation(cardKey, card.location);
     return true;
@@ -393,10 +359,7 @@ export class CardCache {
     this.cachePopulated = false;
     this.cardCache.clear();
     this.childrenIndex.clear();
-    this.insertionOrder.clear();
-    this.nextInsertion = 0;
     this.locationIndex.clear();
-    this.locationHighWater.clear();
   }
 
   /**
@@ -453,8 +416,8 @@ export class CardCache {
   /**
    * Returns all the template cards in the cache.
    * @returns all the template cards in the cache.
-   * @note A scan rather than a walk of the location index: the result is every
-   *   template card, and callers depend on getting them in global cache order.
+   * @note A scan rather than a walk of the location index: the result spans
+   *   every location, so there is nothing to look up.
    */
   public getAllTemplateCards(): CachedCard[] {
     return Array.from(this.cardCache.values()).filter(
@@ -465,7 +428,7 @@ export class CardCache {
   /**
    * Returns the cards in a given location.
    * @param location 'project', or a full template name.
-   * @returns the cards in that location, in cache insertion order.
+   * @returns the cards in that location, in unspecified order.
    */
   public cardsAtLocation(location: string): CachedCard[] {
     const cards: CachedCard[] = [];
@@ -490,7 +453,7 @@ export class CardCache {
   /**
    * Returns the card keys in a given location.
    * @param location 'project', or a full template name.
-   * @returns the card keys in that location, in cache insertion order.
+   * @returns the card keys in that location, in unspecified order.
    */
   public keysAtLocation(location: string): string[] {
     return [...(this.locationIndex.get(location) ?? [])];
@@ -565,7 +528,7 @@ export class CardCache {
   /**
    * Returns the child card keys of a given card.
    * @param cardKey Card key whose children to return.
-   * @returns child card keys, in cache insertion order.
+   * @returns child card keys, in unspecified order.
    */
   public childrenOf(cardKey: string): string[] {
     return this.childrenIndex.get(cardKey) ?? [];

--- a/tools/data-handler/src/containers/project/card-cache.ts
+++ b/tools/data-handler/src/containers/project/card-cache.ts
@@ -46,26 +46,90 @@ const cardContentFile = 'index.adoc';
  */
 export class CardCache {
   private cardCache: Map<string, CachedCard> = new Map();
+  private childrenIndex: Map<string, string[]> = new Map();
+  // Position assigned on first insert and kept while the card stays cached.
+  // Child lists are ordered by it, so a parent change cannot reorder siblings.
+  private insertionOrder: Map<string, number> = new Map();
+  private nextInsertion: number = 0;
   private cachePopulated: boolean = false;
   constructor(private prefix: string) {}
 
-  // Recursively builds children relationships for all cards in the cache.
-  private buildChildrenRelationshipsRecursively() {
-    // Helper function to recursively populate children for a card
-    const populateChildren = (cardKey: string, cardCopy: Card) => {
-      const directChildren: string[] = [];
-      for (const potentialChild of this.getCards()) {
-        if (potentialChild.parent === cardKey) {
-          directChildren.push(potentialChild.key);
-        }
-      }
-      cardCopy.children = directChildren;
-    };
-
-    // Populate children for all cards in the cache
-    for (const card of this.getCards()) {
-      populateChildren(card.key, card);
+  private setChildren(parentKey: string, children: string[]) {
+    if (children.length === 0) {
+      this.childrenIndex.delete(parentKey);
+    } else {
+      this.childrenIndex.set(parentKey, children);
     }
+    const parent = this.cardCache.get(parentKey);
+    if (parent) {
+      parent.children = children;
+    }
+  }
+
+  private attachToParent(cardKey: string, parentKey?: string) {
+    if (!parentKey) {
+      return;
+    }
+    const siblings = this.childrenIndex.get(parentKey);
+    if (!siblings) {
+      this.setChildren(parentKey, [cardKey]);
+      return;
+    }
+    const position = this.positionOf(cardKey);
+    if (position > this.positionOf(siblings[siblings.length - 1])) {
+      siblings.push(cardKey);
+      return;
+    }
+    const at = siblings.findIndex(
+      (sibling) => this.positionOf(sibling) > position,
+    );
+    const updated = [...siblings];
+    updated.splice(at === -1 ? updated.length : at, 0, cardKey);
+    this.setChildren(parentKey, updated);
+  }
+
+  // The list is replaced, not mutated: callers walk a parent's child list while
+  // removing cards from it and must keep seeing the snapshot they started with.
+  private detachFromParent(cardKey: string, parentKey?: string) {
+    if (!parentKey) {
+      return;
+    }
+    const siblings = this.childrenIndex.get(parentKey);
+    if (!siblings?.includes(cardKey)) {
+      return;
+    }
+    this.setChildren(
+      parentKey,
+      siblings.filter((sibling) => sibling !== cardKey),
+    );
+  }
+
+  private positionOf(cardKey: string): number {
+    return this.insertionOrder.get(cardKey) ?? Number.MAX_SAFE_INTEGER;
+  }
+
+  private store(cardKey: string, card: CachedCard) {
+    const previous = this.cardCache.get(cardKey);
+    if (!previous) {
+      this.insertionOrder.set(cardKey, this.nextInsertion++);
+    }
+    card.children = this.childrenIndex.get(cardKey) ?? [];
+    this.cardCache.set(cardKey, card);
+    if (previous?.parent !== card.parent) {
+      this.detachFromParent(cardKey, previous?.parent);
+      this.attachToParent(cardKey, card.parent);
+    }
+  }
+
+  private unstore(cardKey: string): boolean {
+    const card = this.cardCache.get(cardKey);
+    if (!card) {
+      return false;
+    }
+    this.cardCache.delete(cardKey);
+    this.insertionOrder.delete(cardKey);
+    this.detachFromParent(cardKey, card.parent);
+    return true;
   }
 
   // Determines the location from a given path: 'project' for project cards, template name for template cards
@@ -203,7 +267,7 @@ export class CardCache {
   }
 
   // Populates the cache from the given array of cards
-  private populateFromCards(cards: CachedCard[], buildRelationships = true) {
+  private populateFromCards(cards: CachedCard[]) {
     const duplicates: string[] = [];
     const batchKeys = new Set<string>();
     for (const card of cards) {
@@ -220,12 +284,9 @@ export class CardCache {
     }
 
     for (const card of cards) {
-      this.cardCache.set(card.key, card);
+      this.store(card.key, card);
     }
 
-    if (buildRelationships) {
-      this.populateChildrenRelationships();
-    }
     this.cachePopulated = true;
     CardCache.logger.info(`Card cache populated`);
   }
@@ -275,7 +336,7 @@ export class CardCache {
     }
 
     card.attachments.push(attachment);
-    this.cardCache.set(cardKey, card);
+    this.store(cardKey, card);
     return true;
   }
 
@@ -286,6 +347,9 @@ export class CardCache {
     CardCache.logger.info(`Card cache cleared`);
     this.cachePopulated = false;
     this.cardCache.clear();
+    this.childrenIndex.clear();
+    this.insertionOrder.clear();
+    this.nextInsertion = 0;
   }
 
   /**
@@ -294,11 +358,7 @@ export class CardCache {
    * @returns true, if card was removed from the cache; false otherwise
    */
   public deleteCard(cardKey: string) {
-    const cardExists = this.cardCache.has(cardKey);
-    if (cardExists) {
-      this.cardCache.delete(cardKey);
-    }
-    return cardExists;
+    return this.unstore(cardKey);
   }
 
   /**
@@ -421,24 +481,21 @@ export class CardCache {
   }
 
   /**
-   * Re-builds the existing cache's parent-child relationships info.
+   * Returns the child card keys of a given card.
+   * @param cardKey Card key whose children to return.
+   * @returns child card keys, in cache insertion order.
    */
-  public populateChildrenRelationships() {
-    CardCache.logger.info(`Card children relationships re-built`);
-    for (const card of this.getCards()) {
-      card.children = [];
-    }
-    this.buildChildrenRelationshipsRecursively();
+  public childrenOf(cardKey: string): string[] {
+    return this.childrenIndex.get(cardKey) ?? [];
   }
 
   /**
    * Populates the cache from a given path
    * @param path File system path where the cache should be built from.
-   * @param buildRelationships Whether to build parent-child relationships immediately
    */
-  public async populateFromPath(path: string, buildRelationships = true) {
+  public async populateFromPath(path: string) {
     const cards = await this.fetchFileEntries(path);
-    this.populateFromCards(cards, buildRelationships);
+    this.populateFromCards(cards);
   }
 
   /**
@@ -455,7 +512,7 @@ export class CardCache {
         metadata: CardCache.normalizedMetadata(cardData.metadata),
         location: targetLocation,
       };
-      this.cardCache.set(cardKey, extendedCard);
+      this.store(cardKey, extendedCard);
       return;
     }
     if (!card?.path) {
@@ -479,7 +536,7 @@ export class CardCache {
       content: cardData.content ?? card.content,
       attachments: cardData.attachments ?? card.attachments,
     };
-    this.cardCache.set(cardKey, extendedCard);
+    this.store(cardKey, extendedCard);
   }
 
   /**
@@ -495,7 +552,7 @@ export class CardCache {
       return false;
     }
     card.attachments = attachments;
-    this.cardCache.set(cardKey, card);
+    this.store(cardKey, card);
     return true;
   }
 
@@ -512,7 +569,7 @@ export class CardCache {
       return false;
     }
     card.content = content;
-    this.cardCache.set(cardKey, card);
+    this.store(cardKey, card);
     return true;
   }
 
@@ -529,7 +586,7 @@ export class CardCache {
       return false;
     }
     card.metadata = CardCache.normalizedMetadata(metadata);
-    this.cardCache.set(cardKey, card);
+    this.store(cardKey, card);
     return true;
   }
 }

--- a/tools/data-handler/src/containers/project/card-cache.ts
+++ b/tools/data-handler/src/containers/project/card-cache.ts
@@ -41,6 +41,9 @@ interface CachedCard extends Card {
 const cardMetadataFile = 'index.json';
 const cardContentFile = 'index.adoc';
 
+// The location of cards that are not in a template.
+const PROJECT_LOCATION = 'project';
+
 /**
  *
  */
@@ -51,6 +54,8 @@ export class CardCache {
   // Child lists are ordered by it, so a parent change cannot reorder siblings.
   private insertionOrder: Map<string, number> = new Map();
   private nextInsertion: number = 0;
+  private locationIndex: Map<string, Set<string>> = new Map();
+  private locationHighWater: Map<string, number> = new Map();
   private cachePopulated: boolean = false;
   constructor(private prefix: string) {}
 
@@ -108,6 +113,41 @@ export class CardCache {
     return this.insertionOrder.get(cardKey) ?? Number.MAX_SAFE_INTEGER;
   }
 
+  private addToLocation(cardKey: string, location: string) {
+    const position = this.positionOf(cardKey);
+    const keys = this.locationIndex.get(location);
+    if (!keys) {
+      this.locationIndex.set(location, new Set([cardKey]));
+      this.locationHighWater.set(location, position);
+      return;
+    }
+    if (position > (this.locationHighWater.get(location) ?? -1)) {
+      keys.add(cardKey);
+      this.locationHighWater.set(location, position);
+      return;
+    }
+    this.locationIndex.set(
+      location,
+      new Set(
+        [...keys, cardKey].sort(
+          (a, b) => this.positionOf(a) - this.positionOf(b),
+        ),
+      ),
+    );
+  }
+
+  private removeFromLocation(cardKey: string, location?: string) {
+    if (!location) {
+      return;
+    }
+    const keys = this.locationIndex.get(location);
+    if (!keys?.delete(cardKey) || keys.size > 0) {
+      return;
+    }
+    this.locationIndex.delete(location);
+    this.locationHighWater.delete(location);
+  }
+
   private store(cardKey: string, card: CachedCard) {
     const previous = this.cardCache.get(cardKey);
     if (!previous) {
@@ -119,6 +159,10 @@ export class CardCache {
       this.detachFromParent(cardKey, previous?.parent);
       this.attachToParent(cardKey, card.parent);
     }
+    if (previous?.location !== card.location) {
+      this.removeFromLocation(cardKey, previous?.location);
+      this.addToLocation(cardKey, card.location);
+    }
   }
 
   private unstore(cardKey: string): boolean {
@@ -129,12 +173,13 @@ export class CardCache {
     this.cardCache.delete(cardKey);
     this.insertionOrder.delete(cardKey);
     this.detachFromParent(cardKey, card.parent);
+    this.removeFromLocation(cardKey, card.location);
     return true;
   }
 
   // Determines the location from a given path: 'project' for project cards, template name for template cards
   private determineLocationFromPath(path: string): string {
-    return cardPathParts(this.prefix, path).template || 'project';
+    return cardPathParts(this.prefix, path).template || PROJECT_LOCATION;
   }
 
   // Gets all directory entries recursively.
@@ -350,6 +395,8 @@ export class CardCache {
     this.childrenIndex.clear();
     this.insertionOrder.clear();
     this.nextInsertion = 0;
+    this.locationIndex.clear();
+    this.locationHighWater.clear();
   }
 
   /**
@@ -386,10 +433,8 @@ export class CardCache {
    * @param templateName Name of the template
    */
   public deleteCardsFromTemplate(templateName: string) {
-    for (const card of this.cardCache.values()) {
-      if (card.location === templateName) {
-        this.deleteCard(card.key);
-      }
+    for (const cardKey of this.keysAtLocation(templateName)) {
+      this.deleteCard(cardKey);
     }
   }
 
@@ -397,21 +442,58 @@ export class CardCache {
    * Removes all template cards (i.e. cards whose location is not 'project') from the cache.
    */
   public deleteAllTemplateCards() {
-    for (const card of this.cardCache.values()) {
-      if (card.location !== 'project') {
-        this.deleteCard(card.key);
-      }
+    const templateLocations = [...this.locationIndex.keys()].filter(
+      (location) => location !== PROJECT_LOCATION,
+    );
+    for (const location of templateLocations) {
+      this.deleteCardsFromTemplate(location);
     }
   }
 
   /**
    * Returns all the template cards in the cache.
    * @returns all the template cards in the cache.
+   * @note A scan rather than a walk of the location index: the result is every
+   *   template card, and callers depend on getting them in global cache order.
    */
   public getAllTemplateCards(): CachedCard[] {
     return Array.from(this.cardCache.values()).filter(
-      (item) => item.location !== 'project',
+      (item) => item.location !== PROJECT_LOCATION,
     );
+  }
+
+  /**
+   * Returns the cards in a given location.
+   * @param location 'project', or a full template name.
+   * @returns the cards in that location, in cache insertion order.
+   */
+  public cardsAtLocation(location: string): CachedCard[] {
+    const cards: CachedCard[] = [];
+    for (const cardKey of this.locationIndex.get(location) ?? []) {
+      const card = this.cardCache.get(cardKey);
+      if (card) {
+        cards.push(card);
+      }
+    }
+    return cards;
+  }
+
+  /**
+   * Returns how many cards a given location holds.
+   * @param location 'project', or a full template name.
+   * @returns the number of cards in that location.
+   */
+  public cardCountAtLocation(location: string): number {
+    return this.locationIndex.get(location)?.size ?? 0;
+  }
+
+  /**
+   * Returns the card keys in a given location.
+   * @param location 'project', or a full template name.
+   * @returns the card keys in that location, in cache insertion order.
+   */
+  public keysAtLocation(location: string): string[] {
+    return [...(this.locationIndex.get(location) ?? [])];
   }
 
   /**

--- a/tools/data-handler/src/containers/template.ts
+++ b/tools/data-handler/src/containers/template.ts
@@ -458,12 +458,15 @@ export class Template extends CardContainer {
       this.logger.warn('A non-used variable was used in the cards method');
     }
 
-    // Filter cards from the project's card cache that belong to this template.
-    const allCards = [...this.project.cardsCache.getCards()];
-    return allCards.filter(
-      (card) =>
-        card.location !== 'project' && card.location === this.fullTemplateName,
-    );
+    return this.project.cardsCache.cardsAtLocation(this.fullTemplateName);
+  }
+
+  /**
+   * Returns how many cards the template has.
+   * @returns the number of cards in the template.
+   */
+  public cardCount(): number {
+    return this.project.cardsCache.cardCountAtLocation(this.fullTemplateName);
   }
 
   /**
@@ -591,16 +594,7 @@ export class Template extends CardContainer {
       ? `${this.basePath.split(`${sep}modules${sep}`)[1].split(`${sep}templates`)[0]}/templates/${this.templateName}`
       : `${this.project.projectPrefix}/templates/${this.templateName}`;
 
-    const templateCards = Array.from(this.project.cardsCache.getCards()).filter(
-      (cachedCard) => {
-        if (cachedCard.location === 'project') {
-          return false;
-        }
-        const storedTemplateName = cachedCard.location;
-        return storedTemplateName === fullTemplateName;
-      },
-    );
-    return templateCards;
+    return this.project.cardsCache.cardsAtLocation(fullTemplateName);
   }
 
   /**

--- a/tools/data-handler/src/resources/template-resource.ts
+++ b/tools/data-handler/src/resources/template-resource.ts
@@ -117,7 +117,7 @@ export class TemplateResource extends FolderResource<TemplateMetadata, never> {
       displayName: templateMetadata.displayName,
       description: templateMetadata.description,
       path: this.fileName,
-      numberOfCards: container.listCards().length,
+      numberOfCards: container.cardCount(),
     };
   }
 

--- a/tools/data-handler/src/resources/template-resource.ts
+++ b/tools/data-handler/src/resources/template-resource.ts
@@ -100,8 +100,7 @@ export class TemplateResource extends FolderResource<TemplateMetadata, never> {
     // Evict before loading: the cards keep their keys, and the cache rejects a
     // key it already holds.
     this.project.cardsCache.deleteCardsFromTemplate(oldName);
-    await this.project.cardsCache.populateFromPath(this.cardsFolder, false);
-    this.project.cardsCache.populateChildrenRelationships();
+    await this.project.cardsCache.populateFromPath(this.cardsFolder);
   }
 
   /**

--- a/tools/data-handler/src/utils/card-utils.ts
+++ b/tools/data-handler/src/utils/card-utils.ts
@@ -16,6 +16,7 @@ import { CARD_KEY_SEPARATOR, ROOT } from './constants.js';
 
 import type {
   Card,
+  CardAttachment,
   CardWithChildrenCards,
 } from '../interfaces/project-interfaces.js';
 import type { Project } from '../containers/project.js';
@@ -280,6 +281,15 @@ export const sortCards = (a: string, b: string) => {
   if (aParts[1] < bParts[1]) return -1;
   return 0;
 };
+
+/**
+ * Sorts attachments first by the card they belong to, then by file name.
+ * @param a First attachment to be sorted
+ * @param b Second attachment to be sorted
+ * @returns Attachments ordered; first by card key, then by file name.
+ */
+export const compareAttachments = (a: CardAttachment, b: CardAttachment) =>
+  sortCards(a.card, b.card) || a.fileName.localeCompare(b.fileName);
 
 /**
  * Checks whether a value is an external item key (connector:itemKey format)

--- a/tools/data-handler/src/utils/lexorank.ts
+++ b/tools/data-handler/src/utils/lexorank.ts
@@ -156,13 +156,18 @@ export function rebalanceRanks(rankAmount: number): string[] {
 }
 
 /**
- * Sort items based on lexorank
+ * Sort items based on lexorank, breaking rank ties on the item key.
  * @param items items to sort
  * @param rankGetter should return the lexorank of the item
  * @returns sorted items
  */
-export function sortItems<T>(items: T[], rankGetter: (item: T) => string): T[] {
-  return items.toSorted((a, b) => compare(rankGetter(a), rankGetter(b)));
+export function sortItems<T extends { key: string }>(
+  items: T[],
+  rankGetter: (item: T) => string,
+): T[] {
+  return items.toSorted(
+    (a, b) => compare(rankGetter(a), rankGetter(b)) || compare(a.key, b.key),
+  );
 }
 
 /**

--- a/tools/data-handler/test/card-cache.test.ts
+++ b/tools/data-handler/test/card-cache.test.ts
@@ -596,6 +596,212 @@ describe('Card cache', () => {
     });
   });
 
+  describe('index consistency', () => {
+    const locationNames = ['project', 'alpha', 'beta'];
+
+    function expectedLocation(location: string): string {
+      return location === 'project' ? 'project' : `test/templates/${location}`;
+    }
+
+    // A card's location is derived from its path, so these paths are what
+    // actually drive the location index.
+    function pathFor(location: string, cardKey: string): string {
+      return location === 'project'
+        ? join(testCardsPath, cardKey)
+        : join(
+            testProjectPath,
+            '.cards',
+            'local',
+            'templates',
+            location,
+            'c',
+            cardKey,
+          );
+    }
+
+    // Recomputes both indexes from scratch: read the cards in cache order and
+    // group them.
+    function recompute(cards: ReturnType<CardCache['getCards']>) {
+      const children = new Map<string, string[]>();
+      const byLocation = new Map<string, string[]>();
+      for (const card of cards) {
+        if (card.parent) {
+          const siblings = children.get(card.parent) ?? [];
+          siblings.push(card.key);
+          children.set(card.parent, siblings);
+        }
+        const inLocation = byLocation.get(card.location) ?? [];
+        inLocation.push(card.key);
+        byLocation.set(card.location, inLocation);
+      }
+      return { children, byLocation };
+    }
+
+    // Compares the whole shape of each index in one assertion, so a mismatch
+    // reports contents *and* order.
+    function assertIndexesMatchRecomputation(cache: CardCache, step: string) {
+      const cards = cache.getCards();
+      const { children, byLocation } = recompute(cards);
+
+      const parentKeys = [
+        ...new Set([...children.keys(), ...cards.map((card) => card.key)]),
+      ].sort();
+      const indexedChildren: Record<string, string[]> = {};
+      const expectedChildren: Record<string, string[]> = {};
+      for (const parentKey of parentKeys) {
+        indexedChildren[parentKey] = cache.childrenOf(parentKey);
+        expectedChildren[parentKey] = children.get(parentKey) ?? [];
+      }
+      expect(indexedChildren, `${step}: children index`).toEqual(
+        expectedChildren,
+      );
+
+      // Each card's own 'children' field mirrors the index.
+      for (const card of cards) {
+        expect(card.children, `${step}: children of ${card.key}`).toEqual(
+          expectedChildren[card.key],
+        );
+      }
+
+      const locationKeys = [
+        ...new Set([
+          ...byLocation.keys(),
+          ...locationNames.map(expectedLocation),
+        ]),
+      ].sort();
+      const indexedLocations: Record<string, string[]> = {};
+      const expectedLocations: Record<string, string[]> = {};
+      for (const location of locationKeys) {
+        indexedLocations[location] = cache.keysAtLocation(location);
+        expectedLocations[location] = byLocation.get(location) ?? [];
+      }
+      expect(indexedLocations, `${step}: location index`).toEqual(
+        expectedLocations,
+      );
+
+      for (const location of locationKeys) {
+        expect(
+          cache.cardsAtLocation(location).map((card) => card.key),
+          `${step}: cards at ${location}`,
+        ).toEqual(expectedLocations[location]);
+        expect(
+          cache.cardCountAtLocation(location),
+          `${step}: count at ${location}`,
+        ).toBe(expectedLocations[location].length);
+      }
+    }
+
+    // Deterministic PRNG so a failing sequence is reproducible.
+    function random(seed: number) {
+      let state = seed;
+      return () => {
+        state = (state + 0x6d2b79f5) | 0;
+        let t = Math.imul(state ^ (state >>> 15), 1 | state);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+    }
+
+    function cardAt(location: string, cardKey: string, parent: string): Card {
+      return {
+        key: cardKey,
+        path: pathFor(location, cardKey),
+        parent,
+        children: [],
+        attachments: [],
+        content: '',
+        metadata: {
+          title: cardKey,
+          cardType: 'test/cardTypes/page',
+          workflowState: 'Draft',
+          rank: '1|a',
+          links: [],
+        },
+      };
+    }
+
+    it('both indexes match a from-scratch recomputation after a randomized op sequence', () => {
+      const keys = Array.from({ length: 24 }, (_, index) => `test_${index}`);
+      const counts = { add: 0, reparent: 0, relocate: 0, remove: 0 };
+
+      for (const seed of [1, 7, 42, 1337]) {
+        const next = random(seed);
+        const pick = <T>(items: T[]) =>
+          items[Math.floor(next() * items.length)];
+        const cache = new CardCache(prefix);
+
+        for (let step = 0; step < 250; step++) {
+          const cards = cache.getCards();
+          const present = cards.map((card) => card.key);
+          const absent = keys.filter((key) => !present.includes(key));
+          const parentsIn = (location: string) => [
+            ...cards
+              .filter((card) => card.location === expectedLocation(location))
+              .map((card) => card.key),
+            'root',
+          ];
+          const roll = next();
+          const label = `seed ${seed} step ${step}`;
+
+          if (absent.length > 0 && (roll < 0.45 || present.length === 0)) {
+            const location = pick(locationNames);
+            const key = pick(absent);
+            cache.updateCard(
+              key,
+              cardAt(location, key, pick(parentsIn(location))),
+            );
+            counts.add++;
+          } else if (roll < 0.7) {
+            // Re-parent inside the card's own location.
+            const card = pick(cards);
+            const location =
+              locationNames.find(
+                (item) => expectedLocation(item) === card.location,
+              ) ?? 'project';
+            cache.updateCard(card.key, {
+              ...card,
+              parent: pick(
+                parentsIn(location).filter((item) => item !== card.key),
+              ),
+            });
+            counts.reparent++;
+          } else if (roll < 0.85) {
+            // Relocate: a different location means a different path.
+            const card = pick(cards);
+            const location = pick(locationNames);
+            cache.updateCard(
+              card.key,
+              cardAt(
+                location,
+                card.key,
+                pick(parentsIn(location).filter((item) => item !== card.key)),
+              ),
+            );
+            counts.relocate++;
+          } else {
+            cache.deleteCard(pick(present));
+            counts.remove++;
+          }
+
+          assertIndexesMatchRecomputation(cache, label);
+        }
+
+        // The sequence must have produced real nesting and more than one
+        // location, or it would not exercise either index.
+        const cards = cache.getCards();
+        expect(
+          cards.filter((card) => card.parent && card.parent !== 'root').length,
+        ).toBeGreaterThan(0);
+        expect(
+          new Set(cards.map((card) => card.location)).size,
+        ).toBeGreaterThan(1);
+      }
+
+      // Guard against a roll distribution that stops exercising an operation.
+      expect(Math.min(...Object.values(counts))).toBeGreaterThan(0);
+    });
+  });
+
   describe('Template and module operations', () => {
     const tempDir = join(baseDir, 'tmp-card-cache-tests');
     let decisionProjectPath: string;

--- a/tools/data-handler/test/card-cache.test.ts
+++ b/tools/data-handler/test/card-cache.test.ts
@@ -576,23 +576,11 @@ describe('Card cache', () => {
       rmSync(invalidCardPath, { recursive: true, force: true });
     });
 
-    it('should rebuild parent-child relationships', () => {
+    it('should populate parent-child relationships', () => {
       const parentCard = cache.getCard('test_1');
       expect(parentCard).toBeDefined();
-      expect(parentCard!.children).toBeInstanceOf(Array);
-      const originalChildrenCount = parentCard!.children.length;
-
-      if (parentCard) {
-        parentCard.children = [];
-      }
-      expect(parentCard!.children.length).toBe(0);
-
-      cache.populateChildrenRelationships();
-
-      const updatedParentCard = cache.getCard('test_1');
-      expect(updatedParentCard!.children.length).toBe(originalChildrenCount);
-      expect(updatedParentCard!.children).toContain('test_2');
-      expect(updatedParentCard!.children).toContain('test_3');
+      expect(parentCard!.children).toEqual(['test_2', 'test_3']);
+      expect(cache.childrenOf('test_1')).toEqual(parentCard!.children);
     });
 
     it('should return correct population status', async () => {
@@ -775,9 +763,9 @@ describe('Card cache', () => {
       await cache.populateFromPath(dupCardsPath);
       expect(cache.getCard('test_1')!.content).toBe('project card');
 
-      await expect(
-        cache.populateFromPath(dupTemplatePath, false),
-      ).rejects.toThrow(DuplicateCardKeyError);
+      await expect(cache.populateFromPath(dupTemplatePath)).rejects.toThrow(
+        DuplicateCardKeyError,
+      );
 
       expect(cache.getCard('test_1')!.content).toBe('project card');
     });

--- a/tools/data-handler/test/card-cache.test.ts
+++ b/tools/data-handler/test/card-cache.test.ts
@@ -579,7 +579,10 @@ describe('Card cache', () => {
     it('should populate parent-child relationships', () => {
       const parentCard = cache.getCard('test_1');
       expect(parentCard).toBeDefined();
-      expect(parentCard!.children).toEqual(['test_2', 'test_3']);
+      expect(parentCard!.children).toHaveLength(2);
+      expect(parentCard!.children).toEqual(
+        expect.arrayContaining(['test_2', 'test_3']),
+      );
       expect(cache.childrenOf('test_1')).toEqual(parentCard!.children);
     });
 
@@ -596,15 +599,7 @@ describe('Card cache', () => {
     });
   });
 
-  describe('index consistency', () => {
-    const locationNames = ['project', 'alpha', 'beta'];
-
-    function expectedLocation(location: string): string {
-      return location === 'project' ? 'project' : `test/templates/${location}`;
-    }
-
-    // A card's location is derived from its path, so these paths are what
-    // actually drive the location index.
+  describe('index transitions', () => {
     function pathFor(location: string, cardKey: string): string {
       return location === 'project'
         ? join(testCardsPath, cardKey)
@@ -619,89 +614,8 @@ describe('Card cache', () => {
           );
     }
 
-    // Recomputes both indexes from scratch: read the cards in cache order and
-    // group them.
-    function recompute(cards: ReturnType<CardCache['getCards']>) {
-      const children = new Map<string, string[]>();
-      const byLocation = new Map<string, string[]>();
-      for (const card of cards) {
-        if (card.parent) {
-          const siblings = children.get(card.parent) ?? [];
-          siblings.push(card.key);
-          children.set(card.parent, siblings);
-        }
-        const inLocation = byLocation.get(card.location) ?? [];
-        inLocation.push(card.key);
-        byLocation.set(card.location, inLocation);
-      }
-      return { children, byLocation };
-    }
-
-    // Compares the whole shape of each index in one assertion, so a mismatch
-    // reports contents *and* order.
-    function assertIndexesMatchRecomputation(cache: CardCache, step: string) {
-      const cards = cache.getCards();
-      const { children, byLocation } = recompute(cards);
-
-      const parentKeys = [
-        ...new Set([...children.keys(), ...cards.map((card) => card.key)]),
-      ].sort();
-      const indexedChildren: Record<string, string[]> = {};
-      const expectedChildren: Record<string, string[]> = {};
-      for (const parentKey of parentKeys) {
-        indexedChildren[parentKey] = cache.childrenOf(parentKey);
-        expectedChildren[parentKey] = children.get(parentKey) ?? [];
-      }
-      expect(indexedChildren, `${step}: children index`).toEqual(
-        expectedChildren,
-      );
-
-      // Each card's own 'children' field mirrors the index.
-      for (const card of cards) {
-        expect(card.children, `${step}: children of ${card.key}`).toEqual(
-          expectedChildren[card.key],
-        );
-      }
-
-      const locationKeys = [
-        ...new Set([
-          ...byLocation.keys(),
-          ...locationNames.map(expectedLocation),
-        ]),
-      ].sort();
-      const indexedLocations: Record<string, string[]> = {};
-      const expectedLocations: Record<string, string[]> = {};
-      for (const location of locationKeys) {
-        indexedLocations[location] = cache.keysAtLocation(location);
-        expectedLocations[location] = byLocation.get(location) ?? [];
-      }
-      expect(indexedLocations, `${step}: location index`).toEqual(
-        expectedLocations,
-      );
-
-      for (const location of locationKeys) {
-        expect(
-          cache.cardsAtLocation(location).map((card) => card.key),
-          `${step}: cards at ${location}`,
-        ).toEqual(expectedLocations[location]);
-        expect(
-          cache.cardCountAtLocation(location),
-          `${step}: count at ${location}`,
-        ).toBe(expectedLocations[location].length);
-      }
-    }
-
-    // Deterministic PRNG so a failing sequence is reproducible.
-    function random(seed: number) {
-      let state = seed;
-      return () => {
-        state = (state + 0x6d2b79f5) | 0;
-        let t = Math.imul(state ^ (state >>> 15), 1 | state);
-        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-      };
-    }
-
+    // A card's location is derived from its path, so the path is what actually
+    // drives the location index.
     function cardAt(location: string, cardKey: string, parent: string): Card {
       return {
         key: cardKey,
@@ -720,85 +634,71 @@ describe('Card cache', () => {
       };
     }
 
-    it('both indexes match a from-scratch recomputation after a randomized op sequence', () => {
-      const keys = Array.from({ length: 24 }, (_, index) => `test_${index}`);
-      const counts = { add: 0, reparent: 0, relocate: 0, remove: 0 };
-
-      for (const seed of [1, 7, 42, 1337]) {
-        const next = random(seed);
-        const pick = <T>(items: T[]) =>
-          items[Math.floor(next() * items.length)];
-        const cache = new CardCache(prefix);
-
-        for (let step = 0; step < 250; step++) {
-          const cards = cache.getCards();
-          const present = cards.map((card) => card.key);
-          const absent = keys.filter((key) => !present.includes(key));
-          const parentsIn = (location: string) => [
-            ...cards
-              .filter((card) => card.location === expectedLocation(location))
-              .map((card) => card.key),
-            'root',
-          ];
-          const roll = next();
-          const label = `seed ${seed} step ${step}`;
-
-          if (absent.length > 0 && (roll < 0.45 || present.length === 0)) {
-            const location = pick(locationNames);
-            const key = pick(absent);
-            cache.updateCard(
-              key,
-              cardAt(location, key, pick(parentsIn(location))),
-            );
-            counts.add++;
-          } else if (roll < 0.7) {
-            // Re-parent inside the card's own location.
-            const card = pick(cards);
-            const location =
-              locationNames.find(
-                (item) => expectedLocation(item) === card.location,
-              ) ?? 'project';
-            cache.updateCard(card.key, {
-              ...card,
-              parent: pick(
-                parentsIn(location).filter((item) => item !== card.key),
-              ),
-            });
-            counts.reparent++;
-          } else if (roll < 0.85) {
-            // Relocate: a different location means a different path.
-            const card = pick(cards);
-            const location = pick(locationNames);
-            cache.updateCard(
-              card.key,
-              cardAt(
-                location,
-                card.key,
-                pick(parentsIn(location).filter((item) => item !== card.key)),
-              ),
-            );
-            counts.relocate++;
-          } else {
-            cache.deleteCard(pick(present));
-            counts.remove++;
-          }
-
-          assertIndexesMatchRecomputation(cache, label);
-        }
-
-        // The sequence must have produced real nesting and more than one
-        // location, or it would not exercise either index.
-        const cards = cache.getCards();
-        expect(
-          cards.filter((card) => card.parent && card.parent !== 'root').length,
-        ).toBeGreaterThan(0);
-        expect(
-          new Set(cards.map((card) => card.location)).size,
-        ).toBeGreaterThan(1);
+    function cacheWith(...cards: Card[]): CardCache {
+      const cache = new CardCache(prefix);
+      for (const card of cards) {
+        cache.updateCard(card.key, card);
       }
+      return cache;
+    }
 
-      // Guard against a roll distribution that stops exercising an operation.
-      expect(Math.min(...Object.values(counts))).toBeGreaterThan(0);
+    function nestedPair(): CardCache {
+      return cacheWith(
+        cardAt('project', 'test_1', 'root'),
+        cardAt('project', 'test_2', 'root'),
+        cardAt('project', 'test_3', 'test_1'),
+      );
+    }
+
+    it('re-parenting removes the card from its old parent', () => {
+      const cache = nestedPair();
+
+      cache.updateCard('test_3', cardAt('project', 'test_3', 'test_2'));
+
+      expect(cache.childrenOf('test_1')).toEqual([]);
+      expect(cache.getCard('test_1')!.children).toEqual([]);
+    });
+
+    it('re-parenting adds the card to its new parent', () => {
+      const cache = nestedPair();
+
+      cache.updateCard('test_3', cardAt('project', 'test_3', 'test_2'));
+
+      expect(cache.childrenOf('test_2')).toEqual(['test_3']);
+      expect(cache.getCard('test_2')!.children).toEqual(['test_3']);
+    });
+
+    it('relocating a card moves it between the location sets', () => {
+      const cache = cacheWith(cardAt('project', 'test_1', 'root'));
+
+      cache.updateCard('test_1', cardAt('alpha', 'test_1', 'root'));
+
+      expect(cache.keysAtLocation('project')).toEqual([]);
+      expect(cache.keysAtLocation('test/templates/alpha')).toEqual(['test_1']);
+    });
+
+    it('deleting a card clears it from both indexes', () => {
+      const cache = cacheWith(
+        cardAt('project', 'test_1', 'root'),
+        cardAt('project', 'test_2', 'test_1'),
+      );
+
+      expect(cache.deleteCard('test_2')).toBe(true);
+
+      expect(cache.childrenOf('test_1')).toEqual([]);
+      expect(cache.keysAtLocation('project')).toEqual(['test_1']);
+    });
+
+    it('re-storing a card does not duplicate its index entries', () => {
+      const cache = cacheWith(
+        cardAt('project', 'test_1', 'root'),
+        cardAt('project', 'test_2', 'test_1'),
+      );
+
+      cache.updateCard('test_2', cardAt('project', 'test_2', 'test_1'));
+
+      expect(cache.childrenOf('test_1')).toEqual(['test_2']);
+      expect(cache.keysAtLocation('project')).toEqual(['test_1', 'test_2']);
     });
   });
 

--- a/tools/data-handler/test/command-export.test.ts
+++ b/tools/data-handler/test/command-export.test.ts
@@ -1,10 +1,19 @@
 import { mkdirSync, rmSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import { Cmd, Commands } from '../src/command-handler.js';
+import { Cmd, CommandManager, Commands } from '../src/command-handler.js';
 import { copyDir } from '../src/utils/file-utils.js';
 import type { ExportCommandOptions } from '../src/interfaces/command-options.js';
-import { beforeAll, expect, afterAll, it, describe, beforeEach } from 'vitest';
+import {
+  beforeAll,
+  expect,
+  afterAll,
+  it,
+  describe,
+  beforeEach,
+  afterEach,
+} from 'vitest';
 
 const baseDir = import.meta.dirname;
 const testDir = join(baseDir, 'tmp-export-tests');
@@ -75,5 +84,56 @@ describe('export command', () => {
       optionsMini,
     );
     expect(result.statusCode).toBe(400);
+  });
+});
+
+describe('adoc export section order', () => {
+  let orderTestDir: string;
+  let projectPath: string;
+
+  beforeEach(async () => {
+    // Unique dir per test so the CommandManager singleton, keyed on project
+    // path, is rebuilt with a fresh cache.
+    orderTestDir = join(
+      baseDir,
+      `tmp-export-order-tests-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    projectPath = join(orderTestDir, 'valid/decision-records');
+    mkdirSync(orderTestDir, { recursive: true });
+    await copyDir('test/test-data/', orderTestDir);
+  });
+
+  afterEach(() => {
+    rmSync(orderTestDir, { recursive: true, force: true });
+  });
+
+  it('orders the descendants of a card by rank', async () => {
+    const commands = await CommandManager.getInstance(projectPath);
+    const template = 'decision/templates/decision';
+
+    // Two cards below the level the tree query orders, cached in creation
+    // order and ranked the other way around.
+    const firstCreated = (
+      await commands.createCmd.createCard(template, 'decision_6')
+    )[0].key;
+    const lastCreated = (
+      await commands.createCmd.createCard(template, 'decision_6')
+    )[0].key;
+    await commands.moveCmd.rankFirst(lastCreated);
+
+    const rankOrder = [lastCreated, firstCreated];
+    expect(commands.project.findCard('decision_6').children).not.toEqual(
+      rankOrder,
+    );
+
+    await commands.project.calculationEngine.generate();
+    const output = join(orderTestDir, 'output');
+    await commands.exportCmd.exportToADoc(output);
+
+    const adoc = await readFile(join(output, 'index.adoc'), 'utf-8');
+    const positionOf = (cardKey: string) =>
+      adoc.indexOf(`|Card key|${cardKey}\n`);
+    expect(positionOf(lastCreated)).toBeGreaterThan(-1);
+    expect(positionOf(lastCreated)).toBeLessThan(positionOf(firstCreated));
   });
 });

--- a/tools/data-handler/test/command-move.test.ts
+++ b/tools/data-handler/test/command-move.test.ts
@@ -85,7 +85,8 @@ describe('move command', () => {
     const cards = await new Show(project).showProjectCards();
 
     // Use the card created in beforeEach
-    const sourceId = cards[cards.length - 1].key;
+    const sourceId = createdCardKey;
+    expect(cards.map((card) => card.key)).toContain(sourceId);
     const destination = 'root';
     const result = await commandHandler.command(
       Cmd.move,
@@ -98,10 +99,12 @@ describe('move command', () => {
     const project = getTestProject(options.projectPath!);
     await project.populateCaches();
     const cards = await new Show(project).showProjectCards();
-    expect(cards).toHaveLength(2);
+    expect(cards.map((card) => card.key).sort()).toEqual(
+      [createdCardKey, 'decision_5'].sort(),
+    );
 
-    const sourceId = cards[cards.length - 1].key;
-    const destination = cards[cards.length - 2].key;
+    const sourceId = createdCardKey;
+    const destination = 'decision_5';
     const result = await commandHandler.command(
       Cmd.move,
       [sourceId, destination],

--- a/tools/data-handler/test/command-show.test.ts
+++ b/tools/data-handler/test/command-show.test.ts
@@ -187,9 +187,9 @@ describe('shows command', () => {
         optionsDecision,
       );
       expect(result.payload).to.deep.equal([
+        'template-test-label',
         'test',
         'test-two',
-        'template-test-label',
       ]);
     });
     it('show modules (none) - success()', async () => {
@@ -488,8 +488,12 @@ describe('shows command', () => {
       expect(result.statusCode).toBe(200);
       let payloadAsArray = Object.values(result.payload!);
       expect(payloadAsArray.length).toBe(2);
-      expect(payloadAsArray.at(0).card).toBe('decision_5');
-      expect(payloadAsArray.at(0).fileName).toBe('games.jpg');
+      expect(
+        payloadAsArray.map((item) => [item.card, item.fileName]),
+      ).to.deep.equal([
+        ['decision_1', 'the-needle.heic'],
+        ['decision_5', 'games.jpg'],
+      ]);
       const resultFromModule = await commandHandler.command(
         Cmd.show,
         ['attachments'],


### PR DESCRIPTION
The indexes speed up certain operations for cards and the same time the functions are now a bit more determistic as the results are sorted and `sortItems` solves the ties with the card key.