### PR TITLE
INTDEV-733: Tighten the card tree API

### DIFF
--- a/tools/data-handler/src/commands/create.ts
+++ b/tools/data-handler/src/commands/create.ts
@@ -249,7 +249,7 @@ export class Create {
       return sortItems(rootCards, rankOf).concat(
         childCards.toSorted(
           (a, b) =>
-            compare(a.parent ?? '', b.parent ?? '') ||
+            compare(a.parent, b.parent) ||
             compare(rankOf(a), rankOf(b)) ||
             compare(a.key, b.key),
         ),

--- a/tools/data-handler/src/commands/edit.ts
+++ b/tools/data-handler/src/commands/edit.ts
@@ -87,7 +87,7 @@ export class Edit {
   @write((cardKey) => `Edit content of ${cardKey}`)
   public async editCardContent(cardKey: string, changedContent: string) {
     // A template card has no workflow state, so there is nothing to guard.
-    if (!this.project.treeOf(cardKey).validationApplies) {
+    if (this.project.treeOf(cardKey).kind !== 'project') {
       return this.project.updateCardContent(cardKey, changedContent);
     }
     if (this.project.findCard(cardKey)) {
@@ -117,7 +117,7 @@ export class Edit {
     this.assertFieldIsEditable(card, changedKey, newValue);
 
     // A template card has no workflow state, so there is nothing to guard.
-    if (!this.project.treeOf(cardKey).validationApplies) {
+    if (this.project.treeOf(cardKey).kind !== 'project') {
       return this.project.updateCardMetadataKey(cardKey, changedKey, newValue);
     }
 

--- a/tools/data-handler/src/commands/export.ts
+++ b/tools/data-handler/src/commands/export.ts
@@ -32,6 +32,7 @@ import { preprocessMermaidBlocksForPdf } from '../utils/mermaid-renderer.js';
 import { rewriteAsciidocCardXrefs } from '../utils/asciidoc-xref.js';
 import { getStaticDirectoryPath, pdfReport } from '@cyberismo/assets';
 import { Project } from '../containers/project.js';
+import { ROOT } from '../utils/constants.js';
 import type { QueryResult } from '../types/queries.js';
 import { read } from '../utils/rw-lock.js';
 import type { Show } from './show.js';
@@ -272,6 +273,7 @@ export class Export {
     const card: Card = {
       key: treeQueryResult.key,
       path: '',
+      parent: ROOT,
       children: [],
       attachments: [],
     };
@@ -366,6 +368,7 @@ export class Export {
       cards.push({
         key: cardKey,
         path: sourcePath,
+        parent: ROOT,
         children: [],
         attachments: [],
       });

--- a/tools/data-handler/src/commands/move.ts
+++ b/tools/data-handler/src/commands/move.ts
@@ -92,10 +92,10 @@ export class Move {
 
     const destIsProject =
       movingToProjectRoot ||
-      (destinationTree !== undefined && destinationTree.name === 'project');
+      (destinationTree !== undefined && destinationTree.kind === 'project');
     const destIsTemplate =
       targetTemplateName !== undefined ||
-      (destinationTree !== undefined && destinationTree.name !== 'project');
+      (destinationTree !== undefined && destinationTree.kind !== 'project');
     if (
       (sourceIsTemplate && destIsProject) ||
       (!sourceIsTemplate && destIsTemplate)

--- a/tools/data-handler/src/commands/remove.ts
+++ b/tools/data-handler/src/commands/remove.ts
@@ -12,7 +12,7 @@
 */
 
 import { ActionGuard } from '../permissions/action-guard.js';
-import { isModuleCard, isExternalItemKey } from '../utils/card-utils.js';
+import { isExternalItemKey } from '../utils/card-utils.js';
 import { getChildLogger } from '../utils/log-utils.js';
 import { declaredModules, installedModules } from '../modules/inventory.js';
 import { cleanOrphans } from '../modules/orphans.js';
@@ -74,12 +74,12 @@ export class Remove {
     const card = this.project.findCard(cardKey);
 
     // Imported templates cannot be modified.
-    if (isModuleCard(card)) {
+    if (!this.project.treeOf(cardKey).writable) {
       throw new Error(`Cannot modify imported module`);
     }
 
     // Only a card in a workflow has a delete transition to permit.
-    if (this.project.treeOf(cardKey).validationApplies) {
+    if (this.project.treeOf(cardKey).kind === 'project') {
       const actionGuard = new ActionGuard(this.project.calculationEngine);
       await actionGuard.checkPermission('delete', cardKey);
     }

--- a/tools/data-handler/src/commands/show.ts
+++ b/tools/data-handler/src/commands/show.ts
@@ -21,7 +21,7 @@ import { writeFile } from 'node:fs/promises';
 import { type ModuleListFile, MODULE_LIST_FULL_PATH } from './fetch.js';
 import { installedModules } from '../modules/index.js';
 
-import { CardLocation } from '../interfaces/project-interfaces.js';
+import type { CardLocation } from '../interfaces/project-interfaces.js';
 
 import type { attachmentPayload } from '../interfaces/request-status-interfaces.js';
 import type {
@@ -479,10 +479,7 @@ export class Show {
   @read
   public async showProject(): Promise<ProjectMetadata> {
     const p = this.project;
-    const [cards, modules] = await Promise.all([
-      p.listCards(CardLocation.projectOnly),
-      this.showModules(),
-    ]);
+    const modules = await this.showModules();
     return {
       name: p.projectName,
       path: p.basePath,
@@ -492,7 +489,7 @@ export class Show {
       version: p.configuration.version,
       hubs: p.configuration.hubs,
       modules,
-      numberOfCards: cards[0].cards.length,
+      numberOfCards: p.cardTree.count,
     };
   }
 

--- a/tools/data-handler/src/commands/validate.ts
+++ b/tools/data-handler/src/commands/validate.ts
@@ -37,7 +37,7 @@ import type {
   Workflow,
 } from '../interfaces/resource-interfaces.js';
 import { errorFunction } from '../utils/error-utils.js';
-import { isTemplateCard, sortCards } from '../utils/card-utils.js';
+import { sortCards } from '../utils/card-utils.js';
 import { isPredefinedField } from '../utils/constants.js';
 import { pathExists } from '../utils/file-utils.js';
 import type { Project } from '../containers/project.js';
@@ -591,7 +591,7 @@ export class Validate {
 
         for (const card of cards) {
           if (card.metadata) {
-            if (!isTemplateCard(card)) {
+            if (project.treeOf(card.key).kind === 'project') {
               const validWorkflow = await this.validateWorkflowState(
                 project,
                 card,
@@ -953,7 +953,7 @@ export class Validate {
     }
 
     const cardState = card.metadata?.workflowState;
-    if (!isTemplateCard(card)) {
+    if (project.treeOf(card.key).kind === 'project') {
       const found = workflow.states.find((item) => item.name === cardState);
       if (!found) {
         validationErrors.push(

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -401,7 +401,7 @@ export class Project {
           this.templateTree(
             template.fullName,
             template.templateCardsFolder(),
-          ).reload(),
+          ).load(),
         ),
       );
     } catch (error) {
@@ -422,7 +422,7 @@ export class Project {
    * Populate both the project cards, and all template cards into card cache.
    */
   private async populateCardsCache(): Promise<void> {
-    await this.cardTree.reload();
+    await this.cardTree.load();
     await this.populateTemplateCards();
   }
 

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -587,15 +587,15 @@ export class Project {
     return Project.findProjectRoot(parentPath);
   }
 
-  private async saveCardContent(card: Card): Promise<boolean> {
+  private async saveCardContent(card: Card): Promise<void> {
     return this.treeOf(card.key).writeContent(card);
   }
 
-  private async saveCardMetadata(card: Card): Promise<boolean> {
+  private async saveCardMetadata(card: Card): Promise<void> {
     return this.treeOf(card.key).writeMetadata(card);
   }
 
-  private async removeCard(cardKey: string): Promise<boolean> {
+  private async removeCard(cardKey: string): Promise<void> {
     return this.treeOf(cardKey).deleteSubtree(cardKey);
   }
 
@@ -1080,9 +1080,8 @@ export class Project {
    */
   public async updateCardMetadata(card: Card, changedMetadata: CardMetadata) {
     card.metadata = changedMetadata;
-    if (await this.saveCardMetadata(card)) {
-      await this.handleCardChanged(card);
-    }
+    await this.saveCardMetadata(card);
+    await this.handleCardChanged(card);
   }
 
   // Wrapper to run onTransition query.

--- a/tools/data-handler/src/containers/project.ts
+++ b/tools/data-handler/src/containers/project.ts
@@ -111,9 +111,8 @@ export class Project {
     this.projectCardTree = new CardTree({
       name: 'project',
       rootPath: join(path, 'cardRoot'),
+      kind: 'project',
       writable: true,
-      emitsCardFact: true,
-      validationApplies: true,
       keys: this.keyRegistry,
     });
 
@@ -223,9 +222,8 @@ export class Project {
     const tree = new CardTree({
       name: templateName,
       rootPath,
+      kind: 'template',
       writable: !isModulePath(rootPath),
-      emitsCardFact: false,
-      validationApplies: false,
       keys: this.keyRegistry,
     });
     this.templateCardTrees.set(templateName, tree);
@@ -1062,9 +1060,10 @@ export class Project {
       cardAsRecord[changedKey] = newValue ?? null;
     }
 
-    const invalidCard = this.treeOf(cardKey).validationApplies
-      ? await this.validateCard(card)
-      : '';
+    const invalidCard =
+      this.treeOf(cardKey).kind === 'project'
+        ? await this.validateCard(card)
+        : '';
     if (invalidCard.length !== 0) {
       throw new Error(invalidCard);
     }

--- a/tools/data-handler/src/containers/project/card-tree-scan.ts
+++ b/tools/data-handler/src/containers/project/card-tree-scan.ts
@@ -1,0 +1,250 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+// node
+import type { Dirent } from 'node:fs';
+import { basename, dirname, join, relative, resolve } from 'node:path';
+import { readdir, readFile } from 'node:fs/promises';
+
+import type {
+  CardMetadata,
+  MetadataContent,
+} from '../../interfaces/project-interfaces.js';
+import { CardNameRegEx } from '../../interfaces/project-interfaces.js';
+import { getChildLogger } from '../../utils/log-utils.js';
+import { ROOT } from '../../utils/constants.js';
+
+// A card's own files, inside its folder.
+export const CARD_CONTENT_FILE = 'index.adoc';
+export const CARD_METADATA_FILE = 'index.json';
+// A card's attachment folder, inside its folder.
+export const ATTACHMENT_FOLDER = 'a';
+// A card's children live in this folder, inside its folder.
+export const CHILDREN_FOLDER = 'c';
+
+// An attachment as the tree stores it: the file's name, and the folder it
+// sits in relative to its card's attachment folder (empty for the common
+// case). Its full path is derived from its card's.
+export interface StoredAttachment {
+  fileName: string;
+  dir: string;
+}
+
+// A card as the tree stores it: identity, tree position and the card's own
+// data. No path: a card's folder is derived from the edges and the tree's
+// root folder (see pathOf).
+export interface StoredCard {
+  key: string;
+  parent: string;
+  children: string[];
+  metadata?: CardMetadata;
+  content?: string;
+  attachments: StoredAttachment[];
+}
+
+// Stored metadata is frozen; node-level reads share it. Always a fresh
+// object, so the tree never aliases metadata its producer still holds.
+export function normalizedMetadata(
+  metadata?: CardMetadata,
+): CardMetadata | undefined {
+  if (!metadata) {
+    return metadata;
+  }
+  const stored: Record<string, MetadataContent> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    stored[key] = Array.isArray(value) ? frozenList(value) : value;
+  }
+  if (!Array.isArray(stored.links)) {
+    stored.links = frozenList([]);
+  }
+  return Object.freeze(stored) as CardMetadata;
+}
+
+// 'links' and 'externalLinks' hold objects, so the elements are frozen too.
+function frozenList(values: unknown[]): MetadataContent {
+  return Object.freeze(
+    values.map((item) =>
+      item !== null && typeof item === 'object'
+        ? Object.freeze({ ...item })
+        : item,
+    ),
+  ) as MetadataContent;
+}
+
+const logger = getChildLogger({ module: 'cardTree' });
+
+// Gets all directory entries recursively.
+async function entries(path: string): Promise<Dirent[]> {
+  try {
+    return await readdir(path, { withFileTypes: true, recursive: true });
+  } catch (error) {
+    logger.error({ error }, 'Reading entries');
+    return [];
+  }
+}
+
+// Every card's attachment listing, taken out of the one recursive sweep the
+// load already has; going back to disk per card read the same directories a
+// second time.
+function attachmentsByCard(
+  allEntries: Dirent[],
+  cardFolders: Map<string, string>,
+  root: string,
+): Map<string, StoredAttachment[]> {
+  const attachments = new Map<string, StoredAttachment[]>();
+  const seen = new Set<string>();
+
+  for (const entry of allEntries) {
+    const owner = attachmentOwner(entry, cardFolders, root);
+    if (!owner) {
+      continue;
+    }
+    const dir = relative(owner.attachmentFolder, entry.parentPath);
+    const attachmentKey = `${owner.cardKey}:${dir}:${entry.name}`;
+    if (seen.has(attachmentKey)) {
+      logger.warn(
+        `Duplicate attachment found during cache population: ${entry.name} for card ${owner.cardKey}`,
+      );
+      continue;
+    }
+    seen.add(attachmentKey);
+    const attachment: StoredAttachment = { fileName: entry.name, dir };
+    const listing = attachments.get(owner.cardKey);
+    if (listing) {
+      listing.push(attachment);
+    } else {
+      attachments.set(owner.cardKey, [attachment]);
+    }
+  }
+
+  return attachments;
+}
+
+// Which card an entry is an attachment of: walks the entry's folder up to
+// the tree root looking for an attachment folder that belongs to a card.
+// Returns undefined when the entry is not inside one.
+function attachmentOwner(
+  entry: Dirent,
+  cardFolders: Map<string, string>,
+  root: string,
+): { cardKey: string; attachmentFolder: string } | undefined {
+  let folder = resolve(entry.parentPath);
+  while (folder !== root) {
+    const parent = dirname(folder);
+    if (parent === folder) {
+      return undefined;
+    }
+    if (basename(folder) === ATTACHMENT_FOLDER) {
+      const cardKey = cardFolders.get(parent);
+      if (cardKey) {
+        return { cardKey, attachmentFolder: folder };
+      }
+    }
+    folder = parent;
+  }
+  return undefined;
+}
+
+// Gets content from disk.
+async function fetchContent(currentPath: string): Promise<string> {
+  return readFile(join(currentPath, CARD_CONTENT_FILE), {
+    encoding: 'utf-8',
+  });
+}
+
+// Gets metadata from disk.
+async function fetchMetadata(currentPath: string): Promise<string> {
+  return readFile(join(currentPath, CARD_METADATA_FILE), {
+    encoding: 'utf-8',
+  });
+}
+
+/**
+ * Reads the cards under a tree's root folder from disk. A card's parent comes
+ * from where its folder sits: directly under the root it is a root card,
+ * anywhere else it is in its parent's 'c' folder.
+ * @param rootPath Folder the tree's cards are rooted at.
+ * @param treeName Tree the cards are read for; names the scan in the log.
+ */
+export async function scanCardTree(
+  rootPath: string,
+  treeName: string,
+): Promise<StoredCard[]> {
+  const root = resolve(rootPath);
+  const allEntries = await entries(rootPath);
+  const cardEntries = allEntries.filter(
+    (entry) => entry.isDirectory() && CardNameRegEx.test(entry.name),
+  );
+
+  // Card folder -> card key, so an entry can be traced back to the card
+  // whose attachment folder it sits in.
+  const cardFolders = new Map<string, string>(
+    cardEntries.map((entry) => [
+      resolve(join(entry.parentPath, entry.name)),
+      entry.name,
+    ]),
+  );
+  const attachments = attachmentsByCard(allEntries, cardFolders, root);
+  const loadedKeys = new Set(cardEntries.map((entry) => entry.name));
+
+  const cardPromises = cardEntries.map(async (entry) => {
+    const currentPath = join(entry.parentPath, entry.name);
+    const parentFolder = resolve(entry.parentPath);
+    const parent =
+      parentFolder === root ? ROOT : basename(dirname(parentFolder));
+    // A card folder reached through anything but a card's 'c' folder has no
+    // parent to derive its path from, so the load refuses it by name.
+    if (
+      parent !== ROOT &&
+      (basename(parentFolder) !== CHILDREN_FOLDER || !loadedKeys.has(parent))
+    ) {
+      throw new Error(
+        `Card folder '${currentPath}' is not inside a card's '${CHILDREN_FOLDER}' folder`,
+      );
+    }
+
+    const [cardContent, cardMetadata] = await Promise.all([
+      fetchContent(currentPath),
+      fetchMetadata(currentPath),
+    ]);
+
+    let metadata;
+    try {
+      metadata = JSON.parse(cardMetadata);
+    } catch (error) {
+      const metadataPath = join(currentPath, CARD_METADATA_FILE);
+      logger.error(
+        { error, metadataPath, tree: treeName },
+        `Incorrect card metadata file`,
+      );
+      if (error instanceof Error) {
+        throw new Error(
+          `Invalid JSON in file '${metadataPath}': ${error.message}`,
+          { cause: error },
+        );
+      }
+      throw error;
+    }
+
+    return {
+      key: entry.name,
+      children: [],
+      attachments: attachments.get(entry.name) ?? [],
+      content: cardContent,
+      metadata: normalizedMetadata(metadata),
+      parent,
+    };
+  });
+
+  return Promise.all(cardPromises);
+}

--- a/tools/data-handler/src/containers/project/card-tree.ts
+++ b/tools/data-handler/src/containers/project/card-tree.ts
@@ -1165,53 +1165,41 @@ export class CardTree {
   }
 
   /**
-   * Persists a card's content, and keeps the store in step with it.
+   * Persists a card's content, and keeps the store in step with it. A card
+   * carrying no content is left alone.
    * @param card Card to persist.
-   * @returns true if the store was updated; false if the card has no content,
-   *   or the tree does not hold it.
+   * @throws CardNotFoundError if the tree does not hold the card
    */
-  public async writeContent(card: Card): Promise<boolean> {
+  public async writeContent(card: Card): Promise<void> {
     this.assertWritable();
     if (card.content == null) {
-      return false;
+      return;
     }
-    const stored = this.cardStore.get(card.key);
-    if (!stored) {
-      CardTree.logger.warn(`Card '${card.key}' not found`);
-      return false;
-    }
+    const stored = this.stored(card.key);
     await writeFile(
       join(this.pathOfStored(stored), CARD_CONTENT_FILE),
       card.content,
     );
     stored.content = card.content;
-    return true;
   }
 
   /**
    * Persists a card's metadata, and keeps the store in step with it. Stamps
-   * 'lastUpdated'.
+   * 'lastUpdated'. A card carrying no metadata is left alone.
    * @param card Card to persist.
-   * @returns true if the store was updated; false if the card has no metadata,
-   *   or the tree does not hold it.
-   * @throws if the metadata file cannot be written.
+   * @throws CardNotFoundError if the tree does not hold the card
    */
-  public async writeMetadata(card: Card): Promise<boolean> {
+  public async writeMetadata(card: Card): Promise<void> {
     this.assertWritable();
-    const stored = this.cardStore.get(card.key);
-    if (!stored) {
-      CardTree.logger.warn(`Card '${card.key}' not found`);
-      return false;
-    }
+    const stored = this.stored(card.key);
     const sanitizedMetadata = await this.persistMetadata(
       card,
       this.pathOfStored(stored),
     );
     if (!sanitizedMetadata) {
-      return false;
+      return;
     }
     stored.metadata = CardTree.normalizedMetadata(sanitizedMetadata);
-    return true;
   }
 
   // Writes the card's metadata file and stamps 'lastUpdated'. The store is
@@ -1236,13 +1224,10 @@ export class CardTree {
    * store. Children go first, so a failure part-way leaves no card whose
    * folder is gone but whose parent's is not.
    * @param cardKey Root of the subtree to delete.
-   * @returns true if the card was in the tree; false otherwise.
+   * @throws CardNotFoundError if the tree does not hold the card
    */
-  public async deleteSubtree(cardKey: string): Promise<boolean> {
-    const card = this.cardStore.get(cardKey);
-    if (!card) {
-      return false;
-    }
+  public async deleteSubtree(cardKey: string): Promise<void> {
+    const card = this.stored(cardKey);
     this.assertWritable();
     const path = this.pathOfStored(card);
     for (const child of this.childrenOf(cardKey)) {
@@ -1250,7 +1235,7 @@ export class CardTree {
     }
     await deleteDir(path);
     this.options.keys.release([cardKey]);
-    return this.unstore(cardKey);
+    this.unstore(cardKey);
   }
 
   /**

--- a/tools/data-handler/src/containers/project/card-tree.ts
+++ b/tools/data-handler/src/containers/project/card-tree.ts
@@ -1376,11 +1376,14 @@ export class CardTree {
   }
 
   /**
-   * Loads the tree's cards from its root folder.
-   * @throws DuplicateCardKeyError if a loaded card key is already held by any
-   *   tree
+   * Loads the tree's cards from its root folder, replacing whatever it holds.
+   * @throws DuplicateCardKeyError if a loaded card key is already held by
+   *   another tree
    */
   public async load(): Promise<void> {
+    // Evict before loading: reloaded cards keep their keys, and the store
+    // rejects a key it already holds.
+    this.clear();
     const cards = await this.loadEntries();
     this.options.keys.claim(
       cards.map((card) => card.key),
@@ -1400,16 +1403,5 @@ export class CardTree {
     this.populated = false;
     this.cardStore.clear();
     this.childrenIndex.clear();
-  }
-
-  /**
-   * Reloads the tree's cards from disk.
-   *
-   * Evict before loading: reloaded cards keep their keys and the store rejects
-   * a key it already holds.
-   */
-  public async reload(): Promise<void> {
-    this.clear();
-    await this.load();
   }
 }

--- a/tools/data-handler/src/containers/project/card-tree.ts
+++ b/tools/data-handler/src/containers/project/card-tree.ts
@@ -680,7 +680,7 @@ export class CardTree {
   public rootCards(): Card[] {
     const rootCards: Card[] = [];
     for (const card of this.cardStore.values()) {
-      if (card.parent === ROOT || !card.parent) {
+      if (card.parent === ROOT) {
         rootCards.push(this.cardView(card));
       }
     }

--- a/tools/data-handler/src/containers/project/card-tree.ts
+++ b/tools/data-handler/src/containers/project/card-tree.ts
@@ -83,22 +83,21 @@ const ATTACHMENT_FOLDER = 'a';
 const CHILDREN_FOLDER = 'c';
 
 /**
- * How one card tree differs from another.
- *
- * name - the tree's identity: 'project', or a template's full resource name.
- * rootPath - the folder the tree's cards are rooted at.
- * writable - whether the tree accepts writes.
- * emitsCardFact - whether the tree's cards get the card(Key) fact.
- * validationApplies - whether the tree's cards take part in workflow
- *   semantics: metadata validation, and the permissions built on it.
- * keys - the project-level card key registry.
+ * Which kind of cards a tree holds. Project cards take part in workflow
+ * semantics and get the card(Key) fact; template cards do neither.
+ */
+export type CardTreeKind = 'project' | 'template';
+
+/**
+ * How one card tree differs from another. 'name' is the tree's identity:
+ * 'project', or a template's full resource name. 'keys' is the project-level
+ * card key registry the tree shares with its siblings.
  */
 export interface CardTreeOptions {
   name: string;
   rootPath: string;
+  kind: CardTreeKind;
   writable: boolean;
-  emitsCardFact: boolean;
-  validationApplies: boolean;
   keys: CardKeyRegistry;
 }
 
@@ -530,18 +529,17 @@ export class CardTree {
   }
 
   /**
-   * Whether the tree's cards take part in workflow semantics: metadata
-   * validation, and the permissions built on it.
+   * Which kind of cards the tree holds.
    */
-  public get validationApplies(): boolean {
-    return this.options.validationApplies;
+  public get kind(): CardTreeKind {
+    return this.options.kind;
   }
 
   /**
    * How the tree's cards are projected into clingo facts.
    */
   public get factContext(): CardFactContext {
-    return { emitsCardFact: this.options.emitsCardFact, name: this.treeName };
+    return { kind: this.options.kind, name: this.treeName };
   }
 
   /**

--- a/tools/data-handler/src/containers/project/card-tree.ts
+++ b/tools/data-handler/src/containers/project/card-tree.ts
@@ -12,14 +12,11 @@
 */
 
 // node
-import type { Dirent } from 'node:fs';
-import { basename, dirname, join, relative, resolve, sep } from 'node:path';
+import { basename, dirname, join, resolve, sep } from 'node:path';
 import {
   constants as fsConstants,
   copyFile,
   mkdir,
-  readdir,
-  readFile,
   rename,
   rm,
   rmdir,
@@ -34,9 +31,7 @@ import type {
   CardAttachment,
   CardMetadata,
   CardNode,
-  MetadataContent,
 } from '../../interfaces/project-interfaces.js';
-import { CardNameRegEx } from '../../interfaces/project-interfaces.js';
 import { CardNotFoundError } from '../../exceptions/index.js';
 import { copyDir, deleteDir, pathExists } from '../../utils/file-utils.js';
 import { getChildLogger } from '../../utils/log-utils.js';
@@ -46,41 +41,27 @@ import {
   EMPTY_RANK,
   FIRST_RANK,
   getRankAfter,
-  getRankBetween,
-  rebalanceRanks,
   sortItems,
 } from '../../utils/lexorank.js';
+import {
+  ATTACHMENT_FOLDER,
+  CARD_CONTENT_FILE,
+  CARD_METADATA_FILE,
+  CHILDREN_FOLDER,
+  normalizedMetadata,
+  scanCardTree,
+} from './card-tree-scan.js';
+import {
+  planAfter,
+  planFirst,
+  planRebalance,
+  planRebalanceSubtree,
+} from './rank-plan.js';
 
+import type { StoredAttachment, StoredCard } from './card-tree-scan.js';
+import type { RankChange, RankedCard } from './rank-plan.js';
 import type { CardFactContext } from '../../utils/clingo-facts.js';
 import type { CardKeyRegistry } from './card-keys.js';
-
-// An attachment as the tree stores it: the file's name, and the folder it
-// sits in relative to its card's attachment folder (empty for the common
-// case). Its full path is derived from its card's.
-interface StoredAttachment {
-  fileName: string;
-  dir: string;
-}
-
-// A card as the tree stores it: identity, tree position and the card's own
-// data. No path: a card's folder is derived from the edges and the tree's
-// root folder (see pathOf).
-interface StoredCard {
-  key: string;
-  parent: string;
-  children: string[];
-  metadata?: CardMetadata;
-  content?: string;
-  attachments: StoredAttachment[];
-}
-
-// A card's own files, inside its folder.
-const CARD_CONTENT_FILE = 'index.adoc';
-const CARD_METADATA_FILE = 'index.json';
-// A card's attachment folder, inside its folder.
-const ATTACHMENT_FOLDER = 'a';
-// A card's children live in this folder, inside its folder.
-const CHILDREN_FOLDER = 'c';
 
 /**
  * Which kind of cards a tree holds. Project cards take part in workflow
@@ -99,11 +80,6 @@ export interface CardTreeOptions {
   kind: CardTreeKind;
   writable: boolean;
   keys: CardKeyRegistry;
-}
-
-interface RankChange {
-  cardKey: string;
-  rank: string;
 }
 
 /**
@@ -232,35 +208,6 @@ export class CardTree {
     }
   }
 
-  // Stored metadata is frozen; node-level reads share it. Always a fresh
-  // object, so the tree never aliases metadata its producer still holds.
-  private static normalizedMetadata(
-    metadata?: CardMetadata,
-  ): CardMetadata | undefined {
-    if (!metadata) {
-      return metadata;
-    }
-    const stored: Record<string, MetadataContent> = {};
-    for (const [key, value] of Object.entries(metadata)) {
-      stored[key] = Array.isArray(value) ? CardTree.frozenList(value) : value;
-    }
-    if (!Array.isArray(stored.links)) {
-      stored.links = CardTree.frozenList([]);
-    }
-    return Object.freeze(stored) as CardMetadata;
-  }
-
-  // 'links' and 'externalLinks' hold objects, so the elements are frozen too.
-  private static frozenList(values: unknown[]): MetadataContent {
-    return Object.freeze(
-      values.map((item) =>
-        item !== null && typeof item === 'object'
-          ? Object.freeze({ ...item })
-          : item,
-      ),
-    ) as MetadataContent;
-  }
-
   // Identity and tree position. The frozen metadata is shared with the store;
   // 'children' is copied.
   private nodeView(card: StoredCard): CardNode {
@@ -303,169 +250,6 @@ export class CardTree {
       fileName: attachment.fileName,
       mimeType: mime.lookup(attachment.fileName) || null,
     };
-  }
-
-  // Gets all directory entries recursively.
-  private async entries(path: string): Promise<Dirent[]> {
-    try {
-      return await readdir(path, { withFileTypes: true, recursive: true });
-    } catch (error) {
-      CardTree.logger.error({ error }, 'Reading entries');
-      return [];
-    }
-  }
-
-  // Every card's attachment listing, taken out of the one recursive sweep the
-  // load already has; going back to disk per card read the same directories a
-  // second time.
-  private static attachmentsByCard(
-    allEntries: Dirent[],
-    cardFolders: Map<string, string>,
-    root: string,
-  ): Map<string, StoredAttachment[]> {
-    const attachments = new Map<string, StoredAttachment[]>();
-    const seen = new Set<string>();
-
-    for (const entry of allEntries) {
-      const owner = CardTree.attachmentOwner(entry, cardFolders, root);
-      if (!owner) {
-        continue;
-      }
-      const dir = relative(owner.attachmentFolder, entry.parentPath);
-      const attachmentKey = `${owner.cardKey}:${dir}:${entry.name}`;
-      if (seen.has(attachmentKey)) {
-        CardTree.logger.warn(
-          `Duplicate attachment found during cache population: ${entry.name} for card ${owner.cardKey}`,
-        );
-        continue;
-      }
-      seen.add(attachmentKey);
-      const attachment: StoredAttachment = { fileName: entry.name, dir };
-      const listing = attachments.get(owner.cardKey);
-      if (listing) {
-        listing.push(attachment);
-      } else {
-        attachments.set(owner.cardKey, [attachment]);
-      }
-    }
-
-    return attachments;
-  }
-
-  // Which card an entry is an attachment of: walks the entry's folder up to
-  // the tree root looking for an attachment folder that belongs to a card.
-  // Returns undefined when the entry is not inside one.
-  private static attachmentOwner(
-    entry: Dirent,
-    cardFolders: Map<string, string>,
-    root: string,
-  ): { cardKey: string; attachmentFolder: string } | undefined {
-    let folder = resolve(entry.parentPath);
-    while (folder !== root) {
-      const parent = dirname(folder);
-      if (parent === folder) {
-        return undefined;
-      }
-      if (basename(folder) === ATTACHMENT_FOLDER) {
-        const cardKey = cardFolders.get(parent);
-        if (cardKey) {
-          return { cardKey, attachmentFolder: folder };
-        }
-      }
-      folder = parent;
-    }
-    return undefined;
-  }
-
-  // Gets content from disk.
-  private async fetchContent(currentPath: string): Promise<string> {
-    return readFile(join(currentPath, CARD_CONTENT_FILE), {
-      encoding: 'utf-8',
-    });
-  }
-
-  // Gets metadata from disk.
-  private async fetchMetadata(currentPath: string): Promise<string> {
-    return readFile(join(currentPath, CARD_METADATA_FILE), {
-      encoding: 'utf-8',
-    });
-  }
-
-  // Reads the cards under the tree's root folder from disk. A card's parent
-  // comes from where its folder sits: directly under the root it is a root
-  // card, anywhere else it is in its parent's 'c' folder.
-  private async loadEntries(): Promise<StoredCard[]> {
-    const root = resolve(this.treeRoot);
-    const allEntries = await this.entries(this.treeRoot);
-    const cardEntries = allEntries.filter(
-      (entry) => entry.isDirectory() && CardNameRegEx.test(entry.name),
-    );
-
-    // Card folder -> card key, so an entry can be traced back to the card
-    // whose attachment folder it sits in.
-    const cardFolders = new Map<string, string>(
-      cardEntries.map((entry) => [
-        resolve(join(entry.parentPath, entry.name)),
-        entry.name,
-      ]),
-    );
-    const attachments = CardTree.attachmentsByCard(
-      allEntries,
-      cardFolders,
-      root,
-    );
-    const loadedKeys = new Set(cardEntries.map((entry) => entry.name));
-
-    const cardPromises = cardEntries.map(async (entry) => {
-      const currentPath = join(entry.parentPath, entry.name);
-      const parentFolder = resolve(entry.parentPath);
-      const parent =
-        parentFolder === root ? ROOT : basename(dirname(parentFolder));
-      // A card folder reached through anything but a card's 'c' folder has no
-      // parent to derive its path from, so the load refuses it by name.
-      if (
-        parent !== ROOT &&
-        (basename(parentFolder) !== CHILDREN_FOLDER || !loadedKeys.has(parent))
-      ) {
-        throw new Error(
-          `Card folder '${currentPath}' is not inside a card's '${CHILDREN_FOLDER}' folder`,
-        );
-      }
-
-      const [cardContent, cardMetadata] = await Promise.all([
-        this.fetchContent(currentPath),
-        this.fetchMetadata(currentPath),
-      ]);
-
-      let metadata;
-      try {
-        metadata = JSON.parse(cardMetadata);
-      } catch (error) {
-        const metadataPath = join(currentPath, CARD_METADATA_FILE);
-        CardTree.logger.error(
-          { error, metadataPath },
-          `Incorrect card metadata file`,
-        );
-        if (error instanceof Error) {
-          throw new Error(
-            `Invalid JSON in file '${metadataPath}': ${error.message}`,
-            { cause: error },
-          );
-        }
-        throw error;
-      }
-
-      return {
-        key: entry.name,
-        children: [],
-        attachments: attachments.get(entry.name) ?? [],
-        content: cardContent,
-        metadata: CardTree.normalizedMetadata(metadata),
-        parent,
-      };
-    });
-
-    return Promise.all(cardPromises);
   }
 
   // Removes non-metadata fields that should not be persisted.
@@ -744,17 +528,21 @@ export class CardTree {
    * @throws CardNotFoundError if the tree does not hold the card
    */
   public siblingsOf(cardKey: string): string[] {
+    return this.rankedSiblingsOf(cardKey).map((sibling) => sibling.key);
+  }
+
+  // The card's sibling set with ranks, in rank order.
+  private rankedSiblingsOf(cardKey: string): RankedCard[] {
     return this.siblingsUnder(this.stored(cardKey).parent);
   }
 
-  // The keys under a parent, in rank order. 'root' means the tree's root
-  // cards.
-  private siblingsUnder(parentKey: string): string[] {
-    const siblings = this.childrenOf(parentKey).map((key) => this.stored(key));
-    return sortItems(
-      siblings,
-      (card) => this.rankOf(card.key) ?? EMPTY_RANK,
-    ).map((card) => card.key);
+  // The cards under a parent with their ranks, in rank order. 'root' means
+  // the tree's root cards.
+  private siblingsUnder(parentKey: string): RankedCard[] {
+    const siblings = this.childrenOf(parentKey)
+      .map((key) => this.stored(key))
+      .map((card) => ({ key: card.key, rank: this.rankOf(card.key) }));
+    return sortItems(siblings, (sibling) => sibling.rank ?? EMPTY_RANK);
   }
 
   // The rank a card holds, or undefined for none. '' and EMPTY_RANK both mean
@@ -770,7 +558,7 @@ export class CardTree {
 
   private lastRankUnder(parentKey: string): string | undefined {
     return this.siblingsUnder(parentKey)
-      .map((key) => this.rankOf(key))
+      .map((sibling) => sibling.rank)
       .findLast((rank) => rank !== undefined);
   }
 
@@ -801,7 +589,11 @@ export class CardTree {
    * @throws CardNotFoundError if the tree does not hold either card
    */
   public async reorderAfter(cardKey: string, afterKey: string): Promise<void> {
-    await this.applyRanks(this.planAfter(cardKey, afterKey));
+    // The plan is built from afterKey's siblings, which need not hold cardKey.
+    this.stored(cardKey);
+    await this.applyRanks(
+      planAfter(this.rankedSiblingsOf(afterKey), cardKey, afterKey),
+    );
   }
 
   /**
@@ -811,7 +603,7 @@ export class CardTree {
    * @throws CardNotFoundError if the tree does not hold the card
    */
   public async reorderFirst(cardKey: string): Promise<void> {
-    await this.applyRanks(this.planFirst(cardKey));
+    await this.applyRanks(planFirst(this.rankedSiblingsOf(cardKey), cardKey));
   }
 
   /**
@@ -820,7 +612,7 @@ export class CardTree {
    * @param parentKey Parent whose children to rebalance, or 'root'.
    */
   public async rebalanceChildren(parentKey: string): Promise<void> {
-    await this.applyRanks(this.planRebalance(parentKey));
+    await this.applyRanks(planRebalance(this.siblingsUnder(parentKey)));
   }
 
   /**
@@ -828,78 +620,11 @@ export class CardTree {
    * level by level, and persists them.
    */
   public async rebalanceAll(): Promise<void> {
-    await this.applyRanks(this.planRebalanceSubtree(ROOT));
-  }
-
-  private planAfter(cardKey: string, afterKey: string): RankChange[] {
-    this.stored(cardKey);
-    const siblings = this.siblingsOf(afterKey);
-    const index = siblings.indexOf(afterKey);
-    return this.withUsableRanks(siblings, (rankAt) =>
-      index === siblings.length - 1
-        ? [{ cardKey, rank: getRankAfter(rankAt(index)) }]
-        : [{ cardKey, rank: getRankBetween(rankAt(index), rankAt(index + 1)) }],
+    await this.applyRanks(
+      planRebalanceSubtree(this.siblingsUnder(ROOT), (cardKey) =>
+        this.siblingsUnder(cardKey),
+      ),
     );
-  }
-
-  private planFirst(cardKey: string): RankChange[] {
-    const siblings = this.siblingsOf(cardKey);
-    const firstKey = siblings[0];
-    if (firstKey === cardKey && this.rankOf(cardKey)) {
-      return [];
-    }
-    if (this.rankOf(firstKey) !== FIRST_RANK) {
-      return [{ cardKey, rank: FIRST_RANK }];
-    }
-    return this.withUsableRanks(siblings, (rankAt) => [
-      { cardKey: firstKey, rank: getRankBetween(rankAt(0), rankAt(1)) },
-      { cardKey, rank: FIRST_RANK },
-    ]);
-  }
-
-  private planRebalance(parentKey: string): RankChange[] {
-    const siblings = this.siblingsUnder(parentKey);
-    const ranks = rebalanceRanks(siblings.length);
-    return siblings.map((cardKey, index) => ({ cardKey, rank: ranks[index] }));
-  }
-
-  private planRebalanceSubtree(parentKey: string): RankChange[] {
-    const changes = this.planRebalance(parentKey);
-    for (const change of [...changes]) {
-      if (this.childrenOf(change.cardKey).length > 0) {
-        changes.push(...this.planRebalanceSubtree(change.cardKey));
-      }
-    }
-    return changes;
-  }
-
-  // Runs a rank computation against the sibling ranks. A drifted set - a
-  // missing rank, a duplicate or inverted pair - is rebalanced first and the
-  // computation rerun against the repair, which is prepended to the changes.
-  private withUsableRanks(
-    siblings: string[],
-    compute: (rankAt: (index: number) => string) => RankChange[],
-  ): RankChange[] {
-    const ranks = siblings.map((key) => this.rankOf(key));
-    if (ranks.every((rank) => rank !== undefined)) {
-      try {
-        return compute((index) => ranks[index]!);
-      } catch (error) {
-        // Drifted ranks; fall through to the rebalance and retry. A TypeError
-        // is the arithmetic's own failure, not drift.
-        if (error instanceof TypeError) {
-          throw error;
-        }
-      }
-    }
-    const rebalanced = rebalanceRanks(siblings.length);
-    return [
-      ...siblings.map((cardKey, index) => ({
-        cardKey,
-        rank: rebalanced[index],
-      })),
-      ...compute((index) => rebalanced[index]),
-    ];
   }
 
   private async applyRanks(changes: RankChange[]): Promise<void> {
@@ -920,7 +645,7 @@ export class CardTree {
       join(this.pathOfStored(stored), CARD_METADATA_FILE),
       metadata,
     );
-    stored.metadata = CardTree.normalizedMetadata(metadata);
+    stored.metadata = normalizedMetadata(metadata);
   }
 
   /**
@@ -985,7 +710,7 @@ export class CardTree {
         key: card.key,
         parent: card.parent,
         children: [],
-        metadata: CardTree.normalizedMetadata(card.metadata),
+        metadata: normalizedMetadata(card.metadata),
         content: card.content,
         attachments: card.attachments.map((attachment) => ({
           fileName: attachment.fileName,
@@ -1199,7 +924,7 @@ export class CardTree {
     if (!sanitizedMetadata) {
       return;
     }
-    stored.metadata = CardTree.normalizedMetadata(sanitizedMetadata);
+    stored.metadata = normalizedMetadata(sanitizedMetadata);
   }
 
   // Writes the card's metadata file and stamps 'lastUpdated'. The store is
@@ -1384,7 +1109,7 @@ export class CardTree {
     // Evict before loading: reloaded cards keep their keys, and the store
     // rejects a key it already holds.
     this.clear();
-    const cards = await this.loadEntries();
+    const cards = await scanCardTree(this.treeRoot, this.treeName);
     this.options.keys.claim(
       cards.map((card) => card.key),
       this,

--- a/tools/data-handler/src/containers/project/rank-plan.ts
+++ b/tools/data-handler/src/containers/project/rank-plan.ts
@@ -1,0 +1,132 @@
+/**
+  Cyberismo
+  Copyright © Cyberismo Ltd and contributors 2026
+  This program is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Affero General Public License version 3 as published by
+  the Free Software Foundation. This program is distributed in the hope that it
+  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public
+  License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import {
+  FIRST_RANK,
+  getRankAfter,
+  getRankBetween,
+  rebalanceRanks,
+} from '../../utils/lexorank.js';
+
+// A sibling set the planners work over, in rank order. 'rank' is undefined
+// for a card that has none the arithmetic can extend.
+export interface RankedCard {
+  key: string;
+  rank?: string;
+}
+
+export interface RankChange {
+  cardKey: string;
+  rank: string;
+}
+
+/**
+ * Ranks that place a card immediately after one of its siblings.
+ * @param siblings The card's sibling set, the card itself included.
+ * @param cardKey Card to rank.
+ * @param afterKey Sibling to place it after.
+ */
+export function planAfter(
+  siblings: RankedCard[],
+  cardKey: string,
+  afterKey: string,
+): RankChange[] {
+  const index = siblings.findIndex((sibling) => sibling.key === afterKey);
+  return withUsableRanks(siblings, (rankAt) =>
+    index === siblings.length - 1
+      ? [{ cardKey, rank: getRankAfter(rankAt(index)) }]
+      : [{ cardKey, rank: getRankBetween(rankAt(index), rankAt(index + 1)) }],
+  );
+}
+
+/**
+ * Ranks that place a card first among its siblings. Freeing the first rank
+ * may take demoting whoever holds it.
+ * @param siblings The card's sibling set, the card itself included.
+ * @param cardKey Card to rank.
+ */
+export function planFirst(
+  siblings: RankedCard[],
+  cardKey: string,
+): RankChange[] {
+  const first = siblings[0];
+  if (first.key === cardKey && first.rank) {
+    return [];
+  }
+  if (first.rank !== FIRST_RANK) {
+    return [{ cardKey, rank: FIRST_RANK }];
+  }
+  return withUsableRanks(siblings, (rankAt) => [
+    { cardKey: first.key, rank: getRankBetween(rankAt(0), rankAt(1)) },
+    { cardKey, rank: FIRST_RANK },
+  ]);
+}
+
+/**
+ * Ranks that spread a sibling set evenly across the rank space.
+ */
+export function planRebalance(siblings: RankedCard[]): RankChange[] {
+  const ranks = rebalanceRanks(siblings.length);
+  return siblings.map((sibling, index) => ({
+    cardKey: sibling.key,
+    rank: ranks[index],
+  }));
+}
+
+/**
+ * Ranks that spread a sibling set and everything below it evenly across the
+ * rank space, level by level.
+ * @param siblings Sibling set to start from.
+ * @param childrenOf The sibling set under a card, in rank order.
+ */
+export function planRebalanceSubtree(
+  siblings: RankedCard[],
+  childrenOf: (cardKey: string) => RankedCard[],
+): RankChange[] {
+  const changes = planRebalance(siblings);
+  for (const change of [...changes]) {
+    changes.push(
+      ...planRebalanceSubtree(childrenOf(change.cardKey), childrenOf),
+    );
+  }
+  return changes;
+}
+
+// Runs a rank computation against the sibling ranks. A drifted set - a
+// missing rank, a duplicate or inverted pair - is rebalanced first and the
+// computation rerun against the repair, which is prepended to the changes.
+function withUsableRanks(
+  siblings: RankedCard[],
+  compute: (rankAt: (index: number) => string) => RankChange[],
+): RankChange[] {
+  const ranks = siblings.map((sibling) => sibling.rank);
+  if (ranks.every((rank) => rank !== undefined)) {
+    try {
+      return compute((index) => ranks[index]!);
+    } catch (error) {
+      // Drifted ranks; fall through to the rebalance and retry. A TypeError
+      // is the arithmetic's own failure, not drift.
+      if (error instanceof TypeError) {
+        throw error;
+      }
+    }
+  }
+  const rebalanced = rebalanceRanks(siblings.length);
+  return [
+    ...siblings.map((sibling, index) => ({
+      cardKey: sibling.key,
+      rank: rebalanced[index],
+    })),
+    ...compute((index) => rebalanced[index]),
+  ];
+}

--- a/tools/data-handler/src/containers/project/template-instantiation.ts
+++ b/tools/data-handler/src/containers/project/template-instantiation.ts
@@ -160,7 +160,7 @@ function instantiate(
     throw new Error(`Template card '${templateCard.key}' has no metadata`);
   }
   const templateParentKey = templateCard.parent;
-  const isTemplateRootCard = !templateParentKey || templateParentKey === ROOT;
+  const isTemplateRootCard = templateParentKey === ROOT;
   const key = cardKeyMap.get(templateCard.key) ?? templateCard.key;
 
   const attachments: NewCard['attachments'] = [];

--- a/tools/data-handler/src/interfaces/project-interfaces.ts
+++ b/tools/data-handler/src/interfaces/project-interfaces.ts
@@ -25,7 +25,7 @@ export interface Card {
   path: string;
   content?: string;
   metadata?: CardMetadata;
-  parent?: string;
+  parent: string;
   children: string[];
   attachments: CardAttachment[];
 }

--- a/tools/data-handler/src/mutations/handlers/field-type-data-type.ts
+++ b/tools/data-handler/src/mutations/handlers/field-type-data-type.ts
@@ -16,7 +16,6 @@ import type { Handler, MutationContext } from '../handler.js';
 import type { EditInput } from '../types.js';
 import { resourceNameToString } from '../../utils/resource-utils.js';
 import { fromDate, fromNumber, fromString } from '../../utils/value-utils.js';
-import { isModuleCard } from '../../utils/card-utils.js';
 import type {
   Card,
   MetadataContent,
@@ -85,7 +84,7 @@ export class FieldTypeDataTypeHandler implements Handler<EditInput> {
     const projectCards = ctx.project.cardTree.cards().filter(holdsField);
     const templateCards = ctx.project
       .allTemplateCards()
-      .filter((card) => !isModuleCard(card))
+      .filter((card) => ctx.project.treeOf(card.key).writable)
       .filter(holdsField);
     return [...projectCards, ...templateCards];
   }

--- a/tools/data-handler/src/mutations/handlers/link-type-delete.ts
+++ b/tools/data-handler/src/mutations/handlers/link-type-delete.ts
@@ -15,7 +15,6 @@
 import type { Handler, MutationContext } from '../handler.js';
 import type { DeleteInput } from '../types.js';
 import { resourceNameToString } from '../../utils/resource-utils.js';
-import { isModuleCard } from '../../utils/card-utils.js';
 import type { Card } from '../../interfaces/project-interfaces.js';
 
 export class LinkTypeDeleteHandler implements Handler<DeleteInput> {
@@ -59,7 +58,9 @@ export class LinkTypeDeleteHandler implements Handler<DeleteInput> {
   private affectedCards(ctx: MutationContext, name: string): Card[] {
     return [
       ...ctx.project.cardTree.cards(),
-      ...ctx.project.allTemplateCards().filter((c) => !isModuleCard(c)),
+      ...ctx.project
+        .allTemplateCards()
+        .filter((c) => ctx.project.treeOf(c.key).writable),
     ].filter((c) => c.metadata?.links?.some((l) => l.linkType === name));
   }
 }

--- a/tools/data-handler/src/mutations/handlers/link-type-rename.ts
+++ b/tools/data-handler/src/mutations/handlers/link-type-rename.ts
@@ -19,7 +19,6 @@ import {
   rewriteCardContentRefs,
   rewriteContentFileRefs,
 } from '../cascades/rewrite-refs.js';
-import { isModuleCard } from '../../utils/card-utils.js';
 import type { Card } from '../../interfaces/project-interfaces.js';
 
 export class LinkTypeRenameHandler implements Handler<RenameInput> {
@@ -70,7 +69,9 @@ export class LinkTypeRenameHandler implements Handler<RenameInput> {
   private affectedCards(ctx: MutationContext, oldName: string): Card[] {
     const all = [
       ...ctx.project.cardTree.cards(),
-      ...ctx.project.allTemplateCards().filter((card) => !isModuleCard(card)),
+      ...ctx.project
+        .allTemplateCards()
+        .filter((card) => ctx.project.treeOf(card.key).writable),
     ];
     return all.filter((c) =>
       c.metadata?.links?.some((l) => l.linkType === oldName),

--- a/tools/data-handler/src/mutations/handlers/project-rename.ts
+++ b/tools/data-handler/src/mutations/handlers/project-rename.ts
@@ -23,7 +23,6 @@ import {
 import type { Handler, MutationContext } from '../handler.js';
 import type { ProjectRenameInput } from '../types.js';
 import type { Card } from '../../interfaces/project-interfaces.js';
-import { isTemplateCard } from '../../utils/card-utils.js';
 import { resourceName } from '../../utils/resource-utils.js';
 import { ResourcesFrom } from '../../containers/project/resources-from.js';
 
@@ -168,7 +167,7 @@ async function updateCardAttachments(
   card: Card,
   to: string,
 ): Promise<string | undefined> {
-  if (!isTemplateCard(card)) {
+  if (ctx.project.treeOf(card.key).kind === 'project') {
     const fileNames = (card.attachments ?? []).map((item) => item.fileName);
     await Promise.all(
       fileNames.map(async (fileName) => {

--- a/tools/data-handler/src/mutations/handlers/workflow-remove-state.ts
+++ b/tools/data-handler/src/mutations/handlers/workflow-remove-state.ts
@@ -19,7 +19,6 @@ import {
   isInitialTransition,
   resourceNameToString,
 } from '../../utils/resource-utils.js';
-import { isModuleCard } from '../../utils/card-utils.js';
 import type { RemoveOperation } from '../../resources/resource-object.js';
 import type { Card } from '../../interfaces/project-interfaces.js';
 import type { WorkflowState } from '../../interfaces/resource-interfaces.js';
@@ -120,7 +119,7 @@ export class WorkflowRemoveStateHandler implements Handler<EditInput> {
     const projectCards = ctx.project.cardTree.cards().filter(matches);
     const templateCards = ctx.project
       .allTemplateCards()
-      .filter((card) => !isModuleCard(card))
+      .filter((card) => ctx.project.treeOf(card.key).writable)
       .filter(matches);
     return [...projectCards, ...templateCards];
   }

--- a/tools/data-handler/src/mutations/handlers/workflow-rename-state.ts
+++ b/tools/data-handler/src/mutations/handlers/workflow-rename-state.ts
@@ -16,7 +16,6 @@ import type { Handler, MutationContext } from '../handler.js';
 import { resolveCardTypeRename } from '../handler.js';
 import type { EditInput } from '../types.js';
 import { resourceNameToString } from '../../utils/resource-utils.js';
-import { isModuleCard } from '../../utils/card-utils.js';
 import type { ChangeOperation } from '../../resources/resource-object.js';
 import type { Card } from '../../interfaces/project-interfaces.js';
 import type { WorkflowState } from '../../interfaces/resource-interfaces.js';
@@ -96,7 +95,7 @@ export class WorkflowRenameStateHandler implements Handler<EditInput> {
     const projectCards = ctx.project.cardTree.cards().filter(matches);
     const templateCards = ctx.project
       .allTemplateCards()
-      .filter((card) => !isModuleCard(card))
+      .filter((card) => ctx.project.treeOf(card.key).writable)
       .filter(matches);
     return [...projectCards, ...templateCards];
   }

--- a/tools/data-handler/src/utils/card-utils.ts
+++ b/tools/data-handler/src/utils/card-utils.ts
@@ -106,33 +106,12 @@ export const flattenCardArray = (array: Card[], project: Project) => {
 };
 
 /**
- * Checks if given card is in some module.
- * @param card Card object to check
- * @returns true if card exists in a module; false otherwise
- */
-export const isModuleCard = (card: Pick<Card, 'path'>) => {
-  return card.path.includes(`${sep}modules${sep}`);
-};
-
-/**
  * Checks if given path is from a module.
  * @param path Path to check
  * @returns true if path is from a module; false otherwise
  */
 export const isModulePath = (path: string) => {
   return path.includes(`${sep}modules${sep}`);
-};
-
-/**
- * Checks if given card is in some template.
- * @param card card object to check
- * @returns true if card exists in a template; false otherwise
- */
-export const isTemplateCard = (card: Pick<Card, 'path'>) => {
-  return (
-    card.path.includes(`${sep}templates${sep}`) ||
-    card.path.includes(`${sep}modules${sep}`)
-  );
 };
 
 /**

--- a/tools/data-handler/src/utils/card-utils.ts
+++ b/tools/data-handler/src/utils/card-utils.ts
@@ -44,7 +44,7 @@ export const buildCardHierarchy = (
 
     const rootCards: Card[] = [];
     cardMap.forEach((card) => {
-      if (card.parent && cardMap.has(card.parent)) {
+      if (cardMap.has(card.parent)) {
         const parentCard = cardMap.get(card.parent);
         if (parentCard) {
           parentCard.children.push(card.key);
@@ -84,7 +84,7 @@ export const flattenCardArray = (array: Card[], project: Project) => {
   const result: Card[] = [];
 
   array.forEach((item) => {
-    const { key, path, children, attachments, metadata } = item;
+    const { key, path, parent, children, attachments, metadata } = item;
     const childCardIds = project
       .cardKeysToCards(children)
       .map((item) => item.key);
@@ -92,6 +92,7 @@ export const flattenCardArray = (array: Card[], project: Project) => {
     result.push({
       key,
       path,
+      parent,
       children: [...childCardIds],
       attachments,
       metadata,

--- a/tools/data-handler/src/utils/card-utils.ts
+++ b/tools/data-handler/src/utils/card-utils.ts
@@ -129,6 +129,28 @@ export const moduleNameFromCardKey = (cardKey: string) => {
   return parts[0];
 };
 
+const compareSlices = (
+  a: string,
+  aStart: number,
+  aEnd: number,
+  b: string,
+  bStart: number,
+  bEnd: number,
+) => {
+  const shared = Math.min(aEnd - aStart, bEnd - bStart);
+  for (let i = 0; i < shared; i++) {
+    const difference = a.charCodeAt(aStart + i) - b.charCodeAt(bStart + i);
+    if (difference !== 0) return difference < 0 ? -1 : 1;
+  }
+  if (aEnd - aStart === bEnd - bStart) return 0;
+  return aEnd - aStart < bEnd - bStart ? -1 : 1;
+};
+
+const endOfId = (key: string, separator: number) => {
+  const next = key.indexOf(CARD_KEY_SEPARATOR, separator + 1);
+  return next < 0 ? key.length : next;
+};
+
 /**
  * Sorts array of cards first using prefix and then using ID.
  * Prefixes are returned in alphabetical order, and then in numeric order within same prefix.
@@ -138,22 +160,28 @@ export const moduleNameFromCardKey = (cardKey: string) => {
  * @returns Cards ordered; first by prefixes, then by ID.
  */
 export const sortCards = (a: string, b: string) => {
-  const aParts = a.split(CARD_KEY_SEPARATOR);
-  const bParts = b.split(CARD_KEY_SEPARATOR);
-  if (aParts[0] !== bParts[0]) {
-    if (aParts[0] > bParts[0]) return 1;
-    if (aParts[0] < bParts[0]) return -1;
-    return 0;
-  }
-  if (a.length > b.length) {
-    return 1;
-  }
-  if (a.length < b.length) {
-    return -1;
-  }
-  if (aParts[1] > bParts[1]) return 1;
-  if (aParts[1] < bParts[1]) return -1;
-  return 0;
+  // Compared in place: splitting both keys allocated two arrays per comparison,
+  // which dominated the cost of sorting a whole project's keys.
+  const aSeparator = a.indexOf(CARD_KEY_SEPARATOR);
+  const bSeparator = b.indexOf(CARD_KEY_SEPARATOR);
+  const prefixes = compareSlices(
+    a,
+    0,
+    aSeparator < 0 ? a.length : aSeparator,
+    b,
+    0,
+    bSeparator < 0 ? b.length : bSeparator,
+  );
+  if (prefixes !== 0) return prefixes;
+  if (a.length !== b.length) return a.length < b.length ? -1 : 1;
+  return compareSlices(
+    a,
+    aSeparator + 1,
+    endOfId(a, aSeparator),
+    b,
+    bSeparator + 1,
+    endOfId(b, bSeparator),
+  );
 };
 
 /**

--- a/tools/data-handler/src/utils/clingo-facts.ts
+++ b/tools/data-handler/src/utils/clingo-facts.ts
@@ -36,22 +36,21 @@ import { ClingoProgramBuilder } from './clingo-program-builder.js';
 import { isPredefinedField, ROOT } from './constants.js';
 import { getChildLogger } from './log-utils.js';
 import type { Project } from '../containers/project.js';
+import type { CardTreeKind } from '../containers/project/card-tree.js';
 
 const logger = getChildLogger({ module: 'clingo-facts' });
 
 /**
- * How a card container is projected into facts.
- *
- * emitsCardFact - whether the container's cards get the card(Key) fact.
- * name - what the container's root cards name as their parent.
+ * How a card container is projected into facts. 'name' is what the
+ * container's root cards name as their parent.
  */
 export interface CardFactContext {
-  emitsCardFact: boolean;
+  kind: CardTreeKind;
   name: string;
 }
 
 export const PROJECT_CARD_FACTS: CardFactContext = {
-  emitsCardFact: true,
+  kind: 'project',
   name: 'project',
 };
 
@@ -200,12 +199,12 @@ export const createCardFacts = async (
   const parentsPath =
     card.parent && card.parent !== ROOT
       ? card.parent
-      : container.emitsCardFact
+      : container.kind === 'project'
         ? ''
         : `"${container.name}"`;
 
   const builder = new ClingoProgramBuilder().addComment(card.key);
-  if (container.emitsCardFact) {
+  if (container.kind === 'project') {
     builder.addCustomFact('card', (b) => b.addLiteralArgument(card.key));
   }
 
@@ -345,12 +344,7 @@ export const createCardFacts = async (
     );
   }
   builder.addCustomFact(Facts.Common.FIELD, (b) =>
-    b
-      .addLiteralArgument(card.key)
-      .addArguments(
-        'container',
-        container.emitsCardFact ? 'project' : 'template',
-      ),
+    b.addLiteralArgument(card.key).addArguments('container', container.kind),
   );
 
   return builder.buildAll();

--- a/tools/data-handler/src/utils/clingo-facts.ts
+++ b/tools/data-handler/src/utils/clingo-facts.ts
@@ -197,7 +197,7 @@ export const createCardFacts = async (
   // A card names its parent card, or — when it is a root card of a template —
   // the template itself. Project root cards name nothing.
   const parentsPath =
-    card.parent && card.parent !== ROOT
+    card.parent !== ROOT
       ? card.parent
       : container.kind === 'project'
         ? ''

--- a/tools/data-handler/test/card-tree.test.ts
+++ b/tools/data-handler/test/card-tree.test.ts
@@ -36,6 +36,7 @@ import type {
   CardMetadata,
 } from '../src/interfaces/project-interfaces.js';
 import { CommandManager } from '../src/command-manager.js';
+import { ROOT } from '../src/utils/constants.js';
 import {
   CardNotFoundError,
   DuplicateCardKeyError,
@@ -303,6 +304,7 @@ describe('Card tree', () => {
       const unknown: Card = {
         key: 'non_existing_card',
         path: join(testCardsPath, 'non_existing_card'),
+        parent: ROOT,
         children: [],
         attachments: [],
         content: 'some content',
@@ -333,6 +335,7 @@ describe('Card tree', () => {
       const unknown: Card = {
         key: 'non_existing_too',
         path: join(testCardsPath, 'non_existing_too'),
+        parent: ROOT,
         children: [],
         attachments: [],
         metadata: { ...pageCard('Some title'), links: [] },

--- a/tools/data-handler/test/card-tree.test.ts
+++ b/tools/data-handler/test/card-tree.test.ts
@@ -293,14 +293,14 @@ describe('Card tree', () => {
       const card = tree.card('test_1');
       card.content = 'Updated content for test_1';
 
-      expect(await tree.writeContent(card)).toBe(true);
+      await tree.writeContent(card);
       expect(tree.content('test_1')).toBe('Updated content for test_1');
       await expect(
         readFile(join(card.path, 'index.adoc'), 'utf-8'),
       ).resolves.toBe('Updated content for test_1');
     });
 
-    it('returns false when writing content for an unknown card', async () => {
+    it('refuses to write content for an unknown card', async () => {
       const unknown: Card = {
         key: 'non_existing_card',
         path: join(testCardsPath, 'non_existing_card'),
@@ -309,7 +309,9 @@ describe('Card tree', () => {
         attachments: [],
         content: 'some content',
       };
-      expect(await tree.writeContent(unknown)).toBe(false);
+      await expect(tree.writeContent(unknown)).rejects.toThrow(
+        CardNotFoundError,
+      );
     });
 
     it('persists card metadata and keeps the store in step', async () => {
@@ -320,7 +322,7 @@ describe('Card tree', () => {
         workflowState: 'Published',
       };
 
-      expect(await tree.writeMetadata(card)).toBe(true);
+      await tree.writeMetadata(card);
       const stored = tree.node('test_1').metadata!;
       expect(stored.title).toBe('Updated Metadata Title');
       expect(stored.workflowState).toBe('Published');
@@ -331,7 +333,7 @@ describe('Card tree', () => {
       expect(onDisk.title).toBe('Updated Metadata Title');
     });
 
-    it('returns false when writing metadata for an unknown card', async () => {
+    it('refuses to write metadata for an unknown card', async () => {
       const unknown: Card = {
         key: 'non_existing_too',
         path: join(testCardsPath, 'non_existing_too'),
@@ -340,7 +342,9 @@ describe('Card tree', () => {
         attachments: [],
         metadata: { ...pageCard('Some title'), links: [] },
       };
-      expect(await tree.writeMetadata(unknown)).toBe(false);
+      await expect(tree.writeMetadata(unknown)).rejects.toThrow(
+        CardNotFoundError,
+      );
     });
   });
 
@@ -358,7 +362,7 @@ describe('Card tree', () => {
     it('deletes a card, its folder and its descendants', async () => {
       const rootPath = tree.card('test_1').path;
 
-      expect(await tree.deleteSubtree('test_1')).toBe(true);
+      await tree.deleteSubtree('test_1');
 
       for (const cardKey of ['test_1', 'test_2', 'test_3']) {
         expect(tree.has(cardKey)).toBe(false);
@@ -366,8 +370,10 @@ describe('Card tree', () => {
       expect(existsSync(rootPath)).toBe(false);
     });
 
-    it('returns false for a card the tree does not hold', async () => {
-      expect(await tree.deleteSubtree('non_existing_card')).toBe(false);
+    it('refuses to delete a card the tree does not hold', async () => {
+      await expect(tree.deleteSubtree('non_existing_card')).rejects.toThrow(
+        CardNotFoundError,
+      );
     });
   });
 

--- a/tools/data-handler/test/card-tree.test.ts
+++ b/tools/data-handler/test/card-tree.test.ts
@@ -126,9 +126,8 @@ function projectTree(
   return new CardTree({
     name: 'project',
     rootPath,
+    kind: 'project',
     writable: true,
-    emitsCardFact: true,
-    validationApplies: true,
     keys,
   });
 }
@@ -142,9 +141,8 @@ function newTemplateTree(
   return new CardTree({
     name,
     rootPath,
+    kind: 'template',
     writable,
-    emitsCardFact: false,
-    validationApplies: false,
     keys,
   });
 }

--- a/tools/data-handler/test/command-show.test.ts
+++ b/tools/data-handler/test/command-show.test.ts
@@ -790,9 +790,13 @@ describe('show', () => {
     expect(results).to.have.property('prefix');
     expect(results).to.have.property('modules');
     expect(results).to.have.property('hubs');
-    expect(results).to.have.property('numberOfCards');
     expect(results).to.have.property('description');
     expect(results).to.have.property('category');
+    const containers = await showCmd.showCards();
+    expect(results.numberOfCards).to.equal(
+      containers.find((container) => container.type === 'project')!.cards
+        .length,
+    );
   });
   it('showResource - template (success)', async () => {
     const templateName = 'decision/templates/decision';

--- a/tools/data-handler/test/macros/index.test.ts
+++ b/tools/data-handler/test/macros/index.test.ts
@@ -26,7 +26,7 @@ import {
 import type { Project } from '../../src/containers/project.js';
 import TaskQueue from '../../src/macros/task-queue.js';
 
-import { MAX_LEVEL_OFFSET } from '../../src/utils/constants.js';
+import { MAX_LEVEL_OFFSET, ROOT } from '../../src/utils/constants.js';
 
 import type { Card } from '../../src/interfaces/project-interfaces.js';
 import type { MacroGenerationContext } from '../../src/interfaces/macros.js';
@@ -411,6 +411,7 @@ Some content here`;
           key: '',
           path: '',
           content: '',
+          parent: ROOT,
           metadata: {
             title: '',
             cardType: '',
@@ -625,6 +626,7 @@ Some content here`;
           path: '',
           content:
             'Content before raw block.\n\n{{#raw}}{{#scoreCard}}"title": "Should not be evaluated", "value": 42{{/scoreCard}}{{/raw}}\n\nContent after raw block.',
+          parent: ROOT,
           metadata: {
             title: 'Card with Raw Block',
             cardType: '',
@@ -718,6 +720,7 @@ Some content here`;
             key: 'json-content-card',
             path: '',
             content: '{"key": "value", "number": 42}',
+            parent: ROOT,
             metadata: {
               title: 'JSON Card',
               cardType: '',
@@ -769,6 +772,7 @@ Some content here`;
               key: 'json-escape-card',
               path: '',
               content: 'Content with "quotes" and \\ backslash\nand newline',
+              parent: ROOT,
               metadata: {
                 title: 'JSON Escape Card',
                 cardType: '',
@@ -800,6 +804,7 @@ Some content here`;
               key: 'csv-escape-card',
               path: '',
               content: 'Content with "quotes" inside',
+              parent: ROOT,
               metadata: {
                 title: 'CSV Escape Card',
                 cardType: '',
@@ -829,6 +834,7 @@ Some content here`;
               key: 'csv-multi-quote-card',
               path: '',
               content: '"""triple quotes"""',
+              parent: ROOT,
               metadata: {
                 title: 'CSV Multi Quote Card',
                 cardType: '',
@@ -861,6 +867,7 @@ Some content here`;
             key: 'plain-card',
             path: '',
             content: 'Content with "quotes" and newline\nhere',
+            parent: ROOT,
             metadata: {
               title: 'Plain Card',
               cardType: '',
@@ -895,6 +902,7 @@ Some content here`;
           key: '',
           path: '',
           content: '',
+          parent: ROOT,
           metadata: {
             title: '',
             cardType: '',

--- a/tools/data-handler/test/project.test.ts
+++ b/tools/data-handler/test/project.test.ts
@@ -15,7 +15,6 @@ import { CardLocation } from '../src/interfaces/project-interfaces.js';
 import {
   buildCardHierarchy,
   flattenCardArray,
-  isTemplateCard,
 } from '../src/utils/card-utils.js';
 import { Project } from '../src/containers/project.js';
 import { ProjectConfiguration } from '../src/project-settings.js';
@@ -376,7 +375,6 @@ describe('project', () => {
     expect(projectCard.metadata).not.toBeUndefined();
     expect(projectCard.metadata?.title).toBe('Decision Records');
     expect(projectCard.metadata?.workflowState).toBe('Created');
-    expect(isTemplateCard(projectCard)).toBe(false);
     expect(project.treeOf(projectCard.key)).toBe(project.cardTree);
   });
   it('empty project does not have cards', async () => {

--- a/tools/data-handler/test/template.test.ts
+++ b/tools/data-handler/test/template.test.ts
@@ -16,6 +16,7 @@ import {
   instantiateTemplate,
 } from '../src/containers/project/template-instantiation.js';
 import { CardNotFoundError } from '../src/exceptions/index.js';
+import { ROOT } from '../src/utils/constants.js';
 
 // Create test artifacts in a temp directory.
 const baseDir = import.meta.dirname;
@@ -93,6 +94,7 @@ describe('template', () => {
       key: '1111',
       path: '',
       content: '',
+      parent: ROOT,
       children: [],
       attachments: [],
     };
@@ -109,6 +111,7 @@ describe('template', () => {
       key: '1111',
       path: '',
       content: '',
+      parent: ROOT,
       children: [],
       attachments: [],
     };
@@ -179,6 +182,7 @@ describe('template', () => {
     const parentCard: Card = {
       key: 'decision_1',
       path: join(template.templateCardsFolder(), 'decision_1'),
+      parent: ROOT,
       children: [],
       attachments: [],
     };
@@ -226,6 +230,7 @@ describe('template', () => {
     const parentCard: Card = {
       key: 'i-dont-exist',
       path: join(template.templateCardsFolder(), 'decision_1'),
+      parent: ROOT,
       children: [],
       attachments: [],
     };

--- a/tools/data-handler/test/utils/asciidoc-xref.test.ts
+++ b/tools/data-handler/test/utils/asciidoc-xref.test.ts
@@ -4,11 +4,13 @@ import { rewriteAsciidocCardXrefs } from '../../src/utils/asciidoc-xref.js';
 import type { Project } from '../../src/containers/project.js';
 import type { CardNode } from '../../src/interfaces/project-interfaces.js';
 import type { Mode } from '../../src/interfaces/macros.js';
+import { ROOT } from '../../src/utils/constants.js';
 
 function makeCard(key: string, title: string): CardNode {
   return {
     key,
     path: '',
+    parent: ROOT,
     metadata: {
       title,
       cardType: '',

--- a/tools/data-handler/test/utils/card-utils.test.ts
+++ b/tools/data-handler/test/utils/card-utils.test.ts
@@ -90,6 +90,54 @@ describe('card utils', () => {
       expect(cards.at(3)).toBe('zzz_111');
       expect(cards.at(4)).toBe('zzz_999');
     });
+
+    it('orders every pair the way splitting the keys does', () => {
+      const splitting = (a: string, b: string) => {
+        const aParts = a.split('_');
+        const bParts = b.split('_');
+        if (aParts[0] !== bParts[0]) {
+          if (aParts[0] > bParts[0]) return 1;
+          if (aParts[0] < bParts[0]) return -1;
+          return 0;
+        }
+        if (a.length > b.length) return 1;
+        if (a.length < b.length) return -1;
+        if (aParts[1] > bParts[1]) return 1;
+        if (aParts[1] < bParts[1]) return -1;
+        return 0;
+      };
+      const keys = [
+        'test_1',
+        'test_2',
+        'test_10',
+        'test_9',
+        'test_aa7',
+        'test_za1',
+        'demo_aaa',
+        'demo_aa',
+        'dem_aaa',
+        'demo',
+        'dem',
+        'test_A',
+        'test_a',
+        'test_0',
+        'test_',
+        '_test',
+        'jira:PROJ-123',
+        'jira:PROJ-124',
+        'base/calculations/x',
+        'test_1_2',
+        'test_12',
+        'test_1_',
+      ];
+      for (const a of keys) {
+        for (const b of keys) {
+          expect(Math.sign(sortCards(a, b)), `${a} vs ${b}`).toBe(
+            Math.sign(splitting(a, b)),
+          );
+        }
+      }
+    });
   });
 
   it('isExternalItemKey', () => {

--- a/tools/data-handler/test/utils/card-utils.test.ts
+++ b/tools/data-handler/test/utils/card-utils.test.ts
@@ -5,8 +5,6 @@ import { sep } from 'node:path';
 import {
   buildCardHierarchy,
   isExternalItemKey,
-  isModuleCard,
-  isTemplateCard,
   moduleNameFromCardKey,
   sortCards,
 } from '../../src/utils/card-utils.js';
@@ -68,24 +66,6 @@ describe('card utils', () => {
     expect(grandchild.key).toBe('test_3');
     expect(grandchild.children).toHaveLength(0);
     expect(grandchild.childrenCards).toHaveLength(0);
-  });
-
-  it.each([
-    [projectCard, false],
-    [projectChildCard, false],
-    [templateCard, false],
-    [moduleCard, true],
-  ])('isModuleCard validates module cards correctly', (card, expected) => {
-    expect(isModuleCard(card)).toBe(expected);
-  });
-
-  it.each([
-    [projectCard, false],
-    [projectChildCard, false],
-    [templateCard, true],
-    [moduleCard, true],
-  ])('isTemplateCard validates template cards correctly', (card, expected) => {
-    expect(isTemplateCard(card)).toBe(expected);
   });
 
   it.each([


### PR DESCRIPTION
Closes the series by removing the duplicate encodings that made the result hard to read. No behavior changes; five commits, each one idea.

**Ask a tree what kind it is, once.** The same question was asked four ways: `tree.name === 'project'`, an `emitsCardFact` option, a `validationApplies` option, and path sniffing through `isTemplateCard` / `isModuleCard`. One `kind: 'project' | 'template'` replaces all four, and the two path-sniffing helpers are deleted — a card's kind is a property of the tree that holds it, not of the string its folder sits under. Read-only checks that were asking about kind now ask about writability, which is what they meant.

**Give every card a parent.** `Card.parent` becomes required, `ROOT` for a top-level card. The tree already normalised it on load and on store, so the optionality only ever bought sentinel handling at the call sites.

**Make the tree's writers throw instead of reporting failure.** `writeContent`, `writeMetadata` and `deleteSubtree` returned `false` and logged a warning for a card the tree does not hold; they now throw `CardNotFoundError` like every other tree operation. The throw is unreachable from outside the tree — every write enters through `Project`, which resolves the tree first and raises the same error for an unknown key — so this makes the contract uniform rather than adding a failure mode.

**Fold `reload()` into `load()`.** Two entry points differing only in whether they evicted first, where loading without evicting is never what a caller wants: the store rejects a key it already holds, so a second `load()` threw. `load()` now evicts, and `reload()` is gone.

**Split scanning and rank planning out of `card-tree.ts`.** A pure move: `card-tree-scan.ts` reads a tree's cards off disk, `rank-plan.ts` holds the rank computations as pure functions over a sibling set. The tree keeps everything that touches its own state.
