### PR TITLE
INTDEV-733: Pull card facts before a solve instead of pushing after a write

### DIFF
--- a/tools/data-handler/src/command-manager.ts
+++ b/tools/data-handler/src/command-manager.ts
@@ -143,7 +143,6 @@ export class CommandManager {
     this.project.resources.changedModules();
     await this.project.populateCaches();
     await this.project.initializeGit();
-    await this.project.calculationEngine.generate();
   }
 
   /**

--- a/tools/data-handler/src/commands/move.ts
+++ b/tools/data-handler/src/commands/move.ts
@@ -119,8 +119,6 @@ export class Move {
     await actionGuard.checkPermission('move', source);
 
     await this.project.relocateCard(source, newParent, targetTree.name);
-
-    await this.project.handleCardMoved(this.project.cardNode(source));
   }
 
   /**

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -128,7 +128,7 @@ export class Project {
 
     this.logger.info({ path }, 'Initializing project');
 
-    this.calculationEngine = new CalculationEngine(this);
+    this.calculationEngine = new CalculationEngine(this, this.facts);
     this.projectPaths = new ProjectPaths(path);
     this.resourceHandler = new ResourceHandler(this);
     // todo: implement project validation
@@ -162,12 +162,6 @@ export class Project {
 
     this.gitManager = new GitManager(path);
 
-    // Regenerate Clingo facts after every write transaction so that
-    // metadata-only edits (e.g. title changes) are immediately visible.
-    this.lock.onAfterWrite(async () => {
-      await this.calculationEngine.generate();
-    });
-
     this.gitSync = new GitSync(this.gitManager);
 
     if (this.options.autocommit) {
@@ -188,7 +182,6 @@ export class Project {
         this.clearCards();
         await this.populateCardsCache();
         this.resources.changed();
-        await this.calculationEngine.generate();
       });
     }
   }
@@ -606,15 +599,6 @@ export class Project {
   }
 
   /**
-   * When card changes.
-   * @param changedCard Card that was changed.
-   */
-  public async handleCardChanged(changedCard: CardNode) {
-    // Notify the calculation engine about the change
-    return this.calculationEngine.handleCardChanged(changedCard);
-  }
-
-  /**
    * When cards are removed.
    * @param deletedCard Card that is to be removed.
    */
@@ -635,7 +619,6 @@ export class Project {
       }
     }
     await this.removeCard(deletedCard.key);
-    return this.calculationEngine.handleDeleteCard(deletedCard);
   }
 
   /**
@@ -706,17 +689,6 @@ export class Project {
   }
 
   /**
-   * When card is moved.
-   * @param movedCard Card that moved
-   * @param newParentCard New parent for the 'movedCard'
-   * @param oldParentCard Previous parent of the 'movedCard'
-   */
-  public async handleCardMoved(movedCard: CardNode) {
-    await this.handleCardChanged(movedCard);
-    await this.calculationEngine.handleCardMoved();
-  }
-
-  /**
    * Moves a card to a new position in the card tree.
    * @param container Container the card now belongs to: 'project' or a full
    *   template name. Defaults to the one it is in.
@@ -741,7 +713,8 @@ export class Project {
    * side effects it asks for.
    *
    * Must run inside a write-lock context, after the cards were created: the
-   * query only sees them once their facts have been projected.
+   * query projects them as it starts, so they have to be in their tree by
+   * then.
    * @param cardKeys Keys of the cards that were created.
    */
   public async runCreationSideEffects(cardKeys: string[]) {
@@ -1027,7 +1000,6 @@ export class Project {
     // 'lastUpdated', and only the metadata write stamps it.
     await this.saveCardContent(card);
     await this.saveCardMetadata(card);
-    await this.handleCardChanged(card);
   }
 
   /**
@@ -1085,9 +1057,7 @@ export class Project {
    */
   public async updateCardMetadata(card: Card, changedMetadata: CardMetadata) {
     card.metadata = changedMetadata;
-    if (await this.saveCardMetadata(card)) {
-      await this.handleCardChanged(card);
-    }
+    await this.saveCardMetadata(card);
   }
 
   // Wrapper to run onTransition query.

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -19,6 +19,7 @@ import { readdirSync } from 'node:fs';
 import { CalculationEngine } from './project/calculation-engine.js';
 import { CardKeyRegistry } from './project/card-keys.js';
 import { CardTree } from './project/card-tree.js';
+import { FactLog } from './project/fact-log.js';
 import {
   CardNotFoundError,
   DuplicateCardKeyError,
@@ -86,6 +87,7 @@ export class Project {
   // Kept here because a TemplateResource does not survive resources.changed().
   private templateCardTrees: Map<string, CardTree> = new Map();
   private keyRegistry: CardKeyRegistry;
+  private readonly facts = new FactLog();
   private gitManager: GitManager;
   private readonly gitSync: GitSync;
   private logger = getChildLogger({ module: 'Project' });
@@ -115,6 +117,7 @@ export class Project {
       emitsCardFact: true,
       validationApplies: true,
       keys: this.keyRegistry,
+      facts: this.facts,
     });
 
     // Pushing only makes sense for commits this process makes, and both
@@ -227,6 +230,7 @@ export class Project {
       emitsCardFact: false,
       validationApplies: false,
       keys: this.keyRegistry,
+      facts: this.facts,
     });
     this.templateCardTrees.set(templateName, tree);
     return tree;

--- a/tools/data-handler/src/containers/project/calculation-engine.ts
+++ b/tools/data-handler/src/containers/project/calculation-engine.ts
@@ -23,15 +23,12 @@ import type {
   QueryName,
   QueryResult,
 } from '../../types/queries.js';
-import type {
-  Card,
-  CardNode,
-  Context,
-} from '../../interfaces/project-interfaces.js';
+import type { CardNode, Context } from '../../interfaces/project-interfaces.js';
 import ClingoParser from '../../utils/clingo-parser.js';
 
 import Handlebars from 'handlebars';
 import type { Project } from '../../containers/project.js';
+import type { FactLog } from './fact-log.js';
 import { getChildLogger } from '../../utils/log-utils.js';
 import {
   createCalculatedFieldRules,
@@ -68,14 +65,59 @@ import {
 const ALL_CATEGORY = 'all';
 
 export class CalculationEngine {
-  constructor(private project: Project) {}
+  // Draining the log is destructive - whoever takes the changes owes them a
+  // projection - so the engine alone is given it.
+  constructor(
+    private project: Project,
+    private facts: FactLog,
+  ) {}
 
   private clingo = new ClingoContext();
+
+  // Serialises the pulls: reads run concurrently, and draining is destructive.
+  private pulling: Promise<void> = Promise.resolve();
 
   private get logger() {
     return getChildLogger({
       module: 'calculate',
     });
+  }
+
+  /** Declares the resource programs, and the card programs built on them, stale. */
+  public invalidateResources() {
+    this.facts.invalidateResources();
+  }
+
+  // Every path into clingo goes through pull(): run() for solves, and
+  // exportLogicProgram for the one other reader.
+  private async pull(): Promise<void> {
+    const next = this.pulling.then(
+      () => this.refreshPrograms(),
+      // A failed pull must not wedge every later one.
+      () => this.refreshPrograms(),
+    );
+    this.pulling = next.catch(() => {});
+    return next;
+  }
+
+  private async refreshPrograms(): Promise<void> {
+    if (this.facts.resourcesDirty) {
+      await this.rebuild();
+      return;
+    }
+    const { changed, removed } = this.facts.drainCards();
+    try {
+      for (const cardKey of removed) {
+        this.clingo.removeProgram(cardKey);
+      }
+      for (const cardKey of changed) {
+        await this.setCardContent(this.project.treeOf(cardKey).node(cardKey));
+      }
+    } catch (error) {
+      // The drained changes are gone; only a full rebuild cannot miss them.
+      this.facts.invalidateResources();
+      throw error;
+    }
   }
 
   /**
@@ -99,6 +141,7 @@ export class CalculationEngine {
     programs: string[],
     query?: QueryName,
   ) {
+    await this.pull();
     let logicProgram = query ? this.queryContent(query) : '';
     logicProgram += this.clingo.buildProgram('', programs);
     await writeFile(destination, logicProgram);
@@ -288,6 +331,7 @@ export class CalculationEngine {
 
   //
   private async run(query: string, context: Context): Promise<string[]> {
+    await this.pull();
     try {
       // Use the main category to include all programs
       const basePrograms = [ALL_CATEGORY];
@@ -328,9 +372,15 @@ export class CalculationEngine {
   }
 
   /**
-   * Generates a logic program.
+   * Rebuilds the whole logic program.
    */
   public async generate() {
+    this.facts.invalidateResources();
+    await this.pull();
+  }
+
+  private async rebuild() {
+    const revision = this.facts.resourceRevision;
     this.logger.trace(
       {
         clingo: true,
@@ -360,66 +410,16 @@ export class CalculationEngine {
     await this.setTemplatesPrograms();
     await this.setCalculationsPrograms();
 
+    // Everything pending has just been rebuilt along with the rest.
+    this.facts.drainCards();
+    this.facts.resourcesRebuilt(revision);
+
     this.logger.trace(
       {
         clingo: true,
       },
       'Logic program set',
     );
-  }
-
-  /**
-   * When card changes, update the card specific calculations.
-   * @param changedCard Card that was changed.
-   */
-  public async handleCardChanged(changedCard: CardNode) {
-    await this.setCardContent(changedCard);
-  }
-
-  /**
-   * When card is moved, rebuild the entire card tree structure.
-   * Moving cards changes parent-child relationships, so we need to rebuild
-   * the complete card tree facts to ensure consistency.
-   */
-  public async handleCardMoved() {
-    // Rebuild entire tree structure from scratch to ensure all relationships are correct
-    await this.setCardTreeContent();
-  }
-
-  /**
-   * When cards are removed, automatically remove card-specific calculations.
-   * @param deletedCard Card that is to be removed.
-   */
-  public async handleDeleteCard(deletedCard: Card) {
-    if (!deletedCard) {
-      return;
-    }
-    try {
-      if (!this.clingo.removeProgram(deletedCard.key)) {
-        this.logger.warn(
-          {
-            cardKey: deletedCard.key,
-          },
-          'Tried to remove card program that does not exist',
-        );
-      }
-    } catch {
-      this.logger.warn('Removing program failed');
-    }
-  }
-
-  /**
-   * Refreshes the facts of the given cards, so a query run after this sees
-   * them as they are now.
-   * @param cards Cards whose facts to rebuild.
-   */
-  public async refreshCardFacts(cards: CardNode[]) {
-    if (!cards) {
-      return;
-    }
-    for (const card of cards) {
-      await this.setCardContent(card);
-    }
   }
 
   /**

--- a/tools/data-handler/src/containers/project/card-tree.ts
+++ b/tools/data-handler/src/containers/project/card-tree.ts
@@ -53,6 +53,7 @@ import {
 
 import type { CardFactContext } from '../../utils/clingo-facts.js';
 import type { CardKeyRegistry } from './card-keys.js';
+import type { FactLog } from './fact-log.js';
 
 // An attachment as the tree stores it: the file's name, and the folder it
 // sits in relative to its card's attachment folder (empty for the common
@@ -92,6 +93,7 @@ const CHILDREN_FOLDER = 'c';
  * validationApplies - whether the tree's cards take part in workflow
  *   semantics: metadata validation, and the permissions built on it.
  * keys - the project-level card key registry.
+ * facts - the project-level log of card facts still to be projected.
  */
 export interface CardTreeOptions {
   name: string;
@@ -100,6 +102,7 @@ export interface CardTreeOptions {
   emitsCardFact: boolean;
   validationApplies: boolean;
   keys: CardKeyRegistry;
+  facts: FactLog;
 }
 
 interface RankChange {
@@ -551,6 +554,10 @@ export class CardTree {
   public rebase(name: string, rootPath: string) {
     this.treeName = name;
     this.treeRoot = rootPath;
+    // A template's root cards name the template itself as their parent.
+    for (const cardKey of this.cardStore.keys()) {
+      this.options.facts.cardChanged(cardKey);
+    }
   }
 
   /**
@@ -923,6 +930,7 @@ export class CardTree {
       metadata,
     );
     stored.metadata = CardTree.normalizedMetadata(metadata);
+    this.options.facts.cardChanged(cardKey);
   }
 
   /**
@@ -994,6 +1002,7 @@ export class CardTree {
           dir: '',
         })),
       });
+      this.options.facts.cardChanged(card.key);
     }
   }
 
@@ -1062,6 +1071,8 @@ export class CardTree {
     const from = this.pathOfStored(card);
     await CardTree.moveFolder(from, this.pathFor(parent, cardKey));
     this.store(cardKey, { ...card, parent });
+    // Only the moved card: its descendants keep the parent they had.
+    this.options.facts.cardChanged(cardKey);
     if (card.parent !== ROOT) {
       await CardTree.pruneEmptyFolder(dirname(from));
     }
@@ -1163,6 +1174,7 @@ export class CardTree {
         children: [],
         attachments: card.attachments.map((attachment) => ({ ...attachment })),
       });
+      this.options.facts.cardChanged(card.key);
     }
   }
 
@@ -1213,6 +1225,7 @@ export class CardTree {
       return false;
     }
     stored.metadata = CardTree.normalizedMetadata(sanitizedMetadata);
+    this.options.facts.cardChanged(card.key);
     return true;
   }
 
@@ -1252,7 +1265,11 @@ export class CardTree {
     }
     await deleteDir(path);
     this.options.keys.release([cardKey]);
-    return this.unstore(cardKey);
+    const removed = this.unstore(cardKey);
+    if (removed) {
+      this.options.facts.cardRemoved(cardKey);
+    }
+    return removed;
   }
 
   /**
@@ -1405,6 +1422,7 @@ export class CardTree {
     );
     for (const card of cards) {
       this.store(card.key, card);
+      this.options.facts.cardChanged(card.key);
     }
     this.populated = true;
   }
@@ -1413,6 +1431,9 @@ export class CardTree {
    * Empties the tree.
    */
   public clear() {
+    for (const cardKey of this.cardStore.keys()) {
+      this.options.facts.cardRemoved(cardKey);
+    }
     this.options.keys.releaseOwner(this);
     this.populated = false;
     this.cardStore.clear();

--- a/tools/data-handler/src/containers/project/fact-log.ts
+++ b/tools/data-handler/src/containers/project/fact-log.ts
@@ -13,13 +13,15 @@
 
 /**
  * What the calculation engine has not yet pulled: the card facts to refresh,
- * and the card facts to drop.
+ * the card facts to drop, and whether the resource programs need a rebuild.
  *
  * The log outlives the trees that write into it.
  */
 export class FactLog {
   private changed = new Set<string>();
   private removed = new Set<string>();
+  private dirty = true;
+  private revision = 0;
 
   /** Records that a card's facts have to be built again. */
   public cardChanged(cardKey: string) {
@@ -31,6 +33,31 @@ export class FactLog {
   public cardRemoved(cardKey: string) {
     this.changed.delete(cardKey);
     this.removed.add(cardKey);
+  }
+
+  /** Records that the resource programs have to be built again. */
+  public invalidateResources() {
+    this.dirty = true;
+    this.revision++;
+  }
+
+  public get resourcesDirty(): boolean {
+    return this.dirty;
+  }
+
+  public get resourceRevision(): number {
+    return this.revision;
+  }
+
+  /**
+   * Records a completed rebuild; an invalidation that arrived while it ran
+   * leaves the log dirty.
+   * @param revision The revision the rebuild started from.
+   */
+  public resourcesRebuilt(revision: number) {
+    if (revision === this.revision) {
+      this.dirty = false;
+    }
   }
 
   /** Takes the pending card changes, leaving the log clean. */

--- a/tools/data-handler/src/containers/project/fact-log.ts
+++ b/tools/data-handler/src/containers/project/fact-log.ts
@@ -1,0 +1,46 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * What the calculation engine has not yet pulled: the card facts to refresh,
+ * and the card facts to drop.
+ *
+ * The log outlives the trees that write into it.
+ */
+export class FactLog {
+  private changed = new Set<string>();
+  private removed = new Set<string>();
+
+  /** Records that a card's facts have to be built again. */
+  public cardChanged(cardKey: string) {
+    this.removed.delete(cardKey);
+    this.changed.add(cardKey);
+  }
+
+  /** Records that a card's facts have to go. */
+  public cardRemoved(cardKey: string) {
+    this.changed.delete(cardKey);
+    this.removed.add(cardKey);
+  }
+
+  /** Takes the pending card changes, leaving the log clean. */
+  public drainCards(): { changed: string[]; removed: string[] } {
+    const drained = {
+      changed: [...this.changed],
+      removed: [...this.removed],
+    };
+    this.changed.clear();
+    this.removed.clear();
+    return drained;
+  }
+}

--- a/tools/data-handler/src/containers/project/resource-handler.ts
+++ b/tools/data-handler/src/containers/project/resource-handler.ts
@@ -44,8 +44,12 @@ export class ResourceHandler {
    * Creates instance of ResourceHandler.
    * @param project Project to use in cache
    */
-  constructor(project: Project) {
+  constructor(private project: Project) {
     this.cache = ResourceCache.create(project);
+  }
+
+  private invalidateFacts(): void {
+    this.project.calculationEngine.invalidateResources();
   }
 
   /**
@@ -55,6 +59,7 @@ export class ResourceHandler {
    */
   public add(name: string | ResourceName, instance: unknown): void {
     this.cache.addResource(name, instance);
+    this.invalidateFacts();
   }
 
   public byType<T extends keyof ResourceMap>(
@@ -110,6 +115,7 @@ export class ResourceHandler {
    */
   public changed(): void {
     this.cache.changed();
+    this.invalidateFacts();
   }
 
   /**
@@ -118,6 +124,7 @@ export class ResourceHandler {
    */
   public changedModules(moduleName?: string): void {
     this.cache.changedModules(moduleName);
+    this.invalidateFacts();
   }
 
   /**
@@ -156,6 +163,7 @@ export class ResourceHandler {
    */
   public remove(name: string | ResourceName): void {
     this.cache.removeResource(name);
+    this.invalidateFacts();
   }
 
   /**
@@ -164,6 +172,7 @@ export class ResourceHandler {
    */
   public removeModule(moduleName: string): void {
     this.cache.removeModule(moduleName);
+    this.invalidateFacts();
   }
 
   /**
@@ -173,6 +182,7 @@ export class ResourceHandler {
    */
   public rename(oldName: string, newName: string): void {
     this.cache.changeResourceName(oldName, newName);
+    this.invalidateFacts();
   }
 
   /**
@@ -250,6 +260,7 @@ export class ResourceHandler {
    */
   public handleFileSystemChange(fileName: string): void {
     this.cache.handleFileSystemChange(fileName);
+    this.invalidateFacts();
   }
 
   /**

--- a/tools/data-handler/src/containers/project/template-instantiation.ts
+++ b/tools/data-handler/src/containers/project/template-instantiation.ts
@@ -68,9 +68,6 @@ export async function addTemplateCards(
         metadata: { ...DefaultContent.card(cardType), rank: ranks[index] },
       })),
     );
-    await project.calculationEngine.refreshCardFacts(
-      cardKeys.map((cardKey) => template.node(cardKey)),
-    );
     return cardKeys;
   } catch (error) {
     logger.error({ error });
@@ -111,9 +108,7 @@ export async function instantiateTemplate(
     );
     await destination.createCards(newCards);
 
-    const created = newCards.map((card) => destination.card(card.key));
-    await project.calculationEngine.refreshCardFacts(created);
-    return created;
+    return newCards.map((card) => destination.card(card.key));
   } catch (error) {
     logger.error({ error }, 'Failed to create cards');
     throw error;

--- a/tools/data-handler/src/resources/folder-resource.ts
+++ b/tools/data-handler/src/resources/folder-resource.ts
@@ -164,6 +164,10 @@ export abstract class FolderResource<
     if (key) {
       (this.resourceContent as Record<string, unknown>)[key] = parsedContent;
     }
+
+    // A calculation's logic program is one of the programs the engine holds,
+    // and this is the only path that rewrites it.
+    this.project.calculationEngine.invalidateResources();
   }
 
   /**

--- a/tools/data-handler/src/resources/resource-object.ts
+++ b/tools/data-handler/src/resources/resource-object.ts
@@ -624,6 +624,9 @@ export abstract class ResourceObject<
       this.project.resources.rename(resourceString, this.content.name);
     }
     await writeJsonFile(this.fileName, this.content);
+    // The resource stays the object the cache holds, so nothing above tells
+    // the calculation engine that what it projects has changed.
+    this.project.calculationEngine.invalidateResources();
   }
 
   /**

--- a/tools/data-handler/test/calculation-engine.test.ts
+++ b/tools/data-handler/test/calculation-engine.test.ts
@@ -1,4 +1,13 @@
-import { expect, it, describe, beforeAll, afterAll } from 'vitest';
+import {
+  expect,
+  it,
+  describe,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from 'vitest';
 
 import { join } from 'node:path';
 import { mkdirSync, rmSync } from 'node:fs';
@@ -285,5 +294,57 @@ describe('calculation validation on generate', () => {
       'result(X) :- validCalcFact(X).',
     );
     expect(valid.results.map((r) => r.key)).toEqual(['42']);
+  });
+});
+
+describe('a resource change made while the program is being rebuilt', () => {
+  const baseDir = import.meta.dirname;
+  const testDir = join(baseDir, 'tmp-calculate-rebuild-tests');
+  const projectPath = join(testDir, 'invalid/invalid-calculations');
+  const validCalcName = 'mini/calculations/validCalc';
+
+  beforeEach(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir('test/test-data/', testDir);
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('keeps an invalidation that arrives during a rebuild', async () => {
+    const project = getTestProject(projectPath);
+    await project.populateCaches();
+    const engine = project.calculationEngine;
+    const fact = async () => {
+      const result = await engine.runLogicProgram(
+        'result(X) :- validCalcFact(X).',
+      );
+      return result.results.map((item) => item.key);
+    };
+    expect(await fact()).toEqual(['42']);
+
+    // Hold the rebuild at the step that reads the calculations, and rewrite
+    // one while it waits there.
+    let release: () => void = () => {};
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const step = vi
+      .spyOn(
+        engine as unknown as { setCalculationsPrograms: () => Promise<void> },
+        'setCalculationsPrograms',
+      )
+      .mockImplementationOnce(() => held);
+
+    const rebuilding = engine.generate();
+    await project.resources
+      .byType(validCalcName, 'calculations')
+      .updateFile('calculation.lp', 'validCalcFact(43).');
+    release();
+    await rebuilding;
+    step.mockRestore();
+
+    expect(await fact()).toEqual(['43']);
   });
 });

--- a/tools/data-handler/test/card-tree.test.ts
+++ b/tools/data-handler/test/card-tree.test.ts
@@ -31,6 +31,7 @@ import { copyDir } from '../src/utils/file-utils.js';
 import { CardKeyRegistry } from '../src/containers/project/card-keys.js';
 import { CardTree } from '../src/containers/project/card-tree.js';
 import type { NewCard } from '../src/containers/project/card-tree.js';
+import { FactLog } from '../src/containers/project/fact-log.js';
 import type {
   Card,
   CardMetadata,
@@ -122,6 +123,7 @@ const PAGE_TEMPLATE = 'test/templates/page';
 function projectTree(
   rootPath: string,
   keys = new CardKeyRegistry(() => 'test'),
+  facts = new FactLog(),
 ): CardTree {
   return new CardTree({
     name: 'project',
@@ -130,6 +132,7 @@ function projectTree(
     emitsCardFact: true,
     validationApplies: true,
     keys,
+    facts,
   });
 }
 
@@ -138,6 +141,7 @@ function newTemplateTree(
   rootPath: string,
   keys: CardKeyRegistry,
   writable = true,
+  facts = new FactLog(),
 ): CardTree {
   return new CardTree({
     name,
@@ -146,6 +150,7 @@ function newTemplateTree(
     emitsCardFact: false,
     validationApplies: false,
     keys,
+    facts,
   });
 }
 
@@ -1397,6 +1402,142 @@ describe('Card tree', () => {
       await expect(project.populateCaches()).rejects.toThrow(
         /Duplicate card keys found: decision_5/,
       );
+    });
+  });
+
+  describe('fact changes', () => {
+    let facts: FactLog;
+    let tree: CardTree;
+    let template: CardTree;
+
+    // A three-generation line: test_1 -> test_2 -> test_3, and an empty
+    // template tree to move cards into. Both trees log into one FactLog, as
+    // the project's do.
+    beforeEach(async () => {
+      const keys = new CardKeyRegistry(() => 'test');
+      facts = new FactLog();
+      mkdirSync(testCardsPath, { recursive: true });
+      createTestCard('test_1', testCardsPath, pageCard('One'), '');
+      // test_2 carries the rank a move to either root would hand it, so the
+      // moves below leave its rank alone.
+      createTestCard(
+        'test_2',
+        join(testCardsPath, 'test_1', 'c'),
+        pageCard('Two', '0|b'),
+        '',
+      );
+      createTestCard(
+        'test_3',
+        join(testCardsPath, 'test_1', 'c', 'test_2', 'c'),
+        pageCard('Three'),
+        '',
+      );
+      tree = projectTree(testCardsPath, keys, facts);
+      template = newTemplateTree(
+        PAGE_TEMPLATE,
+        templateCardsPath('page'),
+        keys,
+        true,
+        facts,
+      );
+      await tree.load();
+      await template.load();
+    });
+    afterEach(() => {
+      rmSync(testDir, { recursive: true, force: true });
+    });
+
+    // The trees are loaded in beforeEach, so a test that observes one
+    // operation's marks starts from a drained log.
+    function drain() {
+      facts.drainCards();
+    }
+
+    function newCard(cardKey: string, parent: string): NewCard {
+      return {
+        key: cardKey,
+        parent,
+        content: '',
+        attachments: [],
+        metadata: { ...pageCard(cardKey), links: [] },
+      };
+    }
+
+    it('marks every loaded card', () => {
+      const changes = facts.drainCards();
+      expect(changes.changed.sort()).toEqual(['test_1', 'test_2', 'test_3']);
+      expect(changes.removed).toEqual([]);
+    });
+
+    it('marks nothing for a content or an attachment write', async () => {
+      drain();
+      const card = tree.card('test_2');
+      card.content = 'new body';
+      await tree.writeContent(card);
+      expect(facts.drainCards()).toEqual({ changed: [], removed: [] });
+
+      await tree.addAttachment('test_2', 'picture.png', Buffer.from('x'));
+      expect(facts.drainCards()).toEqual({ changed: [], removed: [] });
+
+      await tree.removeAttachment('test_2', 'picture.png');
+      expect(facts.drainCards()).toEqual({ changed: [], removed: [] });
+    });
+
+    it('marks only the relocated card', async () => {
+      drain();
+      await tree.relocate('test_2', 'root');
+
+      expect(facts.drainCards()).toEqual({
+        changed: ['test_2'],
+        removed: [],
+      });
+    });
+
+    it('marks every card of an adopted subtree changed', async () => {
+      drain();
+      await template.adopt(tree, 'test_2', 'root');
+
+      expect(facts.drainCards()).toEqual({
+        changed: ['test_2', 'test_3'],
+        removed: [],
+      });
+    });
+
+    it('marks a card once, as whatever happened to it last', async () => {
+      drain();
+      await tree.deleteSubtree('test_3');
+      await tree.createCards([newCard('test_3', 'test_2')]);
+      expect(facts.drainCards()).toEqual({
+        changed: ['test_3'],
+        removed: [],
+      });
+
+      const card = tree.card('test_3');
+      card.metadata!.title = 'Renamed';
+      await tree.writeMetadata(card);
+      await tree.deleteSubtree('test_3');
+      expect(facts.drainCards()).toEqual({
+        changed: [],
+        removed: ['test_3'],
+      });
+    });
+
+    it('marks every card of a cleared tree as removed', () => {
+      drain();
+      tree.clear();
+
+      const changes = facts.drainCards();
+      expect(changes.changed).toEqual([]);
+      expect(changes.removed.sort()).toEqual(['test_1', 'test_2', 'test_3']);
+    });
+
+    it('marks every card when the tree is renamed', () => {
+      drain();
+      tree.rebase(PAGE_TEMPLATE, testCardsPath);
+
+      const changes = facts.drainCards();
+      expect(changes.changed.sort()).toEqual(['test_1', 'test_2', 'test_3']);
+      expect(changes.removed).toEqual([]);
     });
   });
 });

--- a/tools/data-handler/test/fact-pull.test.ts
+++ b/tools/data-handler/test/fact-pull.test.ts
@@ -1,0 +1,232 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+// testing
+import { expect, it, describe, beforeEach, afterEach, vi } from 'vitest';
+
+// node
+import { join } from 'node:path';
+import { mkdirSync, rmSync } from 'node:fs';
+
+import { CommandManager } from '../src/command-manager.js';
+import { copyDir } from '../src/utils/file-utils.js';
+import { resourceName } from '../src/utils/resource-utils.js';
+import { getTestProject } from './helpers/test-utils.js';
+
+// Facts are pulled before a solve rather than pushed after a write, so each
+// case here writes without querying and then queries: it goes stale if the
+// pull, or one of the invalidations that feed it, goes missing.
+describe('facts are pulled before a solve', () => {
+  const baseDir = import.meta.dirname;
+  const testDir = join(baseDir, 'tmp-fact-pull-tests');
+  const projectPath = join(testDir, 'valid/decision-records');
+  let commands: CommandManager;
+
+  // A project per test: what one write leaves behind is the point of these
+  // cases, and a shared project would let an earlier test's query do the
+  // projection this one is supposed to prove.
+  beforeEach(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir('test/test-data/', testDir);
+    commands = new CommandManager(projectPath, {});
+    await commands.initialize();
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  // What a query sees of a card, straight out of clingo.
+  async function fieldOf(cardKey: string, field: string) {
+    const result = await commands.project.calculationEngine.runLogicProgram(
+      `result(Value) :- field(${cardKey}, "${field}", Value).`,
+    );
+    return result.results.map((item) => item.key);
+  }
+
+  async function cardKeys() {
+    const result = await commands.project.calculationEngine.runLogicProgram(
+      'result(Key) :- card(Key).',
+    );
+    return result.results.map((item) => item.key).sort();
+  }
+
+  it('does not lose the changes a failed pull drained', async () => {
+    // Solve first, so the pull below takes the incremental path instead of
+    // regenerating everything.
+    await cardKeys();
+
+    // A write straight to the tree: it marks the card without solving, so the
+    // change is still pending when the failing pull drains it.
+    const tree = commands.project.cardTree;
+    const card = tree.card('decision_6');
+    card.metadata!.title = 'Renamed';
+    await tree.writeMetadata(card);
+
+    // One failed per-card projection: setCardContent asks the project for the
+    // card's tree, so the next such ask is the projection about to run.
+    vi.spyOn(commands.project, 'treeOf').mockImplementationOnce(() => {
+      throw new Error('projection failed');
+    });
+
+    await expect(fieldOf('decision_6', 'title')).rejects.toThrow(
+      'projection failed',
+    );
+    // The change the failed pull took is not owed by anybody any more, so the
+    // next solve has to rebuild rather than trust what it is holding.
+    expect(await fieldOf('decision_6', 'title')).toEqual(['Renamed']);
+  });
+
+  it('sees a metadata edit made after the last solve', async () => {
+    expect(await fieldOf('decision_6', 'title')).toEqual([
+      'Document Decisions with Decision Records',
+    ]);
+
+    await commands.editCmd.editCardMetadata('decision_6', 'title', 'Renamed');
+
+    expect(await fieldOf('decision_6', 'title')).toEqual(['Renamed']);
+  });
+
+  it('sees a card created after the last solve', async () => {
+    const before = await cardKeys();
+
+    const created = await commands.createCmd.createCard(
+      'decision/templates/decision',
+    );
+    const createdKeys = created.map((card) => card.key).sort();
+    expect(createdKeys.length).toBeGreaterThan(0);
+
+    expect(await cardKeys()).toEqual([...before, ...createdKeys].sort());
+  });
+
+  // A reorder writes ranks and nothing else, so the rank persister is the only
+  // thing that can report it.
+  it('sees a card reordered after the last solve', async () => {
+    const template = 'decision/templates/decision';
+    const firstCreated = (
+      await commands.createCmd.createCard(template, 'decision_6')
+    )[0].key;
+    const lastCreated = (
+      await commands.createCmd.createCard(template, 'decision_6')
+    )[0].key;
+
+    // The two siblings in the order the ranks a solve can see put them.
+    const rankOrder = async () => {
+      const ranked = [];
+      for (const cardKey of [firstCreated, lastCreated]) {
+        ranked.push({ cardKey, rank: (await fieldOf(cardKey, 'rank'))[0] });
+      }
+      return ranked
+        .sort((one, other) => one.rank.localeCompare(other.rank))
+        .map((item) => item.cardKey);
+    };
+    expect(await rankOrder()).toEqual([firstCreated, lastCreated]);
+
+    await commands.moveCmd.rankFirst(lastCreated);
+
+    expect(await rankOrder()).toEqual([lastCreated, firstCreated]);
+  });
+
+  it('stops seeing a card deleted after the last solve', async () => {
+    const before = await cardKeys();
+    expect(before).toContain('decision_6');
+
+    await commands.removeCmd.remove('card', 'decision_6');
+
+    expect(await cardKeys()).toEqual(
+      before.filter((key) => key !== 'decision_6'),
+    );
+  });
+
+  // An edit to a resource that already exists: nothing is added to or removed
+  // from the resource cache, so the resource's own write is the only thing
+  // that can report the change.
+  it('sees an edit to an existing resource made after the last solve', async () => {
+    await cardKeys();
+
+    await commands.updateCmd.apply({
+      kind: 'edit',
+      target: resourceName('decision/workflows/simple'),
+      updateKey: { key: 'displayName' },
+      operation: {
+        name: 'change',
+        target: 'Simple workflow',
+        to: 'Renamed workflow',
+      },
+    });
+
+    const result = await commands.project.calculationEngine.runLogicProgram(
+      'result(Name) :- field("decision/workflows/simple", "displayName", Name).',
+    );
+    expect(result.results.map((item) => item.key)).toEqual([
+      'Renamed workflow',
+    ]);
+  });
+
+  // Removing a resource takes it out of the resource cache; the resource
+  // itself writes nothing, so the cache is the only thing that can report it.
+  it('stops seeing a resource removed after the last solve', async () => {
+    await commands.createCmd.createFieldType('doomedField', 'shortText');
+    const fieldTypes = async () => {
+      const result = await commands.project.calculationEngine.runLogicProgram(
+        'result(Name) :- fieldType(Name).',
+      );
+      return result.results.map((item) => item.key);
+    };
+    expect(await fieldTypes()).toContain('decision/fieldTypes/doomedField');
+
+    await commands.removeCmd.remove(
+      'fieldType',
+      'decision/fieldTypes/doomedField',
+    );
+
+    expect(await fieldTypes()).not.toContain('decision/fieldTypes/doomedField');
+  });
+});
+
+// A calculation's logic program lives in a file next to the resource's
+// metadata rather than in it, so writing it invalidates through a different
+// path.
+describe('a calculation rewritten after the last solve', () => {
+  const baseDir = import.meta.dirname;
+  const testDir = join(baseDir, 'tmp-fact-pull-calculation-tests');
+  const projectPath = join(testDir, 'invalid/invalid-calculations');
+  const validCalcName = 'mini/calculations/validCalc';
+
+  beforeEach(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir('test/test-data/', testDir);
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('is projected before the next solve', async () => {
+    const project = getTestProject(projectPath);
+    await project.populateCaches();
+
+    const fact = async () => {
+      const result = await project.calculationEngine.runLogicProgram(
+        'result(X) :- validCalcFact(X).',
+      );
+      return result.results.map((item) => item.key);
+    };
+    expect(await fact()).toEqual(['42']);
+
+    const calculation = project.resources.byType(validCalcName, 'calculations');
+    await calculation.updateFile('calculation.lp', 'validCalcFact(43).');
+
+    expect(await fact()).toEqual(['43']);
+  });
+});


### PR DESCRIPTION
The calculation engine stops being told about card writes and starts asking for them. Instead of every write pushing its facts into clingo as a side effect, each write records what changed and the next solve pulls it — so a write that is never queried costs nothing, and every path into clingo is serialised through one `pull()`.

What the engine has not yet projected lives in one `FactLog`: the cards whose facts need rebuilding, the cards whose facts must go, and whether the resource programs are stale. It replaces fact tracking that ran in three layers — per-tree sets, a merge in `Project`, a drain callback on the engine — and because the log outlives any individual tree, a tree that is dropped no longer takes its pending removals with it.

Fixes a bug the pull model would otherwise have introduced: an invalidation arriving while a rebuild was running was cleared by that rebuild's own completion, leaving the engine serving stale programs until something else invalidated them. The log carries a revision, and a rebuild only marks itself clean if nothing invalidated it while it ran.

`generate()` keeps its name and its callers, but is now an invalidation followed by a pull rather than a rebuild of its own — one entry point into clingo, not two.
