### PR TITLE
INTDEV-733: Split the card read API into node, content and attachment reads

### DIFF
--- a/tools/data-handler/src/commands/export.ts
+++ b/tools/data-handler/src/commands/export.ts
@@ -275,10 +275,7 @@ export class Export {
       children: [],
       attachments: [],
     };
-    const cardDetailsResponse = await this.showCmd.showCardDetails(
-      card.key,
-      'adoc',
-    );
+    const cardDetailsResponse = await this.showCmd.showCardDetails(card.key);
     let asciiDocContent = '';
     const project = this.project;
     try {

--- a/tools/data-handler/src/commands/show.ts
+++ b/tools/data-handler/src/commands/show.ts
@@ -134,10 +134,9 @@ export class Show {
 
   // Returns attachment details
   private getAttachment(cardKey: string, filename: string) {
-    const card = this.project.findCard(cardKey);
-    const attachment =
-      card.attachments?.find((a) => a.fileName === filename) ?? undefined;
-    return attachment;
+    return this.project
+      .cardAttachments(cardKey)
+      .find((a) => a.fileName === filename);
   }
 
   // Opens the given path using the operating system's default application. Doesn't block the main thread.

--- a/tools/data-handler/src/commands/show.ts
+++ b/tools/data-handler/src/commands/show.ts
@@ -30,8 +30,6 @@ import type {
   CardListContainer,
   CardWithChildrenCards,
   Context,
-  FetchCardDetails,
-  FileContentType,
   HubDetails,
   HubSetting,
   ModuleContent,
@@ -281,29 +279,14 @@ export class Show {
    * Shows details of a particular card (template card, or project card)
    * @note Note that parameter 'cardKey' is optional due to technical limitations of class calling this class. It must be defined to get valid results.
    * @param cardKey card key to find
-   * @param contentType Content format in which content is to be shown
-   * @returns card details
+   * @returns card details: metadata, content, children and attachments
    */
   @read
-  public async showCardDetails(
-    cardKey?: string,
-    contentType?: FileContentType,
-  ): Promise<Card> {
+  public async showCardDetails(cardKey?: string): Promise<Card> {
     if (!cardKey) {
       throw new Error(`Mandatory parameter 'cardKey' missing`);
     }
-    // todo: Make a constant about this
-    const details: FetchCardDetails = {
-      parent: true,
-      metadata: true,
-      children: true,
-      attachments: true,
-      content: true,
-    };
-    if (contentType) {
-      details.contentType = contentType;
-    }
-    return this.project.findCard(cardKey, details);
+    return this.project.findCard(cardKey);
   }
 
   /**

--- a/tools/data-handler/src/containers/card-container.ts
+++ b/tools/data-handler/src/containers/card-container.ts
@@ -56,12 +56,14 @@ export class CardContainer {
     this.cardCache = new CardCache(this.prefix);
   }
 
+  // Node reads share the cached metadata; callers that mutate metadata use
+  // cards() or findCard(), which copy it.
   private static nodeView(card: Card): CardNode {
     return {
       key: card.key,
       path: card.path,
       children: card.children,
-      metadata: structuredClone(card.metadata),
+      metadata: card.metadata,
       parent: card.parent,
     };
   }
@@ -69,6 +71,7 @@ export class CardContainer {
   private static cardView(card: Card): Card {
     return {
       ...CardContainer.nodeView(card),
+      metadata: structuredClone(card.metadata),
       content: card.content,
       attachments: card.attachments,
     };

--- a/tools/data-handler/src/containers/card-container.ts
+++ b/tools/data-handler/src/containers/card-container.ts
@@ -27,7 +27,6 @@ import type {
   CardAttachment,
   Card,
   CardMetadata,
-  FetchCardDetails,
 } from '../interfaces/project-interfaces.js';
 
 import { isPredefinedField, ROOT } from '../utils/constants.js';
@@ -56,48 +55,16 @@ export class CardContainer {
     this.cardCache = new CardCache(this.prefix);
   }
 
-  // Filters one card to only include the details requested.
-  private filterCardDetails(
-    card: Card,
-    details: FetchCardDetails = {
-      attachments: true,
-      children: true,
-      content: true,
-      metadata: true,
-      parent: true,
-    },
-  ): Card {
-    const filteredCard: Card = {
+  private static cardView(card: Card): Card {
+    return {
       key: card.key,
       path: card.path,
-      children: details.children ? card.children : [],
-      attachments: details.attachments ? card.attachments : [],
+      children: card.children,
+      attachments: card.attachments,
+      content: card.content,
+      metadata: structuredClone(card.metadata),
+      parent: card.parent,
     };
-
-    if (details.content) {
-      filteredCard.content = card.content;
-    }
-    if (details.metadata) {
-      filteredCard.metadata = structuredClone(card.metadata);
-    }
-    if (details.parent) {
-      filteredCard.parent = card.parent;
-    }
-    if (details.calculations) {
-      filteredCard.calculations = card.calculations;
-    }
-
-    return filteredCard;
-  }
-
-  // Filters cards to only include the details requested.
-  private filterCardsDetails(
-    cards: Card[],
-    details?: FetchCardDetails,
-  ): Card[] {
-    return cards.map((card) => {
-      return this.filterCardDetails(card, details);
-    });
   }
 
   /**
@@ -136,31 +103,30 @@ export class CardContainer {
   }
 
   /**
-   * Shows all cards from the container with the given details (by default all of them).
+   * Shows all cards from the container.
    * @param path Path where cards should be listed.
-   * @param details Which details of the card should be included
    * @returns all cards from the container
    */
-  protected cards(path: string, details?: FetchCardDetails): Card[] {
+  protected cards(path: string): Card[] {
     if (!this.cardCache.isPopulated) {
       throw new Error('Cards cache is not populated!');
     }
 
     const targetLocation = this.determineContainer(path);
-    const relevantCards = this.cardCache.cardsAtLocation(targetLocation);
-    return this.filterCardsDetails(relevantCards, details);
+    return this.cardCache
+      .cardsAtLocation(targetLocation)
+      .map(CardContainer.cardView);
   }
 
   /**
    * Finds a specific card.
    * @param cardKey Card key to find
-   * @param details Card details to be included in the card
    * @throws if card does not exist in the container
    */
-  protected findCard(cardKey: string, details?: FetchCardDetails): Card {
+  protected findCard(cardKey: string): Card {
     const cachedCard = this.cardCache.getCard(cardKey);
     if (cachedCard) {
-      return this.filterCardDetails(cachedCard, details);
+      return CardContainer.cardView(cachedCard);
     }
     throw new CardNotFoundError(cardKey);
   }

--- a/tools/data-handler/src/containers/card-container.ts
+++ b/tools/data-handler/src/containers/card-container.ts
@@ -27,6 +27,7 @@ import type {
   CardAttachment,
   Card,
   CardMetadata,
+  CardNode,
 } from '../interfaces/project-interfaces.js';
 
 import { isPredefinedField, ROOT } from '../utils/constants.js';
@@ -55,15 +56,21 @@ export class CardContainer {
     this.cardCache = new CardCache(this.prefix);
   }
 
-  private static cardView(card: Card): Card {
+  private static nodeView(card: Card): CardNode {
     return {
       key: card.key,
       path: card.path,
       children: card.children,
-      attachments: card.attachments,
-      content: card.content,
       metadata: structuredClone(card.metadata),
       parent: card.parent,
+    };
+  }
+
+  private static cardView(card: Card): Card {
+    return {
+      ...CardContainer.nodeView(card),
+      content: card.content,
+      attachments: card.attachments,
     };
   }
 
@@ -103,32 +110,83 @@ export class CardContainer {
   }
 
   /**
-   * Shows all cards from the container.
+   * Shows all cards from the container, fully hydrated.
    * @param path Path where cards should be listed.
    * @returns all cards from the container
    */
   protected cards(path: string): Card[] {
-    if (!this.cardCache.isPopulated) {
-      throw new Error('Cards cache is not populated!');
-    }
-
-    const targetLocation = this.determineContainer(path);
-    return this.cardCache
-      .cardsAtLocation(targetLocation)
-      .map(CardContainer.cardView);
+    return this.cachedCards(path).map(CardContainer.cardView);
   }
 
   /**
-   * Finds a specific card.
+   * Metadata-level view of every card in the container.
+   * @param path Path where cards should be listed.
+   * @returns nodes of all cards from the container
+   */
+  protected cardNodes(path: string): CardNode[] {
+    return this.cachedCards(path).map(CardContainer.nodeView);
+  }
+
+  /**
+   * Card keys of every card in the container.
+   * @param path Path where cards should be listed.
+   * @returns keys of all cards from the container
+   */
+  protected cardKeys(path: string): string[] {
+    return this.cachedCards(path).map((card) => card.key);
+  }
+
+  /**
+   * Metadata-level view of one card.
+   * @param cardKey Card key to read
+   * @throws if card does not exist in the container
+   */
+  protected cardNode(cardKey: string): CardNode {
+    return CardContainer.nodeView(this.cachedCard(cardKey));
+  }
+
+  /**
+   * Content of one card.
+   * @param cardKey Card key to read
+   * @returns the card's content, or undefined if it has none
+   * @throws if card does not exist in the container
+   */
+  protected cardContent(cardKey: string): string | undefined {
+    return this.cachedCard(cardKey).content;
+  }
+
+  /**
+   * Attachment listing of one card.
+   * @param cardKey Card key to read
+   * @throws if card does not exist in the container
+   */
+  protected cardAttachments(cardKey: string): CardAttachment[] {
+    return this.cachedCard(cardKey).attachments;
+  }
+
+  /**
+   * Finds a specific card, fully hydrated.
    * @param cardKey Card key to find
    * @throws if card does not exist in the container
    */
   protected findCard(cardKey: string): Card {
-    const cachedCard = this.cardCache.getCard(cardKey);
-    if (cachedCard) {
-      return CardContainer.cardView(cachedCard);
+    return CardContainer.cardView(this.cachedCard(cardKey));
+  }
+
+  private cachedCards(path: string): Card[] {
+    if (!this.cardCache.isPopulated) {
+      throw new Error('Cards cache is not populated!');
     }
-    throw new CardNotFoundError(cardKey);
+
+    return this.cardCache.cardsAtLocation(this.determineContainer(path));
+  }
+
+  private cachedCard(cardKey: string): Card {
+    const cachedCard = this.cardCache.getCard(cardKey);
+    if (!cachedCard) {
+      throw new CardNotFoundError(cardKey);
+    }
+    return cachedCard;
   }
 
   /**

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -34,10 +34,8 @@ import {
   CardLocation,
   type CardListContainer,
   type CardMetadata,
-  type FetchCardDetails,
   type MetadataContent,
   type ModuleContent,
-  type ProjectFetchCardDetails,
 } from '../interfaces/project-interfaces.js';
 import { pathExists } from '../utils/file-utils.js';
 import { generateRandomString } from '../utils/random.js';
@@ -468,14 +466,10 @@ export class Project extends CardContainer {
    * Returns an array of all the cards in the project.
    * @note These are project cards only, by default (unless path dictates otherwise).
    * @param path Path from which to fetch the cards. Generally it is best to fetch from Project root, e.g. Project.cardRootFolder
-   * @param details Which details to include in the cards; by default all details are included.
    * @returns all cards from the given path in the project.
    */
-  public cards(
-    path: string = this.paths.cardRootFolder,
-    details?: FetchCardDetails,
-  ): Card[] {
-    return super.cards(path, details);
+  public cards(path: string = this.paths.cardRootFolder): Card[] {
+    return super.cards(path);
   }
 
   /**
@@ -552,11 +546,10 @@ export class Project extends CardContainer {
   /**
    * Returns specific card.
    * @param cardToFind Card key to find
-   * @param details Defines which card details are included in the return values.
    * @returns specific card details, or undefined if card is not part of the project.
    */
-  public findCard(cardToFind: string, details?: ProjectFetchCardDetails): Card {
-    return super.findCard(cardToFind, details);
+  public findCard(cardToFind: string): Card {
+    return super.findCard(cardToFind);
   }
 
   /**

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -787,14 +787,10 @@ export class Project extends CardContainer {
       cardsFrom === CardLocation.all ||
       cardsFrom === CardLocation.projectOnly
     ) {
-      const projectCards = super
-        .cards(this.paths.cardRootFolder)
-        .map((item) => item.key)
-        .sort(sortCards);
       cardListContainer.push({
         name: this.projectName,
         type: 'project',
-        cards: projectCards,
+        cards: super.cardKeys(this.paths.cardRootFolder).sort(sortCards),
       });
     }
 

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -34,6 +34,7 @@ import {
   CardLocation,
   type CardListContainer,
   type CardMetadata,
+  type CardNode,
   type MetadataContent,
   type ModuleContent,
 } from '../interfaces/project-interfaces.js';
@@ -463,13 +464,61 @@ export class Project extends CardContainer {
   }
 
   /**
-   * Returns an array of all the cards in the project.
+   * Returns an array of all the cards in the project, fully hydrated.
    * @note These are project cards only, by default (unless path dictates otherwise).
    * @param path Path from which to fetch the cards. Generally it is best to fetch from Project root, e.g. Project.cardRootFolder
    * @returns all cards from the given path in the project.
    */
   public cards(path: string = this.paths.cardRootFolder): Card[] {
     return super.cards(path);
+  }
+
+  /**
+   * Metadata-level view of every card at the given path: identity, tree
+   * position and metadata, without the content or the attachment listing.
+   * @param path Path from which to fetch the cards.
+   * @returns nodes of all cards from the given path in the project.
+   */
+  public cardNodes(path: string = this.paths.cardRootFolder): CardNode[] {
+    return super.cardNodes(path);
+  }
+
+  /**
+   * Card keys of every card at the given path.
+   * @param path Path from which to fetch the keys.
+   * @returns keys of all cards from the given path in the project.
+   */
+  public cardKeys(path: string = this.paths.cardRootFolder): string[] {
+    return super.cardKeys(path);
+  }
+
+  /**
+   * Metadata-level view of one card: identity, tree position and metadata,
+   * without the content or the attachment listing.
+   * @param cardKey Card key to read.
+   * @throws if the card is not part of the project
+   */
+  public cardNode(cardKey: string): CardNode {
+    return super.cardNode(cardKey);
+  }
+
+  /**
+   * Content of one card.
+   * @param cardKey Card key to read.
+   * @returns the card's content, or undefined if it has none.
+   * @throws if the card is not part of the project
+   */
+  public cardContent(cardKey: string): string | undefined {
+    return super.cardContent(cardKey);
+  }
+
+  /**
+   * Attachment listing of one card.
+   * @param cardKey Card key to read.
+   * @throws if the card is not part of the project
+   */
+  public cardAttachments(cardKey: string): CardAttachment[] {
+    return super.cardAttachments(cardKey);
   }
 
   /**
@@ -546,7 +595,8 @@ export class Project extends CardContainer {
   /**
    * Returns specific card.
    * @param cardToFind Card key to find
-   * @returns specific card details, or undefined if card is not part of the project.
+   * @returns specific card details, fully hydrated.
+   * @throws if the card is not part of the project
    */
   public findCard(cardToFind: string): Card {
     return super.findCard(cardToFind);
@@ -658,7 +708,7 @@ export class Project extends CardContainer {
 
     // Strip links from surviving cards that point at any card being removed.
     const linkUpdates: Promise<void>[] = [];
-    for (const item of this.cards(this.paths.cardRootFolder)) {
+    for (const item of this.cardNodes(this.paths.cardRootFolder)) {
       if (deletedKeys.has(item.key) || !item.metadata) {
         continue;
       }

--- a/tools/data-handler/src/containers/project/calculation-engine.ts
+++ b/tools/data-handler/src/containers/project/calculation-engine.ts
@@ -23,7 +23,11 @@ import type {
   QueryName,
   QueryResult,
 } from '../../types/queries.js';
-import type { Card, Context } from '../../interfaces/project-interfaces.js';
+import type {
+  Card,
+  CardNode,
+  Context,
+} from '../../interfaces/project-interfaces.js';
 import ClingoParser from '../../utils/clingo-parser.js';
 
 import Handlebars from 'handlebars';
@@ -116,7 +120,7 @@ export class CalculationEngine {
     }
   }
 
-  private async setCardContent(card: Card) {
+  private async setCardContent(card: CardNode) {
     const cardContent = await createCardFacts(card, this.project);
     this.clingo.setProgram(card.key, cardContent, [ALL_CATEGORY]);
   }
@@ -247,12 +251,12 @@ export class CalculationEngine {
   }
 
   // Gets either all the cards (no parent), or a subtree.
-  private getCards(templateName?: string): Card[] {
+  private getCards(templateName?: string): CardNode[] {
     if (templateName) {
       return this.project.templateCards(templateName);
     }
 
-    return this.project.cards();
+    return this.project.cardNodes();
   }
 
   // Checks that Clingo successfully returned result.

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -30,6 +30,9 @@ export interface Card {
   attachments: CardAttachment[];
 }
 
+// A card without its file contents: identity, tree position and metadata.
+export type CardNode = Omit<Card, 'content' | 'attachments'>;
+
 // Single card, but childrenCards as Card array
 export interface CardWithChildrenCards extends Card {
   childrenCards: CardWithChildrenCards[];

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -28,7 +28,6 @@ export interface Card {
   parent?: string;
   children: string[];
   attachments: CardAttachment[];
-  calculations?: unknown[];
 }
 
 // Single card, but childrenCards as Card array
@@ -106,20 +105,6 @@ export interface DotSchemaItem {
 }
 export type DotSchemaContent = DotSchemaItem[];
 
-// Defines which details of a card are fetched.
-export interface FetchCardDetails {
-  attachments?: boolean;
-  calculations?: true;
-  children?: boolean;
-  content?: boolean;
-  contentType?: FileContentType;
-  metadata?: boolean;
-  parent?: boolean;
-}
-export interface ProjectFetchCardDetails extends FetchCardDetails {
-  location?: CardLocation;
-}
-
 /**
  * Options for exporting to pdf.
  * @param name - Name of the exported document.
@@ -138,8 +123,6 @@ export interface ExportPdfOptions {
   revremark?: string;
   version?: string;
 }
-
-export type FileContentType = 'adoc' | 'html';
 
 // Metadata content type.
 export type MetadataContent =

--- a/tools/data-handler/src/macros/image/index.ts
+++ b/tools/data-handler/src/macros/image/index.ts
@@ -40,9 +40,9 @@ export default class ImageMacro extends BaseMacro {
     cardKey: string,
     filename: string,
   ) {
-    const card = context.project.findCard(cardKey);
-    const attachment =
-      card.attachments?.find((a) => a.fileName === filename) ?? undefined;
+    const attachment = context.project
+      .cardAttachments(cardKey)
+      .find((a) => a.fileName === filename);
     if (!attachment) {
       throw new Error(
         `Attachment file '${filename}' not found in card '${cardKey}'`,

--- a/tools/data-handler/src/macros/include/index.ts
+++ b/tools/data-handler/src/macros/include/index.ts
@@ -59,7 +59,7 @@ export default class IncludeMacro extends BaseMacro {
     const title = this.generateTitle(options, card.metadata?.title);
     const cardContent = await this.generateCardContent(
       options,
-      card.content,
+      context.project.cardContent(options.cardKey),
       newContext,
     );
 
@@ -126,7 +126,7 @@ export default class IncludeMacro extends BaseMacro {
   }
 
   private getCard(cardKey: string, context: MacroGenerationContext) {
-    return context.project.findCard(cardKey);
+    return context.project.cardNode(cardKey);
   }
 
   // Adjust asciidoc titles to match the level offset

--- a/tools/data-handler/src/macros/xref/index.ts
+++ b/tools/data-handler/src/macros/xref/index.ts
@@ -50,7 +50,7 @@ export default class XrefMacro extends BaseMacro {
   };
 
   private getCard(cardKey: string, context: MacroGenerationContext) {
-    return context.project.findCard(cardKey);
+    return context.project.cardNode(cardKey);
   }
 
   private validate(input: unknown): XrefMacroOptions {

--- a/tools/data-handler/src/utils/asciidoc-xref.ts
+++ b/tools/data-handler/src/utils/asciidoc-xref.ts
@@ -56,7 +56,7 @@ export function rewriteAsciidocCardXrefs(
       let card;
 
       try {
-        card = project.findCard(cardKey);
+        card = project.cardNode(cardKey);
       } catch {
         card = undefined;
       }

--- a/tools/data-handler/src/utils/card-utils.ts
+++ b/tools/data-handler/src/utils/card-utils.ts
@@ -199,7 +199,7 @@ export const flattenCardArray = (array: Card[], project: Project) => {
  * @param card Card object to check
  * @returns true if card exists in a module; false otherwise
  */
-export const isModuleCard = (card: Card) => {
+export const isModuleCard = (card: Pick<Card, 'path'>) => {
   return card.path.includes(`${sep}modules${sep}`);
 };
 
@@ -217,7 +217,7 @@ export const isModulePath = (path: string) => {
  * @param card card object to check
  * @returns true if card exists in a template; false otherwise
  */
-export const isTemplateCard = (card: Card) => {
+export const isTemplateCard = (card: Pick<Card, 'path'>) => {
   return (
     card.path.includes(`${sep}templates${sep}`) ||
     card.path.includes(`${sep}modules${sep}`)

--- a/tools/data-handler/src/utils/clingo-facts.ts
+++ b/tools/data-handler/src/utils/clingo-facts.ts
@@ -18,7 +18,7 @@ import {
   encodeClingoValue,
 } from './clingo-fact-builder.js';
 import type {
-  Card,
+  CardNode,
   Context,
   ModuleContent,
 } from '../interfaces/project-interfaces.js';
@@ -176,7 +176,7 @@ export const createWorkflowFacts = (workflow: Workflow) => {
  * @param project Project information
  * @returns clingo facts as a string
  */
-export const createCardFacts = async (card: Card, project: Project) => {
+export const createCardFacts = async (card: CardNode, project: Project) => {
   // Small helper to deduce parent path
   // todo: Should use card-utils
   function parentPath(cardPath: string) {
@@ -190,7 +190,7 @@ export const createCardFacts = async (card: Card, project: Project) => {
 
   // Helper to deduce template parent path.
   // todo: Should use card-utils
-  function parentPathFromTemplate(card: Card) {
+  function parentPathFromTemplate(card: CardNode) {
     const cardPath = card.path;
     const pathParts = cardPath.split(sep);
     if (pathParts.length <= 6) {

--- a/tools/data-handler/test/macros/index.test.ts
+++ b/tools/data-handler/test/macros/index.test.ts
@@ -399,8 +399,13 @@ Some content here`;
     });
     describe('includeMacro', () => {
       let cardDetailsByIdStub: sinon.SinonStub;
+      let cardContentStub: sinon.SinonStub;
       beforeEach(() => {
-        cardDetailsByIdStub = stub(project, 'findCard');
+        cardDetailsByIdStub = stub(project, 'cardNode');
+        cardContentStub = stub(project, 'cardContent');
+        cardContentStub.callsFake(
+          (cardKey: string) => (cardDetailsByIdStub(cardKey) as Card).content,
+        );
 
         const baseCard: Card = {
           key: '',
@@ -447,6 +452,7 @@ Some content here`;
       });
       afterEach(() => {
         cardDetailsByIdStub.restore();
+        cardContentStub.restore();
       });
       ['static', 'inject', 'staticSite'].forEach((mode) => {
         it(`includeMacro ${mode} (success)`, async () => {
@@ -883,7 +889,7 @@ Some content here`;
     describe('xrefMacro', () => {
       let cardDetailsByIdStub: sinon.SinonStub;
       beforeEach(() => {
-        cardDetailsByIdStub = stub(project, 'findCard');
+        cardDetailsByIdStub = stub(project, 'cardNode');
 
         const baseCard: Card = {
           key: '',

--- a/tools/data-handler/test/project.test.ts
+++ b/tools/data-handler/test/project.test.ts
@@ -10,10 +10,7 @@ import {
 import { basename, join, resolve, sep } from 'node:path';
 
 import { copyDir } from '../src/utils/file-utils.js';
-import {
-  CardLocation,
-  type FileContentType,
-} from '../src/interfaces/project-interfaces.js';
+import { CardLocation } from '../src/interfaces/project-interfaces.js';
 
 import {
   buildCardHierarchy,
@@ -156,15 +153,7 @@ describe('project', () => {
     expect(card.metadata!.title).toBe('Decision Records');
     expect(card.metadata!.cardType).toBe('decision/cardTypes/simplepage');
     expect(card.metadata!.workflowState).toBe('Created');
-    const details = {
-      contentType: 'adoc' as FileContentType,
-      content: true,
-      metadata: true,
-      children: true,
-      parent: true,
-      attachments: true,
-    };
-    const additionalCardDetails = project.findCard(cardToOperateOn, details);
+    const additionalCardDetails = project.findCard(cardToOperateOn);
     expect(additionalCardDetails).not.toBeUndefined();
     expect(additionalCardDetails.metadata!.title).toBe('Decision Records');
     expect(additionalCardDetails.metadata!.cardType).toBe(
@@ -466,18 +455,7 @@ describe('project', () => {
     const template = project.createTemplateObjectFromCard(templateCards.at(0)!);
     expect(template).not.toBeUndefined();
   });
-  it('find certain card from project - content as adoc (success)', async () => {
-    const decisionRecordsPath = join(testDir, 'valid/decision-records');
-    const project = getTestProject(decisionRecordsPath);
-    await project.populateCaches();
-    expect(project).not.toBeUndefined();
-    const existingCard = project.findCard('decision_5', {
-      content: true,
-      contentType: 'adoc',
-    });
-    expect(existingCard).not.toBeUndefined();
-  });
-  it('find certain card from project - content as html (success)', async () => {
+  it('find certain card from project - with content (success)', async () => {
     const decisionRecordsPath = join(testDir, 'valid/decision-records');
     const project = getTestProject(decisionRecordsPath);
     await project.populateCaches();
@@ -487,21 +465,18 @@ describe('project', () => {
       project.findCard('idontexist');
     }).toThrow(CardNotFoundError);
 
-    const existingCard = project.findCard('decision_5', {
-      content: true,
-      contentType: 'html',
-    });
+    const existingCard = project.findCard('decision_5');
     expect(existingCard).not.toBeUndefined();
+    expect(existingCard.content).not.toBeUndefined();
   });
   it('find certain card from project - card is from template (success)', async () => {
     const decisionRecordsPath = join(testDir, 'valid/decision-records');
     const project = getTestProject(decisionRecordsPath);
     await project.populateCaches();
     expect(project).not.toBeUndefined();
-    const existingCard = project.findCard('decision_1', {
-      content: true,
-    });
+    const existingCard = project.findCard('decision_1');
     expect(existingCard).not.toBeUndefined();
+    expect(existingCard.content).not.toBeUndefined();
   });
   it('check if project is created (success)', async () => {
     const decisionRecordsPath = join(testDir, 'valid/decision-records');

--- a/tools/data-handler/test/utils/asciidoc-xref.test.ts
+++ b/tools/data-handler/test/utils/asciidoc-xref.test.ts
@@ -2,14 +2,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { rewriteAsciidocCardXrefs } from '../../src/utils/asciidoc-xref.js';
 import type { Project } from '../../src/containers/project.js';
-import type { Card } from '../../src/interfaces/project-interfaces.js';
+import type { CardNode } from '../../src/interfaces/project-interfaces.js';
 import type { Mode } from '../../src/interfaces/macros.js';
 
-function makeCard(key: string, title: string): Card {
+function makeCard(key: string, title: string): CardNode {
   return {
     key,
     path: '',
-    content: '',
     metadata: {
       title,
       cardType: '',
@@ -18,12 +17,11 @@ function makeCard(key: string, title: string): Card {
       links: [],
     },
     children: [],
-    attachments: [],
   };
 }
 
-function makeProject(byKey: Record<string, Card>): Project {
-  // Mirror the real Project.findCard contract: throw when the key is unknown,
+function makeProject(byKey: Record<string, CardNode>): Project {
+  // Mirror the real Project.cardNode contract: throw when the key is unknown,
   // never return undefined.
   const lookup = (k: string) => {
     const card = byKey[k];
@@ -32,7 +30,7 @@ function makeProject(byKey: Record<string, Card>): Project {
     }
     return card;
   };
-  return { findCard: lookup } as unknown as Project;
+  return { cardNode: lookup } as unknown as Project;
 }
 
 describe('rewriteAsciidocCardXrefs', () => {


### PR DESCRIPTION
Prep for the refactor: We do not always need the metadata, content and attachments together. The reads also have performance differences, so it is easier to keep them separated. Instead of using an object for filtering certain fields out, this opts for different functions. This is more easier for types, simpler and does not cost much performance, since the separation is split based on the performance considerations.