### PR TITLE
Render card AsciiDoc in the browser instead of the backend

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,9 +225,6 @@ importers:
 
   tools/backend:
     dependencies:
-      '@asciidoctor/core':
-        specifier: ^4.0.11
-        version: 4.0.11
       '@cyberismo/assets':
         specifier: workspace:*
         version: link:../assets

--- a/tools/app/__tests__/ConfigCardEditor.test.tsx
+++ b/tools/app/__tests__/ConfigCardEditor.test.tsx
@@ -78,7 +78,7 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 vi.mock('@/lib/api/actions/card', () => ({
-  parseContent: vi.fn().mockResolvedValue('<p>html</p>'),
+  parseContent: vi.fn().mockResolvedValue('preview adoc'),
 }));
 
 vi.mock('@/lib/utils', async (orig) => ({
@@ -99,7 +99,7 @@ const baseCard = {
   title: 'A template card',
   labels: [],
   rawContent: '== Body',
-  parsedContent: '<h2>Body</h2>',
+  adocContent: '== Body',
   attachments: [],
   deniedOperations: { editField: [] },
   fields: [

--- a/tools/app/src/components/card/CardBody.tsx
+++ b/tools/app/src/components/card/CardBody.tsx
@@ -57,6 +57,7 @@ import { asciidoc } from 'codemirror-asciidoc';
 import { CODE_MIRROR_BASE_PROPS, CODE_MIRROR_THEMES } from '@/lib/constants';
 import { useTranslation } from 'react-i18next';
 import { parseContent } from '@/lib/api/actions/card.js';
+import { adocToHtml } from '@/lib/asciidoc';
 
 const editorExtensions = [
   StreamLanguage.define(asciidoc),
@@ -66,6 +67,8 @@ const editorExtensions = [
 
 type CardBodyProps = {
   card: CardResponse;
+  /** The card's content, already converted from AsciiDoc by the owning layout. */
+  htmlContent: string;
   preview?: boolean;
   onContentSave?: (content: string) => Promise<void>;
   onEditingChange?: (editing: boolean) => void;
@@ -77,7 +80,10 @@ export type CardBodyHandle = {
 };
 
 export const CardBody = forwardRef<CardBodyHandle, CardBodyProps>(
-  function CardBody({ card, preview, onContentSave, onEditingChange }, ref) {
+  function CardBody(
+    { card, htmlContent, preview, onContentSave, onEditingChange },
+    ref,
+  ) {
     const [contentRef, setContentRef] = useState<HTMLDivElement | null>(null);
 
     const lastTitle = useAppSelector((state) => state.page.title);
@@ -172,8 +178,8 @@ export const CardBody = forwardRef<CardBodyHandle, CardBodyProps>(
       setPreviewing(true);
       setPreviewHtml(null);
       try {
-        const html = await parseContent(card.key, editContentRef.current);
-        setPreviewHtml(html);
+        const adoc = await parseContent(card.key, editContentRef.current);
+        setPreviewHtml(await adocToHtml(adoc, card.key));
       } catch {
         setPreviewing(false);
         dispatch(addNotification({ message: t('error'), type: 'error' }));
@@ -206,8 +212,6 @@ export const CardBody = forwardRef<CardBodyHandle, CardBodyProps>(
       setContentRef(node);
     }, []);
 
-    const htmlContent = card.parsedContent || '';
-
     const renderHtml = (html: string) =>
       renderCardHtml(html, {
         macroKey: card.key,
@@ -215,7 +219,7 @@ export const CardBody = forwardRef<CardBodyHandle, CardBodyProps>(
         downloadName: card.title,
       });
 
-    const parsedContent = renderHtml(htmlContent);
+    const renderedBody = renderHtml(htmlContent);
     const isEmpty = !htmlContent.trim();
 
     return (
@@ -377,7 +381,7 @@ export const CardBody = forwardRef<CardBodyHandle, CardBodyProps>(
                 className={canEdit ? 'doc doc--editable' : 'doc'}
                 ref={setRef}
               >
-                {parsedContent}
+                {renderedBody}
               </div>
             )}
           </Box>

--- a/tools/app/src/components/card/CardLayout.tsx
+++ b/tools/app/src/components/card/CardLayout.tsx
@@ -38,7 +38,7 @@ import { useTranslation } from 'react-i18next';
 import MetadataView from '@/components/card/metadata-section/MetadataSection';
 import { CountBadge, LeadingSlot } from '@/components/CountBadge';
 
-import { useAppDispatch, useAppSelector } from '@/lib/hooks';
+import { useAdocHtml, useAppDispatch, useAppSelector } from '@/lib/hooks';
 import { viewChanged } from '@/lib/slices/pageState';
 
 import type {
@@ -219,7 +219,7 @@ export const CardLayout = forwardRef<CardLayoutHandle, CardLayoutProps>(
     const lastTitle = useAppSelector((state) => state.page.title);
     const cardKey = useAppSelector((state) => state.page.cardKey);
 
-    const htmlContent = card.parsedContent || '';
+    const htmlContent = useAdocHtml(card.adocContent || '', card.key);
 
     // On scroll, check which document headers are visible and update state accordingly
     const handleScroll = () => {
@@ -409,6 +409,7 @@ export const CardLayout = forwardRef<CardLayoutHandle, CardLayoutProps>(
               key={`body-${card.key}`}
               ref={bodyRef}
               card={card}
+              htmlContent={htmlContent}
               preview={preview}
               onContentSave={onContentSave}
               onEditingChange={(editing) => {

--- a/tools/app/src/components/config-editors/template-card/TemplateCardEditor.tsx
+++ b/tools/app/src/components/config-editors/template-card/TemplateCardEditor.tsx
@@ -78,7 +78,7 @@ export function TemplateCardEditor({
     metadataValuesEqual,
   );
   const [content, setContent] = useSavedDraft(savedContent);
-  const [previewHtml, setPreviewHtml] = useState<string | null>(null);
+  const [previewAdoc, setPreviewAdoc] = useState<string | null>(null);
   const contentRef = useRef<ContentEditorHandle>(null);
   const titleDenied = (card.deniedOperations.editField ?? [])
     .map((f) => f.fieldName)
@@ -107,8 +107,8 @@ export function TemplateCardEditor({
   useEffect(() => {
     if (!isPreview) return;
     let mounted = true;
-    parseContent(node.id, content).then((html) => {
-      if (mounted) setPreviewHtml(html);
+    parseContent(node.id, content).then((adoc) => {
+      if (mounted) setPreviewAdoc(adoc);
     });
     return () => {
       mounted = false;
@@ -151,13 +151,13 @@ export function TemplateCardEditor({
       title: (draft[TITLE_KEY] as string) ?? card.title,
       labels: (draft[LABELS_KEY] as string[]) ?? card.labels,
       rawContent: content,
-      parsedContent: previewHtml ?? card.parsedContent,
+      adocContent: previewAdoc ?? card.adocContent,
       fields: (card.fields ?? []).map((f) => ({
         ...f,
         value: draft[f.key] as typeof f.value,
       })),
     }),
-    [card, draft, content, previewHtml],
+    [card, draft, content, previewAdoc],
   );
 
   const parent = resourceTree

--- a/tools/app/src/lib/api/actions/card.ts
+++ b/tools/app/src/lib/api/actions/card.ts
@@ -17,10 +17,10 @@ export async function parseContent(
   content: string,
   projectPrefix?: string,
 ) {
-  const result = await callApi<{ parsedContent: string }>(
+  const result = await callApi<{ adocContent: string }>(
     projectApiPaths(projectPrefix).cardParse(key),
     'POST',
     { content },
   );
-  return result.parsedContent;
+  return result.adocContent;
 }

--- a/tools/app/src/lib/api/types.ts
+++ b/tools/app/src/lib/api/types.ts
@@ -33,7 +33,7 @@ import type { SWRResponse } from 'swr';
 import { RESOURCES } from '@/lib/constants';
 
 export type CardResponse = {
-  parsedContent: string;
+  adocContent: string;
   rawContent: string;
   attachments: CardAttachment[];
   path: string;

--- a/tools/app/src/lib/asciidoc.ts
+++ b/tools/app/src/lib/asciidoc.ts
@@ -1,0 +1,91 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2026
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { convert } from '@asciidoctor/core';
+
+import { projectApiPaths } from './swr';
+
+// Asciidoctor resolves include:: over XMLHttpRequest in the browser, so card content
+// could otherwise fetch same-origin endpoints with the viewer's session. SECURE drops
+// includes; icons survives it because asciidoctor's gate is `attr_overrides ||= nil`.
+const SAFE_MODE = 'secure';
+
+const CACHE_LIMIT = 20;
+const cache = new Map<string, string>();
+
+function cacheKey(adoc: string, imagesdir: string): string {
+  return `${imagesdir}\n${adoc}`;
+}
+
+function imagesDirFor(cardKey: string, projectPrefix?: string): string {
+  return projectApiPaths(projectPrefix).cardImages(cardKey);
+}
+
+/**
+ * Returns already-converted HTML for this content, without converting.
+ * @param adoc macro-expanded AsciiDoc, as served by the card API
+ * @param cardKey the card the content belongs to
+ * @param projectPrefix project the card belongs to, defaulting to the current one
+ * @returns the HTML, or undefined if this content has not been converted yet
+ */
+export function cachedAdocHtml(
+  adoc: string,
+  cardKey: string,
+  projectPrefix?: string,
+): string | undefined {
+  if (!adoc) {
+    return '';
+  }
+  return cache.get(cacheKey(adoc, imagesDirFor(cardKey, projectPrefix)));
+}
+
+/**
+ * Converts a card's AsciiDoc to HTML.
+ * @param adoc macro-expanded AsciiDoc, as served by the card API
+ * @param cardKey the card the content belongs to; resolves relative image paths
+ * @param projectPrefix project the card belongs to, defaulting to the current one
+ * @returns the rendered HTML, ready for renderCardHtml
+ */
+export async function adocToHtml(
+  adoc: string,
+  cardKey: string,
+  projectPrefix?: string,
+): Promise<string> {
+  if (!adoc) {
+    return '';
+  }
+
+  const imagesdir = imagesDirFor(cardKey, projectPrefix);
+  const key = cacheKey(adoc, imagesdir);
+
+  const cached = cache.get(key);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const html = (
+    await convert(adoc, {
+      safe: SAFE_MODE,
+      attributes: {
+        imagesdir,
+        icons: 'font',
+      },
+    })
+  ).toString();
+
+  if (cache.size >= CACHE_LIMIT) {
+    cache.delete(cache.keys().next().value as string);
+  }
+  cache.set(key, html);
+
+  return html;
+}

--- a/tools/app/src/lib/hooks/index.ts
+++ b/tools/app/src/lib/hooks/index.ts
@@ -17,5 +17,6 @@ export * from './configurationEditor';
 export * from './theme';
 export * from './themeCycle';
 export * from './savedDraft';
+export * from './useAdocHtml';
 export * from './useListItemEditing';
 export * from './useTreeNodeVisualState';

--- a/tools/app/src/lib/hooks/useAdocHtml.ts
+++ b/tools/app/src/lib/hooks/useAdocHtml.ts
@@ -1,0 +1,54 @@
+/**
+    Cyberismo
+    Copyright © Cyberismo Ltd and contributors 2026
+
+    This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public
+    License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { useEffect, useState } from 'react';
+
+import { adocToHtml, cachedAdocHtml } from '../asciidoc';
+
+/**
+ * Converts a card's AsciiDoc to HTML, re-converting when the content changes.
+ * Content converted before resolves during render, so revisiting a card does
+ * not blank its body.
+ * @param adoc macro-expanded AsciiDoc, as served by the card API
+ * @param cardKey the card the content belongs to
+ * @returns the rendered HTML, empty until the first conversion resolves
+ */
+export function useAdocHtml(adoc: string, cardKey: string): string {
+  // The result is tagged so a pending conversion cannot paint over the next card.
+  const [converted, setConverted] = useState<{
+    token: string;
+    html: string;
+  } | null>(null);
+
+  const token = `${cardKey}\n${adoc}`;
+  const cached = cachedAdocHtml(adoc, cardKey);
+
+  useEffect(() => {
+    if (cached !== undefined) {
+      return;
+    }
+    let current = true;
+    adocToHtml(adoc, cardKey).then((html) => {
+      if (current) {
+        setConverted({ token, html });
+      }
+    });
+    return () => {
+      current = false;
+    };
+  }, [adoc, cardKey, token, cached]);
+
+  if (cached !== undefined) {
+    return cached;
+  }
+  return converted?.token === token ? converted.html : '';
+}

--- a/tools/app/src/lib/swr.ts
+++ b/tools/app/src/lib/swr.ts
@@ -62,6 +62,7 @@ export function projectApiPaths(projectPrefix?: string) {
     templateTree: () => `${base}/templates/tree`,
     attachment: (cardKey: string, attachment: string) =>
       `${base}/cards/${cardKey}/a/${encodeURIComponent(attachment)}`,
+    cardImages: (cardKey: string) => `${base}/cards/${cardKey}/a`,
     cardAttachments: (cardKey: string) =>
       `${base}/cards/${cardKey}/attachments`,
     cardAttachment: (cardKey: string, filename: string) =>

--- a/tools/backend/package.json
+++ b/tools/backend/package.json
@@ -26,7 +26,6 @@
     "node": ">=22"
   },
   "dependencies": {
-    "@asciidoctor/core": "^4.0.11",
     "@cyberismo/assets": "workspace:*",
     "@cyberismo/data-handler": "workspace:*",
     "@cyberismo/mcp": "workspace:*",

--- a/tools/backend/src/domain/cards/lib.ts
+++ b/tools/backend/src/domain/cards/lib.ts
@@ -11,7 +11,6 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { convert } from '@asciidoctor/core';
 import type { Card } from '@cyberismo/data-handler/interfaces/project-interfaces';
 import { type CommandManager, evaluateMacros } from '@cyberismo/data-handler';
 import { preprocessMermaidBlocksForHtml } from '@cyberismo/data-handler/utils/mermaid-renderer';
@@ -69,17 +68,6 @@ export async function getCardDetails(
       commands.project,
       staticMode ? 'staticSite' : 'inject',
     );
-
-    const projectPrefix = commands.project.projectPrefix;
-    const htmlContent = (
-      await convert(asciidocContent, {
-        safe: 'safe',
-        attributes: {
-          imagesdir: `/api/projects/${projectPrefix}/cards/${key}/a`,
-          icons: 'font',
-        },
-      })
-    ).toString();
 
     if (raw) {
       if (!cardDetailsResponse.metadata) {
@@ -143,7 +131,7 @@ export async function getCardDetails(
             editContent: [],
           },
           rawContent: cardDetailsResponse.content || '',
-          parsedContent: htmlContent,
+          adocContent: asciidocContent,
           attachments: cardDetailsResponse.attachments,
           path: cardDetailsResponse.path,
         },
@@ -165,7 +153,7 @@ export async function getCardDetails(
       data: {
         ...card[0],
         rawContent: cardDetailsResponse.content || '',
-        parsedContent: htmlContent,
+        adocContent: asciidocContent,
         attachments: cardDetailsResponse.attachments,
         path: cardDetailsResponse.path,
       },

--- a/tools/backend/src/domain/cards/service.ts
+++ b/tools/backend/src/domain/cards/service.ts
@@ -11,7 +11,6 @@
   License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { convert } from '@asciidoctor/core';
 import type {
   ExportPdfOptions,
   MetadataContent,
@@ -181,18 +180,7 @@ export async function parseContent(
       'inject',
     );
 
-    const projectPrefix = commands.project.projectPrefix;
-    const parsedContent = (
-      await convert(asciidocContent, {
-        safe: 'safe',
-        attributes: {
-          imagesdir: `/api/projects/${projectPrefix}/cards/${key}/a`,
-          icons: 'font',
-        },
-      })
-    ).toString();
-
-    return { parsedContent };
+    return { adocContent: asciidocContent };
   });
 }
 

--- a/tools/backend/test/api.test.ts
+++ b/tools/backend/test/api.test.ts
@@ -34,7 +34,7 @@ afterAll(async () => {
 
 type CardApiResponse = QueryResult<'card'> & {
   rawContent: string;
-  parsedContent: string;
+  adocContent: string;
   attachments?: CardAttachment[];
 };
 

--- a/tools/data-handler/src/commands/export.ts
+++ b/tools/data-handler/src/commands/export.ts
@@ -114,6 +114,15 @@ export class Export {
     const proc = spawn(
       'asciidoctor-pdf',
       [
+        // Card content is untrusted: SECURE blocks include:: reading server files.
+        // It also locks icons and source-highlighter off, so both are restored here;
+        // a command-line attribute cannot be overridden from a card.
+        '--safe-mode',
+        'secure',
+        '-a',
+        'source-highlighter=rouge',
+        '-a',
+        'icons=font',
         '-a',
         'pdf-theme=cyberismo',
         '-a',

--- a/tools/data-handler/test/command-export-pdf.test.ts
+++ b/tools/data-handler/test/command-export-pdf.test.ts
@@ -51,6 +51,10 @@ describe('PDF export — AsciiDoc source assembly', () => {
   });
 });
 
+// Each case spawns the asciidoctor-pdf CLI, which overruns the default timeout
+// when the suite runs several files at once.
+const PDF_SPAWN_TIMEOUT = 60000;
+
 describe('PDF export - asciidoctor safe mode', () => {
   const baseDir = import.meta.dirname;
   const testDir = join(baseDir, 'tmp-export-pdf-safe-mode-tests');
@@ -96,18 +100,23 @@ describe('PDF export - asciidoctor safe mode', () => {
 
       expect(pdf.toString('latin1')).not.toContain('env_leak_canary_qqz');
     },
+    PDF_SPAWN_TIMEOUT,
   );
 
-  it('does not read files outside the project into the PDF', async () => {
-    const secretFile = join(outsideDir, 'secret.adoc');
-    writeFileSync(secretFile, '== File Leak Canary Zzx\n');
-    await commands.editCmd.editCardContent(
-      'decision_5',
-      `== Testing\ninclude::${secretFile}[]\n`,
-    );
+  it(
+    'does not read files outside the project into the PDF',
+    async () => {
+      const secretFile = join(outsideDir, 'secret.adoc');
+      writeFileSync(secretFile, '== File Leak Canary Zzx\n');
+      await commands.editCmd.editCardContent(
+        'decision_5',
+        `== Testing\ninclude::${secretFile}[]\n`,
+      );
 
-    const pdf = await exportCmd.exportPdfBuffer(options);
+      const pdf = await exportCmd.exportPdfBuffer(options);
 
-    expect(pdf.toString('latin1')).not.toContain('file_leak_canary_zzx');
-  });
+      expect(pdf.toString('latin1')).not.toContain('file_leak_canary_zzx');
+    },
+    PDF_SPAWN_TIMEOUT,
+  );
 });

--- a/tools/data-handler/test/command-export-pdf.test.ts
+++ b/tools/data-handler/test/command-export-pdf.test.ts
@@ -1,6 +1,7 @@
 import { expect, it, describe, beforeAll, afterAll } from 'vitest';
 import { join } from 'node:path';
-import { mkdirSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 
 import { copyDir } from '../src/utils/file-utils.js';
 import { CommandManager } from '../src/command-manager.js';
@@ -47,5 +48,66 @@ describe('PDF export — AsciiDoc source assembly', () => {
 
     expect(source).toContain('<<decision_5,Parent decision>>');
     expect(source).not.toContain('xref:decision_5.adoc[Parent decision]');
+  });
+});
+
+describe('PDF export - asciidoctor safe mode', () => {
+  const baseDir = import.meta.dirname;
+  const testDir = join(baseDir, 'tmp-export-pdf-safe-mode-tests');
+  const decisionRecordsPath = join(testDir, 'valid/decision-records');
+  let outsideDir: string;
+  let commands: CommandManager;
+  let exportCmd: Export;
+
+  const options: ExportPdfOptions = {
+    name: 'decision-records',
+    title: 'Decision Records',
+    cardKey: 'decision_5',
+    recursive: false,
+  };
+
+  beforeAll(async () => {
+    mkdirSync(testDir, { recursive: true });
+    await copyDir('test/test-data/', testDir);
+    outsideDir = mkdtempSync(join(tmpdir(), 'cyberismo-pdf-safe-'));
+    commands = new CommandManager(decisionRecordsPath, {});
+    await commands.initialize();
+    exportCmd = commands.exportCmd;
+  });
+
+  afterAll(() => {
+    rmSync(testDir, { recursive: true, force: true });
+    rmSync(outsideDir, { recursive: true, force: true });
+    delete process.env.CYBERISMO_PDF_SAFE_MODE_CANARY;
+  });
+
+  // The canary is an inline anchor, so a leak becomes a named destination that
+  // appears verbatim in the PDF bytes rather than as font-encoded text.
+  it.runIf(process.platform === 'linux')(
+    'does not leak the process environment into the PDF',
+    async () => {
+      process.env.CYBERISMO_PDF_SAFE_MODE_CANARY = '[[env_leak_canary_qqz]]';
+      await commands.editCmd.editCardContent(
+        'decision_5',
+        '== Testing\ninclude::/proc/self/environ[]\n',
+      );
+
+      const pdf = await exportCmd.exportPdfBuffer(options);
+
+      expect(pdf.toString('latin1')).not.toContain('env_leak_canary_qqz');
+    },
+  );
+
+  it('does not read files outside the project into the PDF', async () => {
+    const secretFile = join(outsideDir, 'secret.adoc');
+    writeFileSync(secretFile, '== File Leak Canary Zzx\n');
+    await commands.editCmd.editCardContent(
+      'decision_5',
+      `== Testing\ninclude::${secretFile}[]\n`,
+    );
+
+    const pdf = await exportCmd.exportPdfBuffer(options);
+
+    expect(pdf.toString('latin1')).not.toContain('file_leak_canary_zzx');
   });
 });

--- a/tools/mcp/src/lib/render.ts
+++ b/tools/mcp/src/lib/render.ts
@@ -179,7 +179,7 @@ export async function renderCard(
         // Convert AsciiDoc to HTML
         parsedContent = (
           await convert(asciidocContent, {
-            safe: 'safe',
+            safe: 'secure',
             attributes: {
               imagesdir: `/api/cards/${cardKey}/a`,
               icons: 'font',


### PR DESCRIPTION
Improves safety + performance. Taking the syncronous convert operation from backend frees up pressure from it and the secure mode prevents access to file system.