### PR TITLE
Fix two flaky e2e navigation tests

### DIFF
--- a/tools/app/e2e/helpers.ts
+++ b/tools/app/e2e/helpers.ts
@@ -1,9 +1,9 @@
 import { type Page, expect } from '@playwright/test';
 import t from '../src/locales/en/translation.json' with { type: 'json' };
 
-/** Click the "Edit body" button (force-clickable even when .doc has 0 height). */
+/** Click the "Edit body" button. */
 export async function editPage(page: Page) {
-  await page.getByTestId('editBodyButton').click({ force: true });
+  await page.getByTestId('editBodyButton').click();
 }
 
 /** Create a card from the "Page" template via the toolbar dialog. */

--- a/tools/app/e2e/tests/app.spec.ts
+++ b/tools/app/e2e/tests/app.spec.ts
@@ -420,6 +420,9 @@ test.describe('Navigation', () => {
       page.getByRole('heading', { level: 1, name: /^Untitled page$/ }),
     ).toBeVisible();
     await page.locator('p').filter({ hasText: 'Updated title' }).click();
+    await expect(
+      page.getByRole('heading', { level: 1, name: /^Updated title$/ }),
+    ).toBeVisible();
 
     await editPage(page);
     await expect(page.locator('.cm-editor')).toBeVisible();

--- a/tools/app/e2e/tests/last-visited-page.spec.ts
+++ b/tools/app/e2e/tests/last-visited-page.spec.ts
@@ -9,7 +9,9 @@ base.describe('Remember last visited page per project', () => {
     'reopening the app returns to the last visited card, not the card list',
     async ({ page }) => {
       await page.goto('/');
-      await expect(page).toHaveURL(/\/projects\/.+\/cards$/);
+      // Not `/cards$` — CardsPage forwards that to the first card within
+      // ~100ms, so anchoring on the card list races the hop.
+      await expect(page).toHaveURL(/\/projects\/[^/]+\/cards/);
 
       await page.getByTestId('createNewButton').click();
       await page
@@ -104,7 +106,12 @@ base.describe('Remember last visited page per project', () => {
       }, cardKey);
 
       await page.goto('/');
-      await expect(page).toHaveURL(/\/projects\/.+\/cards$/);
+      // CardsPage forwards /cards to the first card in the tree, so the card
+      // list is only ever a way station (~100ms) — asserting on it races that
+      // hop. Wait for the forward to land, then assert what this test is
+      // really about: the reopen must not replay the deleted card.
+      await expect(page).toHaveURL(/\/cards\/[\w-]+$/);
+      expect(page.url()).not.toContain(cardKey);
     },
   );
 });


### PR DESCRIPTION
CI actions seemed to be flaky, spawned a session to fix. Fixes seem valid and only touch tests, so I'd just merge them